### PR TITLE
Add more distributions to contrib

### DIFF
--- a/numpyro/contrib/distributions/__init__.py
+++ b/numpyro/contrib/distributions/__init__.py
@@ -1,14 +1,49 @@
-from numpyro.contrib.distributions.continuous import Cauchy, Exponential, HalfCauchy, Normal, Uniform
-from numpyro.contrib.distributions.discrete import Bernoulli, BernoulliWithLogits, Binomial, BinomialWithLogits
+from numpyro.contrib.distributions.continuous import (
+    Beta,
+    Cauchy,
+    Chi2,
+    Dirichlet,
+    Exponential,
+    Gamma,
+    HalfCauchy,
+    LogNormal,
+    Normal,
+    Pareto,
+    StudentT,
+    Uniform,
+)
+from numpyro.contrib.distributions.discrete import (
+    Bernoulli,
+    BernoulliWithLogits,
+    Binomial,
+    BinomialWithLogits,
+    Categorical,
+    CategoricalWithLogits,
+    Multinomial,
+    MultinomialWithLogits,
+    Poisson,
+)
 
 __all__ = [
     'Bernoulli',
     'BernoulliWithLogits',
+    'Beta',
     'Binomial',
     'BinomialWithLogits',
+    'Categorical',
+    'CategoricalWithLogits',
     'Cauchy',
+    'Chi2',
+    'Dirichlet',
     'Exponential',
+    'Gamma',
     'HalfCauchy',
+    'LogNormal',
+    'Multinomial',
+    'MultinomialWithLogits',
     'Normal',
+    'Pareto',
+    'Poisson',
+    'StudentT',
     'Uniform',
 ]

--- a/numpyro/contrib/distributions/continuous.py
+++ b/numpyro/contrib/distributions/continuous.py
@@ -1,15 +1,72 @@
+# The implementation largely follows the design in PyTorch's `torch.distributions`
+#
+# Copyright (c) 2016-     Facebook, Inc            (Adam Paszke)
+# Copyright (c) 2014-     Facebook, Inc            (Soumith Chintala)
+# Copyright (c) 2011-2014 Idiap Research Institute (Ronan Collobert)
+# Copyright (c) 2012-2014 Deepmind Technologies    (Koray Kavukcuoglu)
+# Copyright (c) 2011-2012 NEC Laboratories America (Koray Kavukcuoglu)
+# Copyright (c) 2011-2013 NYU                      (Clement Farabet)
+# Copyright (c) 2006-2010 NEC Laboratories America (Ronan Collobert, Leon Bottou, Iain Melvin, Jason Weston)
+# Copyright (c) 2006      Idiap Research Institute (Samy Bengio)
+# Copyright (c) 2001-2004 Idiap Research Institute (Ronan Collobert, Samy Bengio, Johnny Mariethoz)
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+
 import jax.numpy as np
 import jax.random as random
 from jax import lax
+from jax.scipy.special import gammaln
 
 from numpyro.contrib.distributions.distribution import Distribution, TransformedDistribution
 from numpyro.distributions import constraints
-from numpyro.distributions.transforms import AbsTransform
-from numpyro.distributions.util import get_dtypes, promote_shapes
+from numpyro.distributions.transforms import AbsTransform, ExpTransform, AffineTransform
+from numpyro.distributions.util import get_dtypes, promote_shapes, standard_gamma
+
+
+class Beta(Distribution):
+    arg_constraints = {'concentration1': constraints.positive, 'concentration0': constraints.positive}
+    support = constraints.unit_interval
+
+    def __init__(self, concentration1, concentration0, validate_args=None):
+        batch_shape = lax.broadcast_shapes(np.shape(concentration1), np.shape(concentration0))
+        self.concentration1 = np.broadcast_to(concentration1, batch_shape)
+        self.concentration0 = np.broadcast_to(concentration0, batch_shape)
+        self._dirichlet = Dirichlet(np.stack([self.concentration1, self.concentration0],
+                                             axis=-1))
+        super(Beta, self).__init__(batch_shape=batch_shape, validate_args=validate_args)
+
+    def sample(self, key, size=()):
+        return self._dirichlet.sample(key, size=size)[..., 0]
+
+    def log_prob(self, value):
+        if self._validate_args:
+            self._validate_sample(value)
+        return self._dirichlet.log_prob(np.stack([value, 1. - value], -1))
+
+    @property
+    def mean(self):
+        return self.concentration1 / (self.concentration1 + self.concentration0)
+
+    @property
+    def variance(self):
+        total = self.concentration1 + self.concentration0
+        return (self.concentration1 * self.concentration0 /
+                (total ** 2 * (total + 1)))
 
 
 class Cauchy(Distribution):
-    is_reparametrized = True
+    reparametrized_params = [(0, 'loc'), (1, 'scale')]
     arg_constraints = {'loc': constraints.real, 'scale': constraints.positive}
     support = constraints.real
 
@@ -37,8 +94,83 @@ class Cauchy(Distribution):
         return np.broadcast_to(np.nan, self.batch_shape)
 
 
