### PR TITLE
Use contrib.distributions in tests and examples

### DIFF
--- a/numpyro/contrib/distributions/__init__.py
+++ b/numpyro/contrib/distributions/__init__.py
@@ -1,3 +1,5 @@
+from jax import numpy as np
+
 from numpyro.contrib.distributions.continuous import (
     Beta,
     Cauchy,
@@ -47,3 +49,50 @@ __all__ = [
     'StudentT',
     'Uniform',
 ]
+
+# TODO: remove before release
+
+
+def get_bern(p, is_logits=False):
+    if is_logits:
+        return BernoulliWithLogits(p)
+    else:
+        return Bernoulli(p)
+
+
+def get_binom(n, p, is_logits=False):
+    if is_logits:
+        return BinomialWithLogits(p, n)
+    else:
+        return Binomial(p, n)
+
+
+def get_categorical(p, is_logits=False):
+    if is_logits:
+        return CategoricalWithLogits(p)
+    else:
+        return Categorical(p)
+
+
+def get_multinomial(n, p, is_logits=False):
+    if is_logits:
+        return MultinomialWithLogits(p, n)
+    else:
+        return MultinomialWithLogits(p, n)
+
+
+beta = Beta
+bernoulli = get_bern
+binom = get_binom
+cauchy = lambda loc=0., scale=1.: Cauchy(loc, scale)
+categorical = get_categorical
+dirichlet = lambda alpha: Dirichlet(concentration=alpha)
+expon = Exponential
+gamma = lambda conc, scale=1.: Gamma(conc, rate=1./scale)
+halfcauchy = lambda scale: HalfCauchy(scale)
+lognorm = lambda s, scale=1.: LogNormal(loc=np.log(scale), scale=s)
+multinomial = get_multinomial
+norm = lambda loc=0., scale=1.: Normal(loc, scale)
+pareto = lambda alpha, scale=1.: Pareto(scale, alpha)
+t = lambda df, loc=0., scale=1.: StudentT(df, loc, scale)
+uniform = Uniform

--- a/numpyro/contrib/distributions/__init__.py
+++ b/numpyro/contrib/distributions/__init__.py
@@ -1,3 +1,5 @@
+# flake8: noqa
+
 from jax import numpy as np
 
 from numpyro.contrib.distributions.continuous import (

--- a/numpyro/contrib/distributions/continuous.py
+++ b/numpyro/contrib/distributions/continuous.py
@@ -136,7 +136,7 @@ class Dirichlet(Distribution):
 class Gamma(Distribution):
     arg_constraints = {'concentration': constraints.positive,
                        'rate': constraints.positive}
-    support = constraints.simplex
+    support = constraints.positive
 
     def __init__(self, concentration, rate, validate_args=None):
         self.concentration, self.rate = promote_shapes(concentration, rate)
@@ -168,6 +168,7 @@ class Chi2(Gamma):
     arg_constraints = {'df': constraints.positive}
 
     def __init__(self, df, validate_args=None):
+        self.df = df
         super(Chi2, self).__init__(0.5 * df, 0.5, validate_args=validate_args)
 
 
@@ -205,6 +206,7 @@ class HalfCauchy(TransformedDistribution):
 
     def __init__(self, scale, validate_args=None):
         base_dist = Cauchy(0, scale)
+        self.scale = scale
         super(HalfCauchy, self).__init__(base_dist, AbsTransform(),
                                          validate_args=validate_args)
 

--- a/numpyro/distributions/constraints.py
+++ b/numpyro/distributions/constraints.py
@@ -83,7 +83,7 @@ class _Multinomial(Constraint):
         self.upper_bound = upper_bound
 
     def __call__(self, value):
-        return np.sum(value, -1) == self.upper_bound
+        return (value >= 0) & (np.sum(value, -1) == self.upper_bound)
 
 
 class _Real(Constraint):

--- a/numpyro/distributions/constraints.py
+++ b/numpyro/distributions/constraints.py
@@ -78,6 +78,14 @@ class _Interval(Constraint):
         return (value > self.lower_bound) & (value < self.upper_bound)
 
 
+class _Multinomial(Constraint):
+    def __init__(self, upper_bound):
+        self.upper_bound = upper_bound
+
+    def __call__(self, value):
+        return np.sum(value, -1) == self.upper_bound
+
+
 class _Real(Constraint):
     def __call__(self, x):
         return np.isfinite(x)
@@ -89,12 +97,15 @@ class _Simplex(Constraint):
         return np.all(x > 0, axis=-1) & (x_sum <= 1) & (x_sum > 1 - 1e-6)
 
 
+# TODO: Make types consistent
+
 boolean = _Boolean()
-dependent = _Dependent
+dependent = _Dependent()
 greater_than = _GreaterThan
 integer_interval = _IntegerInterval
 integer_greater_than = _IntegerGreaterThan
 interval = _Interval
+multinomial = _Multinomial
 nonnegative_integer = _IntegerGreaterThan(0)
 positive_integer = _IntegerGreaterThan(1)
 positive = _GreaterThan(0)

--- a/numpyro/distributions/constraints.py
+++ b/numpyro/distributions/constraints.py
@@ -93,7 +93,7 @@ class _Multinomial(Constraint):
         self.upper_bound = upper_bound
 
     def __call__(self, value):
-        return (value >= 0) & (np.sum(value, -1) == self.upper_bound)
+        return np.all(value >= 0, axis=-1) & (np.sum(value, -1) == self.upper_bound)
 
 
 class _Real(Constraint):

--- a/numpyro/distributions/util.py
+++ b/numpyro/distributions/util.py
@@ -328,7 +328,7 @@ def binomial(key, p, n=1, shape=()):
     return np.sum(mask * lax.lt(uniforms, p), axis=-1, keepdims=False)
 
 
-#@partial(jit, static_argnums=(2,))
+@partial(jit, static_argnums=(2,))
 def categorical_rvs(key, p, shape=()):
     # this implementation is fast when event shape is small, and slow otherwise
     # Ref: https://stackoverflow.com/a/34190035
@@ -367,7 +367,7 @@ def _scatter_add_one(operand, indices, updates):
                                                        scatter_dims_to_operand_dims=(0,)))
 
 
