### PR TITLE
Use transforms for models with constrained latent variables

### DIFF
--- a/numpyro/distributions/transforms.py
+++ b/numpyro/distributions/transforms.py
@@ -29,6 +29,10 @@ from numpyro.distributions import constraints
 from numpyro.distributions.util import sum_rightmost
 
 
+def clipped_expit(x):
+    return np.clip(expit(x), a_min=np.finfo(x.dtype).tiny, a_max=1.-np.finfo(x.dtype).eps)
+
+
 class Transform(object):
     domain = constraints.real
     codomain = constraints.real
@@ -155,8 +159,7 @@ class SigmoidTransform(Transform):
     codomain = constraints.unit_interval
 
     def __call__(self, x):
-        # XXX consider to clamp to (0, 1) for stability if necessary
-        return expit(x)
+        return clipped_expit(x)
 
     def inv(self, y):
         return logit(y)
@@ -173,7 +176,7 @@ class StickBreakingTransform(Transform):
         # we shift x to obtain a balanced mapping (0, 0, ..., 0) -> (1/K, 1/K, ..., 1/K)
         x = x - np.log(x.shape[-1] - np.arange(x.shape[-1]))
         # convert to probabilities (relative to the remaining) of each fraction of the stick
-        z = expit(x)  # XXX consider to clamp to (0, 1) for stability if necessary
+        z = clipped_expit(x)
         z1m_cumprod = np.cumprod(1 - z, axis=-1)
         pad_width = [(0, 0)] * x.ndim
         pad_width[-1] = (0, 1)

--- a/numpyro/handlers.py
+++ b/numpyro/handlers.py
@@ -94,7 +94,7 @@ def apply_stack(msg):
         if msg.get("stop"):
             break
     if msg['value'] is None:
-        msg['value'] = msg['fn'](*msg['args'], **msg['kwargs'])
+        msg['value'] = msg['fn'].rvs(*msg['args'], **msg['kwargs'])
 
     # A Messenger that sets msg["stop"] == True also prevents application
     # of postprocess_message by Messengers above it on the stack

--- a/numpyro/hmc_util.py
+++ b/numpyro/hmc_util.py
@@ -557,10 +557,10 @@ def log_density(model, model_args, model_kwargs, params):
 def potential_energy(model, model_args, model_kwargs, transforms):
     def _potential_energy(params):
         params_constrained = {k: transforms[k](v) for k, v in params.items()}
-        log_joint = jax.partial(log_density, model, model_args, model_kwargs)(params)[0]
+        log_joint = jax.partial(log_density, model, model_args, model_kwargs)(params_constrained)[0]
         for name, t in transforms.items():
             log_joint = log_joint + np.sum(t.log_abs_det_jacobian(params[name], params_constrained[name]))
-        return log_joint
+        return - log_joint
 
     return _potential_energy
 

--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -121,12 +121,12 @@ def _identity(x):
 
 def tscan(f, a, bs, transform=_identity):
     if _DISABLE_CONTROL_FLOW_PRIM:
-        _tscan_nonprim(f, a, bs, transform=_identity)
+        return _tscan_nonprim(f, a, bs, transform)
     else:
         return _tscan(f, a, bs, transform)
 
 
-def _tscan_nonprim(f, a, bs, transform=_identity):
+def _tscan_nonprim(f, a, bs, transform):
     length = tree_flatten(bs)[0][0].shape[0]
     for i in range(length):
         b = tree_map(lambda x: x[i], bs)
@@ -140,7 +140,7 @@ def _tscan_nonprim(f, a, bs, transform=_identity):
     return out
 
 