+class Dirichlet(Distribution):
+    arg_constraints = {'concentration': constraints.positive}
+    support = constraints.simplex
+
+    def __init__(self, concentration, validate_args=None):
+        if np.ndim(concentration) < 1:
+            raise ValueError("`concentration` parameter must be at least one-dimensional.")
+        self.concentration = concentration
+        batch_shape, event_shape = concentration.shape[:-1], concentration.shape[-1:]
+        super(Dirichlet, self).__init__(batch_shape=batch_shape,
+                                        event_shape=event_shape,
+                                        validate_args=validate_args)
+
+    def sample(self, key, size=()):
+        shape = size + self.batch_shape + self.event_shape
+        gamma_samples = standard_gamma(key, self.concentration, shape=shape)
+        return gamma_samples / np.sum(gamma_samples, axis=-1, keepdims=True)
+
+    def log_prob(self, value):
+        if self._validate_args:
+            self._validate_sample(value)
+        return (np.sum(np.log(value) * (self.concentration - 1.), axis=-1) +
+                gammaln(np.sum(self.concentration, axis=-1)) -
+                np.sum(gammaln(self.concentration), axis=-1))
+
+    @property
+    def mean(self):
+        return np.broadcast_to(self.concentration / np.sum(self.concentration, axis=-1, keepdims=True),
+                               self.batch_shape + self.event_shape)
+
+    @property
+    def variance(self):
+        con0 = np.sum(self.concentration, axis=-1, keepdims=True)
+        return np.broadcast_to(self.concentration * (con0 - self.concentration) /
+                               (con0 ** 2 * (con0 + 1)),
+                               self.batch_shape + self.event_shape)
+
+
+class Gamma(Distribution):
+    arg_constraints = {'concentration': constraints.positive,
+                       'rate': constraints.positive}
+    support = constraints.simplex
+
+    def __init__(self, concentration, rate, validate_args=None):
+        self.concentration, self.rate = promote_shapes(concentration, rate)
+        batch_shape = lax.broadcast_shapes(np.shape(concentration), np.shape(rate))
+        super(Gamma, self).__init__(batch_shape=batch_shape,
+                                    validate_args=validate_args)
+
+    def sample(self, key, size=()):
+        shape = size + self.batch_shape + self.event_shape
+        return standard_gamma(key, self.concentration, shape=shape) / self.rate
+
+    def log_prob(self, value):
+        if self._validate_args:
+            self._validate_sample(value)
+        return (self.concentration * np.log(self.rate) + (self.concentration - 1) * np.log(value) -
+                self.rate * value - gammaln(self.concentration))
+
+    @property
+    def mean(self):
+        return np.broadcast_to(self.concentration / self.rate, self.batch_shape)
+
+    @property
+    def variance(self):
+        return np.broadcast_to(self.concentration / np.power(self.rate, 2), self.batch_shape)
+
+
+class Chi2(Gamma):
+    arg_constraints = {'df': constraints.positive}
+
+    def __init__(self, df, validate_args=None):
+        super(Chi2, self).__init__(0.5 * df, 0.5, validate_args=validate_args)
+
+
 class Exponential(Distribution):
-    is_reparametrized = True
+    reparametrized_params = [(0, 'rate')]
     arg_constraints = {'rate': constraints.positive}
     support = constraints.positive
 
@@ -65,7 +197,7 @@ class Exponential(Distribution):
 
 
 class HalfCauchy(TransformedDistribution):
-    is_reparametrized = True
+    reparametrized_params = [(0, 'scale')]
     arg_constraints = {'scale': constraints.positive}
     support = constraints.positive
 
@@ -92,9 +224,9 @@ class HalfCauchy(TransformedDistribution):
 
 
 class Normal(Distribution):
-    is_reparametrized = True
     arg_constraints = {'loc': constraints.real, 'scale': constraints.positive}
     support = constraints.real
+    reparametrized_params = [(0, 'loc'), (1, 'scale')]
 
     def __init__(self, loc, scale, validate_args=None):
         self.loc, self.scale = promote_shapes(loc, scale)
@@ -120,9 +252,56 @@ class Normal(Distribution):
         return np.broadcast_to(self.scale ** 2, self.batch_shape)
 
 
+class LogNormal(TransformedDistribution):
+    arg_constraints = {'loc': constraints.real, 'scale': constraints.positive}
+    support = constraints.positive
+    reparametrized_params = [(0, 'loc'), (1, 'scale')]
+
+    def __init__(self, loc, scale, validate_args=None):
+        base_dist = Normal(loc, scale)
+        self.loc, self.scale = base_dist.loc, base_dist.scale
+        super(LogNormal, self).__init__(base_dist, ExpTransform(), validate_args=validate_args)
+
+    @property
+    def mean(self):
+        return np.exp(self.loc + self.scale ** 2 / 2)
+
+    @property
+    def variance(self):
+        return (np.exp(self.scale ** 2) - 1) * np.exp(2 * self.loc + self.scale ** 2)
+
+
+class Pareto(TransformedDistribution):
+    arg_constraints = {'alpha': constraints.positive, 'scale': constraints.positive}
+    support = constraints.real
+
+    def __init__(self, scale, alpha, validate_args=None):
+        batch_shape = lax.broadcast_shapes(np.shape(scale), np.shape(alpha))
+        self.scale, self.alpha = np.broadcast_to(scale, batch_shape), np.broadcast_to(alpha, batch_shape)
+        base_dist = Exponential(self.alpha)
+        transforms = [ExpTransform(), AffineTransform(loc=0, scale=self.scale)]
+        super(Pareto, self).__init__(base_dist, transforms, validate_args=validate_args)
+
+    @property
+    def mean(self):
+        # mean is inf for alpha <= 1
+        a = np.clip(self.alpha, a_min=1.)
+        return a * self.scale / (a - 1)
+
+    @property
+    def variance(self):
+        # var is inf for alpha <= 2
+        a = np.clip(self.alpha, a_min=2.)
+        return (self.scale ** 2) * a / ((a - 1) ** 2 * (a - 2))
+
+    @property
+    def support(self):
+        return constraints.greater_than(self.scale)
+
+
 class Uniform(Distribution):
