### PR TITLE
Unify args validation for discrete and continuous distributions

### DIFF
--- a/numpyro/distributions/constraints.py
+++ b/numpyro/distributions/constraints.py
@@ -31,9 +31,6 @@ class Constraint(object):
 
 
 class _Boolean(Constraint):
-    """
-    Constrain to the two values `{0, 1}`.
-    """
     def __call__(self, value):
         return (value == 0) | (value == 1)
 

--- a/numpyro/distributions/constraints.py
+++ b/numpyro/distributions/constraints.py
@@ -30,6 +30,14 @@ class Constraint(object):
         raise NotImplementedError
 
 
+class _Boolean(Constraint):
+    """
+    Constrain to the two values `{0, 1}`.
+    """
+    def __call__(self, value):
+        return (value == 0) | (value == 1)
+
+
 class _GreaterThan(Constraint):
     def __init__(self, lower_bound):
         self.lower_bound = lower_bound
@@ -45,6 +53,14 @@ class _IntegerInterval(Constraint):
 
     def __call__(self, x):
         return (x >= self.lower_bound) & (x <= self.upper_bound) & (x == np.floor(x))
+
+
+class _IntegerGreaterThan(Constraint):
+    def __init__(self, lower_bound):
+        self.lower_bound = lower_bound
+
+    def __call__(self, value):
+        return (value % 1 == 0) & (value >= self.lower_bound)
 
 
 class _Interval(Constraint):
@@ -67,9 +83,12 @@ class _Simplex(Constraint):
         return np.all(x > 0, axis=-1) & (x_sum <= 1) & (x_sum > 1 - 1e-6)
 
 
+boolean = _Boolean()
 greater_than = _GreaterThan
 integer_interval = _IntegerInterval
 interval = _Interval
+nonnegative_integer = _IntegerGreaterThan(0)
+positive_integer = _IntegerGreaterThan(1)
 positive = _GreaterThan(0)
 real = _Real()
 simplex = _Simplex()

--- a/numpyro/distributions/discrete.py
+++ b/numpyro/distributions/discrete.py
@@ -15,11 +15,15 @@ from jax import device_put, lax
 from jax.numpy.lax_numpy import _promote_dtypes
 from jax.scipy.special import expit, gammaln
 
+from numpyro.distributions import constraints
 from numpyro.distributions.distribution import jax_discrete
 from numpyro.distributions.util import binary_cross_entropy_with_logits, entr, promote_shapes, xlog1py, xlogy
 
 
 class _binom_gen(jax_discrete, binom_gen):
+    arg_constraints = {'n': constraints.nonnegative_integer,
+                       'p': constraints.unit_interval}
+
     def _logpmf(self, x, n, p):
         k = np.floor(x)
         n, p = _promote_dtypes(n, p)
@@ -33,6 +37,9 @@ class _binom_gen(jax_discrete, binom_gen):
 
 
 class _bernoulli_gen(jax_discrete, bernoulli_gen):
+    # TODO: This should depend on initialization
+    arg_constraints = {'p': constraints.real}
+
     def __new__(cls, *args, **kwargs):
         return super(_bernoulli_gen, cls).__new__(cls)
 

--- a/numpyro/distributions/distribution.py
+++ b/numpyro/distributions/distribution.py
@@ -132,6 +132,7 @@ class jax_discrete(jax_generic, osp_stats.rv_discrete):
     def _support_mask(self, k):
         return (k >= self.a) & (k <= self.b) & (np.floor(k) == k)
 
+    # TODO: This will not work for the case that loc != 0
     def _support(self, *args, **kwargs):
         return self._support_mask
 

--- a/numpyro/distributions/util.py
+++ b/numpyro/distributions/util.py
@@ -311,12 +311,3 @@ def binomial(key, p, n=1, shape=()):
     p, uniforms = promote_shapes(p, uniforms)
     return np.sum(mask * lax.lt(uniforms, p), axis=-1, keepdims=False)
 
-
-@contextmanager
-def validation_disabled():
-    discrete_dist_args_check = jax_discrete.args_check
-    try:
-        jax_discrete.args_check = False
-        yield
-    finally:
-        jax_discrete.args_check = discrete_dist_args_check

--- a/numpyro/distributions/util.py
+++ b/numpyro/distributions/util.py
@@ -1,4 +1,3 @@
-from contextlib import contextmanager
 from numbers import Number
 
 import numpy as onp
@@ -10,8 +9,6 @@ from jax.core import Primitive
 from jax.interpreters import ad, partial_eval, xla
 from jax.numpy.lax_numpy import _promote_args_like, _promote_shapes
 from jax.util import partial
-
-from numpyro.distributions.distribution import jax_discrete
 
 
 def _standard_gamma_one(key, alpha):
@@ -310,4 +307,3 @@ def binomial(key, p, n=1, shape=()):
     mask = (np.arange(n_max) > n).astype(uniforms.dtype)
     p, uniforms = promote_shapes(p, uniforms)
     return np.sum(mask * lax.lt(uniforms, p), axis=-1, keepdims=False)
-

--- a/numpyro/hmc_util.py
+++ b/numpyro/hmc_util.py
@@ -7,7 +7,6 @@ from jax.scipy.special import expit
 from jax.tree_util import tree_multimap
 
 from numpyro.distributions.distribution import jax_continuous
-from numpyro.distributions.util import validation_disabled
 from numpyro.handlers import seed, substitute, trace
 from numpyro.util import cond, laxtuple, while_loop
 
@@ -543,8 +542,7 @@ def build_tree(verlet_update, kinetic_fn, verlet_state, inverse_mass_matrix, ste
 
 def log_density(model, model_args, model_kwargs, params):
     def logp(d, val):
-        with validation_disabled():
-            return d.logpdf(val) if isinstance(d.dist, jax_continuous) else d.logpmf(val)
+        return d.logpdf(val) if isinstance(d.dist, jax_continuous) else d.logpmf(val)
 
     model = substitute(model, params)
     model_trace = trace(model).get_trace(*model_args, **model_kwargs)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,5 +1,5 @@
-from numpyro.util import set_rng_seed
 from numpyro.distributions.distribution import jax_frozen
+from numpyro.util import set_rng_seed
 
 
 def pytest_runtest_setup(item):

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1,9 +1,9 @@
 import pytest
-from jax.test_util import check_eq
 from numpy.testing import assert_allclose
 
 import jax.numpy as np
 from jax import lax
+from jax.test_util import check_eq
 from jax.tree_util import tree_map
 
 from numpyro.util import control_flow_prims_disabled, laxtuple, optional, scan, tscan


### PR DESCRIPTION
This refactor addresses the following:
 - Add some more constraints for discrete distributions.
 - Removes existing `_args_check` logic to instead use the `_validate_args` checks from @fehiepsi's earlier PRs #98. 
 - Changes the default behavior to not validate (this is something that can be changed later). Changes the `validation_disabled` contextmanager to `validation_enabled` and moves this to `distribution.py` so as to avoid circular dependencies.

Right now, some dependent constraints cannot be checked, e.g. for `logits` vs `probs`. That will require these properties to be set at the instance level, and it gets complicated with the existing distributions hierarchy. Also note that this doesn't handle the multinomial distribution which is complicated for similar reasons. All of these should be addressed once #82 is fixed. 

Fixes #50. 