### PR TITLE
Add ability to use models directly to do inference in HMC

### DIFF
--- a/numpyro/distributions/multivariate.py
+++ b/numpyro/distributions/multivariate.py
@@ -9,8 +9,8 @@
 import jax.numpy as np
 from jax.scipy.special import digamma, gammaln
 
-from numpyro.distributions.util import xlogy, standard_gamma
 from numpyro.distributions.distribution import jax_mvcontinuous
+from numpyro.distributions.util import standard_gamma, xlogy
 
 
 def _lnB(alpha):

--- a/numpyro/handlers.py
+++ b/numpyro/handlers.py
@@ -81,8 +81,7 @@ class substitute(Messenger):
         super(substitute, self).__init__(fn)
 
     def process_message(self, msg):
-        if msg['type'] == 'param':
-            assert msg['name'] in self.param_map
+        if msg['name'] in self.param_map:
             msg['value'] = self.param_map[msg['name']]
 
 

--- a/numpyro/handlers.py
+++ b/numpyro/handlers.py
@@ -118,6 +118,7 @@ def sample(name, fn, obs=None):
         'args': (),
         'kwargs': {},
         'value': obs,
+        'is_observed': obs is not None,
     }
 
     # ...and use apply_stack to send it to the Messengers

--- a/numpyro/hmc_util.py
+++ b/numpyro/hmc_util.py
@@ -8,7 +8,7 @@ from jax.tree_util import tree_multimap
 
 from numpyro.distributions.distribution import jax_continuous
 from numpyro.distributions.util import validation_disabled
-from numpyro.handlers import substitute, trace, seed
+from numpyro.handlers import seed, substitute, trace
 from numpyro.util import cond, laxtuple, while_loop
 
 AdaptWindow = laxtuple("AdaptWindow", ["start", "end"])

--- a/numpyro/mcmc.py
+++ b/numpyro/mcmc.py
@@ -6,13 +6,7 @@ from jax.flatten_util import ravel_pytree
 from jax.random import PRNGKey
 
 import numpyro.distributions as dist
-from numpyro.hmc_util import (
-    IntegratorState,
-    build_tree,
-    find_reasonable_step_size,
-    velocity_verlet,
-    warmup_adapter
-)
+from numpyro.hmc_util import IntegratorState, build_tree, find_reasonable_step_size, velocity_verlet, warmup_adapter
 from numpyro.util import cond, fori_loop, laxtuple
 
 HMCState = laxtuple('HMCState', ['z', 'z_grad', 'potential_energy', 'num_steps', 'accept_prob',

--- a/test/test_mcmc.py
+++ b/test/test_mcmc.py
@@ -43,9 +43,9 @@ def test_logistic_regression(algo):
 
     with validation_disabled():
         def model(labels):
-            coefs = sample("coefs", dist.norm(np.zeros(dim), np.ones(dim)))
+            coefs = sample('coefs', dist.norm(np.zeros(dim), np.ones(dim)))
             logits = np.sum(coefs * data, axis=-1)
-            return sample("obs", dist.bernoulli(logits, is_logits=True), obs=labels)
+            return sample('obs', dist.bernoulli(logits, is_logits=True), obs=labels)
 
         init_params, potential_fn = initialize_model(random.PRNGKey(2), model, (labels,), {})
         init_kernel, sample_kernel = hmc_kernel(potential_fn, algo=algo)
@@ -55,4 +55,4 @@ def test_logistic_regression(algo):
                                 num_warmup_steps=warmup_steps)
         hmc_states = scan(lambda state, i: sample_kernel(state),
                           hmc_state, np.arange(num_samples))
-        assert_allclose(np.mean(hmc_states.z, 0), true_coefs, atol=0.2)
+        assert_allclose(np.mean(hmc_states.z['coefs'], 0), true_coefs, atol=0.2)

--- a/test/test_mcmc.py
+++ b/test/test_mcmc.py
@@ -1,9 +1,9 @@
 import pytest
-from jax import jit
 from numpy.testing import assert_allclose
 
 import jax.numpy as np
 import jax.random as random
+from jax import jit
 from jax.scipy.special import expit
 
 import numpyro.distributions as dist

--- a/test/test_mcmc.py
+++ b/test/test_mcmc.py
@@ -1,4 +1,5 @@
 import pytest
+from jax import jit
 from numpy.testing import assert_allclose
 
 import jax.numpy as np
@@ -53,6 +54,7 @@ def test_logistic_regression(algo):
                                 step_size=0.1,
                                 num_steps=15,
                                 num_warmup_steps=warmup_steps)
+        sample_kernel = jit(sample_kernel)
         hmc_states = scan(lambda state, i: sample_kernel(state),
                           hmc_state, np.arange(num_samples))
         assert_allclose(np.mean(hmc_states.z['coefs'], 0), true_coefs, atol=0.2)


### PR DESCRIPTION
Resolves #74. 

I have resorted to providing an `initialize_model` utility that returns the `potential_fn` for that model, as well as an initial trace from the prior, which can be used in `init_samples` instead. An alternative design would be to have `hmc_kernel` itself take an optional `model` arg which is used to set the potential energy and initial samples if not specified.

TODO:
 - [x] Fix `test_mcmc` that fails under JIT.
 - [x] Fix slowdown in mcmc test. (I'm getting ~10s for HMC and ~25s for NUTS, but there doesn't seem to be a regression with this PR)