-    is_reparametrized = True
     arg_constraints = {'low': constraints.dependent, 'high': constraints.dependent}
+    reparametrized_params = [(0, 'low'), (1, 'high')]
 
     def __init__(self, low, high, validate_args=None):
         self.low, self.high = promote_shapes(low, high)
@@ -151,3 +330,40 @@ class Uniform(Distribution):
     @property
     def support(self):
         return constraints.interval(self.low, self.high)
+
+
+class StudentT(Distribution):
+    arg_constraints = {'df': constraints.positive, 'loc': constraints.real, 'scale': constraints.positive}
+    support = constraints.real
+    reparametrized_params = [(1, 'loc'), (2, 'scale')]
+
+    def __init__(self, df, loc=0., scale=1., validate_args=None):
+        self.df, self.loc, self.scale = promote_shapes(df, loc, scale)
+        self._chi2 = Chi2(self.df)
+        batch_shape = lax.broadcast_shapes(np.shape(self.df), np.shape(self.loc), np.shape(self.scale))
+        super(StudentT, self).__init__(batch_shape, validate_args=validate_args)
+
+    def sample(self, key, size=()):
+        std_normal = random.normal(key, shape=size + self.batch_shape)
+        z = self._chi2.sample(key, size)
+        y = std_normal * np.sqrt(self.df / z)
+        return self.loc + self.scale * y
+
+    def log_prob(self, value):
+        if self._validate_args:
+            self._validate_sample(value)
+        y = (value - self.loc) / self.scale
+        z = (np.log(self.scale) + 0.5 * np.log(self.df) + 0.5 * np.log(np.pi) +
+             gammaln(0.5 * self.df) - gammaln(0.5 * (self.df + 1.)))
+        return -0.5 * (self.df + 1.) * np.log1p(y**2. / self.df) - z
+
+    @property
+    def mean(self):
+        # for df <= 1. should be np.nan (keeping np.inf for consistency with scipy)
+        return np.broadcast_to(np.where(self.df <= 1, np.inf, self.loc), self.batch_shape)
+
+    @property
+    def variance(self):
+        var = np.where(self.df > 2, self.scale ** 2 * self.df / (self.df - 2.0), np.inf)
+        var = np.where(self.df <= 1, np.nan, var)
+        return np.broadcast_to(var, self.batch_shape)

--- a/numpyro/contrib/distributions/discrete.py
+++ b/numpyro/contrib/distributions/discrete.py
@@ -1,33 +1,70 @@
+# The implementation largely follows the design in PyTorch's `torch.distributions`
+#
+# Copyright (c) 2016-     Facebook, Inc            (Adam Paszke)
+# Copyright (c) 2014-     Facebook, Inc            (Soumith Chintala)
+# Copyright (c) 2011-2014 Idiap Research Institute (Ronan Collobert)
+# Copyright (c) 2012-2014 Deepmind Technologies    (Koray Kavukcuoglu)
+# Copyright (c) 2011-2012 NEC Laboratories America (Koray Kavukcuoglu)
+# Copyright (c) 2011-2013 NYU                      (Clement Farabet)
+# Copyright (c) 2006-2010 NEC Laboratories America (Ronan Collobert, Leon Bottou, Iain Melvin, Jason Weston)
+# Copyright (c) 2006      Idiap Research Institute (Samy Bengio)
+# Copyright (c) 2001-2004 Idiap Research Institute (Ronan Collobert, Samy Bengio, Johnny Mariethoz)
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+
 import jax.numpy as np
 import jax.random as random
 from jax import lax
-from jax.scipy.special import gammaln
+from jax.scipy.special import gammaln, logsumexp
 
 from numpyro.contrib.distributions.distribution import Distribution
 from numpyro.distributions import constraints
 from numpyro.distributions.util import (
     binary_cross_entropy_with_logits,
     binomial,
+    categorical_rvs,
     get_dtypes,
     lazy_property,
+    multinomial_rvs,
     promote_shapes,
     xlog1py,
-    xlogy
-)
+    xlogy,
+    poisson)
+
+
+def clamp_probs(probs):
+    finfo = np.finfo(get_dtypes(probs)[0])
+    return np.clip(probs, a_min=finfo.tiny, a_max=1. - finfo.eps)
 
 
 def _to_probs_bernoulli(logits):
     return 1 / (1 + np.exp(-logits))
 
 
-def clamp_probs(probs):
-    eps = np.finfo(get_dtypes(probs)[0]).eps
-    return np.clip(probs, a_min=eps, a_max=1 - eps)
-
-
 def _to_logits_bernoulli(probs):
     ps_clamped = clamp_probs(probs)
     return np.log(ps_clamped) - np.log1p(-ps_clamped)
