### PR TITLE
pump jax version to 0.1.21

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     author='Uber AI Labs',
     author_email='npradhan@uber.com',
     install_requires=[
-        'jax>=0.1.20',
+        'jax>=0.1.21',
         'jaxlib>=0.1.7',
     ],
     extras_require={


### PR DESCRIPTION
@neerajprad the lognorm test is failed with version 0.1.20 but passed with version 0.1.21 (I'm not sure which PR is changed during that). So I pump the requirement to the newer version. A nice feature of the new version is `lax.cond`. :)