### PR TITLE
Add xlog1py primitive

### DIFF
--- a/numpyro/distributions/util.py
+++ b/numpyro/distributions/util.py
@@ -227,3 +227,33 @@ xlogy_p.def_impl(partial(xla.apply_primitive, xlogy_p))
 xlogy_p.def_abstract_eval(xlogy_abstract_eval)
 xla.translations[xlogy_p] = xlogy_translate
 ad.defjvp(xlogy_p, xlogy_jvp_lhs, xlogy_jvp_rhs)
+
+
+def xlog1py(x, y):
+    jaxpr, out, consts = partial_eval.trace_unwrapped_to_jaxpr(xlog1py_impl, tuple(lax._abstractify(o) for o in (x, y)))
+    aval, _ = out
+    return xlog1py_p.bind(x, y, jaxpr=jaxpr, aval=aval, consts=consts)
+
+
+def xlog1py_impl(x, y):
+    return x * np.where(x == 0., 0., np.log1p(y))
+
+
+def xlog1py_jvp_lhs(g, x, y, jaxpr, aval, consts):
+    x, y = _promote_args_like(sp.xlog1py, x, y)
+    g, y = _promote_args_like(sp.xlog1py, g, y)
+    return lax._safe_mul(lax._brcast(g, y), lax._brcast(lax.log1p(y), g))
+
+
+def xlog1py_jvp_rhs(g, x, y, jaxpr, aval, consts):
+    x, y = _promote_args_like(sp.xlog1py, x, y)
+    g, x = _promote_args_like(sp.xlog1py, g, x)
+    jac = lax._safe_mul(lax._brcast(x, y), lax._brcast(lax.reciprocal(1 + y), x))
+    return lax.mul(lax._brcast(g, jac), jac)
+
+
+xlog1py_p = Primitive('xlog1py')
+xlog1py_p.def_impl(partial(xla.apply_primitive, xlog1py_p))
+xlog1py_p.def_abstract_eval(xlogy_abstract_eval)
+xla.translations[xlog1py_p] = xlogy_translate
+ad.defjvp(xlog1py_p, xlog1py_jvp_lhs, xlog1py_jvp_rhs)

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -4,7 +4,7 @@ import scipy.special as sp
 from jax import jit, lax, partial, grad
 from numpy.testing import assert_allclose
 
-from numpyro.distributions.util import xlogy
+from numpyro.distributions.util import xlogy, xlog1py
 from numpyro.util import dual_averaging
 
 _zeros = partial(lax.full_like, fill_value=0)
@@ -23,19 +23,49 @@ def test_xlogy(x, y, jit_fn):
 
 @pytest.mark.parametrize('x, y, grad1, grad2', [
     (np.array([1., 1., 1.]), np.array([1., 2., 3.]),
-     np.log(np.array([1, 2, 3])), np.array([1. / 1., 1. / 2., 1. / 3.])),
+     np.log(np.array([1, 2, 3])), np.array([1., 0.5, 1./3])),
     (np.array([1.]), np.array([1., 2., 3.]),
-     np.sum(np.log(np.array([1, 2, 3]))), np.array([1. / 1., 1. / 2., 1. / 3.])),
+     np.sum(np.log(np.array([1, 2, 3]))), np.array([1., 0.5, 1./3])),
     (np.array([1., 2., 3.]), np.array([2.]),
      np.log(np.array([2., 2., 2.])), np.array([3.])),
     (np.array([0.]), np.array([0, 0]),
      np.array([-float('inf')]), np.array([0, 0])),
-    (np.array([[0], [0]]), np.array([1., 2.]),
-     np.array([[0], [0]]), np.array([0, 0])),
+    (np.array([[0.], [0.]]), np.array([1., 2.]),
+     np.array([[np.log(2.)], [np.log(2.)]]), np.array([0, 0])),
 ])
 def test_xlogy_jac(x, y, grad1, grad2):
-    assert_allclose(jit(grad(lambda x, y: np.sum(xlogy(x, y))))(x, y), grad1)
-    assert_allclose(jit(grad(lambda x, y: np.sum(xlogy(x, y)), 1))(x, y), grad2)
+    assert_allclose(grad(lambda x, y: np.sum(xlogy(x, y)))(x, y), grad1)
+    assert_allclose(grad(lambda x, y: np.sum(xlogy(x, y)), 1)(x, y), grad2)
+
+
+@pytest.mark.parametrize('x, y', [
+    (np.array([1]), np.array([0, 1, 2])),
+    (np.array([0]), np.array([-1, -1])),
+    (np.array([[0.], [0.]]), np.array([1., 2.])),
+])
+@pytest.mark.parametrize('jit_fn', [False, True])
+def test_xlog1py(x, y, jit_fn):
+    fn = xlog1py if not jit_fn else jit(xlog1py)
+    assert_allclose(fn(x, y), sp.xlog1py(x, y))
+
+
+@pytest.mark.parametrize('x, y, grad1, grad2', [
+    (np.array([1., 1., 1.]), np.array([0., 1., 2.]),
+     np.log(np.array([1, 2, 3])), np.array([1., 0.5, 1./3])),
+    (np.array([1., 1., 1.]), np.array([-1., 0., 1.]),
+     np.log(np.array([0, 1, 2])), np.array([float('inf'), 1., 0.5])),
+    (np.array([1.]), np.array([0., 1., 2.]),
+     np.sum(np.log(np.array([1, 2, 3]))), np.array([1., 0.5, 1./3])),
+    (np.array([1., 2., 3.]), np.array([1.]),
+     np.log(np.array([2., 2., 2.])), np.array([3.])),
+    (np.array([0.]), np.array([-1, -1]),
+     np.array([-float('inf')]), np.array([0, 0])),
+    (np.array([[0.], [0.]]), np.array([1., 2.]),
+     np.array([[np.log(6.)], [np.log(6.)]]), np.array([0, 0])),
+])
+def test_xlog1py_jac(x, y, grad1, grad2):
+    assert_allclose(grad(lambda x, y: np.sum(xlog1py(x, y)))(x, y), grad1)
+    assert_allclose(grad(lambda x, y: np.sum(xlog1py(x, y)), 1)(x, y), grad2)
 
 
 @pytest.mark.parametrize('jitted', [True, False])


### PR DESCRIPTION
Addresses #14; very similar to #18. I wanted to create a new primitive to make use of `log1p` instead of defining this in terms of `xlogy`.