### PR TITLE
Implement dirichlet distribution

### DIFF
--- a/numpyro/distributions/__init__.py
+++ b/numpyro/distributions/__init__.py
@@ -1,12 +1,14 @@
 import numpyro.distributions.patch  # noqa: F401
 from numpyro.distributions.continuous import beta, cauchy, expon, gamma, lognorm, norm, t, uniform
 from numpyro.distributions.discrete import bernoulli, binom, multinomial
+from numpyro.distributions.multivariate import dirichlet
 
 __all__ = [
     'beta',
     'bernoulli',
     'binom',
     'cauchy',
+    'dirichlet',
     'expon',
     'gamma',
     'lognorm',

--- a/numpyro/distributions/continuous.py
+++ b/numpyro/distributions/continuous.py
@@ -20,8 +20,8 @@ class beta_gen(jax_continuous):
         # XXX the implementation is different from PyTorch's one
         # in PyTorch, a sample is generated from dirichlet distribution
         key_a, key_b = random.split(self._random_state)
-        gamma_a = standard_gamma(key_a, a, self._size)
-        gamma_b = standard_gamma(key_b, b, self._size)
+        gamma_a = standard_gamma(key_a, a, shape=self._size)
+        gamma_b = standard_gamma(key_b, b, shape=self._size)
         return gamma_a / (gamma_a + gamma_b)
 
     def _cdf(self, x, a, b):
@@ -40,7 +40,7 @@ class cauchy_gen(jax_continuous):
     def _rvs(self):
         # TODO: move this implementation upstream to jax.random.standard_cauchy
         # Another way is to generate X, Y ~ Normal(0, 1) and return X / Y
-        u = random.uniform(self._random_state, self._size)
+        u = random.uniform(self._random_state, shape=self._size)
         return np.tan(np.pi * (u - 0.5))
 
     def _pdf(self, x):
@@ -68,7 +68,7 @@ class cauchy_gen(jax_continuous):
 
 class expon_gen(jax_continuous):
     def _rvs(self):
-        u = random.uniform(self._random_state, self._size)
+        u = random.uniform(self._random_state, shape=self._size)
         return -np.log(u)
 
     def _cdf(self, x):
@@ -95,7 +95,7 @@ class expon_gen(jax_continuous):
 
 class gamma_gen(jax_continuous):
     def _rvs(self, a):
-        return standard_gamma(self._random_state, a, self._size)
+        return standard_gamma(self._random_state, a, shape=self._size)
 
     # TODO: add _cdf/_sf methods when incomplete gamma is available
     # https://github.com/google/jax/issues/479
@@ -124,7 +124,7 @@ class lognorm_gen(jax_continuous):
     _support_mask = jax_continuous._open_support_mask
 
     def _rvs(self, s):
-        return np.exp(s * random.normal(self._random_state, self._size))
+        return np.exp(s * random.normal(self._random_state, shape=self._size))
 
     def _pdf(self, x, s):
         # lognorm.pdf(x, s) = 1 / (s*x*sqrt(2*pi)) * exp(-1/2*(log(x)/s)**2)
@@ -155,7 +155,7 @@ def _norm_logpdf(x):
 
 class norm_gen(jax_continuous):
     def _rvs(self):
-        return random.normal(self._random_state, self._size)
+        return random.normal(self._random_state, shape=self._size)
 
     def _stats(self):
         return 0.0, 1.0, 0.0, 0.0
@@ -167,9 +167,9 @@ class norm_gen(jax_continuous):
 class t_gen(jax_continuous):
     def _rvs(self, df):
         key_n, key_g = random.split(self._random_state)
-        normal = random.normal(key_n, self._size)
+        normal = random.normal(key_n, shape=self._size)
         half_df = df / 2.0
-        gamma = standard_gamma(key_n, half_df, self._size)
+        gamma = standard_gamma(key_n, half_df, shape=self._size)
         return normal * np.sqrt(half_df / gamma)
 
     def _pdf(self, x, df):
@@ -199,7 +199,7 @@ class t_gen(jax_continuous):
 
 class uniform_gen(jax_continuous):
     def _rvs(self):
-        return random.uniform(self._random_state, self._size, minval=0.0, maxval=1.0)
+        return random.uniform(self._random_state, shape=self._size)
 
     def _cdf(self, x):
         return x

--- a/numpyro/distributions/distribution.py
+++ b/numpyro/distributions/distribution.py
@@ -8,6 +8,7 @@
 
 import numpy as onp
 import scipy.stats as osp_stats
+from scipy.stats._distn_infrastructure import rv_generic
 
 import jax.numpy as np
 from jax import device_put, lax
@@ -76,3 +77,9 @@ class jax_discrete(osp_stats.rv_discrete):
             if not np.all(cond1):
                 raise ValueError('Invalid values provided to {}.logpmf'.format(self))
         return self._logpmf(k, *args)
+
+
+class jax_multivariate(rv_generic):
+    pass
+    # This class serves as a midpoint between multivariate distribution
+    # implementations and rv_generic behaviour.

--- a/numpyro/distributions/distribution.py
+++ b/numpyro/distributions/distribution.py
@@ -8,7 +8,8 @@
 
 import numpy as onp
 import scipy.stats as osp_stats
-from scipy.stats._distn_infrastructure import rv_generic
+from scipy._lib._util import getargspec_no_self
+from scipy.stats._distn_infrastructure import instancemethod
 
 import jax.numpy as np
 from jax import device_put, lax
@@ -38,6 +39,9 @@ class jax_continuous(osp_stats.rv_continuous):
         if not size:
             shapes = [np.shape(arg) for arg in args] + [np.shape(loc), np.shape(scale)]
             size = lax.broadcast_shapes(*shapes)
+        # TODO(fehiepsi): add test for int size
+        elif isinstance(size, int):
+            size = (size,)
         self._random_state = rng
         self._size = size
         vals = self._rvs(*args)
@@ -59,6 +63,9 @@ class jax_continuous(osp_stats.rv_continuous):
 class jax_discrete(osp_stats.rv_discrete):
     args_check = True
 
+    def _support_mask(self, k):
+        return (k >= self.a) & (k <= self.b) & (np.floor(k) == k)
+
     # Discrete distribution instances use scipy samplers directly
     # and put the samples on device later.
     def rvs(self, *args, **kwargs):
@@ -76,7 +83,7 @@ class jax_discrete(osp_stats.rv_discrete):
         k = k - loc
         if self.args_check:
             cond0 = self._argcheck(*args)
-            cond1 = (k >= self.a) & (k <= self.b) & (np.floor(k) == k)
+            cond1 = self._support_mask(k)
             if not np.all(cond0):
                 raise ValueError('Invalid distribution arguments provided to {}.logpmf'.format(self))
             if not np.all(cond1):
@@ -84,7 +91,56 @@ class jax_discrete(osp_stats.rv_discrete):
         return self._logpmf(k, *args)
 
 
-class jax_multivariate(rv_generic):
-    pass
-    # This class serves as a midpoint between multivariate distribution
-    # implementations and rv_generic behaviour.
+_parse_arg_template = """
+def _parse_args(self, {shape_arg_str}):
+    return ({shape_arg_str}), 0, 1
+"""
+
+
+class jax_mvcontinuous(osp_stats.rv_continuous):
+    def _construct_argparser(self, *args, **kwargs):
+        if self.shapes:
+            shapes = self.shapes.replace(',', ' ').split()
+        else:
+            shapes = getargspec_no_self(self._rvs).args
+
+        # have the arguments, construct the method from template
+        shapes_str = ', '.join(shapes) + ', ' if shapes else ''  # NB: not None
+        dct = dict(shape_arg_str=shapes_str)
+        ns = {}
+        exec(_parse_arg_template.format(**dct), ns)
+        # NB: attach to the instance, not class
+        for name in ['_parse_args']:
+            setattr(self, name, instancemethod(ns[name], self, self.__class__))
+
+        self.shapes = ', '.join(shapes) if shapes else None
+        if not hasattr(self, 'numargs'):
+            self.numargs = len(shapes)
+
+    def rvs(self, *args, **kwargs):
+        rng = kwargs.pop('random_state')
+        if rng is None:
+            rng = self.random_state
+        # assert that rng is PRNGKey and not mtrand.RandomState object from numpy.
+        assert _is_prng_key(rng)
+
+        args = list(args)
+        size = kwargs.pop('size', args.pop() if len(args) > self.numargs else None)
+
+        args, _, _ = self._parse_args(*args, **kwargs)
+        # XXX we might not need to verify that args is empty for multivariate distributions
+        args = _promote_args("rvs", *args)
+
+        # TODO: make this code compatible to mvn distribution
+        if not size:
+            size = args[-1].shape[:-1]
+        elif isinstance(size, int):
+            size = (size,)
+
+        self._random_state = rng
+        self._size = size
+        return self._rvs(*args)
+
+    def logpdf(self, *args, **kwargs):
+        # TODO: check args, check input
+        return self._logpdf(*args, **kwargs)

--- a/numpyro/distributions/multivariate.py
+++ b/numpyro/distributions/multivariate.py
@@ -42,7 +42,7 @@ class dirichlet_gen(jax_mvcontinuous):
 
     def _rvs(self, alpha):
         K = alpha.shape[-1]
-        gamma_samples = standard_gamma(self._random_state, alpha, self._size + (K,))
+        gamma_samples = standard_gamma(self._random_state, alpha, shape=self._size + (K,))
         return gamma_samples / np.sum(gamma_samples, axis=-1, keepdims=True)
 
 

--- a/numpyro/distributions/multivariate.py
+++ b/numpyro/distributions/multivariate.py
@@ -1,0 +1,81 @@
+# Source code modified from scipy.stats._multivariate.py
+#
+# Copyright (c) 2001, 2002 Enthought, Inc.
+# All rights reserved.
+#
+# Copyright (c) 2003-2019 SciPy Developers.
+# All rights reserved.
+
+import jax.numpy as np
+from jax import random
+from jax.scipy.special import digamma, gammaln
+
+from numpyro.distributions.distribution import jax_multivariate
+from numpyro.distributions.util import xlogy
+
+
+def _lnB(alpha):
+    return np.sum(gammaln(alpha)) - gammaln(np.sum(alpha))
+
+
+class dirichlet_gen(jax_multivariate):
+    def _logpdf(self, x, alpha):
+        lnB = _lnB(alpha)
+        return -lnB + np.sum((xlogy(alpha - 1, x.T)).T, 0)
+
+    def logpdf(self, x, alpha):
+        alpha = _dirichlet_check_parameters(alpha)
+        x = _dirichlet_check_input(alpha, x)
+
+        out = self._logpdf(x, alpha)
+        return _squeeze_output(out)
+
+    def pdf(self, x, alpha):
+        alpha = _dirichlet_check_parameters(alpha)
+        x = _dirichlet_check_input(alpha, x)
+
+        out = np.exp(self._logpdf(x, alpha))
+        return _squeeze_output(out)
+
+    def mean(self, alpha):
+        alpha = _dirichlet_check_parameters(alpha)
+
+        out = alpha / (np.sum(alpha))
+        return _squeeze_output(out)
+
+    def var(self, alpha):
+        alpha = _dirichlet_check_parameters(alpha)
+
+        alpha0 = np.sum(alpha)
+        out = (alpha * (alpha0 - alpha)) / ((alpha0 * alpha0) * (alpha0 + 1))
+        return _squeeze_output(out)
+
+    def entropy(self, alpha):
+        alpha = _dirichlet_check_parameters(alpha)
+
+        alpha0 = np.sum(alpha)
+        lnB = _lnB(alpha)
+        K = alpha.shape[0]
+
+        out = lnB + (alpha0 - K) * scipy.special.psi(alpha0) - np.sum(
+            (alpha - 1) * scipy.special.psi(alpha))
+        return _squeeze_output(out)
+
+    def rvs(self, alpha, size=1, random_state=None):
+        """
+        Draw random samples from a Dirichlet distribution.
+        Parameters
+        ----------
+        %(_dirichlet_doc_default_callparams)s
+        size : int, optional
+            Number of samples to draw (default 1).
+        %(_doc_random_state)s
+        Returns
+        -------
+        rvs : ndarray or scalar
+            Random variates of size (`size`, `N`), where `N` is the
+            dimension of the random variable.
+        """
+        alpha = _dirichlet_check_parameters(alpha)
+        random_state = self._get_random_state(random_state)
+        return random_state.dirichlet(alpha, size=size)

--- a/numpyro/distributions/multivariate.py
+++ b/numpyro/distributions/multivariate.py
@@ -17,7 +17,7 @@ def _lnB(alpha):
     return np.sum(gammaln(alpha), axis=-1) - gammaln(np.sum(alpha, axis=-1))
 
 
-class _dirichlet_gen(jax_mvcontinuous):
+class dirichlet_gen(jax_mvcontinuous):
     # TODO: use dirichlet doc instead of the default one of rv_continuous
     # TODO: add _argcheck, _support_mask with simplex
     def _logpdf(self, x, alpha):
@@ -46,4 +46,4 @@ class _dirichlet_gen(jax_mvcontinuous):
         return gamma_samples / np.sum(gamma_samples, axis=-1, keepdims=True)
 
 
-dirichlet = _dirichlet_gen(a=0.0, b=1.0, name='dirichlet')
+dirichlet = dirichlet_gen(a=0.0, b=1.0, name='dirichlet')


### PR DESCRIPTION
This PR implements dirichlet distribution.

I have bad experience while implementing this distribution. It took me 2 weeks to make things work and compatible with scipy. I can't inherit from dirichlet_gen because the frozen version requires arg check. But in scipy, dirichlet distribution does not support batch so arg check won't work for batched alpha (or batched samples). Inherit from multi_rv_generic requires implementing again both unfrozen and frozen versions, which does not make sense to me. So I decide to make a layer jax_mvcontinuous which inherited from rv_continuous. Luckily, I don't have to reimplement rv_continuous.__ init__ method. Instead, rewriting `_construct_argparser` logic to remove log/scale things is enough.

I am not sure if this will make the work of implementing other multivariate distributions less painful. Hope that when we have a few of them, we can make a better common interface.