### PR TITLE
Add a transform function to tscan

### DIFF
--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -115,7 +115,7 @@ def scan(f, a, bs):
         return lax.scan(f, a, bs)
 
 
-def tscan(f, a, bs, transform=None):
+def tscan(f, a, bs, transform):
     if not transform:
         def transform(x): return x
     if _DISABLE_CONTROL_FLOW_PRIM:
@@ -152,9 +152,9 @@ def _tscan(f, a, bs, transform=None):
 
     a, a_tree = pytree_to_flatjaxtuple(a)
     bs, b_tree = pytree_to_flatjaxtuple(bs)
-    f, out_tree = pytree_fun_to_flatjaxtuple_fun(wrap_init(f), (a_tree, b_tree))
-    transform_f, transform_tree = pytree_fun_to_flatjaxtuple_fun(wrap_init(transform),
-                                                                 (a_tree,))
+    f, _ = pytree_fun_to_flatjaxtuple_fun(wrap_init(f), (a_tree, b_tree))
+    transform_f, transform_tree = pytree_fun_to_flatjaxtuple_fun(
+        wrap_init(transform), (a_tree,))
 
     # convert arrays to abstract values
     a_aval, _ = lax._abstractify(a)

--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -203,12 +203,3 @@ tscan_p = core.Primitive('tscan')
 tscan_p.def_impl(_tscan_impl)
 tscan_p.def_abstract_eval(_tscan_abstract_eval)
 xla.translations[tscan_p] = partial(xla.lower_fun, _tscan_impl)
-
-
-def f(x, y):
-    return {"i": x["i"] + y["i"], "j": x["j"] - y["j"]}
-
-
-print(tscan(f, {"i": np.array([0.]), "j": np.array([1.])},
-               {"i": np.array([1., 2., 3.]), "j": np.array([2., 3., 6.])},
-            transform=lambda x: {"i": x["i"]}))

--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -115,20 +115,15 @@ def scan(f, a, bs):
         return lax.scan(f, a, bs)
 
 
-def tscan(f, a, bs, fields=(0,)):
+def tscan(f, a, bs, transform=None):
+    if not transform:
+        def transform(x): return x
     if _DISABLE_CONTROL_FLOW_PRIM:
         length = tree_flatten(bs)[0][0].shape[0]
         for i in range(length):
             b = tree_map(lambda x: x[i], bs)
             a = f(a, b)
-            a_out = tree_map(lambda x: x[None, ...], a)
-
-            # the following three lines are necessary for tscan;
-            # it might be useful in the case you want to use `transform` instead of `fields`
-            a_flat, a_tree = tree_flatten(a_out)
-            a_selected = [field if i in fields else None for i, field in enumerate(a_out)]
-            a_out = tree_unflatten(a_tree, a_selected)
-
+            a_out = transform(tree_map(lambda x: x[None, ...], a))
             if i == 0:
                 out = a_out
             else:
@@ -136,10 +131,10 @@ def tscan(f, a, bs, fields=(0,)):
                                     out, a_out)
         return out
     else:
