### PR TITLE
Add distribution classes that do not depend on scipy

### DIFF
--- a/numpyro/contrib/distributions/__init__.py
+++ b/numpyro/contrib/distributions/__init__.py
@@ -1,0 +1,8 @@
+from numpyro.contrib.distributions.continuous import Normal, Uniform
+from numpyro.contrib.distributions.discrete import Bernoulli
+
+__all__ = [
+    'Bernoulli',
+    'Normal',
+    'Uniform',
+]

--- a/numpyro/contrib/distributions/continuous.py
+++ b/numpyro/contrib/distributions/continuous.py
@@ -1,0 +1,57 @@
+import jax.numpy as np
+import jax.random as random
+from jax import lax
+
+from numpyro.contrib.distributions.distribution import Distribution
+from numpyro.distributions.util import get_dtypes, promote_shapes
+
+
+class Normal(Distribution):
+    is_reparametrized = True
+
+    def __init__(self, loc, scale, validate_args=None):
+        self.loc, self.scale = promote_shapes(loc, scale)
+        batch_shape = lax.broadcast_shapes(np.shape(loc), np.shape(scale))
+        super().__init__(batch_shape=batch_shape, validate_args=validate_args)
+
+    def sample(self, key, size=()):
+        eps = random.normal(key, shape=size)
+        return self.loc + eps * self.scale
+
+    def log_prob(self, value):
+        return -((value - self.loc) ** 2) / (2.0 * self.scale ** 2) \
+               - np.log(self.scale) - np.log(np.sqrt(2 * np.pi))
+
+    @property
+    def mean(self):
+        return self.loc
+
+    @property
+    def variance(self):
+        return self.scale
+
+
+class Uniform(Distribution):
+    is_reparametrized = False
+
+    def __init__(self, low, high, validate_args=None):
+        self.low, self.high = promote_shapes(low, high)
+        batch_shape = lax.broadcast_shapes(np.shape(low), np.shape(high))
+        super().__init__(batch_shape=batch_shape, validate_args=validate_args)
+
+    def sample(self, key, size=()):
+        size = size or self.batch_shape
+        return self.low + random.uniform(key, shape=size) * (self.high - self.low)
+
+    def log_prob(self, value):
+        within_bounds = ((value >= self.low) & (value < self.high))
+        return np.log(lax.convert_element_type(within_bounds, get_dtypes(self.low)[0])) - \
+            np.log(self.high - self.low)
+
+    @property
+    def mean(self):
+        return (self.high - self.low) / 2.
+
+    @property
+    def variance(self):
+        return (self.high - self.low) ** 2 / 12.

--- a/numpyro/contrib/distributions/discrete.py
+++ b/numpyro/contrib/distributions/discrete.py
@@ -1,0 +1,42 @@
+import jax.numpy as np
+import jax.random as random
+
+from numpyro.contrib.distributions.distribution import Distribution
+from numpyro.distributions.util import binary_cross_entropy_with_logits, get_dtypes
+
+
+def _to_probs_bernoulli(logits):
+    return 1 / (1 + np.exp(logits))
+
+
+def clamp_probs(probs):
+    eps = np.finfo(get_dtypes(probs)[0]).eps
+    return np.clip(probs, a_min=eps, a_max=1 - eps)
+
+
+def _to_logits_bernoulli(probs):
+    ps_clamped = clamp_probs(probs)
+    return np.log(ps_clamped) - np.log1p(-ps_clamped)
+
+
+class Bernoulli(Distribution):
+    def __init__(self, probs=None, logits=None, validate_args=None):
+        assert (probs is None) != (logits is None), \
+            'Only one of `probs` or `logits` must be specified.'
+        self.probs = probs if probs is not None else _to_probs_bernoulli(logits)
+        self.logits = logits if logits is not None else _to_logits_bernoulli(probs)
+        super(Bernoulli, self).__init__(batch_shape=np.shape(self.probs), validate_args=validate_args)
+
+    def sample(self, key, size=()):
+        return random.bernoulli(key, self.probs, shape=size)
+
+    def log_prob(self, value):
+        return -binary_cross_entropy_with_logits(self.logits, value)
+
+    @property
+    def mean(self):
+        return self.probs
+
+    @property
+    def variance(self):
+        return self.probs * (1 - self.probs)

