### PR TITLE
Fix rng split

### DIFF
--- a/numpyro/handlers.py
+++ b/numpyro/handlers.py
@@ -72,7 +72,7 @@ class seed(Messenger):
     def process_message(self, msg):
         if msg['type'] == 'sample':
             msg['kwargs']['random_state'] = self.rng
-            _, self.rng = random.split(self.rng)
+            self.rng, = random.split(self.rng, 1)
 
 
 class substitute(Messenger):

--- a/numpyro/svi.py
+++ b/numpyro/svi.py
@@ -30,9 +30,9 @@ class SVI(object):
         return self.opt_init(params)
 
     def _seed(self, rng):
-        model = seed(self.model, rng)
-        _, subkey = random.split(rng)
-        guide = seed(self.guide, subkey)
+        model_seed, guide_seed = random.split(rng, 2)
+        model = seed(self.model, model_seed)
+        guide = seed(self.guide, guide_seed)
         return model, guide
 
     def step(self, i, *args, **kwargs):
@@ -48,7 +48,7 @@ class SVI(object):
             opt_state = self.init_state(*args, **kwargs)
         if not self._jitted_fn:
             self._jitted_fn = jit(jit_fn)
-        _, self.rng = random.split(self.rng)
+        self.rng, = random.split(self.rng, 1)
         return self._jitted_fn(i, opt_state, self.rng, args, kwargs)
 
 


### PR DESCRIPTION
Currently, we split seed of model into a subkey and use the subkey for `guide`. But in model's trace, we also split the same seed of model. This PR fixes that behaviour by splitting svi's seed into two keys: one is used for model, 1 is used for guide. In addition, we also need to update svi's key in each step. Luckily, `random.split(key, 1)` and `random.split(key, 2)` will give 3 different keys, so this approach is safe to me.

Another approach is to split svi's key into 3 keys by `random.split(key, 3)`, where first key is used for the next svi step, 2nd and 3rd keys are used for the current model and guide respectively. This way is clearer IMO. WDYT @neerajprad ?

**Edit** it seems that we don't need to seed for model so another approach is to not seed the model at all.