-        return _tscan(f, a, bs, fields)
+        return _tscan(f, a, bs, transform)
 
 
-def _tscan(f, a, bs, fields=(0,)):
+def _tscan(f, a, bs, transform=None):
     """
     Works as jax.lax.scan but has additional `fields` argument to select only
     necessary fields from `a`'s structure. Defaults to selecting only the first
@@ -154,10 +149,12 @@ def _tscan(f, a, bs, fields=(0,)):
     # Licensed under the Apache License, Version 2.0 (the "License")
 
     # convert pytree to flat jaxtuple
+
     a, a_tree = pytree_to_flatjaxtuple(a)
     bs, b_tree = pytree_to_flatjaxtuple(bs)
-    fields, _ = pytree_to_flatjaxtuple(fields)
     f, out_tree = pytree_fun_to_flatjaxtuple_fun(wrap_init(f), (a_tree, b_tree))
+    transform_f, transform_tree = pytree_fun_to_flatjaxtuple_fun(wrap_init(transform),
+                                                                 (a_tree,))
 
     # convert arrays to abstract values
     a_aval, _ = lax._abstractify(a)
@@ -169,34 +166,33 @@ def _tscan(f, a, bs, fields=(0,)):
     a_pval = partial_eval.PartialVal((a_aval, core.unit))
     b_pval = partial_eval.PartialVal((b_aval, core.unit))
     jaxpr, pval_out, consts = partial_eval.trace_to_jaxpr(f, (a_pval, b_pval))
+    transform_jaxpr, _, _ = partial_eval.trace_to_jaxpr(transform_f, (a_pval,))
     aval_out, _ = pval_out
     consts = core.pack(consts)
 
-    out = tscan_p.bind(a, bs, fields, consts, aval_out=aval_out, jaxpr=jaxpr)
-    return tree_unflatten(out_tree(), out)
+    out = tscan_p.bind(a, bs, consts, aval_out=aval_out, jaxpr=jaxpr, transform_jaxpr=transform_jaxpr)
+    return tree_unflatten(transform_tree(), out)
 
 
-def _tscan_impl(a, bs, fields, consts, aval_out, jaxpr):
+def _tscan_impl(a, bs, consts, aval_out, jaxpr, transform_jaxpr):
     length = tuple(bs)[0].shape[0]
-    state = [lax.full((length,) + a[i].shape, 0, lax._dtype(a[i])) for i in fields]
+    template = core.eval_jaxpr(transform_jaxpr, (), (), a)
+    state = [lax.full((length,) + t.shape, 0, lax._dtype(t)) for t in template]
 
     def body_fun(i, vals):
         a, state = vals
         # select i-th element from each b
         b = [lax.dynamic_index_in_dim(b, i, keepdims=False) for b in bs]
         a_out = core.eval_jaxpr(jaxpr, consts, (), a, core.pack(b))
+
         # select fields from a_out and update state
-        state_out = [lax.dynamic_update_index_in_dim(s, a[None, ...], i, axis=0)
-                     for a, s in zip([tuple(a_out)[j] for j in fields], state)]
+        t_out = core.eval_jaxpr(transform_jaxpr, (), (), a_out)
+        state_out = [lax.dynamic_update_index_in_dim(s, t[None, ...], i, axis=0)
+                     for t, s in zip(t_out, state)]
         return a_out, state_out
 
     _, state = lax.fori_loop(0, length, body_fun, (a, state))
-
-    # set None for non-selected fields
-    out = [None] * len(a)
-    for field, i in zip(fields, range(len(fields))):
-        out[field] = state[i]
-    return core.pack(out)
+    return core.pack(state)
 
 
 def _tscan_abstract_eval(a, bs, fields, consts, aval_out, jaxpr):
@@ -207,3 +203,12 @@ tscan_p = core.Primitive('tscan')
 tscan_p.def_impl(_tscan_impl)
 tscan_p.def_abstract_eval(_tscan_abstract_eval)
 xla.translations[tscan_p] = partial(xla.lower_fun, _tscan_impl)
+
+
+def f(x, y):
+    return {"i": x["i"] + y["i"], "j": x["j"] - y["j"]}
+
+
+print(tscan(f, {"i": np.array([0.]), "j": np.array([1.])},
+               {"i": np.array([1., 2., 3.]), "j": np.array([2., 3., 6.])},
+            transform=lambda x: {"i": x["i"]}))

--- a/test/test_mcmc.py
+++ b/test/test_mcmc.py
@@ -26,9 +26,10 @@ def test_unnormalized_normal(algo):
     hmc_state = init_kernel(init_samples,
                             num_steps=10,
                             num_warmup_steps=warmup_steps)
-    hmc_states = tscan(lambda state, i: sample_kernel(state), hmc_state, np.arange(num_samples))
-    assert_allclose(np.mean(hmc_states.z), true_mean, rtol=0.05)
-    assert_allclose(np.std(hmc_states.z), true_std, rtol=0.05)
+    hmc_states = tscan(lambda state, i: sample_kernel(state), hmc_state, np.arange(num_samples),
+                       transform=lambda x: x.z)
+    assert_allclose(np.mean(hmc_states), true_mean, rtol=0.05)
+    assert_allclose(np.std(hmc_states), true_std, rtol=0.05)
 
 
 @pytest.mark.parametrize('algo', ['HMC', 'NUTS'])
@@ -53,6 +54,6 @@ def test_logistic_regression(algo):
                                 num_steps=15,
                                 num_warmup_steps=warmup_steps)
         sample_kernel = jit(sample_kernel)
-        hmc_states = tscan(lambda state, i: sample_kernel(state),
-                           hmc_state, np.arange(num_samples))
-        assert_allclose(np.mean(hmc_states.z['coefs'], 0), true_coefs, atol=0.2)
+        hmc_states = tscan(lambda state, i: sample_kernel(state), hmc_state, np.arange(num_samples),
+                           transform=lambda x: x.z)
+        assert_allclose(np.mean(hmc_states['coefs'], 0), true_coefs, atol=0.2)

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1,4 +1,5 @@
 import pytest
+from jax.test_util import check_eq
 from numpy.testing import assert_allclose
 
 import jax.numpy as np
@@ -15,18 +16,32 @@ def test_tscan(prims_disabled):
         return tree_map(lambda x: (x + y) * z, tree)
 
     Tree = laxtuple("Tree", ["x", "y", "z"])
+    OutTree = laxtuple("OutTree", ["x", "z"])
     a = Tree(np.array([1., 2.]),
              np.array(3., dtype=np.float32),
              np.array(4., dtype=np.float32))
     bs = (np.array([1., 2., 3., 4.]),
           np.array([4., 3., 2., 1.]))
 
-    expected_tree = lax.scan(f, a, bs)
+    scan_tree = lax.scan(f, a, bs)
+    expected_tree = OutTree(scan_tree.x, scan_tree.z)
     with optional(prims_disabled, control_flow_prims_disabled()):
-        actual_tree = tscan(f, a, bs, fields=(0, 2))
-    assert_allclose(actual_tree.x, expected_tree.x)
-    assert_allclose(actual_tree.z, expected_tree.z)
-    assert actual_tree.y is None
+        actual_tree = tscan(f, a, bs, transform=lambda a: OutTree(a.x, a.z))
+    check_eq(actual_tree, expected_tree)
+
+
+@pytest.mark.parametrize('prims_disabled', [True, False])
+def test_tscan_dict(prims_disabled):
+    def f(x, y):
+        return {'i': x['i'] + y['i'], 'j': x['j'] - y['j']}
+
+    a = {'i': np.array([0.]), 'j': np.array([1.])}
+    bs = {'i': np.array([1., 2., 3.]), 'j': np.array([2., 3., 6.])}
+    scan_tree = lax.scan(f, a, bs)
+    expected_tree = {'i': scan_tree['i']}
+    with optional(prims_disabled, control_flow_prims_disabled()):
+        actual_tree = tscan(f, a, bs, transform=lambda a: {'i': a['i']})
+    check_eq(actual_tree, expected_tree)
 
 
 def test_scan_prims_disabled():

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -44,6 +44,19 @@ def test_tscan_dict(prims_disabled):
     check_eq(actual_tree, expected_tree)
 
 
+@pytest.mark.parametrize('prims_disabled', [True, False])
+def test_scan_scalar(prims_disabled):
+    def f(x, y):
+        return {'i': x['i'] + y['i'], 'j': x['j'] - y['j']}
+
+    a = {'i': np.array(0.), 'j': np.array(1.)}
+    bs = {'i': np.array([1., 2., 3.]), 'j': np.array([2., 3., 6.])}
+    expected_tree = {'i': np.array([1., 3., 6.])}
+    with optional(prims_disabled, control_flow_prims_disabled()):
+        actual_tree = tscan(f, a, bs, transform=lambda a: {'i': a['i']})
+    check_eq(actual_tree, expected_tree)
+
+
 def test_scan_prims_disabled():
     def f(tree, yz):
         y, z = yz


### PR DESCRIPTION
This builds on top of @fehiepsi's #84 that takes in a `transform` arg instead of `fields` and can be used more broadly to specify the output data structure in scan. An example is in the `test_util.py`. e.g. in the case of HMC, we use tscan to specify the output fields of interest:

```python
samples = tscan(lambda state, i: sample_kernel(state), hmc_state, np.arange(num_samples),
                transform=lambda x: {'z': x.z, 'potential_energy': x.potential_energy})
```