### PR TITLE
implement a custom lax.scan (for tuple) which only stores selected fields

### DIFF
--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -4,9 +4,14 @@ from contextlib import contextmanager
 
 import numpy as onp
 
-from jax import lax
+from jax import core, lax
+from jax.abstract_arrays import ShapedArray
+from jax.api_util import pytree_fun_to_flatjaxtuple_fun, pytree_to_flatjaxtuple
 from jax.flatten_util import ravel_pytree
+from jax.interpreters import partial_eval, xla
+from jax.linear_util import wrap_init
 from jax.tree_util import register_pytree_node, tree_flatten, tree_unflatten
+from jax.util import partial
 
 _DATA_TYPES = {}
 _DISABLE_CONTROL_FLOW_PRIM = False
@@ -104,3 +109,65 @@ def scan(f, a, bs):
         return tree_unflatten(tree_def, as_)
     else:
         return lax.scan(f, a, bs)
+
+
+def tscan(f, a, bs, fields=(0,)):
+    """
+    Works as jax.lax.scan but has additional `fields` arguments to select only
+    necessary fields from `a`'s structure. Defaults to selecting only the first
+    field. Other fields will be filled by None.
+    """
+    # convert pytree to flat jaxtuple
+    a, a_tree = pytree_to_flatjaxtuple(a)
+    bs, b_tree = pytree_to_flatjaxtuple(bs)
+    fields, _ = pytree_to_flatjaxtuple(fields)
+    f, out_tree = pytree_fun_to_flatjaxtuple_fun(wrap_init(f), (a_tree, b_tree))
+
+    # convert arrays to abstract values
+    a_aval, _ = lax._abstractify(a)
+    bs_aval, _ = lax._abstractify(bs)
+    # convert bs to b
+    b_aval = core.AbstractTuple([ShapedArray(b.shape[1:], b.dtype) for b in bs_aval])
+
+    # convert abstract values to partial values (?) then evaluate to get jaxpr
+    a_pval = partial_eval.PartialVal((a_aval, core.unit))
+    b_pval = partial_eval.PartialVal((b_aval, core.unit))
+    jaxpr, pval_out, consts = partial_eval.trace_to_jaxpr(f, (a_pval, b_pval))
+    aval_out, _ = pval_out
+    consts = core.pack(consts)
+
+    out = tscan_p.bind(a, bs, fields, consts, aval_out=aval_out, jaxpr=jaxpr)
+    return tree_unflatten(out_tree(), out)
+
+
+def _tscan_impl(a, bs, fields, consts, aval_out, jaxpr):
+    length = tuple(bs)[0].shape[0]
+    state = [lax.full((length,) + a[i].shape, 0, lax._dtype(a[i])) for i in fields]
+
+    def body_fun(i, vals):
+        a, state = vals
+        # select i-th element from each b
+        b = [lax.dynamic_index_in_dim(b, i, keepdims=False) for b in bs]
+        a_out = core.eval_jaxpr(jaxpr, consts, (), a, core.pack(b))
+        # select fields from a_out and update state
+        state_out = [lax.dynamic_update_index_in_dim(s, a[None, ...], i, axis=0)
+                     for a, s in zip([tuple(a_out)[i] for i in fields], state)]
+        return a_out, state_out
+
+    _, state = lax.fori_loop(0, length, body_fun, (a, state))
+
+    # set None for non-selected fields
+    out = [None] * len(a)
+    for field, i in zip(fields, range(len(fields))):
+        out[field] = state[i]
+    return core.pack(out)
+
+
+def _tscan_abstract_eval(a, bs, fields, consts, aval_out, jaxpr):
+    return lax.maybe_tracer_tuple_to_abstract_tuple(aval_out)
+
+
+tscan_p = core.Primitive('tscan')
+tscan_p.def_impl(_tscan_impl)
+tscan_p.def_abstract_eval(_tscan_abstract_eval)
+xla.translations[tscan_p] = partial(xla.lower_fun, _tscan_impl)

--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -117,6 +117,14 @@ def tscan(f, a, bs, fields=(0,)):
     necessary fields from `a`'s structure. Defaults to selecting only the first
     field. Other fields will be filled by None.
     """
+    # Note: code is copied and modified from lax.scan implementation in
+    # [JAX](https://github.com/google/jax) to support the additional `fields`
+    # arg. Original code has the following copyright:
+    #
+    # Copyright 2018 Google LLC
+    #
+    # Licensed under the Apache License, Version 2.0 (the "License")
+
     # convert pytree to flat jaxtuple
     a, a_tree = pytree_to_flatjaxtuple(a)
     bs, b_tree = pytree_to_flatjaxtuple(bs)

--- a/test/test_mcmc.py
+++ b/test/test_mcmc.py
@@ -3,12 +3,12 @@ from numpy.testing import assert_allclose
 
 import jax.numpy as np
 import jax.random as random
-from jax import lax
 from jax.scipy.special import expit
 
 import numpyro.distributions as dist
 from numpyro.distributions.util import validation_disabled
 from numpyro.mcmc import hmc_kernel
+from numpyro.util import tscan
 
 
 @pytest.mark.parametrize('algo', ['HMC', 'NUTS'])
@@ -27,7 +27,7 @@ def test_unnormalized_normal(algo):
     hmc_state = init_kernel(init_samples,
                             num_steps=10,
                             num_warmup_steps=warmup_steps)
-    hmc_states = lax.scan(lambda state, i: sample_kernel(state), hmc_state, np.arange(num_samples))
+    hmc_states = tscan(lambda state, i: sample_kernel(state), hmc_state, np.arange(num_samples))
     assert_allclose(np.mean(hmc_states.z), true_mean, rtol=0.05)
     assert_allclose(np.std(hmc_states.z), true_std, rtol=0.05)
 
@@ -58,6 +58,6 @@ def test_logistic_regression(algo):
                                 step_size=0.1,
                                 num_steps=15,
                                 num_warmup_steps=warmup_steps)
-        hmc_states = lax.scan(lambda state, i: sample_kernel(state),
-                              hmc_state, np.arange(num_samples))
+        hmc_states = tscan(lambda state, i: sample_kernel(state),
+                           hmc_state, np.arange(num_samples))
         assert_allclose(np.mean(hmc_states.z, 0), true_coefs, atol=0.2)

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1,0 +1,26 @@
+from numpy.testing import assert_allclose
+
+import jax.numpy as np
+from jax import lax
+from jax.tree_util import tree_map
+
+from numpyro.util import laxtuple, tscan
+
+
+def test_tscan():
+    def f(tree, yz):
+        y, z = yz
+        return tree_map(lambda x: (x + y) * z, tree)
+
+    Tree = laxtuple("Tree", ["x", "y", "z"])
+    a = Tree(np.array([1., 2.]),
+             np.array(3., dtype=np.float32),
+             np.array(4., dtype=np.float32))
+    bs = (np.array([1., 2., 3., 4.]),
+          np.array([4., 3., 2., 1.]))
+
+    expected_tree = lax.scan(f, a, bs)
+    actual_tree = tscan(f, a, bs, fields=(0, 2))
+    assert_allclose(actual_tree.x, expected_tree.x)
+    assert_allclose(actual_tree.z, expected_tree.z)
+    assert actual_tree.y is None


### PR DESCRIPTION
Addresses point 7 of #74. Having to scan inverse_mass_matrix and z_grad requires 3x memory storage so it would be more effective if we only store some selected fields from HMCState. This is achieve by using `tscan` in this PR. Currently, it is tested for laxtuple but the code is expected to work for general pytree.