### PR TITLE
disable fast math for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ sudo: false
 env:
     global:
         - PYTHONPATH=$PWD:$PYTHONPATH
+        - XLA_FLAGS=--xla_cpu_enable_fast_math=false
 
 cache:
     directories:


### PR DESCRIPTION
Using fast math gives inconsistent behaviour, especially for tests which require high precision or involve overflow/underflow. In addition, this feature will be disabled by default in JAX in the future.