+
+
+def _to_probs_multinom(logits):
+    x = np.exp(logits - np.max(logits, -1, keepdims=True))
+    return x / x.sum(-1, keepdims=True)
+
+
+def _to_logits_multinom(probs):
+    minval = np.finfo(get_dtypes(probs)[0]).min
+    return np.clip(np.log(probs), a_min=minval)
 
 
 class Bernoulli(Distribution):
@@ -92,7 +129,8 @@ class Binomial(Distribution):
 
     def __init__(self, probs, total_count=1, validate_args=None):
         self.probs, self.total_count = promote_shapes(probs, total_count)
-        super(Binomial, self).__init__(batch_shape=np.shape(self.probs), validate_args=validate_args)
+        batch_shape = lax.broadcast_shapes(np.shape(probs), np.shape(total_count))
+        super(Binomial, self).__init__(batch_shape=batch_shape, validate_args=validate_args)
 
     def sample(self, key, size=()):
         return binomial(key, self.probs, n=self.total_count, shape=size + self.batch_shape)
@@ -124,7 +162,8 @@ class BinomialWithLogits(Distribution):
 
     def __init__(self, logits, total_count=1, validate_args=None):
         self.logits, self.total_count = promote_shapes(logits, total_count)
-        super(BinomialWithLogits, self).__init__(batch_shape=np.shape(self.probs), validate_args=validate_args)
+        batch_shape = lax.broadcast_shapes(np.shape(logits), np.shape(total_count))
+        super(BinomialWithLogits, self).__init__(batch_shape=batch_shape, validate_args=validate_args)
 
     def sample(self, key, size=()):
         return binomial(key, self.probs, n=self.total_count, shape=size + self.batch_shape)
@@ -152,3 +191,190 @@ class BinomialWithLogits(Distribution):
     @property
     def variance(self):
         return np.broadcast_to(self.total_count * self.probs * (1 - self.probs), self.batch_shape)