--- a/numpyro/contrib/distributions/distribution.py
+++ b/numpyro/contrib/distributions/distribution.py
@@ -1,0 +1,34 @@
+class Distribution(object):
+    arg_constraints = {}
+    support = None
+    is_reparametrized = False
+    _validate_args = False
+
+    def __init__(self, batch_shape=(), event_shape=(), validate_args=None):
+        self._batch_shape = batch_shape
+        self._event_shape = event_shape
+        if validate_args is None:
+            self._validate_args = validate_args
+        super(Distribution, self).__init__()
+
+    @property
+    def batch_shape(self):
+        return self._batch_shape
+
+    @property
+    def event_shape(self):
+        return self._event_shape
+
+    def sample(self, key, size=()):
+        raise NotImplementedError
+
+    def log_prob(self, value):
+        raise NotImplementedError
+
+    @property
+    def mean(self):
+        raise NotImplementedError
+
+    @property
+    def variance(self):
+        raise NotImplementedError

--- a/numpyro/distributions/util.py
+++ b/numpyro/distributions/util.py
@@ -1,9 +1,11 @@
 from contextlib import contextmanager
+from numbers import Number
 
+import numpy as onp
 import scipy.special as osp_special
 
 import jax.numpy as np
-from jax import jit, lax, random, vmap
+from jax import canonicalize_dtype, jit, lax, random, vmap
 from jax.core import Primitive
 from jax.interpreters import ad, partial_eval, xla
 from jax.numpy.lax_numpy import _promote_args_like, _promote_shapes
@@ -288,6 +290,11 @@ def promote_shapes(*args, shape=()):
         num_dims = len(lax.broadcast_shapes(shape, *shapes))
         return [lax.reshape(arg, (1,) * (num_dims - len(s)) + s)
                 if len(s) < num_dims else arg for arg, s in zip(args, shapes)]
+
+
+def get_dtypes(*args):
+    return [canonicalize_dtype(type(arg)) if isinstance(arg, Number)
+            else canonicalize_dtype(onp.dtype(arg)) for arg in args]
 
 
 # TODO: inefficient implementation; jit currently fails due to

--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -10,7 +10,7 @@ from jax.abstract_arrays import ShapedArray
 from jax.api_util import pytree_fun_to_flatjaxtuple_fun, pytree_to_flatjaxtuple
 from jax.interpreters import partial_eval, xla
 from jax.linear_util import wrap_init
-from jax.tree_util import register_pytree_node, tree_flatten, tree_unflatten, tree_map, tree_multimap
+from jax.tree_util import register_pytree_node, tree_flatten, tree_map, tree_multimap, tree_unflatten
 from jax.util import partial
 
 _DATA_TYPES = {}

