### PR TITLE
rename hmc_kernel to hmc

### DIFF
--- a/numpyro/mcmc.py
+++ b/numpyro/mcmc.py
@@ -37,7 +37,7 @@ def _euclidean_ke(inverse_mass_matrix, r):
     return 0.5 * np.dot(v, r)
 
 
-def hmc_kernel(potential_fn, kinetic_fn=None, algo='NUTS'):
+def hmc(potential_fn, kinetic_fn=None, algo='NUTS'):
     if kinetic_fn is None:
         kinetic_fn = _euclidean_ke
     vv_init, vv_update = velocity_verlet(potential_fn, kinetic_fn)

--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -126,7 +126,7 @@ def tscan(f, a, bs, transform=_identity):
         return _tscan(f, a, bs, transform)
 
 
-def tscan_nonprim(f, a, bs, transform=_identity):
+def _tscan_nonprim(f, a, bs, transform=_identity):
     length = tree_flatten(bs)[0][0].shape[0]
     for i in range(length):
         b = tree_map(lambda x: x[i], bs)

--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -121,7 +121,7 @@ def _identity(x):
 
 def tscan(f, a, bs, transform=_identity):
     if _DISABLE_CONTROL_FLOW_PRIM:
-        tscan_nonprim(f, a, bs, transform=_identity)
+        _tscan_nonprim(f, a, bs, transform=_identity)
     else:
         return _tscan(f, a, bs, transform)
 

--- a/test/test_mcmc.py
+++ b/test/test_mcmc.py
@@ -7,7 +7,7 @@ from jax import jit, random
 import numpyro.distributions as dist
 from numpyro.handlers import sample
 from numpyro.hmc_util import initialize_model
-from numpyro.mcmc import hmc_kernel
+from numpyro.mcmc import hmc
 from numpyro.util import tscan
 
 
@@ -20,7 +20,7 @@ def test_unnormalized_normal(algo):
     def potential_fn(z):
         return 0.5 * np.sum(((z - true_mean) / true_std) ** 2)
 
-    init_kernel, sample_kernel = hmc_kernel(potential_fn, algo=algo)
+    init_kernel, sample_kernel = hmc(potential_fn, algo=algo)
     init_samples = np.array(0.)
     hmc_state = init_kernel(init_samples,
                             num_steps=10,
@@ -46,7 +46,7 @@ def test_logistic_regression(algo):
         return sample('obs', dist.bernoulli(logits, is_logits=True), obs=labels)
 
     init_params, potential_fn = initialize_model(random.PRNGKey(2), model, (labels,), {})
-    init_kernel, sample_kernel = hmc_kernel(potential_fn, algo=algo)
+    init_kernel, sample_kernel = hmc(potential_fn, algo=algo)
     hmc_state = init_kernel(init_params,
                             step_size=0.1,
                             num_steps=15,


### PR DESCRIPTION
just a quick rename to avoid confusion.

@neerajprad  The name transition_kernel seems overlapping the the transition kernel for acceptance probability in HMC/NUTS. So I keep the name `sample_kernel` as is. Btw, renaming hmc_kernel to hmc has already resolved my confusion. :)