### PR TITLE
Support logits to frozen Bernoulli distribution

### DIFF
--- a/numpyro/distributions/discrete.py
+++ b/numpyro/distributions/discrete.py
@@ -16,8 +16,7 @@ from jax.numpy.lax_numpy import _promote_dtypes
 from jax.scipy.special import expit, gammaln
 
 from numpyro.distributions.distribution import jax_discrete
-from numpyro.distributions.util import (binary_cross_entropy_with_logits, entr, promote_shapes,
-                                        xlog1py, xlogy)
+from numpyro.distributions.util import binary_cross_entropy_with_logits, entr, promote_shapes, xlog1py, xlogy
 
 
 class _binom_gen(jax_discrete, binom_gen):

--- a/numpyro/distributions/distribution.py
+++ b/numpyro/distributions/distribution.py
@@ -67,11 +67,11 @@ class jax_discrete(osp_stats.rv_discrete):
         # assert that rng is PRNGKey and not mtrand.RandomState object from numpy.
         assert _is_prng_key(rng)
         kwargs['random_state'] = onp.random.RandomState(rng)
-        sample = super(osp_stats.rv_discrete, self).rvs(*args, **kwargs)
+        sample = super(jax_discrete, self).rvs(*args, **kwargs)
         return device_put(sample)
 
-    def logpmf(self, k, *args, **kwds):
-        args, loc, _ = self._parse_args(*args, **kwds)
+    def logpmf(self, k, *args, **kwargs):
+        args, loc, _ = self._parse_args(*args, **kwargs)
         k = k - loc
         if self.args_check:
             cond0 = self._argcheck(*args)

--- a/numpyro/distributions/util.py
+++ b/numpyro/distributions/util.py
@@ -273,6 +273,12 @@ def entr(p):
     return e
 
 
+def binary_cross_entropy_with_logits(x, y):
+    # compute -y * log(sigmoid(x)) - (1 - y) * log(1 - sigmoid(x))
+    # Ref: https://www.tensorflow.org/api_docs/python/tf/nn/sigmoid_cross_entropy_with_logits
+    return np.clip(x, 0) - x * y + np.log1p(np.exp(-np.abs(x)))
+
+
 def promote_shapes(*args, shape=()):
     # adapted from lax.lax_numpy
     if len(args) < 2 and not shape:

--- a/numpyro/distributions/util.py
+++ b/numpyro/distributions/util.py
@@ -276,7 +276,7 @@ def entr(p):
 def binary_cross_entropy_with_logits(x, y):
     # compute -y * log(sigmoid(x)) - (1 - y) * log(1 - sigmoid(x))
     # Ref: https://www.tensorflow.org/api_docs/python/tf/nn/sigmoid_cross_entropy_with_logits
-    return np.clip(x, 0) - x * y + np.log1p(np.exp(-np.abs(x)))
+    return np.clip(x, 0) + np.log1p(np.exp(-np.abs(x))) - x * y
 
 
 def promote_shapes(*args, shape=()):

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -209,4 +209,4 @@ def test_discrete_with_logits(jax_dist, dist_args):
 
     actual_pmf = jax_dist.logpmf(actual_sample, *dist_args)
     expected_pmf = jax_dist(*logit_args, is_logits=True).logpmf(actual_sample)
-    assert_allclose(actual_pmf, expected_pmf)
+    assert_allclose(actual_pmf, expected_pmf, rtol=1e-6)

--- a/test/test_distributions_util.py
+++ b/test/test_distributions_util.py
@@ -8,8 +8,7 @@ from jax import grad, jit, lax, random
 from jax.scipy.special import expit
 from jax.util import partial
 
-from numpyro.distributions.util import (binary_cross_entropy_with_logits, standard_gamma,
-                                        xlog1py, xlogy)
+from numpyro.distributions.util import binary_cross_entropy_with_logits, standard_gamma, xlog1py, xlogy
 
 _zeros = partial(lax.full_like, fill_value=0)
 

--- a/test/test_distributions_util.py
+++ b/test/test_distributions_util.py
@@ -5,9 +5,11 @@ from numpy.testing import assert_allclose
 
 import jax.numpy as np
 from jax import grad, jit, lax, random
+from jax.scipy.special import expit
 from jax.util import partial
 
-from numpyro.distributions.util import standard_gamma, xlog1py, xlogy
+from numpyro.distributions.util import (binary_cross_entropy_with_logits, standard_gamma,
+                                        xlog1py, xlogy)
 
 _zeros = partial(lax.full_like, fill_value=0)
 
@@ -68,6 +70,16 @@ def test_xlog1py(x, y, jit_fn):
 def test_xlog1py_jac(x, y, grad1, grad2):
     assert_allclose(grad(lambda x, y: np.sum(xlog1py(x, y)))(x, y), grad1)
     assert_allclose(grad(lambda x, y: np.sum(xlog1py(x, y)), 1)(x, y), grad2)
+
+
+@pytest.mark.parametrize('x, y', [
+    (0.2, 10.),
+    (0.6, -10.),
+])
+def test_binary_cross_entropy_with_logits(x, y):
+    actual = -y * np.log(expit(x)) - (1 - y) * np.log(expit(-x))
+    expect = binary_cross_entropy_with_logits(x, y)
+    assert_allclose(actual, expect, rtol=1e-6)
 
 
 @pytest.mark.parametrize('alpha, shape', [

--- a/test/test_mcmc.py
+++ b/test/test_mcmc.py
@@ -44,10 +44,8 @@ def test_logistic_regression():
         def potential_fn(beta):
             coefs_mean = np.zeros(dim)
             coefs_lpdf = dist.norm(coefs_mean, np.ones(dim)).logpdf(beta)
-            probs = np.clip(expit(np.sum(beta * data, axis=-1)),
-                            a_min=np.finfo(np.float32).tiny,
-                            a_max=(1 - np.finfo(np.float32).eps))
-            y_lpdf = dist.bernoulli(probs).logpmf(labels)
+            logits = np.sum(beta * data, axis=-1)
+            y_lpdf = dist.bernoulli(logits, is_logits=True).logpmf(labels)
             return - (np.sum(coefs_lpdf) + np.sum(y_lpdf))
 
         def kinetic_fn(beta, m_inv):


### PR DESCRIPTION
This PR supports a kwarg `is_logits` to Bernoulli distribution. By default, is_logits=False and it will be so for non-frozen distribution. For frozen distribution, by adding `is_logits` argument, the arg `p` will be considered as a logit, instead of prob.

@neerajprad Pls find my reasoning in comments. There might be some edge cases which I have not figured it out yet, so please let me know your thought about this change. :)