-#@partial(jit, static_argnums=(1, 3))
+@partial(jit, static_argnums=(1, 3))
 def multinomial_rvs(key, n, p, shape=()):
     if np.shape(n) != np.shape(p)[:-1]:
         broadcast_shape = lax.broadcast_shapes(np.shape(n), np.shape(p)[:-1])

--- a/numpyro/distributions/util.py
+++ b/numpyro/distributions/util.py
@@ -328,7 +328,7 @@ def binomial(key, p, n=1, shape=()):
     return np.sum(mask * lax.lt(uniforms, p), axis=-1, keepdims=False)
 
 
-@partial(jit, static_argnums=(2,))
+#@partial(jit, static_argnums=(2,))
 def categorical_rvs(key, p, shape=()):
     # this implementation is fast when event shape is small, and slow otherwise
     # Ref: https://stackoverflow.com/a/34190035
@@ -367,7 +367,7 @@ def _scatter_add_one(operand, indices, updates):
                                                        scatter_dims_to_operand_dims=(0,)))
 
 
-@partial(jit, static_argnums=(1, 3))
+#@partial(jit, static_argnums=(1, 3))
 def multinomial_rvs(key, n, p, shape=()):
     if np.shape(n) != np.shape(p)[:-1]:
         broadcast_shape = lax.broadcast_shapes(np.shape(n), np.shape(p)[:-1])

--- a/numpyro/examples/covtype.py
+++ b/numpyro/examples/covtype.py
@@ -8,7 +8,7 @@ import jax
 import jax.numpy as np
 from jax import random
 
-import numpyro.distributions as dist
+import numpyro.contrib.distributions as dist
 from numpyro.handlers import sample
 from numpyro.hmc_util import initialize_model
 from numpyro.mcmc import hmc

--- a/numpyro/examples/minipyro.py
+++ b/numpyro/examples/minipyro.py
@@ -5,7 +5,7 @@ from jax import lax, random
 from jax.experimental import optimizers
 from jax.random import PRNGKey
 
-import numpyro.distributions as dist
+import numpyro.contrib.distributions as dist
 from numpyro.handlers import param, sample
 from numpyro.svi import elbo, svi
 

--- a/numpyro/handlers.py
+++ b/numpyro/handlers.py
@@ -94,7 +94,7 @@ def apply_stack(msg):
         if msg.get("stop"):
             break
     if msg['value'] is None:
-        msg['value'] = msg['fn'].rvs(*msg['args'], **msg['kwargs'])
+        msg['value'] = msg['fn'](*msg['args'], **msg['kwargs'])
 
     # A Messenger that sets msg["stop"] == True also prevents application
     # of postprocess_message by Messengers above it on the stack

--- a/numpyro/hmc_util.py
+++ b/numpyro/hmc_util.py
@@ -6,6 +6,7 @@ from jax.ops import index_update
 from jax.scipy.special import expit
 from jax.tree_util import tree_multimap
 
+from numpyro.contrib.distributions.distribution import Distribution
 from numpyro.distributions import biject_to
 from numpyro.distributions.distribution import jax_continuous
 from numpyro.handlers import seed, substitute, trace
@@ -543,7 +544,12 @@ def build_tree(verlet_update, kinetic_fn, verlet_state, inverse_mass_matrix, ste
 
 def log_density(model, model_args, model_kwargs, params):
     def logp(d, val):
-        return d.logpdf(val) if isinstance(d.dist, jax_continuous) else d.logpmf(val)
+        if isinstance(d, Distribution):
+            return d.log_prob(val)
+        elif isinstance(d.dist, jax_continuous):
+            return d.logpdf(val)
+        else:
+            return d.logpmf(val)
 
     model = substitute(model, params)
     model_trace = trace(model).get_trace(*model_args, **model_kwargs)

--- a/numpyro/mcmc.py
+++ b/numpyro/mcmc.py
@@ -7,7 +7,7 @@ from jax import jit, partial, random
 from jax.flatten_util import ravel_pytree
 from jax.random import PRNGKey
 
-import numpyro.distributions as dist
+import numpyro.contrib.distributions as dist
 from numpyro.hmc_util import IntegratorState, build_tree, find_reasonable_step_size, velocity_verlet, warmup_adapter
 from numpyro.util import cond, fori_loop, laxtuple
 


### PR DESCRIPTION
Fixes #82 
 - Adds some temporary utilities for compatibility with existing wrapper, which should be removed before release. For the time being, this allows us to switch between the two wrappers.
 - Moved tests / examples (not notebooks) to use the new wrappers.
 - Added constraint tests, and fixed bugs that were caught in existing implementations.