+
+
+class Multinomial(Distribution):
+    arg_constraints = {'total_count': constraints.nonnegative_integer,
+                       'probs': constraints.simplex}
+
+    def __init__(self, probs, total_count=1, validate_args=None):
+        if np.ndim(probs) < 1:
+            raise ValueError("`probs` parameter must be at least one-dimensional.")
+        batch_shape = lax.broadcast_shapes(np.shape(probs)[:-1], np.shape(total_count))
+        self.probs = promote_shapes(probs, shape=batch_shape + np.shape(probs)[-1:])[0]
+        self.total_count = promote_shapes(total_count, shape=batch_shape)[0]
+        super(Multinomial, self).__init__(batch_shape=batch_shape,
+                                          event_shape=np.shape(self.probs)[-1:],
+                                          validate_args=validate_args)
+
+    def sample(self, key, size=()):
+        return multinomial_rvs(key, self.total_count, self.probs, shape=size + self.batch_shape)
+
+    def log_prob(self, value):
+        if self._validate_args:
+            self._validate_sample(value)
+        dtype = get_dtypes(self.probs)[0]
+        value = lax.convert_element_type(value, dtype)
+        total_count = lax.convert_element_type(self.total_count, dtype)
+        return gammaln(total_count + 1) + np.sum(xlogy(value, self.probs) - gammaln(value + 1), axis=-1)
+
+    @property
+    def mean(self):
+        return np.broadcast_to(self.probs * np.expand_dims(self.total_count, -1),
+                               self.batch_shape + self.event_shape)
+
+    @property
+    def variance(self):
+        return np.broadcast_to(np.expand_dims(self.total_count, -1) * self.probs * (1 - self.probs),
+                               self.batch_shape + self.event_shape)
+
+    @property
+    def support(self):
+        return constraints.integer_interval(0, self.total_count)
+
+
+class MultinomialWithLogits(Distribution):
+    arg_constraints = {'total_count': constraints.nonnegative_integer,
+                       'logits': constraints.real}
+
+    def __init__(self, logits, total_count=1, validate_args=None):
+        if np.ndim(logits) < 1:
+            raise ValueError("`logits` parameter must be at least one-dimensional.")
+        batch_shape = lax.broadcast_shapes(np.shape(logits)[:-1], np.shape(total_count))
+        logits = logits - logsumexp(logits)
+        self.logits = promote_shapes(logits, shape=batch_shape + np.shape(logits)[-1:])[0]
+        self.total_count = promote_shapes(total_count, shape=batch_shape)[0]
+        super(MultinomialWithLogits, self).__init__(batch_shape=batch_shape,
+                                                    event_shape=np.shape(self.logits)[-1:],
+                                                    validate_args=validate_args)
+
+    def sample(self, key, size=()):
+        return multinomial_rvs(key, self.total_count, self.probs, shape=size + self.batch_shape)
+
+    def log_prob(self, value):
+        if self._validate_args:
+            self._validate_sample(value)
+        dtype = get_dtypes(self.probs)[0]
+        value = lax.convert_element_type(value, dtype)
+        total_count = lax.convert_element_type(self.total_count, dtype)
+        logits = self.logits
+        logits = np.clip(logits, a_min=np.finfo(get_dtypes(logits)[0]).min)
+        return gammaln(total_count + 1) + np.sum(value * logits - gammaln(value + 1), axis=-1)
+
+    @lazy_property
+    def probs(self):
+        return _to_probs_multinom(self.logits)
+
+    @property
+    def mean(self):
+        return np.broadcast_to(np.expand_dims(self.total_count, -1) * self.probs,
+                               self.batch_shape + self.event_shape)
+
+    @property
+    def variance(self):
+        return np.broadcast_to(np.expand_dims(self.total_count, -1) * self.probs * (1 - self.probs),
+                               self.batch_shape + self.event_shape)
+
+
+class Categorical(Distribution):
+    arg_constraints = {'probs': constraints.simplex}
+
+    def __init__(self, probs, validate_args=None):
+        if np.ndim(probs) < 1:
+            raise ValueError("`probs` parameter must be at least one-dimensional.")
+        self.probs = probs
+        super(Categorical, self).__init__(batch_shape=np.shape(self.probs)[:-1],
+                                          validate_args=validate_args)
+
+    def sample(self, key, size=()):
+        return categorical_rvs(key, self.probs, shape=size + self.batch_shape)
+
+    def log_prob(self, value):
+        if self._validate_args:
+            self._validate_sample(value)
+        value = np.expand_dims(value, -1)
+        value, log_pmf = promote_shapes(value, self.logits)
+        value = value[..., :1]
+        return np.take_along_axis(log_pmf, value, -1)[..., 0]
+
+    @lazy_property
+    def logits(self):
+        return _to_logits_multinom(self.probs)
+
+    @property
+    def mean(self):
+        return np.broadcast_to(np.nan, self.batch_shape)
+
+    @property
+    def variance(self):
+        return np.broadcast_to(np.nan, self.batch_shape)
+
+    @property
+    def support(self):
+        return constraints.integer_interval(0, np.shape(self.probs)[-1])
+
+
+class CategoricalWithLogits(Distribution):
+    arg_constraints = {'total_count': constraints.nonnegative_integer,
+                       'logits': constraints.simplex}
+
+    def __init__(self, logits, total_count=1, validate_args=None):
+        if np.ndim(logits) < 1:
+            raise ValueError("`logits` parameter must be at least one-dimensional.")
+        logits = logits - logsumexp(logits)
+        self.logits = logits
+        super(CategoricalWithLogits, self).__init__(batch_shape=np.shape(logits)[:-1],
+                                                    validate_args=validate_args)
+
+    def sample(self, key, size=()):
+        return categorical_rvs(key, self.probs, shape=size + self.batch_shape)
+
+    def log_prob(self, value):
+        if self._validate_args:
+            self._validate_sample(value)
+        value = np.expand_dims(value, -1)
+        value, log_pmf = promote_shapes(value, self.logits)
+        value = value[..., :1]
+        return np.take_along_axis(log_pmf, value, -1)[..., 0]
+
+    @lazy_property
+    def probs(self):
+        return _to_probs_multinom(self.logits)
+
+    @property
+    def mean(self):
+        return np.broadcast_to(np.nan, self.batch_shape)
+
+    @property
+    def variance(self):
+        return np.broadcast_to(np.nan, self.batch_shape)
+
+    @property
+    def support(self):
+        return constraints.integer_interval(0, np.shape(self.logits)[-1])
+
+
+class Poisson(Distribution):
+    arg_constraints = {'rate': constraints.positive}
+    support = constraints.nonnegative_integer
+
+    def __init__(self, rate, validate_args=None):
+        self.rate = rate
+        super(Poisson, self).__init__(np.shape(rate), validate_args=validate_args)
+
+    def sample(self, key, size=()):
+        return poisson(key, self.rate, shape=size + self.batch_shape)
+
+    def log_prob(self, value):
+        if self._validate_args:
+            self._validate_sample(value)
+        value = value.astype(get_dtypes(self.rate)[0])
+        return (np.log(self.rate) * value) - self.rate - gammaln(value + 1)
+
+    @property
+    def mean(self):
+        return self.rate
+
+    @property
+    def variance(self):
+        return self.rate

--- a/numpyro/contrib/distributions/distribution.py
+++ b/numpyro/contrib/distributions/distribution.py
@@ -32,7 +32,7 @@ from numpyro.distributions.util import sum_rightmost
 class Distribution(object):
     arg_constraints = {}
     support = None
-    is_reparametrized = False
+    reparametrized_params = []
     _validate_args = False
 
     def __init__(self, batch_shape=(), event_shape=(), validate_args=None):

--- a/test/test_distributions_contrib.py
+++ b/test/test_distributions_contrib.py
@@ -1,3 +1,4 @@
+import inspect
 from collections import namedtuple
 
 import pytest
@@ -132,7 +133,7 @@ def test_sample_gradient(jax_dist, sp_dist, params):
     if not jax_dist.reparametrized_params:
         pytest.skip('{} not reparametrized.'.format(jax_dist.__name__))
 
-    reparametrized = set(i for i, _ in jax_dist.reparametrized_params)
+    dist_args = [p.name for p in inspect.signature(jax_dist).parameters.values()]
 
     rng = random.PRNGKey(0)
 
@@ -144,7 +145,8 @@ def test_sample_gradient(jax_dist, sp_dist, params):
 
     eps = 1e-5
     for i in range(len(params)):
-        if np.result_type(params[i]) in (np.int32, np.int64) or i not in reparametrized:
+        if np.result_type(params[i]) in (np.int32, np.int64) or \
+                dist_args[i] not in jax_dist.reparametrized_params:
             continue
         args_lhs = [p if j != i else p - eps for j, p in enumerate(params)]
         args_rhs = [p if j != i else p + eps for j, p in enumerate(params)]

