### PR TITLE
separate jax from other third parties

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@ all: test
 lint: FORCE
 	flake8
 
+format: FORCE
+	isort -rc .
+
 test: lint FORCE
 	pytest -v test
 

--- a/numpyro/distributions/continuous.py
+++ b/numpyro/distributions/continuous.py
@@ -9,7 +9,7 @@
 
 import jax.numpy as np
 import jax.random as random
-from jax.scipy import special
+from jax.scipy.special import digamma, gammaln
 
 from numpyro.distributions.distribution import jax_continuous
 from numpyro.distributions.util import standard_gamma
@@ -106,7 +106,7 @@ class gamma_gen(jax_continuous):
         return a, a, 2.0 / np.sqrt(a), 6.0 / a
 
     def _entropy(self, a):
-        return special.digamma(a) * (1 - a) + a + special.gammaln(a)
+        return digamma(a) * (1 - a) + a + gammaln(a)
 
 
 _norm_pdf_C = np.sqrt(2 * np.pi)
@@ -177,13 +177,13 @@ class t_gen(jax_continuous):
         # t.pdf(x, df) = ---------------------------------------------------
         #                sqrt(pi*df) * gamma(df/2) * (1+x**2/df)**((df+1)/2)
         r = np.asarray(df * 1.0)
-        Px = np.exp(special.gammaln((r + 1) / 2) - special.gammaln(r / 2))
+        Px = np.exp(gammaln((r + 1) / 2) - gammaln(r / 2))
         Px = Px / np.sqrt(r * np.pi) * (1 + (x ** 2) / r) ** ((r + 1) / 2)
         return Px
 
     def _logpdf(self, x, df):
         r = df * 1.0
-        lPx = special.gammaln((r + 1) / 2) - special.gammaln(r / 2)
+        lPx = gammaln((r + 1) / 2) - gammaln(r / 2)
         lPx = lPx - (0.5 * np.log(r * np.pi) + (r + 1) / 2 * np.log(1 + (x ** 2) / r))
         return lPx
 

--- a/numpyro/distributions/distribution.py
+++ b/numpyro/distributions/distribution.py
@@ -6,16 +6,17 @@
 # Copyright (c) 2003-2019 SciPy Developers.
 # All rights reserved.
 
-import jax.numpy as np
-import jax.scipy
 import numpy as onp
-import scipy.stats as sp
+import scipy.stats as osp_stats
+
+import jax.numpy as np
 from jax import device_put, lax
 from jax.numpy.lax_numpy import _promote_args
 from jax.random import _is_prng_key
+from jax.scipy import stats
 
 
-class jax_continuous(sp.rv_continuous):
+class jax_continuous(osp_stats.rv_continuous):
     def rvs(self, *args, **kwargs):
         rng = kwargs.pop('random_state')
         if rng is None:
@@ -42,26 +43,26 @@ class jax_continuous(sp.rv_continuous):
         return vals * scale + loc
 
     def pdf(self, x, *args, **kwargs):
-        if hasattr(jax.scipy.stats, self.name):
-            return getattr(jax.scipy.stats, self.name).pdf(x, *args, **kwargs)
+        if hasattr(stats, self.name):
+            return getattr(stats, self.name).pdf(x, *args, **kwargs)
         else:
             return super(jax_continuous, self).pdf(x, *args, **kwargs)
 
     def logpdf(self, x, *args, **kwargs):
-        if hasattr(jax.scipy.stats, self.name):
-            return getattr(jax.scipy.stats, self.name).logpdf(x, *args, **kwargs)
+        if hasattr(stats, self.name):
+            return getattr(stats, self.name).logpdf(x, *args, **kwargs)
         else:
             return super(jax_continuous, self).logpdf(x, *args, **kwargs)
 
 
-class jax_discrete(sp.rv_discrete):
+class jax_discrete(osp_stats.rv_discrete):
     args_check = True
 
     # Discrete distribution instances use scipy samplers directly
     # and put the samples on device later.
     def rvs(self, *args, **kwargs):
         kwargs['random_state'] = onp.random.RandomState(kwargs['random_state'])
-        sample = super(sp.rv_discrete, self).rvs(*args, **kwargs)
+        sample = super(osp_stats.rv_discrete, self).rvs(*args, **kwargs)
         return device_put(sample)
 
     def logpmf(self, k, *args, **kwds):

--- a/numpyro/distributions/patch.py
+++ b/numpyro/distributions/patch.py
@@ -1,4 +1,5 @@
 import scipy
+import scipy.stats
 
 
 def patch_dependency(target, root_module):

--- a/numpyro/distributions/util.py
+++ b/numpyro/distributions/util.py
@@ -1,11 +1,13 @@
 from contextlib import contextmanager
 
+import scipy.special as osp_special
+
 import jax.numpy as np
-import scipy.special as sp
-from jax import jit, lax, partial, random
+from jax import jit, lax, random
 from jax.core import Primitive
 from jax.interpreters import ad, partial_eval, xla
 from jax.numpy.lax_numpy import _promote_args_like, _promote_shapes
+from jax.util import partial
 
 from numpyro.distributions.distribution import jax_discrete
 
@@ -213,14 +215,14 @@ def xlogy_translate(c, x, y, jaxpr, aval, consts):
 
 
 def xlogy_jvp_lhs(g, x, y, jaxpr, aval, consts):