-def _tscan(f, a, bs, transform=None):
+def _tscan(f, a, bs, transform):
     """
     Works as jax.lax.scan but has additional `fields` argument to select only
     necessary fields from `a`'s structure. Defaults to selecting only the first
@@ -172,17 +172,18 @@ def _tscan(f, a, bs, transform=None):
     a_pval = partial_eval.PartialVal((a_aval, core.unit))
     b_pval = partial_eval.PartialVal((b_aval, core.unit))
     jaxpr, pval_out, consts = partial_eval.trace_to_jaxpr(f, (a_pval, b_pval))
-    transform_jaxpr, _, _ = partial_eval.trace_to_jaxpr(transform_f, (a_pval,))
+    transform_jaxpr, _, t_consts = partial_eval.trace_to_jaxpr(transform_f, (a_pval,))
     aval_out, _ = pval_out
     consts = core.pack(consts)
 
-    out = tscan_p.bind(a, bs, consts, aval_out=aval_out, jaxpr=jaxpr, transform_jaxpr=transform_jaxpr)
+    out = tscan_p.bind(a, bs, consts, aval_out=aval_out, jaxpr=jaxpr, transform_jaxpr=transform_jaxpr,
+                       transform_consts=core.pack(t_consts))
     return tree_unflatten(transform_tree(), out)
 
 
-def _tscan_impl(a, bs, consts, aval_out, jaxpr, transform_jaxpr):
+def _tscan_impl(a, bs, consts, aval_out, jaxpr, transform_jaxpr, transform_consts):
     length = tuple(bs)[0].shape[0]
-    template = core.eval_jaxpr(transform_jaxpr, (), (), a)
+    template = core.eval_jaxpr(transform_jaxpr, transform_consts, (), a)
     state = [lax.full((length,) + np.shape(t), 0, lax._dtype(t)) for t in template]
 
     def body_fun(i, vals):
@@ -192,7 +193,7 @@ def _tscan_impl(a, bs, consts, aval_out, jaxpr, transform_jaxpr):
         a_out = core.eval_jaxpr(jaxpr, consts, (), a, core.pack(b))
 
         # select fields from a_out and update state
-        t_out = core.eval_jaxpr(transform_jaxpr, (), (), a_out)
+        t_out = core.eval_jaxpr(transform_jaxpr, transform_consts, (), a_out)
         state_out = [lax.dynamic_update_index_in_dim(s, t[None, ...], i, axis=0)
                      for t, s in zip(t_out, state)]
         return a_out, state_out

--- a/test/test_mcmc.py
+++ b/test/test_mcmc.py
@@ -8,7 +8,7 @@ import numpyro.distributions as dist
 from numpyro.handlers import sample
 from numpyro.hmc_util import initialize_model
 from numpyro.mcmc import hmc
-from numpyro.util import control_flow_prims_disabled, tscan
+from numpyro.util import tscan
 
 
 # TODO: add test for diag_mass=False
@@ -69,14 +69,14 @@ def test_beta_bernoulli(algo):
 
     true_probs = np.array([0.9, 0.1])
     data = dist.bernoulli(true_probs).rvs(size=(1000, 2), random_state=random.PRNGKey(0))
-    init_params, potential_fn, transforms = initialize_model(random.PRNGKey(2), model, (data,), {})
+    init_params, potential_fn, transform_fn = initialize_model(random.PRNGKey(2), model, (data,), {})
     init_kernel, sample_kernel = hmc(potential_fn, algo=algo)
     hmc_state = init_kernel(init_params,
                             step_size=0.1,
                             num_steps=15,
                             num_warmup_steps=warmup_steps)
     hmc_states = tscan(lambda state, i: sample_kernel(state), hmc_state, np.arange(num_samples),
-                       transform=lambda x: {k: transforms[k](v) for k, v in x.z.items()})
+                       transform=lambda x: transform_fn(x.z))
     assert_allclose(np.mean(hmc_states['p_latent'], 0), true_probs, rtol=0.05)
 
 
@@ -93,12 +93,12 @@ def test_dirichlet_categorical(algo):
 
     true_probs = np.array([0.1, 0.6, 0.3])
     data = dist.multinomial(p=true_probs, n=1).rvs(size=(2000,))
-    init_params, potential_fn, transforms = initialize_model(random.PRNGKey(2), model, (data,), {})
+    init_params, potential_fn, transform_fn = initialize_model(random.PRNGKey(2), model, (data,), {})
     init_kernel, sample_kernel = hmc(potential_fn, algo=algo)
     hmc_state = init_kernel(init_params,
                             step_size=0.1,
                             num_steps=15,
                             num_warmup_steps=warmup_steps)
     hmc_states = tscan(lambda state, i: sample_kernel(state), hmc_state, np.arange(num_samples),
-                       transform=lambda x: {k: transforms[k](v) for k, v in x.z.items()})
+                       transform=lambda x: transform_fn(x.z))
     assert_allclose(np.mean(hmc_states['p_latent'], 0), true_probs, rtol=0.05)

--- a/test/test_mcmc.py
+++ b/test/test_mcmc.py
@@ -2,13 +2,13 @@ import pytest
 from numpy.testing import assert_allclose
 
 import jax.numpy as np
-from jax import jit, random
+from jax import random
 
 import numpyro.distributions as dist
 from numpyro.handlers import sample
 from numpyro.hmc_util import initialize_model
 from numpyro.mcmc import hmc
-from numpyro.util import tscan
+from numpyro.util import control_flow_prims_disabled, tscan
 
 
 # TODO: add test for diag_mass=False
@@ -51,7 +51,54 @@ def test_logistic_regression(algo):
                             step_size=0.1,
                             num_steps=15,
                             num_warmup_steps=warmup_steps)
-    sample_kernel = jit(sample_kernel)
     hmc_states = tscan(lambda state, i: sample_kernel(state), hmc_state, np.arange(num_samples),
                        transform=lambda x: {k: transforms[k](v) for k, v in x.z.items()})
     assert_allclose(np.mean(hmc_states['coefs'], 0), true_coefs, atol=0.2)
+
+
+@pytest.mark.parametrize('algo', ['HMC', 'NUTS'])
+def test_beta_bernoulli(algo):
+    warmup_steps, num_samples = 100, 1000
+
+    def model(data):
+        alpha = np.array([1.1, 1.1])
+        beta = np.array([1.1, 1.1])
+        p_latent = sample('p_latent', dist.beta(alpha, beta))
+        sample('obs', dist.bernoulli(p_latent), obs=data)
+        return p_latent
+
+    true_probs = np.array([0.9, 0.1])
+    data = dist.bernoulli(true_probs).rvs(size=(1000, 2), random_state=random.PRNGKey(0))
+    init_params, potential_fn, transforms = initialize_model(random.PRNGKey(2), model, (data,), {})
+    init_kernel, sample_kernel = hmc(potential_fn, algo=algo)
+    hmc_state = init_kernel(init_params,
+                            step_size=0.1,
+                            num_steps=15,
+                            num_warmup_steps=warmup_steps)
+    hmc_states = tscan(lambda state, i: sample_kernel(state), hmc_state, np.arange(num_samples),
+                       transform=lambda x: {k: transforms[k](v) for k, v in x.z.items()})
+    assert_allclose(np.mean(hmc_states['p_latent'], 0), true_probs, rtol=0.05)
+
+
+@pytest.mark.parametrize('algo', ['HMC', 'NUTS'])
+@pytest.mark.xfail(reason=".support() does not work for multivariate distributions.")
+def test_dirichlet_categorical(algo):
+    warmup_steps, num_samples = 100, 1000
+
+    def model(data):
+        concentration = np.array([1.0, 1.0, 1.0])
+        p_latent = sample('p_latent', dist.dirichlet(alpha=concentration))
+        sample("obs", dist.multinomial(p=p_latent, n=1), obs=data)
+        return p_latent
+
+    true_probs = np.array([0.1, 0.6, 0.3])
+    data = dist.multinomial(p=true_probs, n=1).rvs(size=(2000,))
+    init_params, potential_fn, transforms = initialize_model(random.PRNGKey(2), model, (data,), {})
+    init_kernel, sample_kernel = hmc(potential_fn, algo=algo)
+    hmc_state = init_kernel(init_params,
+                            step_size=0.1,
+                            num_steps=15,
+                            num_warmup_steps=warmup_steps)
+    hmc_states = tscan(lambda state, i: sample_kernel(state), hmc_state, np.arange(num_samples),
+                       transform=lambda x: {k: transforms[k](v) for k, v in x.z.items()})
+    assert_allclose(np.mean(hmc_states['p_latent'], 0), true_probs, rtol=0.05)


### PR DESCRIPTION
This is based off of @fehiepsi's suggestion in #107. 
 - The nice thing is that no changes are needed within the `hmc` implementation, since that only takes in a potential energy computation. So this only involves a change in `potential_energy` computation and the `initialize_model` functions.
 - The not so nice thing is that the user needs to write some boiler-plate code to transform the latent sites to constrained space, but this doesn't seem too bad, and besides this is unavoidable with the current API where HMC does not access the model directly. We could, in the future, provide some convenience wrappers that could take in a model callable directly to wrap over the boiler-plate code.
 - Made some changes to `tscan` so that the non-primitive version works with more complex transforms.
 - Added a `clipped_expit` without which the beta-bernoulli model gives NaNs.

TODO: When `.support` works with multivariate distributions, I will remove the `xfail` marker from `test_dirichlet_categorical`. I intend to fix this directly in `contrib.distributions`.