--- a/test/test_distributions_contrib.py
+++ b/test/test_distributions_contrib.py
@@ -9,7 +9,7 @@ import jax.numpy as np
 import jax.random as random
 
 import numpyro.contrib.distributions as dist
-from numpyro.contrib.distributions.discrete import _to_probs_bernoulli
+from numpyro.contrib.distributions.discrete import _to_probs_bernoulli, _to_probs_multinom
 
 
 def _identity(x): return x
@@ -17,34 +17,66 @@ def _identity(x): return x
 
 class T(namedtuple('TestCase', ['jax_dist', 'sp_dist', 'params'])):
     def __new__(cls, jax_dist, *params):
-        sp_dist = _DIST_MAP[jax_dist]
+        sp_dist = None
+        if jax_dist in _DIST_MAP:
+            sp_dist = _DIST_MAP[jax_dist]
         return super(cls, T).__new__(cls, jax_dist, sp_dist, params)
 
 
 _DIST_MAP = {
     dist.Bernoulli: lambda probs: osp.bernoulli(p=probs),
     dist.BernoulliWithLogits: lambda logits: osp.bernoulli(p=_to_probs_bernoulli(logits)),
+    dist.Beta: lambda con1, con0: osp.beta(con1, con0),
     dist.Binomial: lambda probs, total_count: osp.binom(n=total_count, p=probs),
     dist.BinomialWithLogits: lambda logits, total_count: osp.binom(n=total_count, p=_to_probs_bernoulli(logits)),
     dist.Cauchy: lambda loc, scale: osp.cauchy(loc=loc, scale=scale),
+    dist.Chi2: lambda df: osp.chi2(df),
+    dist.Dirichlet: lambda conc: osp.dirichlet(conc),
     dist.Exponential: lambda rate: osp.expon(scale=np.reciprocal(rate)),
+    dist.Gamma: lambda conc, rate: osp.gamma(conc, scale=1./rate),
     dist.HalfCauchy: lambda scale: osp.halfcauchy(scale=scale),
+    dist.LogNormal: lambda loc, scale: osp.lognorm(s=scale, scale=np.exp(loc)),
+    dist.Multinomial: lambda probs, total_count: osp.multinomial(n=total_count, p=probs),
+    dist.MultinomialWithLogits: lambda logits, total_count: osp.multinomial(n=total_count,
+                                                                            p=_to_probs_multinom(logits)),
     dist.Normal: lambda loc, scale: osp.norm(loc=loc, scale=scale),
+    dist.Pareto: lambda scale, alpha: osp.pareto(alpha, scale=scale),
+    dist.Poisson: lambda rate: osp.poisson(rate),
+    dist.StudentT: lambda df, loc, scale: osp.t(df=df, loc=loc, scale=scale),
     dist.Uniform: lambda a, b: osp.uniform(a, b - a),
 }
 
 
 CONTINUOUS = [
+    T(dist.Beta, 1., 2.),
+    T(dist.Beta, 1., np.array([2., 2.])),
+    T(dist.Beta, 1., np.array([[1., 1.], [2., 2.]])),
+    T(dist.Chi2, 2.),
+    T(dist.Chi2, np.array([0.3, 1.3])),
     T(dist.Cauchy, 0., 1.),
     T(dist.Cauchy, 0., np.array([1., 2.])),
     T(dist.Cauchy, np.array([0., 1.]), np.array([[1.], [2.]])),
-    T(dist.Exponential, 2.,),
+    T(dist.Dirichlet, np.array([1.7])),
+    T(dist.Dirichlet, np.array([0.2, 1.1])),
+    T(dist.Dirichlet, np.array([[0.2, 1.1], [2., 2.]])),
+    T(dist.Exponential, 2.),
     T(dist.Exponential, np.array([4., 2.])),
+    T(dist.Gamma, np.array([1.7]), np.array([[2.], [3.]])),
+    T(dist.Gamma, np.array([0.5, 1.3]), np.array([[1.], [3.]])),
     T(dist.HalfCauchy, 1.),
     T(dist.HalfCauchy, np.array([1., 2.])),
+    T(dist.LogNormal, 1., 0.2),
+    T(dist.LogNormal, -1., np.array([0.5, 1.3])),
+    T(dist.LogNormal, np.array([0.5, -0.7]), np.array([[0.1, 0.4], [0.5, 0.1]])),
     T(dist.Normal, 0., 1.),
     T(dist.Normal, 1., np.array([1., 2.])),
     T(dist.Normal, np.array([0., 1.]), np.array([[1.], [2.]])),
+    T(dist.Pareto, 2., 1.),
+    T(dist.Pareto, np.array([0.3, 2.]), np.array([1., 0.5])),
+    T(dist.Pareto, np.array([1., 0.5]), np.array([[1.], [3.]])),
+    T(dist.StudentT, 1., 1., 0.5),
+    T(dist.StudentT, 1.5, np.array([1., 2.]), 2.),
+    T(dist.StudentT, np.array([3, 5]), np.array([[1.], [2.]]), 2.),
     T(dist.Uniform, 0., 2.),
     T(dist.Uniform, 1., np.array([2., 3.])),
     T(dist.Uniform, np.array([0., 0.]), np.array([[2.], [3.]])),
@@ -58,7 +90,22 @@ DISCRETE = [
     T(dist.Binomial, np.array([0.2, 0.7]), np.array([10, 2])),
     T(dist.Binomial, np.array([0.2, 0.7]), np.array([5, 8])),
     T(dist.BinomialWithLogits, np.array([-1., 3.]), np.array([5, 8])),
+    T(dist.Categorical, np.array([1.])),
+    T(dist.Categorical, np.array([0.1, 0.5, 0.4])),
+    T(dist.Categorical, np.array([[0.1, 0.5, 0.4], [0.4, 0.4, 0.2]])),
+    T(dist.CategoricalWithLogits, np.array([-5.])),
+    T(dist.CategoricalWithLogits, np.array([1., 2., -2.])),
+    T(dist.CategoricalWithLogits, np.array([[-1, 2., 3.], [3., -4., -2.]])),
+    T(dist.Multinomial, np.array([0.2, 0.7, 0.1]), 10),
+    T(dist.Multinomial, np.array([0.2, 0.7, 0.1]), np.array([5, 8])),
+    T(dist.MultinomialWithLogits, np.array([-1., 3.]), np.array([[5], [8]])),
+    T(dist.Poisson, 2.),
+    T(dist.Poisson, np.array([2., 3., 5.])),
 ]
+
+
+def _is_batched_multivariate(jax_dist):
+    return len(jax_dist.event_shape) > 0 and len(jax_dist.batch_shape) > 0
 
 
 @pytest.mark.parametrize('jax_dist, sp_dist, params', CONTINUOUS + DISCRETE)
@@ -69,20 +116,23 @@ DISCRETE = [
 ])
 def test_dist_shape(jax_dist, sp_dist, params, prepend_shape):
     jax_dist = jax_dist(*params)
