### PR TITLE
Remove args check logic from discrete distributions

### DIFF
--- a/numpyro/distributions/discrete.py
+++ b/numpyro/distributions/discrete.py
@@ -59,8 +59,7 @@ class _multinomial_gen(multinomial_gen):
         lax.dynamic_update_slice_in_dim(p, p_, 0, axis=-1)
 
         # true for bad p
-        pcond = np.any(p < 0, axis=-1)
-        pcond |= np.any(p > 1, axis=-1)
+        pcond = np.any(p < 0, axis=-1) | np.any(p > 1, axis=-1)
 
         # true for bad n
         n = np.array(n, dtype=np.int32)

--- a/numpyro/distributions/distribution.py
+++ b/numpyro/distributions/distribution.py
@@ -65,7 +65,7 @@ class jax_discrete(sp.rv_discrete):
     def logpmf(self, k, *args, **kwds):
         args_check = kwds.pop('args_check', True)
         args, loc, _ = self._parse_args(*args, **kwds)
-        k = (k-loc)
+        k = k - loc
         if args_check:
             cond0 = self._argcheck(*args)
             cond1 = (k >= self.a) & (k <= self.b) & (np.floor(k) == k)

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -175,7 +175,7 @@ def test_discrete_logpmf(jax_dist, dist_args, shape):
 
         for i in range(len(dist_args)):
             logpmf_grad = grad(fn, i + 1)(samples, *dist_args)
-            assert not (np.any(np.isinf(logpmf_grad) | np.isnan(logpmf_grad)))
+            assert np.all(np.isfinite(logpmf_grad))
 
 
 @pytest.mark.parametrize('jax_dist, dist_args', [


### PR DESCRIPTION
Addresses #45. 

This removes any in-place mutation within `logpmf` computation for discrete distributions, which isn't compatible with JAX. Instead we simply throw an exception for out of support values and invalid params. Also tested that the logpmf method is traceable and doesn't return `inf` or `nan` values.