### PR TITLE
Add CorrCholesky transform

### DIFF
--- a/numpyro/distributions/constraint_registry.py
+++ b/numpyro/distributions/constraint_registry.py
@@ -26,6 +26,7 @@ from numpyro.distributions import constraints
 from numpyro.distributions.transforms import (
     AffineTransform,
     ComposeTransform,
+    CorrCholeskyTransform,
     ExpTransform,
     IdentityTransform,
     SigmoidTransform,
@@ -56,6 +57,11 @@ class ConstraintRegistry(object):
 
 
 biject_to = ConstraintRegistry()
+
+
+@biject_to.register(constraints.corr_cholesky)
+def _transform_to_corr_cholesky(constraint):
+    return CorrCholeskyTransform()
 
 
 @biject_to.register(constraints.greater_than)

--- a/numpyro/distributions/constraints.py
+++ b/numpyro/distributions/constraints.py
@@ -38,7 +38,7 @@ class _Boolean(Constraint):
 class _CorrCholesky(Constraint):
     def __call__(self, x):
         tril = np.tril(x)
-        lower_triangular = np.all((tril == x).reshape(x.shape[:-2] + (-1,)), axis=-1)
+        lower_triangular = np.all(np.reshape(tril == x, x.shape[:-2] + (-1,)), axis=-1)
         positive_diagonal = np.all(np.diagonal(x, axis1=-2, axis2=-1) > 0, axis=-1)
         x_norm = np.linalg.norm(x, axis=-1)
         unit_norm_row = np.all((x_norm <= 1) & (x_norm > 1 - 1e-6), axis=-1)

--- a/numpyro/distributions/constraints.py
+++ b/numpyro/distributions/constraints.py
@@ -35,6 +35,16 @@ class _Boolean(Constraint):
         return (value == 0) | (value == 1)
 
 
+class _CorrCholesky(Constraint):
+    def __call__(self, x):
+        tril = np.tril(x)
+        lower_triangular = np.all((tril == x).reshape(x.shape[:-2] + (-1,)), axis=-1)
+        positive_diagonal = np.all(np.diagonal(x, axis1=-2, axis2=-1) > 0, axis=-1)
+        x_norm = np.linalg.norm(x, axis=-1)
+        unit_norm_row = np.all((x_norm <= 1) & (x_norm > 1 - 1e-6), axis=-1)
+        return lower_triangular & positive_diagonal & unit_norm_row
+
+
 class _Dependent(Constraint):
     def __call__(self, x):
         raise ValueError('Cannot determine validity of dependent constraint')
@@ -90,6 +100,7 @@ class _Simplex(Constraint):
 
 
 boolean = _Boolean()
+corr_cholesky = _CorrCholesky()
 dependent = _Dependent
 greater_than = _GreaterThan
 integer_interval = _IntegerInterval

--- a/numpyro/distributions/transforms.py
+++ b/numpyro/distributions/transforms.py
@@ -26,7 +26,7 @@ import jax.numpy as np
 from jax.scipy.special import expit, logit
 
 from numpyro.distributions import constraints
-from numpyro.distributions.util import cumprod, cumsum, sum_rightmost
+from numpyro.distributions.util import cumprod, cumsum, matrix_to_tril_vec, sum_rightmost, vec_to_tril_matrix
 
 
 def _clipped_expit(x):
@@ -127,6 +127,91 @@ class ComposeTransform(Transform):
         result = result + sum_rightmost(self.parts[-1].log_abs_det_jacobian(x, y),
                                         self.event_dim - self.parts[-1].event_dim)
         return result
+
+
+def _signed_stick_breaking_tril(t):
+    # transform t to tril matrix with identity diagonal
+    r = vec_to_tril_matrix(t, diagonal=-1)
+    r = r + np.identity(r.shape[-1])
+
+    # apply stick-breaking on the squared values;
+    # we omit the step of computing s = z * z_cumprod by using the fact:
+    #     y = sign(r) * s = sign(r) * sqrt(z * z_cumprod) = r * sqrt(z_cumprod)
+    z = r ** 2
+    z1m_cumprod = cumprod(1 - z)
+
+    # to workaround the issue: NaN propagated through backward pass even when not accessed
+    # at https://github.com/pytorch/pytorch/issues/15506 (which also happens in JAX),
+    # here we only take sqrt at tril part
+    z1m_cumprod_tril_sqrt = np.sqrt(matrix_to_tril_vec(z1m_cumprod, diagonal=-1))
+    z1m_cumprod_sqrt = vec_to_tril_matrix(z1m_cumprod_tril_sqrt, diagonal=-1)
+
+    pad_width = [(0, 0)] * z.ndim
+    pad_width[-1] = (1, 0)
+    z1m_cumprod_sqrt_shifted = np.pad(z1m_cumprod_sqrt[..., :-1], pad_width,
+                                      mode="constant", constant_values=1.)
+    y = r * z1m_cumprod_sqrt_shifted
+    return y
+
+
+class CorrCholeskyTransform(Transform):
+    r"""
+    Transforms a uncontrained real vector :math:`x` with length :math:`D*(D-1)/2` into the
+    Cholesky factor of a D-dimension correlation matrix. This Cholesky factor is a lower
+    triangular matrix with positive diagonals and unit Euclidean norm for each row.
+    The transform is processed as follows:
+    1. First we convert :math:`x` into a lower triangular matrix with the following order:
+    .. math::
+        \begin{bmatrix}
+            1   & 0 & 0 & 0 \\
+            x_0 & 1 & 0 & 0 \\
+            x_1 & x_2 & 1 & 0 \\
+            x_3 & x_4 & x_5 & 1
+        \end{bmatrix}
+    2. For each row :math:`X_i` of the lower triangular part, we apply a *signed* version of
+    class :class:`StickBreakingTransform` to transform :math:`X_i` into a
+    unit Euclidean length vector using the following steps:
+        a. Scales into the interval :math:`(-1, 1)` domain: :math:`r_i = \tanh(X_i)`.
+        b. Transforms into an unsigned domain: :math:`z_i = r_i^2`.
+        c. Applies :math:`s_i = StickBreakingTransform(z_i)`.
+        d. Transforms back into signed domain: :math:`y_i = (sign(r_i), 1) * \sqrt{s_i}`.
+    """
+    codomain = constraints.corr_cholesky
+    event_dim = 1
+
+    def __call__(self, x):
+        # we interchange step 1 and step 2.a for a better performance
+        eps = np.finfo(x.dtype).eps
+        t = np.clip(np.tanh(x), a_min=(-1 + eps), a_max=(1 - eps))
+        return _signed_stick_breaking_tril(t)
+
+    def inv(self, y):
+        # inverse stick-breaking
+        z1m_cumprod = 1 - cumsum(y * y)
+        pad_width = [(0, 0)] * y.ndim
+        pad_width[-1] = (1, 0)
+        z1m_cumprod_shifted = np.pad(z1m_cumprod[..., :-1], pad_width,
+                                     mode="constant", constant_values=1.)
+        t = matrix_to_tril_vec(y, diagonal=-1) / np.sqrt(
+            matrix_to_tril_vec(z1m_cumprod_shifted, diagonal=-1))
+        # inverse of tanh
+        x = np.log((1 + t) / (1 - t)) / 2
+        return x
+
+    def log_abs_det_jacobian(self, x, y):
+        # NB: because domain and codomain are two spaces with different dimensions, determinant of
+        # Jacobian is not well-defined. Here we return `log_abs_det_jacobian` of `x` and the
+        # flatten lower triangular part of `y`.
+
+        # stick_breaking_logdet = log(y / r) = log(z_cumprod)  (modulo right shifted)
+        z1m_cumprod = 1 - cumsum(y * y)
+        # by taking diagonal=-2, we don't need to shift z_cumprod to the right
+        # NB: diagonal=-2 works fine for (2 x 2) matrix, where we get an empty array
+        z1m_cumprod_tril = matrix_to_tril_vec(z1m_cumprod, diagonal=-2)
+        stick_breaking_logdet = 0.5 * np.sum(np.log(z1m_cumprod_tril), axis=-1)
+
+        tanh_logdet = -2 * np.sum(np.log(np.cosh(x)), axis=-1)
+        return stick_breaking_logdet + tanh_logdet
 
 
 class ExpTransform(Transform):

--- a/numpyro/distributions/util.py
+++ b/numpyro/distributions/util.py
@@ -392,7 +392,7 @@ def multinomial_rvs(key, n, p, shape=()):
                                                             dtype=indices.dtype),
                                                    np.expand_dims(indices_2D, axis=-1),
                                                    np.ones(indices_2D.shape, dtype=indices.dtype))
