### PR TITLE
Make utilities work for the newer version of JAX

### DIFF
--- a/numpyro/contrib/distributions/multivariate.py
+++ b/numpyro/contrib/distributions/multivariate.py
@@ -15,7 +15,7 @@ from jax.scipy.special import digamma, gammaln
 from numpyro.contrib.distributions.discrete import binom
 from numpyro.contrib.distributions.distribution import jax_continuous, jax_discrete, jax_multivariate
 from numpyro.distributions import constraints
-from numpyro.distributions.util import categorical_rvs, entr, multinomial_rvs, standard_gamma, xlogy
+from numpyro.distributions.util import categorical as categorical_rvs, entr, multinomial as multinomial_rvs, standard_gamma, xlogy
 
 
 def _lnB(alpha):
@@ -148,7 +148,7 @@ class multinomial_gen(jax_multivariate, jax_discrete):
     def _rvs(self, n, p):
         if self.is_logits:
             p = softmax(p)
-        return multinomial_rvs(self._random_state, n, p, self._size)
+        return multinomial_rvs(self._random_state, p, n, self._size)
 
 
 categorical = categorical_gen(name='categorical')

--- a/numpyro/contrib/distributions/multivariate.py
+++ b/numpyro/contrib/distributions/multivariate.py
@@ -15,7 +15,10 @@ from jax.scipy.special import digamma, gammaln
 from numpyro.contrib.distributions.discrete import binom
 from numpyro.contrib.distributions.distribution import jax_continuous, jax_discrete, jax_multivariate
 from numpyro.distributions import constraints
-from numpyro.distributions.util import categorical as categorical_rvs, entr, multinomial as multinomial_rvs, standard_gamma, xlogy
+from numpyro.distributions.util import categorical as categorical_rvs
+from numpyro.distributions.util import entr
+from numpyro.distributions.util import multinomial as multinomial_rvs
+from numpyro.distributions.util import standard_gamma, xlogy
 
 
 def _lnB(alpha):

--- a/numpyro/distributions/continuous.py
+++ b/numpyro/distributions/continuous.py
@@ -85,11 +85,11 @@ class Cauchy(Distribution):
 
     @property
     def mean(self):
-        return np.broadcast_to(np.nan, self.batch_shape)
+        return np.full(self.batch_shape, np.nan)
 
     @property
     def variance(self):
-        return np.broadcast_to(np.nan, self.batch_shape)
+        return np.full(self.batch_shape, np.nan)
 
 
 class Dirichlet(Distribution):
@@ -210,11 +210,11 @@ class HalfCauchy(TransformedDistribution):
 
     @property
     def mean(self):
-        return np.full(np.inf, self.batch_shape)
+        return np.full(self.batch_shape, np.inf)
 
     @property
     def variance(self):
-        return np.full(np.inf, self.batch_shape)
+        return np.full(self.batch_shape, np.inf)
 
 
 class Normal(Distribution):

--- a/numpyro/distributions/continuous.py
+++ b/numpyro/distributions/continuous.py
@@ -61,14 +61,13 @@ class Beta(Distribution):
     @property
     def variance(self):
         total = self.concentration1 + self.concentration0
-        return (self.concentration1 * self.concentration0 /
-                (total ** 2 * (total + 1)))
+        return self.concentration1 * self.concentration0 / (total ** 2 * (total + 1))
 
 
 class Cauchy(Distribution):
-    reparametrized_params = ['loc', 'scale']
     arg_constraints = {'loc': constraints.real, 'scale': constraints.positive}
     support = constraints.real
+    reparametrized_params = ['loc', 'scale']
 
     def __init__(self, loc, scale, validate_args=None):
         self.loc, self.scale = promote_shapes(loc, scale)
@@ -116,59 +115,16 @@ class Dirichlet(Distribution):
             self._validate_sample(value)
         normalize_term = (np.sum(gammaln(self.concentration), axis=-1) -
                           gammaln(np.sum(self.concentration, axis=-1)))
-        return (np.sum(np.log(value) * (self.concentration - 1.), axis=-1) -
-                normalize_term)
+        return np.sum(np.log(value) * (self.concentration - 1.), axis=-1) - normalize_term
 
     @property
     def mean(self):
