### PR TITLE
Implement cauchy+exponential distribution

### DIFF
--- a/numpyro/distributions/__init__.py
+++ b/numpyro/distributions/__init__.py
@@ -1,10 +1,12 @@
 from numpyro.distributions.cauchy import cauchy
+from numpyro.distributions.expon import expon
 from numpyro.distributions.normal import norm
 from numpyro.distributions.uniform import uniform
 import numpyro.distributions.patch  # noqa: F401
 
 __all__ = [
     'cauchy',
+    'expon',
     'norm',
     'uniform',
 ]

--- a/numpyro/distributions/cauchy.py
+++ b/numpyro/distributions/cauchy.py
@@ -25,7 +25,7 @@ class cauchy_gen(jax_continuous):
     def _rvs(self):
         # TODO: move this implementation upstream to jax.random.standard_cauchy
         # Another way is to generate X, Y ~ Normal(0, 1) and return X / Y
-        u = random.uniform(self._random_state, self._size, minval=0.0, maxval=1.0)
+        u = random.uniform(self._random_state, self._size)
         return np.tan(np.pi * (u - 0.5))
 
     def _pdf(self, x):

--- a/numpyro/distributions/expon.py
+++ b/numpyro/distributions/expon.py
@@ -1,0 +1,61 @@
+import jax.numpy as np
+import jax.random as random
+
+from numpyro.distributions.distribution import jax_continuous
+
+# Copyright (c) 2001, 2002 Enthought, Inc.
+# All rights reserved.
+#
+# Copyright (c) 2003-2019 SciPy Developers.
+# All rights reserved.
+
+
+class expon_gen(jax_continuous):
+    r"""An exponential continuous random variable.
+    %(before_notes)s
+    Notes
+    -----
+    The probability density function for `expon` is:
+    .. math::
+        f(x) = \exp(-x)
+    for :math:`x \ge 0`.
+    %(after_notes)s
+    A common parameterization for `expon` is in terms of the rate parameter
+    ``lambda``, such that ``pdf = lambda * exp(-lambda * x)``. This
+    parameterization corresponds to using ``scale = 1 / lambda``.
+    %(example)s
+    """
+    def _rvs(self):
+        u = random.uniform(self._random_state, self._size)
+        return -np.log1p(-u)
+
+    def _pdf(self, x):
+        # expon.pdf(x) = exp(-x)
+        return np.exp(-x)
+
+    def _logpdf(self, x):
+        return -x
+
+    def _cdf(self, x):
+        return -np.expm1(-x)
+
+    def _ppf(self, q):
+        return -np.log1p(-q)
+
+    def _sf(self, x):
+        return np.exp(-x)
+
+    def _logsf(self, x):
+        return -x
+
+    def _isf(self, q):
+        return -np.log(q)
+
+    def _stats(self):
+        return 1.0, 1.0, 2.0, 6.0
+
+    def _entropy(self):
+        return 1.0
+
+
+expon = expon_gen(name='expon')

--- a/numpyro/distributions/util.py
+++ b/numpyro/distributions/util.py
@@ -12,7 +12,7 @@ def _standard_gamma_one(alpha, key):
 
     # TODO: use lax.cond here
     # boost for the case alpha < 1
-    boost = np.where(alpha >= 1.0, 1.0, random.uniform(key, ()) ** (1.0 / alpha))
+    boost = np.where(alpha >= 1.0, 1.0, (1 - random.uniform(key, ())) ** (1.0 / alpha))
     key, = random.split(key, 1)  # NOTE: always split the key after calling random.foo
     alpha = np.where(alpha >= 1.0, alpha, alpha + 1.0)
 
@@ -36,7 +36,7 @@ def _standard_gamma_one(alpha, key):
         key, x, v = lax.while_loop(lambda kxv: kxv[2] <= 0.0, _next_kxv, (key, 0.0, -1.0))
         X = x * x
         V = v * v * v
-        U = random.uniform(key, ())
+        U = 1 - random.uniform(key, ())
         key, = random.split(key, 1)
         return key, X, V, U
 

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -14,6 +14,7 @@ from numpyro.distributions.util import standard_gamma
 
 @pytest.mark.parametrize('jax_dist', [
     dist.cauchy,
+    dist.expon,
     dist.norm,
     dist.uniform,
 ], ids=lambda jax_dist: jax_dist.name)
@@ -40,6 +41,7 @@ def test_shape(jax_dist, loc, scale, prepend_shape):
 
 @pytest.mark.parametrize('jax_dist', [
     dist.cauchy,
+    dist.expon,
     dist.norm,
     dist.uniform,
 ], ids=lambda jax_dist: jax_dist.name)
@@ -60,6 +62,7 @@ def test_sample_gradient(jax_dist, loc, scale):
 
 @pytest.mark.parametrize('jax_dist', [
     dist.cauchy,
+    dist.expon,
     dist.norm,
     dist.uniform,
 ], ids=lambda jax_dist: jax_dist.name)


### PR DESCRIPTION
While implementing rvs for exponential, I recognize that `random.uniform` generates numbers in [0, 1). So I fixes its behaviour at various places by using (1 - random.uniform).