-    sp_dist = sp_dist(*params)
     rng = random.PRNGKey(0)
-    expected_shape = prepend_shape + jax_dist.batch_shape
+    expected_shape = prepend_shape + jax_dist.batch_shape + jax_dist.event_shape
     samples = jax_dist.sample(key=rng, size=prepend_shape)
-    sp_samples = sp_dist.rvs(size=expected_shape)
     assert isinstance(samples, jax.interpreters.xla.DeviceArray)
     assert np.shape(samples) == expected_shape
-    assert np.shape(sp_samples) == expected_shape
+    if sp_dist and not _is_batched_multivariate(jax_dist):
+        sp_dist = sp_dist(*params)
+        sp_samples = sp_dist.rvs(size=prepend_shape + jax_dist.batch_shape)
+        assert np.shape(sp_samples) == expected_shape
 
 
 @pytest.mark.parametrize('jax_dist, sp_dist, params', CONTINUOUS)
 def test_sample_gradient(jax_dist, sp_dist, params):
-    if not jax_dist.is_reparametrized:
-        pass
+    if not jax_dist.reparametrized_params:
+        pytest.skip('{} not reparametrized.'.format(jax_dist.__name__))
+
+    reparametrized = set(i for i, _ in jax_dist.reparametrized_params)
 
     rng = random.PRNGKey(0)
 
@@ -94,7 +144,7 @@ def test_sample_gradient(jax_dist, sp_dist, params):
 
     eps = 1e-5
     for i in range(len(params)):
-        if np.result_type(params[i]) in (np.int32, np.int64):
+        if np.result_type(params[i]) in (np.int32, np.int64) or i not in reparametrized:
             continue
         args_lhs = [p if j != i else p - eps for j, p in enumerate(params)]
         args_rhs = [p if j != i else p + eps for j, p in enumerate(params)]
@@ -116,9 +166,19 @@ def test_sample_gradient(jax_dist, sp_dist, params):
 def test_log_prob(jax_dist, sp_dist, params, prepend_shape, jit):
     jit_fn = _identity if not jit else jax.jit
     jax_dist = jax_dist(*params)
-    sp_dist = sp_dist(*params)
     rng = random.PRNGKey(0)
     samples = jax_dist.sample(key=rng, size=prepend_shape)
+    if not sp_dist:
+        pytest.skip('no corresponding scipy distn.')
+    if _is_batched_multivariate(jax_dist):
+        pytest.skip('batching not allowed in multivariate distns.')
+    if jax_dist.event_shape and prepend_shape:
+        # >>> d = sp.dirichlet([1.1, 1.1])
+        # >>> samples = d.rvs(size=(2,))
+        # >>> d.logpdf(samples)
+        # ValueError: The input vector 'x' must lie within the normal simplex ...
+        pytest.skip('batched samples cannot be scored by multivariate distributions.')
+    sp_dist = sp_dist(*params)
     try:
         expected = sp_dist.logpdf(samples)
     except AttributeError:
@@ -128,9 +188,6 @@ def test_log_prob(jax_dist, sp_dist, params, prepend_shape, jit):
 
 @pytest.mark.parametrize('jax_dist, sp_dist, params', CONTINUOUS + DISCRETE)
 def test_log_prob_gradient(jax_dist, sp_dist, params):
-    if not jax_dist.is_reparametrized:
-        pass
-
     rng = random.PRNGKey(0)
 
     def fn(args, value):