-        return np.broadcast_to(self.concentration / np.sum(self.concentration, axis=-1, keepdims=True),
-                               self.batch_shape + self.event_shape)
+        return self.concentration / np.sum(self.concentration, axis=-1, keepdims=True)
 
     @property
     def variance(self):
         con0 = np.sum(self.concentration, axis=-1, keepdims=True)
-        return np.broadcast_to(self.concentration * (con0 - self.concentration) /
-                               (con0 ** 2 * (con0 + 1)),
-                               self.batch_shape + self.event_shape)
-
-
-class Gamma(Distribution):
-    arg_constraints = {'concentration': constraints.positive,
-                       'rate': constraints.positive}
-    support = constraints.positive
-
-    def __init__(self, concentration, rate, validate_args=None):
-        self.concentration, self.rate = promote_shapes(concentration, rate)
-        batch_shape = lax.broadcast_shapes(np.shape(concentration), np.shape(rate))
-        super(Gamma, self).__init__(batch_shape=batch_shape,
-                                    validate_args=validate_args)
-
-    def sample(self, key, size=()):
-        shape = size + self.batch_shape + self.event_shape
-        return standard_gamma(key, self.concentration, shape=shape) / self.rate
-
-    def log_prob(self, value):
-        if self._validate_args:
-            self._validate_sample(value)
-        normalize_term = (gammaln(self.concentration) -
-                          self.concentration * np.log(self.rate))
-        return (self.concentration - 1) * np.log(value) - self.rate * value - normalize_term
-
-    @property
-    def mean(self):
-        return np.broadcast_to(self.concentration / self.rate, self.batch_shape)
-
-    @property
-    def variance(self):
-        return np.broadcast_to(self.concentration / np.power(self.rate, 2), self.batch_shape)
-
-
-class Chi2(Gamma):
-    arg_constraints = {'df': constraints.positive}
-
-    def __init__(self, df, validate_args=None):
-        self.df = df
-        super(Chi2, self).__init__(0.5 * df, 0.5, validate_args=validate_args)
+        return self.concentration * (con0 - self.concentration) / (con0 ** 2 * (con0 + 1))
 
 
 class Exponential(Distribution):
@@ -197,6 +153,45 @@ class Exponential(Distribution):
         return np.reciprocal(self.rate ** 2)
 
 
+class Gamma(Distribution):
+    arg_constraints = {'concentration': constraints.positive,
+                       'rate': constraints.positive}
+    support = constraints.positive
+
+    def __init__(self, concentration, rate, validate_args=None):
+        self.concentration, self.rate = promote_shapes(concentration, rate)
+        batch_shape = lax.broadcast_shapes(np.shape(concentration), np.shape(rate))
+        super(Gamma, self).__init__(batch_shape=batch_shape,
+                                    validate_args=validate_args)
+
+    def sample(self, key, size=()):
+        shape = size + self.batch_shape + self.event_shape
+        return standard_gamma(key, self.concentration, shape=shape) / self.rate
+
+    def log_prob(self, value):
+        if self._validate_args:
+            self._validate_sample(value)
+        normalize_term = (gammaln(self.concentration) -
+                          self.concentration * np.log(self.rate))
+        return (self.concentration - 1) * np.log(value) - self.rate * value - normalize_term
+
+    @property
+    def mean(self):
+        return self.concentration / self.rate
+
+    @property
+    def variance(self):
+        return self.concentration / np.power(self.rate, 2)
+
+
+class Chi2(Gamma):
+    arg_constraints = {'df': constraints.positive}
+
+    def __init__(self, df, validate_args=None):
+        self.df = df
+        super(Chi2, self).__init__(0.5 * df, 0.5, validate_args=validate_args)
+
+
 class HalfCauchy(TransformedDistribution):
     reparametrized_params = ['scale']
     arg_constraints = {'scale': constraints.positive}
@@ -215,11 +210,11 @@ class HalfCauchy(TransformedDistribution):
 
     @property
     def mean(self):
-        return np.broadcast_to(np.inf, self.batch_shape)
+        return np.full(np.inf, self.batch_shape)
 
     @property
     def variance(self):
-        return np.broadcast_to(np.inf, self.batch_shape)
+        return np.full(np.inf, self.batch_shape)
 
 
 class Normal(Distribution):
@@ -298,37 +293,6 @@ class Pareto(TransformedDistribution):
         return constraints.greater_than(self.scale)
 
 