--- a/test/test_distributions_contrib.py
+++ b/test/test_distributions_contrib.py
@@ -1,0 +1,93 @@
+from collections import namedtuple
+
+import pytest
+import scipy.stats as osp
+from numpy.testing import assert_allclose
+
+import jax
+import jax.numpy as np
+import jax.random as random
+
+import numpyro.contrib.distributions as dist
+
+
+class T(namedtuple('TestCase', ['jax_dist', 'sp_dist', 'params', 'sp_params'])):
+    def __new__(cls, jax_dist, sp_dist, params, sp_params=None):
+        if sp_params is None:
+            sp_params = params
+        return super(cls, T).__new__(cls, jax_dist, sp_dist, params, sp_params)
+
+
+CONTINUOUS = [
+    T(dist.Normal, osp.norm, (0., 1.)),
+    T(dist.Normal, osp.norm, (1., np.array([1., 2.]))),
+    T(dist.Normal, osp.norm, (np.array([0., 1.]), np.array([[1.], [2.]]))),
+    T(dist.Uniform, osp.uniform, (0., 2.)),
+    T(dist.Uniform, osp.uniform, (1., np.array([2., 3.])), (1., np.array([1., 2.]))),
+    T(dist.Uniform, osp.uniform, (np.array([0., 0.]), np.array([[2.], [3.]]))),
+]
+
+
+DISCRETE = [
+    T(dist.Bernoulli, osp.bernoulli, (0.2,)),
+    T(dist.Bernoulli, osp.bernoulli, (np.array([0.2, 0.7]),)),
+]
+
+
+@pytest.mark.parametrize('jax_dist, sp_dist, params, sp_params', CONTINUOUS + DISCRETE)
+@pytest.mark.parametrize('prepend_shape', [
+    (),
+    (2,),
+    (2, 3),
+])
+def test_continuous_shape(jax_dist, sp_dist, params, sp_params, prepend_shape):
+    jax_dist = jax_dist(*params)
+    sp_dist = sp_dist(*params)
+    rng = random.PRNGKey(0)
+    expected_shape = prepend_shape + jax_dist.batch_shape
+    samples = jax_dist.sample(key=rng, size=expected_shape)
+    sp_samples = sp_dist.rvs(size=expected_shape)
+    assert isinstance(samples, jax.interpreters.xla.DeviceArray)
+    assert np.shape(samples) == expected_shape
+    assert np.shape(sp_samples) == expected_shape
+
+
+@pytest.mark.parametrize('jax_dist, sp_dist, params, sp_params', CONTINUOUS)
+def test_sample_gradient(jax_dist, sp_dist, params, sp_params):
+    rng = random.PRNGKey(0)
+
+    def fn(args):
+        return jax_dist(*args).sample(key=rng).sum()
+
+    actual_grad = jax.grad(fn)(params)
+    assert len(actual_grad) == len(params)
+
+    eps = 1e-6
+    for i in range(len(params)):
+        args_lhs = [p if j != i else p - eps for j, p in enumerate(params)]
+        args_rhs = [p if j != i else p + eps for j, p in enumerate(params)]
+        fn_lhs = fn(args_lhs)
+        fn_rhs = fn(args_rhs)
+        # finite diff approximation
+        expected_grad = (fn_rhs - fn_lhs) / (2. * eps)
+        assert np.shape(actual_grad[i]) == np.shape(params[i])
+        assert_allclose(np.sum(actual_grad[i]), expected_grad, rtol=0.12)
+
+
+@pytest.mark.parametrize('jax_dist, sp_dist, params, sp_params', CONTINUOUS + DISCRETE)
+@pytest.mark.parametrize('prepend_shape', [
+    (),
+    (2,),
+    (2, 3),
+])
+def test_log_prob(jax_dist, sp_dist, params, sp_params, prepend_shape):
+    jax_dist = jax_dist(*params)
+    sp_dist = sp_dist(*sp_params)
+    rng = random.PRNGKey(0)
+    expected_shape = prepend_shape + jax_dist.batch_shape
+    samples = jax_dist.sample(key=rng, size=expected_shape)
+    try:
+        expected = sp_dist.logpdf(samples)
+    except AttributeError:
+        expected = sp_dist.logpmf(samples)
+    assert_allclose(jax_dist.log_prob(samples), expected, atol=1e-5)

--- a/test/test_distributions_contrib.py
+++ b/test/test_distributions_contrib.py
@@ -42,7 +42,7 @@ DISCRETE = [
 ])
 def test_continuous_shape(jax_dist, sp_dist, params, sp_params, prepend_shape):
     jax_dist = jax_dist(*params)
-    sp_dist = sp_dist(*params)
+    sp_dist = sp_dist(*sp_params)
     rng = random.PRNGKey(0)
     expected_shape = prepend_shape + jax_dist.batch_shape
     samples = jax_dist.sample(key=rng, size=expected_shape)

--- a/test/test_distributions_contrib.py
+++ b/test/test_distributions_contrib.py
@@ -71,7 +71,7 @@ def test_sample_gradient(jax_dist, sp_dist, params, sp_params):
         # finite diff approximation
         expected_grad = (fn_rhs - fn_lhs) / (2. * eps)
         assert np.shape(actual_grad[i]) == np.shape(params[i])
-        assert_allclose(np.sum(actual_grad[i]), expected_grad, rtol=0.12)
+        assert_allclose(np.sum(actual_grad[i]), expected_grad, rtol=0.15)
 
 
 @pytest.mark.parametrize('jax_dist, sp_dist, params, sp_params', CONTINUOUS + DISCRETE)


### PR DESCRIPTION
Initial attempt at #82. Note that this doesn't refactor / change existing behavior in any way.

This adds support for a few distribution classes (normal, uniform and bernoulli) in `contrib.distributions`. Note that these classes are tested but they are not being used anywhere. Once this module is fully developed and we are happy with the interface, we can move these distributions into the main `distributions` module.

I have kept the API largely similar to that of `torch.distributions`. This will help integrate with `funsor` / `pyro`. More importantly it will be easy to do args validation / use constraints etc by following the same patterns as in PyTorch.