### PR TITLE
Add custom named tuple for common data types

### DIFF
--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -1,8 +1,38 @@
 import random
+from collections import namedtuple
 
 import numpy as onp
+
+from jax.tree_util import register_pytree_node
+
+
+_DATA_TYPES = {}
 
 
 def set_rng_seed(rng_seed):
     random.seed(rng_seed)
     onp.random.seed(rng_seed)
+
+
+# let JAX recognize _TreeInfo structure
+# ref: https://github.com/google/jax/issues/446
+# TODO: remove this when namedtuple is supported in JAX
+def register_pytree(cls):
+    if not getattr(cls, '_registered', False):
+        register_pytree_node(
+            cls,
+            lambda xs: (tuple(xs), None),
+            lambda _, xs: cls(*xs)
+        )
+    cls._registered = True
+
+
+def laxtuple(name, fields):
+    key = (name,) + tuple(fields)
+    if key in _DATA_TYPES:
+        return _DATA_TYPES[key]
+    cls = namedtuple(name, fields)
+    register_pytree(cls)
+    cls.update = cls._replace
+    _DATA_TYPES[key] = cls
+    return cls

--- a/test/test_hmc_util.py
+++ b/test/test_hmc_util.py
@@ -9,16 +9,16 @@ import jax.numpy as np
 from jax import device_put, grad, jit, lax, random, tree_map
 
 from numpyro.hmc_util import (
-    adapt_window,
+    AdaptWindow,
+    _is_iterative_turning,
+    _leaf_idx_to_ckpt_idxs,
     build_adaptation_schedule,
     build_tree,
     dual_averaging,
     find_reasonable_step_size,
     velocity_verlet,
     warmup_adapter,
-    welford_covariance,
-    _leaf_idx_to_ckpt_idxs,
-    _is_iterative_turning,
+    welford_covariance
 )
 
 logger = logging.getLogger(__name__)
@@ -236,7 +236,7 @@ def test_find_reasonable_step_size(jitted, init_step_size):
 ])
 def test_build_adaptation_schedule(num_steps, expected):
     adaptation_schedule = build_adaptation_schedule(num_steps)
-    expected_schedule = [adapt_window(i, j) for i, j in expected]
+    expected_schedule = [AdaptWindow(i, j) for i, j in expected]
     assert adaptation_schedule == expected_schedule
 
 


### PR DESCRIPTION
Many of our HMC utils cycle a certain data structure back and forth. It becomes quite tiresome and error prone to read/update these. e.g. 

```python
step_size, inverse_mass, _, _, _ = wa_update(..)
```

This wraps these data types into a namedtuple that also registers it as a pytree node in jax. With this, we can use the following syntax:

```python
state = wa_update(..)
vv_update(state.step_size..)
```

We can also do updates with the following instead of first unwrapping and then wrapping the arguments again (note that this shouldn't be used all over the place as it can be more expensive without JIT).

```
wa_state = wa_state.update(step_size = 0.3)
```