-class Uniform(Distribution):
-    arg_constraints = {'low': constraints.dependent, 'high': constraints.dependent}
-    reparametrized_params = ['low', 'high']
-
-    def __init__(self, low, high, validate_args=None):
-        self.low, self.high = promote_shapes(low, high)
-        batch_shape = lax.broadcast_shapes(np.shape(low), np.shape(high))
-        super(Uniform, self).__init__(batch_shape=batch_shape, validate_args=validate_args)
-
-    def sample(self, key, size=()):
-        size = size + self.batch_shape
-        return self.low + random.uniform(key, shape=size) * (self.high - self.low)
-
-    def log_prob(self, value):
-        if self._validate_args:
-            self._validate_sample(value)
-        return - np.broadcast_to(np.log(self.high - self.low), np.shape(value))
-
-    @property
-    def mean(self):
-        return np.broadcast_to(self.low + (self.high - self.low) / 2., self.batch_shape)
-
-    @property
-    def variance(self):
-        return np.broadcast_to((self.high - self.low) ** 2 / 12., self.batch_shape)
-
-    @property
-    def support(self):
-        return constraints.interval(self.low, self.high)
-
-
 class StudentT(Distribution):
     arg_constraints = {'df': constraints.positive, 'loc': constraints.real, 'scale': constraints.positive}
     support = constraints.real
@@ -364,3 +328,34 @@ class StudentT(Distribution):
         var = np.where(self.df > 2, self.scale ** 2 * self.df / (self.df - 2.0), np.inf)
         var = np.where(self.df <= 1, np.nan, var)
         return np.broadcast_to(var, self.batch_shape)
+
+
+class Uniform(Distribution):
+    arg_constraints = {'low': constraints.dependent, 'high': constraints.dependent}
+    reparametrized_params = ['low', 'high']
+
+    def __init__(self, low, high, validate_args=None):
+        self.low, self.high = promote_shapes(low, high)
+        batch_shape = lax.broadcast_shapes(np.shape(low), np.shape(high))
+        super(Uniform, self).__init__(batch_shape=batch_shape, validate_args=validate_args)
+
+    def sample(self, key, size=()):
+        size = size + self.batch_shape
+        return self.low + random.uniform(key, shape=size) * (self.high - self.low)
+
+    def log_prob(self, value):
+        if self._validate_args:
+            self._validate_sample(value)
+        return - np.broadcast_to(np.log(self.high - self.low), np.shape(value))
+
+    @property
+    def mean(self):
+        return self.low + (self.high - self.low) / 2.
+
+    @property
+    def variance(self):
+        return (self.high - self.low) ** 2 / 12.
+
+    @property
+    def support(self):
+        return constraints.interval(self.low, self.high)

--- a/numpyro/distributions/discrete.py
+++ b/numpyro/distributions/discrete.py
@@ -82,11 +82,11 @@ class Bernoulli(Distribution):
 
     @property
     def mean(self):
-        return self.probs
+        return np.broadcast_to(self.probs, self.batch_shape)
 
     @property
     def variance(self):
-        return self.probs * (1 - self.probs)
+        return np.broadcast_to(self.probs * (1 - self.probs), self.batch_shape)
 
 
 class BernoulliWithLogits(Distribution):
@@ -113,11 +113,11 @@ class BernoulliWithLogits(Distribution):
 
     @property
     def mean(self):
-        return self.probs
+        return np.broadcast_to(self.probs, self.batch_shape)
 
     @property
     def variance(self):
-        return self.probs * (1 - self.probs)
+        return np.broadcast_to(self.probs * (1 - self.probs), self.batch_shape)
 
 
 class Binomial(Distribution):
@@ -200,81 +200,6 @@ class BinomialWithLogits(Distribution):
         return constraints.integer_interval(0, self.total_count)
 
 
