### PR TITLE
Always require jax key for discrete distribution

### DIFF
--- a/numpyro/distributions/distribution.py
+++ b/numpyro/distributions/distribution.py
@@ -61,7 +61,12 @@ class jax_discrete(osp_stats.rv_discrete):
     # Discrete distribution instances use scipy samplers directly
     # and put the samples on device later.
     def rvs(self, *args, **kwargs):
-        kwargs['random_state'] = onp.random.RandomState(kwargs['random_state'])
+        rng = kwargs.pop('random_state')
+        if rng is None:
+            rng = self.random_state
+        # assert that rng is PRNGKey and not mtrand.RandomState object from numpy.
+        assert _is_prng_key(rng)
+        kwargs['random_state'] = onp.random.RandomState(rng)
         sample = super(osp_stats.rv_discrete, self).rvs(*args, **kwargs)
         return device_put(sample)
 


### PR DESCRIPTION
Address #76, where sometimes we forget to setup a PRNGKey for the frozen distribution, hence sampler uses None random state by default, which in turns gives inconsistency results. This also makes a consistent behaviour for discrete and continuous distributions.