@@ -140,7 +197,7 @@ def test_log_prob_gradient(jax_dist, sp_dist, params):
     actual_grad = jax.grad(fn)(params, value)
     assert len(actual_grad) == len(params)
 
-    eps = 1e-5
+    eps = 1e-4
     for i in range(len(params)):
         if np.result_type(params[i]) in (np.int32, np.int64):
             continue
@@ -151,20 +208,35 @@ def test_log_prob_gradient(jax_dist, sp_dist, params):
         # finite diff approximation
         expected_grad = (fn_rhs - fn_lhs) / (2. * eps)
         assert np.shape(actual_grad[i]) == np.shape(params[i])
-        assert_allclose(np.sum(actual_grad[i]), expected_grad, rtol=0.10)
+        assert_allclose(np.sum(actual_grad[i]), expected_grad, rtol=0.10, atol=1e-3)
 
 
 @pytest.mark.parametrize('jax_dist, sp_dist, params', CONTINUOUS + DISCRETE)
 def test_mean_var(jax_dist, sp_dist, params):
-    n = 100000
+    n = 200000
     d_jax = jax_dist(*params)
-    d_sp = sp_dist(*params)
     k = random.PRNGKey(0)
     samples = d_jax.sample(k, size=(n,))
-    sp_mean, sp_var = d_sp.stats(moments='mv')
-    assert_allclose(d_jax.mean, sp_mean)
-    assert_allclose(d_jax.variance, sp_var)
-    if np.all(np.isfinite(sp_mean)):
-        assert_allclose(np.mean(samples, 0), d_jax.mean, rtol=0.05, atol=1e-2)
-    if np.all(np.isfinite(sp_var)):
-        assert_allclose(np.std(samples, 0), np.sqrt(d_jax.variance), rtol=0.05, atol=1e-2)
+    # check with suitable scipy implementation if available
+    if sp_dist and not _is_batched_multivariate(d_jax):
+        d_sp = sp_dist(*params)
+        sp_mean = d_sp.mean()
+        # for multivariate distns try .cov first
+        if d_jax.event_shape:
+            try:
+                sp_var = np.diag(d_sp.cov())
+            except AttributeError:
+                sp_var = d_sp.var()
+        else:
+            sp_var = d_sp.var()
+        assert_allclose(d_jax.mean, sp_mean, rtol=0.01, atol=1e-7)
+        assert_allclose(d_jax.variance, sp_var, rtol=0.01, atol=1e-7)
+        if np.all(np.isfinite(sp_mean)):
+            assert_allclose(np.mean(samples, 0), d_jax.mean, rtol=0.05, atol=1e-2)
+        if np.all(np.isfinite(sp_var)):
+            assert_allclose(np.std(samples, 0), np.sqrt(d_jax.variance), rtol=0.05, atol=1e-2)
+    else:
+        if np.all(np.isfinite(d_jax.mean)):
+            assert_allclose(np.mean(samples, 0), d_jax.mean, rtol=0.05, atol=1e-2)
+        if np.all(np.isfinite(d_jax.variance)):
+            assert_allclose(np.std(samples, 0), np.sqrt(d_jax.variance), rtol=0.05, atol=1e-2)

--- a/test/test_distributions_util.py
+++ b/test/test_distributions_util.py
@@ -1,3 +1,5 @@
+from numbers import Number
+
 import numpy as onp
 import pytest
 import scipy.special as osp_special
@@ -198,8 +200,13 @@ def test_multinomial_shape(p, shape):
     np.array([0.2, 0.3, 0.5]),
     np.array([0.8, 0.1, 0.1]),
 ])
-def test_multinomial_stats(p):
+@pytest.mark.parametrize("n", [
+    10000,
+    np.array([10000, 20000]),
+])
+def test_multinomial_stats(p, n):
     rng = random.PRNGKey(0)
-    n = 10000
     z = multinomial_rvs(rng, n, p)
-    assert_allclose(z / float(n), p, atol=0.01)
+    n = float(n) if isinstance(n, Number) else np.expand_dims(n.astype(p.dtype), -1)
+    p = np.broadcast_to(p, z.shape)
+    assert_allclose(z / n, p, atol=0.01)


### PR DESCRIPTION
This adds most of the distributions that are being currently used to `contrib`. Once this merges, I'll add some more tests, and have our existing tests / examples start using this API. This has become a priority given that we have many more examples in the pipeline, and the migration will be tougher the more we keep adding to the scipy API. 

The reason why I believe that it is a good idea to not build on top of scipy's API is because it has many quirks that may be expected from an old distribution ([e.g.](https://github.com/scipy/scipy/blob/master/scipy/stats/_distn_infrastructure.py#L972)), and there is no reason for a new codebase to inherit these warts in the API. PyTorch's codebase or TensorFlow Probability is a much better template to follow in this regard, and will be easier to maintain as well as for new users to contribute to. This will also make it easier to plug this into `pyro.generic` with minimal boilerplate code.

Major changes:
 - changed `is_reparametrized` to `reparametrized_params` since a distribution may be reparametrizable w.r.t. some params and not others.
 - augmented multinomial sampler to take in batched `n`. The scalar `n` case is the same as earlier. Batched `n` while allowed is slow. I think when we have a faster, improved implementation, we can consider moving it upstream.
 - Simple poisson sampler based on Knuth's algorithm (more efficient sampler algorithms are available but this is probably good enough).