-class Categorical(Distribution):
-    arg_constraints = {'probs': constraints.simplex}
-
-    def __init__(self, probs, validate_args=None):
-        if np.ndim(probs) < 1:
-            raise ValueError("`probs` parameter must be at least one-dimensional.")
-        self.probs = probs
-        super(Categorical, self).__init__(batch_shape=np.shape(self.probs)[:-1],
-                                          validate_args=validate_args)
-
-    def sample(self, key, size=()):
-        return categorical(key, self.probs, shape=size + self.batch_shape)
-
-    def log_prob(self, value):
-        if self._validate_args:
-            self._validate_sample(value)
-        batch_shape = lax.broadcast_shapes(np.shape(value), self.batch_shape)
-        value = np.expand_dims(value, axis=-1)
-        value = np.broadcast_to(value, batch_shape + (1,))
-        logits = _to_logits_multinom(self.probs)
-        log_pmf = np.broadcast_to(logits, batch_shape + np.shape(logits)[-1:])
-        return np.take_along_axis(log_pmf, value, axis=-1)[..., 0]
-
-    @property
-    def mean(self):
-        return np.full(self.batch_shape, np.nan, dtype=self.probs.dtype)
-
-    @property
-    def variance(self):
-        return np.full(self.batch_shape, np.nan, dtype=self.probs.dtype)
-
-    @property
-    def support(self):
-        return constraints.integer_interval(0, np.shape(self.probs)[-1])
-
-
-class CategoricalWithLogits(Distribution):
-    arg_constraints = {'logits': constraints.real}
-
-    def __init__(self, logits, validate_args=None):
-        if np.ndim(logits) < 1:
-            raise ValueError("`logits` parameter must be at least one-dimensional.")
-        logits = logits - logsumexp(logits)
-        self.logits = logits
-        super(CategoricalWithLogits, self).__init__(batch_shape=np.shape(logits)[:-1],
-                                                    validate_args=validate_args)
-
-    def sample(self, key, size=()):
-        return categorical(key, self.probs, shape=size + self.batch_shape)
-
-    def log_prob(self, value):
-        if self._validate_args:
-            self._validate_sample(value)
-        value = np.expand_dims(value, -1)
-        value, log_pmf = promote_shapes(value, self.logits)
-        value = value[..., :1]
-        return np.take_along_axis(log_pmf, value, -1)[..., 0]
-
-    @lazy_property
-    def probs(self):
-        return _to_probs_multinom(self.logits)
-
-    @property
-    def mean(self):
-        return np.full(self.batch_shape, np.nan, dtype=self.logits.dtype)
-
-    @property
-    def variance(self):
-        return np.full(self.batch_shape, np.nan, dtype=self.logits.dtype)
-
-    @property
-    def support(self):
-        return constraints.integer_interval(0, np.shape(self.logits)[-1])
-
-
 class Multinomial(Distribution):
     arg_constraints = {'total_count': constraints.nonnegative_integer,
                        'probs': constraints.simplex}
@@ -302,11 +227,13 @@ class Multinomial(Distribution):
 
     @property
     def mean(self):
-        return self.probs * np.expand_dims(self.total_count, -1)
+        return np.broadcast_to(self.probs * np.expand_dims(self.total_count, -1),
+                               self.batch_shape + self.event_shape)
 
     @property
     def variance(self):
-        return np.expand_dims(self.total_count, -1) * self.probs * (1 - self.probs)
+        return np.broadcast_to(np.expand_dims(self.total_count, -1) * self.probs * (1 - self.probs),
+                               self.batch_shape + self.event_shape)
 
     @property
     def support(self):
@@ -345,15 +272,92 @@ class MultinomialWithLogits(Distribution):
 
     @property
     def mean(self):
-        return np.expand_dims(self.total_count, -1) * self.probs
+        return np.broadcast_to(np.expand_dims(self.total_count, -1) * self.probs,
+                               self.batch_shape + self.event_shape)
 
     @property
     def variance(self):
-        return np.expand_dims(self.total_count, -1) * self.probs * (1 - self.probs)
+        return np.broadcast_to(np.expand_dims(self.total_count, -1) * self.probs * (1 - self.probs),
+                               self.batch_shape + self.event_shape)
 
     @property
     def support(self):
         return constraints.multinomial(self.total_count)