-    return samples_2D.reshape(shape + p.shape[-1:]) - excess
+    return np.reshape(samples_2D, shape + p.shape[-1:]) - excess
 
 
 def sum_rightmost(x, dim):
@@ -407,12 +407,13 @@ def matrix_to_tril_vec(x, diagonal=0):
 def vec_to_tril_matrix(t, diagonal=0):
     # NB: the following formula only works for diagonal <= 0
     n = round((math.sqrt(1 + 8 * t.shape[-1]) - 1) / 2) - diagonal
-    idx = onp.arange(n * n).reshape((n, n))[onp.tril_indices(n, diagonal)]
-    x = lax.scatter_add(np.zeros(t.shape[:-1] + (n * n,)), np.expand_dims(idx, axis=-1), t,
+    n2 = n * n
+    idx = np.reshape(np.arange(n2), (n, n))[onp.tril_indices(n, diagonal)]
+    x = lax.scatter_add(np.zeros(t.shape[:-1] + (n2,)), np.expand_dims(idx, axis=-1), t,
                         lax.ScatterDimensionNumbers(update_window_dims=range(t.ndim - 1),
                                                     inserted_window_dims=(t.ndim - 1,),
                                                     scatter_dims_to_operand_dims=(t.ndim - 1,)))
-    return x.reshape(x.shape[:-1] + (n, n))
+    return np.reshape(x, x.shape[:-1] + (n, n))
 
 
 # The is sourced from: torch.distributions.util.py


### PR DESCRIPTION
This PR adds CorrCholesky transform. Because each row of the triangular part of the cholesky of a correlation matrix has norm 1 (or diagonal part of correlation matrix is 1), we can apply StickBreaking process for the square of each row. Using that fact, we can vectorize this transform and avoid "for" loops in the transform.