### PR TITLE
Use scipy samplers for discrete distributions

### DIFF
--- a/numpyro/distributions/discrete.py
+++ b/numpyro/distributions/discrete.py
@@ -9,68 +9,29 @@
 import jax.numpy as np
 from jax.lax import lgamma
 from jax.numpy.lax_numpy import _promote_dtypes
+from scipy.stats._discrete_distns import binom_gen, bernoulli_gen
 
 from numpyro.distributions.distribution import jax_discrete
-from numpyro.distributions.util import entr, xlogy, xlog1py, binomial
+from numpyro.distributions.util import entr, xlogy, xlog1py
 
 
-class binom_gen(jax_discrete):
-    def _rvs(self, n, p):
-        return binomial(self._random_state, p, n, self._size)
-
-    def _argcheck(self, n, p):
-        self.b = n
-        return (n >= 0) & (p >= 0) & (p <= 1)
-
+class _binom_gen(jax_discrete, binom_gen):
     def _logpmf(self, x, n, p):
         k = np.floor(x)
         n, p = _promote_dtypes(n, p)
         combiln = (lgamma(n + 1) - (lgamma(k + 1) + lgamma(n - k + 1)))
         return combiln + xlogy(k, p) + xlog1py(n - k, -p)
 
-    def _pmf(self, x, n, p):
-        # binom.pmf(k) = choose(n, k) * p**k * (1-p)**(n-k)
-        return np.exp(self._logpmf(x, n, p))
-
-    def _stats(self, n, p, moments='mv'):
-        q = 1.0 - p
-        mu = n * p
-        var = n * p * q
-        g1, g2 = None, None
-        if 's' in moments:
-            g1 = (q - p) / np.sqrt(var)
-        if 'k' in moments:
-            g2 = (1.0 - 6 * p * q) / var
-        return mu, var, g1, g2
-
     def _entropy(self, n, p):
-        k = np.r_[0:n + 1]
+        k = np.arange(n + 1)
         vals = self._pmf(k, n, p)
         return np.sum(entr(vals), axis=0)
 
 
-class bernoulli_gen(binom_gen):
-    # TODO: use more efficient implementation from jax.random
-    def _rvs(self, p):
-        return binom_gen._rvs(self, 1, p)
-
-    def _argcheck(self, p):
-        return (p >= 0) & (p <= 1)
-
-    def _logpmf(self, x, p):
-        return binom._logpmf(x, 1, p)
-
-    def _pmf(self, x, p):
-        # bernoulli.pmf(k) = 1-p  if k = 0
-        #                  = p    if k = 1
-        return binom._pmf(x, 1, p)
-
-    def _stats(self, p):
-        return binom._stats(1, p)
-
+class _bernoulli_gen(jax_discrete, bernoulli_gen):
     def _entropy(self, p):
         return entr(p) + entr(1 - p)
 
 
-bernoulli = bernoulli_gen(b=1, name='bernoulli')
-binom = binom_gen(name='binom')
+bernoulli = _bernoulli_gen(b=1, name='bernoulli')
+binom = _binom_gen(name='binom')

--- a/numpyro/distributions/distribution.py
+++ b/numpyro/distributions/distribution.py
@@ -7,41 +7,43 @@
 # All rights reserved.
 
 import scipy.stats as sp
-from jax import lax
+from jax import lax, device_put
 from jax.random import _is_prng_key
 from jax.numpy.lax_numpy import _promote_args
 import jax.numpy as np
-
-
-def _rvs(_instance, *args, **kwargs):
-    rng = kwargs.pop('random_state')
-    if rng is None:
-        rng = _instance.random_state
-    # assert that rng is PRNGKey and not mtrand.RandomState object from numpy.
-    assert _is_prng_key(rng)
-    args = list(args)
-    # If 'size' is not in kwargs, then it is either the last element of args
-    # or it will take default value (which is None).
-    # Note: self.numargs is the number of shape parameters.
-    size = kwargs.pop('size', args.pop() if len(args) > (_instance.numargs + 2) else None)
-    args, loc, scale = _instance._parse_args(*args, **kwargs)
-    # FIXME(fehiepsi): Using _promote_args_like requires calling `super(jax_continuous, self).rvs` but
-    # it will call `self._rvs` (which is written using JAX and requires JAX random state).
-    loc, scale, *args = _promote_args("rvs", loc, scale, *args)
-    if not size:
-        shapes = [np.shape(arg) for arg in args] + [np.shape(loc), np.shape(scale)]
-        size = lax.broadcast_shapes(*shapes)
-    _instance._random_state = rng
-    _instance._size = size
-    vals = _instance._rvs(*args)
-    return vals * scale + loc
+import numpy as onp
 
 
 class jax_continuous(sp.rv_continuous):
     def rvs(self, *args, **kwargs):
-        return _rvs(self, *args, **kwargs)
+        rng = kwargs.pop('random_state')
+        if rng is None:
+            rng = self.random_state
+        # assert that rng is PRNGKey and not mtrand.RandomState object from numpy.
+        assert _is_prng_key(rng)
+        args = list(args)
+        # If 'size' is not in kwargs, then it is either the last element of args
+        # or it will take default value (which is None).
+        # Note: self.numargs is the number of shape parameters.
+        size = kwargs.pop('size', args.pop() if len(args) > (self.numargs + 2) else None)
+        args, loc, scale = self._parse_args(*args, **kwargs)
+        # FIXME(fehiepsi): Using _promote_args_like requires calling `super(jax_continuous, self).rvs` but
+        # it will call `self._rvs` (which is written using JAX and requires JAX random state).
+        loc, scale, *args = _promote_args("rvs", loc, scale, *args)
+        if not size:
+            shapes = [np.shape(arg) for arg in args] + [np.shape(loc), np.shape(scale)]
+            size = lax.broadcast_shapes(*shapes)
+        self._random_state = rng
+        self._size = size
+        vals = self._rvs(*args)
+        return vals * scale + loc
 
 
 class jax_discrete(sp.rv_discrete):
+    # Discrete distribution instances use scipy samplers directly
+    # and put the samples on device later.
     def rvs(self, *args, **kwargs):
-        return _rvs(self, *args, **kwargs)
+        key = kwargs.pop('random_state')
+        onp.random.seed(key)
+        sample = super(sp.rv_discrete, self).rvs(*args, **kwargs)
+        return device_put(sample)


### PR DESCRIPTION
Until we have better support for discrete samplers like multinomial in JAX, it would be much faster (at least on the CPU) to use scipy samplers and transferring the `np.ndarray` to device later. This should be fine for most cases since these samplers are not reparametrized anyways. As such, this PR makes discrete distributions merely very light wrappers over the corresponding scipy implementations. I will add more such distributions, including the multinomial in a separate PR.

I tested that this is an order of magnitude faster on the CPU for binomial.

Addresses #34 