+
+
+class Categorical(Distribution):
+    arg_constraints = {'probs': constraints.simplex}
+
+    def __init__(self, probs, validate_args=None):
+        if np.ndim(probs) < 1:
+            raise ValueError("`probs` parameter must be at least one-dimensional.")
+        self.probs = probs
+        super(Categorical, self).__init__(batch_shape=np.shape(self.probs)[:-1],
+                                          validate_args=validate_args)
+
+    def sample(self, key, size=()):
+        return categorical(key, self.probs, shape=size + self.batch_shape)
+
+    def log_prob(self, value):
+        if self._validate_args:
+            self._validate_sample(value)
+        batch_shape = lax.broadcast_shapes(np.shape(value), self.batch_shape)
+        value = np.expand_dims(value, axis=-1)
+        value = np.broadcast_to(value, batch_shape + (1,))
+        logits = _to_logits_multinom(self.probs)
+        log_pmf = np.broadcast_to(logits, batch_shape + np.shape(logits)[-1:])
+        return np.take_along_axis(log_pmf, value, axis=-1)[..., 0]
+
+    @property
+    def mean(self):
+        return lax.full(self.batch_shape, np.nan, dtype=self.probs.dtype)
+
+    @property
+    def variance(self):
+        return lax.full(self.batch_shape, np.nan, dtype=self.probs.dtype)
+
+    @property
+    def support(self):
+        return constraints.integer_interval(0, np.shape(self.probs)[-1])
+
+
+class CategoricalWithLogits(Distribution):
+    arg_constraints = {'logits': constraints.real}
+
+    def __init__(self, logits, validate_args=None):
+        if np.ndim(logits) < 1:
+            raise ValueError("`logits` parameter must be at least one-dimensional.")
+        logits = logits - logsumexp(logits)
+        self.logits = logits
+        super(CategoricalWithLogits, self).__init__(batch_shape=np.shape(logits)[:-1],
+                                                    validate_args=validate_args)
+
+    def sample(self, key, size=()):
+        return categorical(key, self.probs, shape=size + self.batch_shape)
+
+    def log_prob(self, value):
+        if self._validate_args:
+            self._validate_sample(value)
+        value = np.expand_dims(value, -1)
+        value, log_pmf = promote_shapes(value, self.logits)
+        value = value[..., :1]
+        return np.take_along_axis(log_pmf, value, -1)[..., 0]
+
+    @lazy_property
+    def probs(self):
+        return _to_probs_multinom(self.logits)
+
+    @property
+    def mean(self):
+        return lax.full(self.batch_shape, np.nan, dtype=self.logits.dtype)
+
+    @property
+    def variance(self):
+        return lax.full(self.batch_shape, np.nan, dtype=self.logits.dtype)
+
+    @property
+    def support(self):
+        return constraints.integer_interval(0, np.shape(self.logits)[-1])
 
 
 class Poisson(Distribution):

--- a/numpyro/distributions/discrete.py
+++ b/numpyro/distributions/discrete.py
@@ -225,11 +225,11 @@ class Categorical(Distribution):
 
     @property
     def mean(self):
-        return lax.full(self.batch_shape, np.nan, dtype=self.probs.dtype)
+        return np.full(self.batch_shape, np.nan, dtype=self.probs.dtype)
 
     @property
     def variance(self):
-        return lax.full(self.batch_shape, np.nan, dtype=self.probs.dtype)
+        return np.full(self.batch_shape, np.nan, dtype=self.probs.dtype)
 
     @property
     def support(self):
@@ -264,11 +264,11 @@ class CategoricalWithLogits(Distribution):
 
     @property
     def mean(self):
-        return lax.full(self.batch_shape, np.nan, dtype=self.logits.dtype)
+        return np.full(self.batch_shape, np.nan, dtype=self.logits.dtype)
 
     @property
     def variance(self):
-        return lax.full(self.batch_shape, np.nan, dtype=self.logits.dtype)
+        return np.full(self.batch_shape, np.nan, dtype=self.logits.dtype)
 
     @property
     def support(self):
@@ -345,13 +345,11 @@ class MultinomialWithLogits(Distribution):
 
     @property
     def mean(self):
-        return np.broadcast_to(np.expand_dims(self.total_count, -1) * self.probs,
-                               self.batch_shape + self.event_shape)
+        return np.expand_dims(self.total_count, -1) * self.probs
 
     @property
     def variance(self):
-        return np.broadcast_to(np.expand_dims(self.total_count, -1) * self.probs * (1 - self.probs),
-                               self.batch_shape + self.event_shape)
+        return np.expand_dims(self.total_count, -1) * self.probs * (1 - self.probs)
 
     @property
     def support(self):

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -13,7 +13,7 @@ from jax import lax
 import numpyro.distributions as dist
 import numpyro.distributions.constraints as constraints
 from numpyro.distributions.discrete import _to_probs_bernoulli, _to_probs_multinom
-from numpyro.distributions.util import multinomial_rvs, poisson
+from numpyro.distributions.util import multinomial, poisson
 
 
 def _identity(x): return x
