### PR TITLE
Provide context manager to disable tracing in control flow primitives

### DIFF
--- a/numpyro/hmc_util.py
+++ b/numpyro/hmc_util.py
@@ -5,7 +5,7 @@ from jax.ops import index_update
 from jax.scipy.special import expit
 from jax.tree_util import tree_multimap
 
-from numpyro.util import cond, control_flow_prims_disabled, laxtuple, optional, while_loop
+from numpyro.util import cond, laxtuple, while_loop
 
 AdaptWindow = laxtuple("AdaptWindow", ["start", "end"])
 AdaptState = laxtuple("AdaptState", ["step_size", "inverse_mass_matrix", "ss_state", "mm_state", "window_idx"])

--- a/numpyro/hmc_util.py
+++ b/numpyro/hmc_util.py
@@ -578,6 +578,10 @@ def build_tree(verlet_update, kinetic_fn, verlet_state, inverse_mass_matrix, ste
         return tree, key
 
     state = (tree, key)
-    with optional(not iterative_build, control_flow_prims_disabled()):
+    if iterative_build:
         tree, _ = while_loop(_cond_fn, _body_fn, state)
+    else:
+        while _cond_fn(state):
+            state = _body_fn(state)
+        tree, _ = state
     return tree

--- a/numpyro/hmc_util.py
+++ b/numpyro/hmc_util.py
@@ -1,5 +1,5 @@
 import jax.numpy as np
-from jax import grad, jit, lax, partial, random, value_and_grad
+from jax import grad, jit, partial, random, value_and_grad
 from jax.flatten_util import ravel_pytree
 from jax.ops import index_update
 from jax.scipy.special import expit

--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -1,12 +1,14 @@
 import random
 from collections import namedtuple
+from contextlib import contextmanager
 
 import numpy as onp
 
+from jax import lax
 from jax.tree_util import register_pytree_node
 
-
 _DATA_TYPES = {}
+_DISABLE_CONTROL_FLOW_PRIM = False
 
 
 def set_rng_seed(rng_seed):
@@ -36,3 +38,60 @@ def laxtuple(name, fields):
     cls.update = cls._replace
     _DATA_TYPES[key] = cls
     return cls
+
+
+@contextmanager
+def optional(condition, context_manager):
+    """
+    Optionally wrap inside `context_manager` if condition is `True`.
+    """
+    if condition:
+        with context_manager:
+            yield
+    else:
+        yield
+
+
+def disable_jit(control_flow_prims=False):
+    if not control_flow_prims:
+        global _DISABLE_CONTROL_FLOW_PRIM
+        _DISABLE_CONTROL_FLOW_PRIM = True
+
+
+@contextmanager
+def control_flow_prims_disabled():
+    global _DISABLE_CONTROL_FLOW_PRIM
+    stored_flag = _DISABLE_CONTROL_FLOW_PRIM
+    try:
+        _DISABLE_CONTROL_FLOW_PRIM = True
+        yield
+    finally:
+        _DISABLE_CONTROL_FLOW_PRIM = stored_flag
+
+
+def cond(pred, true_operand, true_fun, false_operand, false_fun):
+    if _DISABLE_CONTROL_FLOW_PRIM:
+        if pred:
+            return true_fun(true_operand)
+    else:
+        return lax.cond(pred, true_operand, true_fun, false_operand, false_fun)
+
+
+def while_loop(cond_fun, body_fun, init_val):
+    if _DISABLE_CONTROL_FLOW_PRIM:
+        val = init_val
+        while cond_fun(val):
+            val = body_fun(val)
+        return val
+    else:
+        return lax.while_loop(cond_fun, body_fun, init_val)
+
+
+def fori_loop(lower, upper, body_fun, init_val):
+    if _DISABLE_CONTROL_FLOW_PRIM:
+        val = init_val
+        for i in range(lower, upper):
+            val = body_fun(i, val)
+        return val
+    else:
+        return lax.fori_loop(lower, upper, body_fun, init_val)

--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -67,6 +67,8 @@ def cond(pred, true_operand, true_fun, false_operand, false_fun):
     if _DISABLE_CONTROL_FLOW_PRIM:
         if pred:
             return true_fun(true_operand)
+        else:
+            return false_fun(false_operand)
     else:
         return lax.cond(pred, true_operand, true_fun, false_operand, false_fun)
 

--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -52,12 +52,6 @@ def optional(condition, context_manager):
         yield
 
 
-def disable_jit(control_flow_prims=False):
-    if not control_flow_prims:
-        global _DISABLE_CONTROL_FLOW_PRIM
-        _DISABLE_CONTROL_FLOW_PRIM = True
-
-
 @contextmanager
 def control_flow_prims_disabled():
     global _DISABLE_CONTROL_FLOW_PRIM

--- a/test/test_hmc_util.py
+++ b/test/test_hmc_util.py
@@ -6,7 +6,7 @@ import pytest
 from numpy.testing import assert_allclose
 
 import jax.numpy as np
-from jax import device_put, disable_jit, grad, jit, random, tree_map
+from jax import device_put, disable_jit, grad, jit, lax, random, tree_map
 
 from numpyro.hmc_util import (
     AdaptWindow,

--- a/test/test_hmc_util.py
+++ b/test/test_hmc_util.py
@@ -56,6 +56,7 @@ def test_welford_covariance(jitted, diagonal, regularize):
         x = onp.random.multivariate_normal(loc, target_cov, size=(2000,))
         x = device_put(x)
 
+        @jit
         def get_cov(x):
             wc_init, wc_update, wc_final = welford_covariance(diagonal=diagonal)
             wc_state = wc_init(3)
@@ -63,8 +64,7 @@ def test_welford_covariance(jitted, diagonal, regularize):
             cov = wc_final(wc_state, regularize=regularize)
             return cov
 
-        fn = jit(get_cov) if jitted else get_cov
-        cov = fn(x)
+        cov = get_cov(x)
 
         if diagonal:
             assert_allclose(cov, np.diagonal(target_cov), rtol=0.06)

--- a/test/test_hmc_util.py
+++ b/test/test_hmc_util.py
@@ -6,7 +6,7 @@ import pytest
 from numpy.testing import assert_allclose
 
 import jax.numpy as np
-from jax import device_put, disable_jit, grad, jit, lax, random, tree_map
+from jax import device_put, disable_jit, grad, jit, random, tree_map
 
 from numpyro.hmc_util import (
     AdaptWindow,

--- a/test/test_hmc_util.py
+++ b/test/test_hmc_util.py
@@ -6,7 +6,7 @@ import pytest
 from numpy.testing import assert_allclose
 
 import jax.numpy as np
-from jax import device_put, grad, jit, lax, random, tree_map
+from jax import device_put, disable_jit, grad, jit, lax, random, tree_map
 
 from numpyro.hmc_util import (
     AdaptWindow,
@@ -20,6 +20,7 @@ from numpyro.hmc_util import (
     warmup_adapter,
     welford_covariance
 )
+from numpyro.util import control_flow_prims_disabled, fori_loop, optional
 
 logger = logging.getLogger(__name__)
 
@@ -47,27 +48,28 @@ def test_dual_averaging(jitted):
 @pytest.mark.parametrize('diagonal', [True, False])
 @pytest.mark.parametrize('regularize', [True, False])
 def test_welford_covariance(jitted, diagonal, regularize):
-    onp.random.seed(0)
-    loc = onp.random.randn(3)
-    a = onp.random.randn(3, 3)
-    target_cov = onp.matmul(a, a.T)
-    x = onp.random.multivariate_normal(loc, target_cov, size=(2000,))
-    x = device_put(x)
+    with optional(jitted, disable_jit()), optional(jitted, control_flow_prims_disabled()):
+        onp.random.seed(0)
+        loc = onp.random.randn(3)
+        a = onp.random.randn(3, 3)
+        target_cov = onp.matmul(a, a.T)
+        x = onp.random.multivariate_normal(loc, target_cov, size=(2000,))
+        x = device_put(x)
 
-    def get_cov(x):
-        wc_init, wc_update, wc_final = welford_covariance(diagonal=diagonal)
-        wc_state = wc_init(3)
-        wc_state = lax.fori_loop(0, 2000, lambda i, val: wc_update(x[i], val), wc_state)
-        cov = wc_final(wc_state, regularize=regularize)
-        return cov
+        def get_cov(x):
+            wc_init, wc_update, wc_final = welford_covariance(diagonal=diagonal)
+            wc_state = wc_init(3)
+            wc_state = fori_loop(0, 2000, lambda i, val: wc_update(x[i], val), wc_state)
+            cov = wc_final(wc_state, regularize=regularize)
+            return cov
 
-    fn = jit(get_cov) if jitted else get_cov
-    cov = fn(x)
+        fn = jit(get_cov) if jitted else get_cov
+        cov = fn(x)
 
-    if diagonal:
-        assert_allclose(cov, np.diagonal(target_cov), rtol=0.06)
-    else:
-        assert_allclose(cov, target_cov, rtol=0.06)
+        if diagonal:
+            assert_allclose(cov, np.diagonal(target_cov), rtol=0.06)
+        else:
+            assert_allclose(cov, target_cov, rtol=0.06)
 
 
 ########################################


### PR DESCRIPTION
Fixes #72. 

This provides a context manager `control_flow_prims_disabled` that converts all control flow primitives into regular python loops / conditionals. Once (if) this is moved to JAX, we can simply change the import to `lax` without adding ugly boilerplate code like I have done in #70. 

Note that jit compilation can already be disabled with `jax.api.disable_jit()` context_manager, and I have kept this change decoupled so that it is more generally useful. To disable both, we will need to use:

```python
with disable_jit(), control_flow_prims_disabled():
```
Suggestions on shorter name is welcome!

### Testing
I have tested this on one of our faster hmc util tests, as this can be really slow!