### PR TITLE
JIT tscan and HMC warmup steps

### DIFF
--- a/numpyro/__init__.py
+++ b/numpyro/__init__.py
@@ -1,0 +1,1 @@
+import numpyro.patch

--- a/numpyro/__init__.py
+++ b/numpyro/__init__.py
@@ -1,1 +1,1 @@
-import numpyro.patch
+import numpyro.patch  # noqa: F401

--- a/numpyro/examples/covtype.py
+++ b/numpyro/examples/covtype.py
@@ -16,7 +16,7 @@ from numpyro.util import tscan
 
 
 step_size = 0.00167132
-init_params = {"coefs": np.array(
+init_params = {"coefs": onp.array(
     [+2.03420663e+00, -3.53567265e-02, -1.49223924e-01, -3.07049364e-01,
      -1.00028366e-01, -1.46827862e-01, -1.64167881e-01, -4.20344204e-01,
      +9.47479829e-02, -1.12681836e-02, +2.64442056e-01, -1.22087866e-01,
@@ -63,10 +63,7 @@ def model(data, labels):
 
 
 def benchmark_hmc(args, features, labels):
-    N, dim = features.shape
     trajectory_length = step_size * args.num_steps
-    init_params = {'coefs': random.normal(key=random.PRNGKey(0), shape=(dim,))}
-
     _, potential_fn, _ = initialize_model(random.PRNGKey(1), model, (features, labels,), {})
     init_kernel, sample_kernel = hmc(potential_fn, algo=args.algo)
     t0 = time.time()

--- a/numpyro/examples/covtype.py
+++ b/numpyro/examples/covtype.py
@@ -57,7 +57,6 @@ def benchmark_hmc(args, features, labels):
                                   trajectory_length=trajectory_length, run_warmup=False)
     t1 = time.time()
     print("time for hmc_init: ", t1 - t0)
-    hmc_state = hmc_state.update(step_size=1.)
 
     def transform(state): return {'coefs': state.z['coefs'],
                                   'num_steps': state.num_steps}

--- a/numpyro/examples/covtype.py
+++ b/numpyro/examples/covtype.py
@@ -64,6 +64,7 @@ def benchmark_hmc(args, features, labels):
     def body_fn(state, i):
         return sample_kernel(state)
 
+    hmc_state = hmc_state.update(step_size=1.)
     tscan(body_fn, hmc_state, np.arange(1), transform=transform)
     t2 = time.time()
     print("time to compile sample_kernel: ", t2 - t1)

--- a/numpyro/examples/covtype.py
+++ b/numpyro/examples/covtype.py
@@ -15,7 +15,7 @@ from numpyro.mcmc import hmc
 from numpyro.util import tscan
 
 
-jax.config.update("jax_platform_name", "gpu")
+
 
 
 # TODO: add to datasets.py so as to avoid dependency on scikit-learn
@@ -76,6 +76,7 @@ def benchmark_hmc(args, features, labels):
 
 
 def main(args):
+    jax.config.update("jax_platform_name", args.device)
     features, labels = load_dataset()
     benchmark_hmc(args, features, labels)
 
@@ -85,5 +86,6 @@ if __name__ == '__main__':
     parser.add_argument('-n', '--num-samples', default=100, type=int, help='number of samples')
     parser.add_argument('--num-steps', default=10, type=int, help='number of steps (for "HMC")')
     parser.add_argument('--algo', default='NUTS', type=str, help='whether to run "HMC" or "NUTS"')
+    parser.add_argument('--device', default='cpu', type=str, help='use "cpu" or "cuda".')
     args = parser.parse_args()
     main(args)

--- a/numpyro/examples/covtype.py
+++ b/numpyro/examples/covtype.py
@@ -4,6 +4,7 @@ import time
 import numpy as onp
 from sklearn.datasets import fetch_covtype
 
+import jax
 import jax.numpy as np
 from jax import random
 
@@ -12,6 +13,9 @@ from numpyro.handlers import sample
 from numpyro.hmc_util import initialize_model
 from numpyro.mcmc import hmc
 from numpyro.util import tscan
+
+
+jax.config.update("jax_platform_name", "gpu")
 
 
 # TODO: add to datasets.py so as to avoid dependency on scikit-learn
@@ -69,7 +73,6 @@ def benchmark_hmc(args, features, labels):
     num_leapfrogs = np.sum(hmc_states['num_steps'])
     print('number of leapfrog steps: ', num_leapfrogs)
     print('avg. time for each step: ', (time.time() - t1) / num_leapfrogs)
-    print(hmc_states['coefs'])
 
 
 def main(args):

--- a/numpyro/examples/covtype.py
+++ b/numpyro/examples/covtype.py
@@ -47,7 +47,7 @@ def benchmark_hmc(args, features, labels):
     N, dim = features.shape
     step_size = np.sqrt(0.5 / N)
     trajectory_length = step_size * args.num_steps
-    init_params = {'coefs': np.zeros(dim)}
+    init_params = {'coefs': random.normal(key=random.PRNGKey(0), shape=(dim,))}
 
     _, potential_fn, _ = initialize_model(random.PRNGKey(1), model, (features, labels,), {})
     init_kernel, sample_kernel = hmc(potential_fn, algo=args.algo)
@@ -64,15 +64,12 @@ def benchmark_hmc(args, features, labels):
     def body_fn(state, i):
         return sample_kernel(state)
 
-    hmc_state = hmc_state.update(step_size=1.)
-    tscan(body_fn, hmc_state, np.arange(1), transform=transform)
-    t2 = time.time()
-    print("time to compile sample_kernel: ", t2 - t1)
     hmc_state = hmc_state.update(step_size=step_size)
     hmc_states = tscan(body_fn, hmc_state, np.arange(args.num_samples), transform=transform)
     num_leapfrogs = np.sum(hmc_states['num_steps'])
     print('number of leapfrog steps: ', num_leapfrogs)
-    print('avg. time for each step: ', (time.time() - t2) / num_leapfrogs)
+    print('avg. time for each step: ', (time.time() - t1) / num_leapfrogs)
+    print(hmc_states['coefs'])
 
 
 def main(args):

--- a/numpyro/examples/covtype.py
+++ b/numpyro/examples/covtype.py
@@ -1,0 +1,89 @@
+import argparse
+import time
+
+import numpy as onp
+from sklearn.datasets import fetch_covtype
+
+import jax.numpy as np
+from jax import random
+
+import numpyro.distributions as dist
+from numpyro.handlers import sample
+from numpyro.hmc_util import initialize_model
+from numpyro.mcmc import hmc
+from numpyro.util import tscan
+
+
+# TODO: add to datasets.py so as to avoid dependency on scikit-learn
+def load_dataset():
+    data = fetch_covtype()
+    features = data.data
+    labels = data.target
+
+    # normalize features and add intercept
+    features = (features - features.mean(0)) / features.std(0)
+    features = np.hstack([features, np.ones((features.shape[0], 1))])
+
+    # make binary feature
+    _, counts = onp.unique(labels, return_counts=True)
+    specific_category = np.argmax(counts)
+    labels = (labels == specific_category)
+
+    N, dim = features.shape
+    print("Data shape:", features.shape)
+    print("Label distribution: {} has label 1, {} has label 0"
+          .format(labels.sum(), N - labels.sum()))
+    return features, labels
+
+
+def model(data, labels):
+    N, dim = data.shape
+    coefs = sample('coefs', dist.norm(np.zeros(dim), np.ones(dim)))
+    logits = np.dot(data, coefs)
+    return sample('obs', dist.bernoulli(logits, is_logits=True), obs=labels)
+
+
+def benchmark_hmc(args, features, labels):
+    N, dim = features.shape
+    step_size = np.sqrt(0.5 / N)
+    trajectory_length = step_size * args.num_steps
+    init_params = {'coefs': np.zeros(dim)}
+
+    _, potential_fn, _ = initialize_model(random.PRNGKey(1), model, (features, labels,), {})
+    init_kernel, sample_kernel = hmc(potential_fn, algo=args.algo)
+    t0 = time.time()
+    # Do not run warmup for consistent benchmark
+    hmc_state, _, _ = init_kernel(init_params, num_warmup_steps=0, step_size=step_size,
+                                  trajectory_length=trajectory_length, run_warmup=False)
+    t1 = time.time()
+    print("time for hmc_init: ", t1 - t0)
+    hmc_state = hmc_state.update(step_size=1.)
+
+    def transform(state): return {'coefs': state.z['coefs'],
+                                  'num_steps': state.num_steps}
+
+    def body_fn(state, i):
+        return sample_kernel(state)
+
+    tscan(body_fn, hmc_state, np.arange(1), transform=transform)
+    t2 = time.time()
+    print("time to compile sample_kernel: ", t2 - t1)
+    hmc_state = hmc_state.update(step_size=step_size)
+    hmc_states = tscan(body_fn, hmc_state, np.arange(args.num_samples), transform=transform)
+    num_leapfrogs = np.sum(hmc_states['num_steps'])
+    print('number of leapfrog steps: ', num_leapfrogs)
+    print('avg. time for each step: ', (time.time() - t2) / num_leapfrogs)
+
+
+def main(args):
+    features, labels = load_dataset()
+    benchmark_hmc(args, features, labels)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="parse args")
+    parser.add_argument('-n', '--num-samples', default=100, type=int, help='number of samples')
+    parser.add_argument('--num-steps', default=10, type=int, help='number of steps (for "HMC")')
+    parser.add_argument('--algo', default='NUTS', type=str, help='whether to run "HMC" or "NUTS"')
+    args = parser.parse_args()
+    main(args)

--- a/numpyro/mcmc.py
+++ b/numpyro/mcmc.py
@@ -7,7 +7,7 @@ from jax.random import PRNGKey
 
 import numpyro.distributions as dist
 from numpyro.hmc_util import IntegratorState, build_tree, find_reasonable_step_size, velocity_verlet, warmup_adapter
-from numpyro.util import cond, fori_loop, laxtuple, tscan
+from numpyro.util import cond, fori_loop, laxtuple
 
 HMCState = laxtuple('HMCState', ['z', 'z_grad', 'potential_energy', 'num_steps', 'accept_prob',
                                  'step_size', 'inverse_mass_matrix', 'rng'])

--- a/numpyro/mcmc.py
+++ b/numpyro/mcmc.py
@@ -1,7 +1,7 @@
 import math
 
 import jax.numpy as np
-from jax import partial, random, jit
+from jax import jit, partial, random
 from jax.flatten_util import ravel_pytree
 from jax.random import PRNGKey
 

--- a/numpyro/patch.py
+++ b/numpyro/patch.py
@@ -1,0 +1,28 @@
+import jax
+import jax.interpreters.partial_eval as pe
+import jax.linear_util as lu
+
+
+def patch_dependency(target, root_module):
+    parts = target.split('.')
+    assert parts[0] == root_module.__name__
+    module = root_module
+    for part in parts[1:-1]:
+        module = getattr(module, part)
+    name = parts[-1]
+    old_fn = getattr(module, name)
+    old_fn = getattr(old_fn, '_pyro_unpatched', old_fn)  # ensure patching is idempotent
+
+    def decorator(new_fn):
+        new_fn.__name__ = name
+        new_fn._pyro_unpatched = old_fn
+        setattr(module, name, new_fn)
+        return new_fn
+
+    return decorator
+
+
+# TODO: Remove with jax v0.1.26
+@patch_dependency('jax.interpreters.partial_eval.trace_unwrapped_to_jaxpr', jax)
+def _trace_unwrapped_to_jaxpr(fun, pvals, **kwargs):
+    return pe.trace_to_jaxpr(lu.wrap_init(fun, kwargs), pvals)

--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -2,15 +2,14 @@ import random
 from collections import namedtuple
 from contextlib import contextmanager
 
-import jax
 import numpy as onp
 
+import jax
 import jax.numpy as np
 from jax import core, lax
 from jax.abstract_arrays import ShapedArray
 from jax.api_util import pytree_fun_to_flatjaxtuple_fun, pytree_to_flatjaxtuple
 from jax.interpreters import partial_eval, xla
-from jax.interpreters.xla import aval_from_xla_shape
 from jax.linear_util import wrap_init
 from jax.tree_util import register_pytree_node, tree_flatten, tree_map, tree_multimap, tree_unflatten
 from jax.util import partial

--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -2,6 +2,7 @@ import random
 from collections import namedtuple
 from contextlib import contextmanager
 
+import jax
 import numpy as onp
 
 import jax.numpy as np
@@ -9,6 +10,7 @@ from jax import core, lax
 from jax.abstract_arrays import ShapedArray
 from jax.api_util import pytree_fun_to_flatjaxtuple_fun, pytree_to_flatjaxtuple
 from jax.interpreters import partial_eval, xla
+from jax.interpreters.xla import aval_from_xla_shape
 from jax.linear_util import wrap_init
 from jax.tree_util import register_pytree_node, tree_flatten, tree_map, tree_multimap, tree_unflatten
 from jax.util import partial
@@ -119,6 +121,7 @@ def _identity(x):
     return x
 
 
+@jax.partial(jax.jit, static_argnums=(0, 3))
 def tscan(f, a, bs, transform=_identity):
     if _DISABLE_CONTROL_FLOW_PRIM:
         return _tscan_nonprim(f, a, bs, transform)
@@ -171,17 +174,17 @@ def _tscan(f, a, bs, transform):
     # convert abstract values to partial values (?) then evaluate to get jaxpr
     a_pval = partial_eval.PartialVal((a_aval, core.unit))
     b_pval = partial_eval.PartialVal((b_aval, core.unit))
-    jaxpr, pval_out, consts = partial_eval.trace_to_jaxpr(f, (a_pval, b_pval))
-    transform_jaxpr, _, t_consts = partial_eval.trace_to_jaxpr(transform_f, (a_pval,))
+    jaxpr, intermed_out, consts = partial_eval.trace_to_jaxpr(f, (a_pval, b_pval))
+    transform_jaxpr, pval_out, t_consts = partial_eval.trace_to_jaxpr(transform_f, (intermed_out,))
     aval_out, _ = pval_out
     consts = core.pack(consts)
 
-    out = tscan_p.bind(a, bs, consts, aval_out=aval_out, jaxpr=jaxpr, transform_jaxpr=transform_jaxpr,
-                       transform_consts=core.pack(t_consts))
+    out = tscan_p.bind(a, bs, consts=consts, transform_consts=core.pack(t_consts), aval_out=aval_out,
+                       jaxpr=jaxpr, transform_jaxpr=transform_jaxpr)
     return tree_unflatten(transform_tree(), out)
 
 
-def _tscan_impl(a, bs, consts, aval_out, jaxpr, transform_jaxpr, transform_consts):
+def _tscan_impl(a, bs, consts, transform_consts, aval_out, jaxpr, transform_jaxpr):
     length = tuple(bs)[0].shape[0]
     template = core.eval_jaxpr(transform_jaxpr, transform_consts, (), a)
     state = [lax.full((length,) + np.shape(t), 0, lax._dtype(t)) for t in template]
@@ -202,7 +205,7 @@ def _tscan_impl(a, bs, consts, aval_out, jaxpr, transform_jaxpr, transform_const
     return core.pack(state)
 
 
-def _tscan_abstract_eval(a, bs, fields, consts, aval_out, jaxpr):
+def _tscan_abstract_eval(a, bs, consts, transform_consts, aval_out, jaxpr, transform_jaxpr):
     return lax.maybe_tracer_tuple_to_abstract_tuple(aval_out)
 
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,5 +1,8 @@
+import os
+
 from numpyro.util import set_rng_seed
 
 
 def pytest_runtest_setup(item):
     set_rng_seed(0)
+    os.environ['XLA_FLAGS'] = '--xla_cpu_enable_fast_math=false'

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,8 +1,5 @@
-import os
-
 from numpyro.util import set_rng_seed
 
 
 def pytest_runtest_setup(item):
     set_rng_seed(0)
-    os.environ['XLA_FLAGS'] = '--xla_cpu_enable_fast_math=false'


### PR DESCRIPTION
Fixes #114. 

This fixes the issue with `tscan` not being jittable. With this change and jitting the `warmup_update` step, we get significantly faster run times, specially for NUTS. e.g. for `test_beta_bernoulli`, the run time goes down from 21s to 15s. 

I have also added a minimal version of @fehiepsi's #92 as an example to test how this change fares on the benchmark, and also so that it is easy to make changes and see how the benchmark moves (which takes a few more steps in a jupyter notebook). It seems that this is competitive for HMC, but for NUTS, this is still quite slow. @fehiepsi - is it important to start with the step size and initial param values as in the notebook?

TODO:
 - [x] Figure out why NUTS is still slow wrt the original benchmark.