@@ -135,7 +135,7 @@ def gen_values_within_bounds(constraint, size, key=random.PRNGKey(11)):
         return osp.dirichlet.rvs(alpha=np.ones((size[-1],)), size=size[:-1])
     elif isinstance(constraint, constraints._Multinomial):
         n = size[-1]
-        return multinomial_rvs(key, n=constraint.upper_bound, p=np.ones((n,)) / n, shape=size[:-1])
+        return multinomial(key, p=np.ones((n,)) / n, n=constraint.upper_bound, shape=size[:-1])
     else:
         raise NotImplementedError('{} not implemented.'.format(constraint))
 
@@ -159,7 +159,7 @@ def gen_values_outside_bounds(constraint, size, key=random.PRNGKey(11)):
         return osp.dirichlet.rvs(alpha=np.ones((size[-1],)), size=size[:-1]) + 1e-2
     elif isinstance(constraint, constraints._Multinomial):
         n = size[-1]
-        return multinomial_rvs(key, n=constraint.upper_bound, p=np.ones((n,)) / n, shape=size[:-1]) + 1
+        return multinomial(key, p=np.ones((n,)) / n, n=constraint.upper_bound, shape=size[:-1]) + 1
     else:
         raise NotImplementedError('{} not implemented.'.format(constraint))
 

--- a/test/test_distributions_util.py
+++ b/test/test_distributions_util.py
@@ -13,10 +13,10 @@ from jax.util import partial
 
 from numpyro.distributions.util import (
     binary_cross_entropy_with_logits,
-    categorical_rvs,
+    categorical,
     cumprod,
     cumsum,
-    multinomial_rvs,
+    multinomial,
     standard_gamma,
     vec_to_tril_matrix,
     xlog1py,
@@ -169,7 +169,7 @@ def test_standard_gamma_grad(alpha):
 def test_categorical_shape(p, shape):
     rng = random.PRNGKey(0)
     expected_shape = lax.broadcast_shapes(p.shape[:-1], shape)
-    assert np.shape(categorical_rvs(rng, p, shape)) == expected_shape
+    assert np.shape(categorical(rng, p, shape)) == expected_shape
 
 
 @pytest.mark.parametrize("p", [
@@ -179,7 +179,7 @@ def test_categorical_shape(p, shape):
 def test_categorical_stats(p):
     rng = random.PRNGKey(0)
     n = 10000
-    z = categorical_rvs(rng, p, (n,))
+    z = categorical(rng, p, (n,))
     _, counts = onp.unique(z, return_counts=True)
     assert_allclose(counts / float(n), p, atol=0.01)
 
@@ -194,7 +194,7 @@ def test_multinomial_shape(p, shape):
     rng = random.PRNGKey(0)
     n = 10000
     expected_shape = lax.broadcast_shapes(p.shape[:-1], shape) + p.shape[-1:]
-    assert np.shape(multinomial_rvs(rng, n, p, shape)) == expected_shape
+    assert np.shape(multinomial(rng, p, n, shape)) == expected_shape
 
 
 @pytest.mark.parametrize("p", [
@@ -207,7 +207,7 @@ def test_multinomial_shape(p, shape):
 ])
 def test_multinomial_stats(p, n):
     rng = random.PRNGKey(0)
-    z = multinomial_rvs(rng, n, p)
+    z = multinomial(rng, p, n)
     n = float(n) if isinstance(n, Number) else np.expand_dims(n.astype(p.dtype), -1)
     p = np.broadcast_to(p, z.shape)
     assert_allclose(z / n, p, atol=0.01)

--- a/test/test_distributions_util.py
+++ b/test/test_distributions_util.py
@@ -157,7 +157,7 @@ def test_standard_gamma_grad(alpha):
     pdf = osp_stats.gamma.pdf(z, alpha)
     expected_grad = -cdf_dot / pdf
 
-    assert_allclose(actual_grad, expected_grad, rtol=0.0005)
+    assert_allclose(actual_grad, expected_grad, atol=1e-8, rtol=0.0005)
 
 
 @pytest.mark.parametrize('p, shape', [


### PR DESCRIPTION
Fix #112 by using `custom_transform` decorator.

In addition, this PR fixes tests with for fastmath mode (Peter (jax devs) mentioned that `np.inf`, `np.nan`, `np.exp` is fixed in the newer version of jaxlib so I would like to test it out and fixes errors during the way).