### PR TITLE
Use JAX master for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ dist: xenial
 
 install:
     - pip install -U pip
+    - pip install jaxlib
+    - pip install git+https://github.com/google/jax.jit@850e8a756a78388605745d241a7f25daa371a23b
     - pip install .[test]
     - pip freeze
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ dist: xenial
 install:
     - pip install -U pip
     - pip install jaxlib
-    - pip install git+https://github.com/google/jax.jit@850e8a756a78388605745d241a7f25daa371a23b
+    - pip install -e git+git://github.com/google/jax.git@850e8a756a78388605745d241a7f25daa371a23b
     - pip install .[test]
     - pip freeze
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ dist: xenial
 install:
     - pip install -U pip
     - pip install jaxlib
-    - pip install -e git+git://github.com/google/jax.git@850e8a756a78388605745d241a7f25daa371a23b
+    - pip install -e git+git://github.com/google/jax.git@850e8a756a78388605745d241a7f25daa371a23b#egg=jax
     - pip install .[test]
     - pip freeze
 


### PR DESCRIPTION
Fixes #63. Note that I'm using the pypi released jaxlib, so this won't work if JAX master requires a newer build of jaxlib, which we'll need to build and host at our end. 