### PR TITLE
Add fori_append construct in util

### DIFF
--- a/numpyro/examples/covtype.py
+++ b/numpyro/examples/covtype.py
@@ -12,8 +12,7 @@ import numpyro.distributions as dist
 from numpyro.handlers import sample
 from numpyro.hmc_util import initialize_model
 from numpyro.mcmc import hmc
-from numpyro.util import tscan
-
+from numpyro.util import fori_append
 
 step_size = 0.00167132
 init_params = {"coefs": onp.array(
@@ -77,11 +76,9 @@ def benchmark_hmc(args, features, labels):
     def transform(state): return {'coefs': state.z['coefs'],
                                   'num_steps': state.num_steps}
 
-    def body_fn(state, i):
-        return sample_kernel(state)
-
     hmc_state = hmc_state.update(step_size=step_size)
-    hmc_states = tscan(body_fn, hmc_state, np.arange(args.num_samples), transform=transform)
+    hmc_states = fori_append(sample_kernel, hmc_state, args.num_samples,
+                             transform=transform)
     num_leapfrogs = np.sum(hmc_states['num_steps'])
     print('number of leapfrog steps: ', num_leapfrogs)
     print('avg. time for each step: ', (time.time() - t1) / num_leapfrogs)

--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -1,5 +1,4 @@
 import random
-import time
 from collections import namedtuple
 from contextlib import contextmanager
 

--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -1,4 +1,5 @@
 import random
+import time
 from collections import namedtuple
 from contextlib import contextmanager
 
@@ -212,3 +213,28 @@ tscan_p = core.Primitive('tscan')
 tscan_p.def_impl(_tscan_impl)
 tscan_p.def_abstract_eval(_tscan_abstract_eval)
 xla.translations[tscan_p] = partial(xla.lower_fun, _tscan_impl)
+
+
+def fori_append(f, a, n, transform, jit=True):
+    init_val, a_treedef = tree_flatten(a)
+    a, trans_treedef = tree_flatten(transform(a))
+    state = [lax.full((n,) + np.shape(i), 0, lax._dtype(i)) for i in a]
+
+    def body_fun(i, vals):
+        a, state = vals
+        a = tree_unflatten(a_treedef, a)
+        a_out = f(a)
+        state_out = transform(a_out)
+        a_out, state_out = tree_flatten(a_out)[0], tree_flatten(state_out)[0]
+        state_out = [lax.dynamic_update_index_in_dim(s, t[None, ...], i, axis=0)
+                     for t, s in zip(state_out, state)]
+        return a_out, state_out
+
+    def fn_loop(n, x): return lax.fori_loop(0, n, body_fun, x)
+
+    if jit:
+        # JIT on a single step.
+        fn_loop = jax.jit(fn_loop)
+        fn_loop(1, (init_val, state))
+    _, state = fn_loop(n, (init_val, state))
+    return tree_unflatten(trans_treedef, state)

--- a/test/test_mcmc.py
+++ b/test/test_mcmc.py
@@ -2,7 +2,7 @@ import pytest
 from numpy.testing import assert_allclose
 
 import jax.numpy as np
-from jax import random, jit
+from jax import random
 
 import numpyro.distributions as dist
 from numpyro.handlers import sample
@@ -50,7 +50,7 @@ def test_logistic_regression(algo):
     hmc_state = init_kernel(init_params,
                             trajectory_length=10,
                             num_warmup_steps=warmup_steps)
-    hmc_states = fori_append(jit(sample_kernel), hmc_state, num_samples,
+    hmc_states = fori_append(sample_kernel, hmc_state, num_samples,
                              transform=lambda x: transform_fn(x.z))
     assert_allclose(np.mean(hmc_states['coefs'], 0), true_coefs, atol=0.2)
 

--- a/test/test_mcmc.py
+++ b/test/test_mcmc.py
@@ -2,13 +2,13 @@ import pytest
 from numpy.testing import assert_allclose
 
 import jax.numpy as np
-from jax import random
+from jax import random, jit
 
 import numpyro.distributions as dist
 from numpyro.handlers import sample
 from numpyro.hmc_util import initialize_model
 from numpyro.mcmc import hmc
-from numpyro.util import tscan
+from numpyro.util import fori_append
 
 
 # TODO: add test for diag_mass=False
@@ -25,8 +25,8 @@ def test_unnormalized_normal(algo):
     hmc_state = init_kernel(init_samples,
                             trajectory_length=10,
                             num_warmup_steps=warmup_steps)
-    hmc_states = tscan(lambda state, i: sample_kernel(state), hmc_state, np.arange(num_samples),
-                       transform=lambda x: x.z)
+    hmc_states = fori_append(sample_kernel, hmc_state, num_samples,
+                             transform=lambda x: x.z)
     assert_allclose(np.mean(hmc_states), true_mean, rtol=0.05)
     assert_allclose(np.std(hmc_states), true_std, rtol=0.05)
 
@@ -50,8 +50,8 @@ def test_logistic_regression(algo):
     hmc_state = init_kernel(init_params,
                             trajectory_length=10,
                             num_warmup_steps=warmup_steps)
-    hmc_states = tscan(lambda state, i: sample_kernel(state), hmc_state, np.arange(num_samples),
-                       transform=lambda x: transform_fn(x.z))
+    hmc_states = fori_append(jit(sample_kernel), hmc_state, num_samples,
+                             transform=lambda x: transform_fn(x.z))
     assert_allclose(np.mean(hmc_states['coefs'], 0), true_coefs, atol=0.2)
 
 
@@ -73,8 +73,8 @@ def test_beta_bernoulli(algo):
     hmc_state = init_kernel(init_params,
                             trajectory_length=1.,
                             num_warmup_steps=warmup_steps)
-    hmc_states = tscan(lambda state, i: sample_kernel(state), hmc_state, np.arange(num_samples),
-                       transform=lambda x: transform_fn(x.z))
+    hmc_states = fori_append(sample_kernel, hmc_state, num_samples,
+                             transform=lambda x: transform_fn(x.z))
     assert_allclose(np.mean(hmc_states['p_latent'], 0), true_probs, atol=0.05)
 
 
@@ -95,6 +95,6 @@ def test_dirichlet_categorical(algo):
     hmc_state = init_kernel(init_params,
                             trajectory_length=1.,
                             num_warmup_steps=warmup_steps)
-    hmc_states = tscan(lambda state, i: sample_kernel(state), hmc_state, np.arange(num_samples),
-                       transform=lambda x: transform_fn(x.z))
+    hmc_states = fori_append(sample_kernel, hmc_state, num_samples,
+                             transform=lambda x: transform_fn(x.z))
     assert_allclose(np.mean(hmc_states['p_latent'], 0), true_probs, atol=0.02)

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -6,7 +6,7 @@ from jax import lax
 from jax.test_util import check_eq
 from jax.tree_util import tree_map
 
-from numpyro.util import control_flow_prims_disabled, laxtuple, optional, scan, tscan
+from numpyro.util import control_flow_prims_disabled, laxtuple, optional, scan, tscan, fori_append
 
 
 @pytest.mark.parametrize('prims_disabled', [True, False])
@@ -41,6 +41,17 @@ def test_tscan_dict(prims_disabled):
     expected_tree = {'i': scan_tree['i']}
     with optional(prims_disabled, control_flow_prims_disabled()):
         actual_tree = tscan(f, a, bs, transform=lambda a: {'i': a['i']})
+    check_eq(actual_tree, expected_tree)
+
+
+def test_fori_append():
+    def f(x):
+        return {'i': x['i'] + x['j'], 'j': x['i'] - x['j']}
+
+    a = {'i': np.array([0.]), 'j': np.array([1.])}
+    scan_tree = lax.scan(lambda x, y: f(x), a, np.arange(3))
+    expected_tree = {'i': scan_tree['i']}
+    actual_tree = fori_append(f, a, 3, transform=lambda a: {'i': a['i']})
     check_eq(actual_tree, expected_tree)
 
 


### PR DESCRIPTION
This introduces a simpler version of `tscan` called `fori_append`, which as the name suggests, runs a for loop and gathers the results along the leading dimension of the pytree arg. This is simpler than the existing `tscan` version and slightly faster. 

Few things that I discovered:
 - Jitting the internal `fori_loop` is important. I have a version of this that uses a standard python `for` loop (and lax dynamic slice update) and only uses a jitted `f` arg, but it is slower (sometimes 2X so). Unfortunately, that also means that we cannot use the JITed version with tqdm / other updates. But we can probably use `jit=False` and print diagnostic information if needed.
 - After trying out many other versions, it seems unlikely that we can get further performance improvements from just the JIT alone. 
 - The `sample_kernel` if already compiled should be quite fast, i.e. there is no issue with double compilation.