-    x, y = _promote_args_like(sp.xlogy, x, y)
-    g, y = _promote_args_like(sp.xlogy, g, y)
+    x, y = _promote_args_like(osp_special.xlogy, x, y)
+    g, y = _promote_args_like(osp_special.xlogy, g, y)
     return lax._safe_mul(lax._brcast(g, y), lax._brcast(lax.log(y), g))
 
 
 def xlogy_jvp_rhs(g, x, y, jaxpr, aval, consts):
-    x, y = _promote_args_like(sp.xlogy, x, y)
-    g, x = _promote_args_like(sp.xlogy, g, x)
+    x, y = _promote_args_like(osp_special.xlogy, x, y)
+    g, x = _promote_args_like(osp_special.xlogy, g, x)
     jac = lax._safe_mul(lax._brcast(x, y), lax._brcast(lax.reciprocal(y), x))
     return lax.mul(lax._brcast(g, jac), jac)
 
@@ -243,14 +245,14 @@ def xlog1py_impl(x, y):
 
 
 def xlog1py_jvp_lhs(g, x, y, jaxpr, aval, consts):
-    x, y = _promote_args_like(sp.xlog1py, x, y)
-    g, y = _promote_args_like(sp.xlog1py, g, y)
+    x, y = _promote_args_like(osp_special.xlog1py, x, y)
+    g, y = _promote_args_like(osp_special.xlog1py, g, y)
     return lax._safe_mul(lax._brcast(g, y), lax._brcast(lax.log1p(y), g))
 
 
 def xlog1py_jvp_rhs(g, x, y, jaxpr, aval, consts):
-    x, y = _promote_args_like(sp.xlog1py, x, y)
-    g, x = _promote_args_like(sp.xlog1py, g, x)
+    x, y = _promote_args_like(osp_special.xlog1py, x, y)
+    g, x = _promote_args_like(osp_special.xlog1py, g, x)
     jac = lax._safe_mul(lax._brcast(x, y), lax._brcast(lax.reciprocal(1 + y), x))
     return lax.mul(lax._brcast(g, jac), jac)
 

--- a/numpyro/examples/datasets.py
+++ b/numpyro/examples/datasets.py
@@ -6,6 +6,7 @@ from urllib.parse import urlparse
 from urllib.request import urlretrieve
 
 import numpy as np
+
 from jax import device_put, lax
 
 DATA_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__),

--- a/numpyro/examples/vae.py
+++ b/numpyro/examples/vae.py
@@ -2,10 +2,10 @@ import argparse
 import os
 import time
 
-import jax.numpy as np
-import jax.random as random
 import matplotlib.pyplot as plt
-from jax import jit, lax
+
+import jax.numpy as np
+from jax import jit, lax, random
 from jax.experimental import optimizers, stax
 from jax.random import PRNGKey
 

--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -1,11 +1,10 @@
-from __future__ import division
-
 import random
 from collections import namedtuple
 
+import numpy as onp
+
 import jax.lax as lax
 import jax.numpy as np
-import numpy as onp
 from jax import grad, value_and_grad
 from jax.tree_util import tree_multimap
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,8 +6,10 @@ exclude = docs/src, build, dist, .ipynb_checkpoints
 line_length = 120
 not_skip = __init__.py
 skip_glob = .ipynb_checkpoints
-known_first_party = numpyro, tests
-known_third_party = opt_einsum, six, torch, torchvision
+known_first_party = numpyro, test
+known_third_party = opt_einsum
+known_jax = jax
+sections = FUTURE, STDLIB, THIRDPARTY, JAX, FIRSTPARTY, LOCALFOLDER
 multi_line_output = 3
 
 [tool:pytest]

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -2,12 +2,14 @@ import logging
 import os
 from collections import namedtuple
 
-import jax.numpy as np
 import numpy as onp
 import pytest
-import scipy.special as sp
-from jax import device_put, grad, jit, lax, partial, tree_map
+import scipy.special as osp_special
 from numpy.testing import assert_allclose
+
+import jax.numpy as np
+from jax import device_put, grad, jit, lax, tree_map
+from jax.util import partial
 
 from numpyro.distributions.util import xlog1py, xlogy
 from numpyro.util import (
@@ -32,7 +34,7 @@ _zeros = partial(lax.full_like, fill_value=0)
 @pytest.mark.parametrize('jit_fn', [False, True])
 def test_xlogy(x, y, jit_fn):
     fn = xlogy if not jit_fn else jit(xlogy)
-    assert np.allclose(fn(x, y), sp.xlogy(x, y))
+    assert_allclose(fn(x, y), osp_special.xlogy(x, y))
 
 
 @pytest.mark.parametrize('x, y, grad1, grad2', [
@@ -60,7 +62,7 @@ def test_xlogy_jac(x, y, grad1, grad2):
 @pytest.mark.parametrize('jit_fn', [False, True])
 def test_xlog1py(x, y, jit_fn):
     fn = xlog1py if not jit_fn else jit(xlog1py)
-    assert_allclose(fn(x, y), sp.xlog1py(x, y))
+    assert_allclose(fn(x, y), osp_special.xlog1py(x, y))
 
 
 @pytest.mark.parametrize('x, y, grad1, grad2', [


### PR DESCRIPTION
This PR mainly separates jax from other third parties and make the import consistence. During the way, there are several small nits addressed.