### PR TITLE
Add baseball example in numpyro

### DIFF
--- a/numpyro/distributions/continuous.py
+++ b/numpyro/distributions/continuous.py
@@ -314,7 +314,7 @@ class Uniform(Distribution):
     def log_prob(self, value):
         if self._validate_args:
             self._validate_sample(value)
-        return - np.broadcast_to(np.log(self.high - self.low), np.shape(value))
+        return - np.log(np.broadcast_to(self.high - self.low, np.shape(value)))
 
     @property
     def mean(self):

--- a/numpyro/distributions/continuous.py
+++ b/numpyro/distributions/continuous.py
@@ -314,7 +314,7 @@ class Uniform(Distribution):
     def log_prob(self, value):
         if self._validate_args:
             self._validate_sample(value)
-        return - np.log(np.broadcast_to(self.high - self.low, np.shape(value)))
+        return - np.broadcast_to(np.log(self.high - self.low), np.shape(value))
 
     @property
     def mean(self):

--- a/numpyro/examples/baseball.py
+++ b/numpyro/examples/baseball.py
@@ -14,8 +14,8 @@ from numpyro.mcmc import hmc
 from numpyro.util import fori_collect
 
 """
-Original example from Pyro: 
-https://github.com/pyro-ppl/pyro/blob/dev/examples/baseball.py 
+Original example from Pyro:
+https://github.com/pyro-ppl/pyro/blob/dev/examples/baseball.py
 
 Example has been adapted from [1]. It demonstrates how to do Bayesian inference using
 NUTS (or, HMC) in Pyro, and use of some common inference utilities.

--- a/numpyro/examples/baseball.py
+++ b/numpyro/examples/baseball.py
@@ -58,6 +58,14 @@ DATA_URL = "https://d2fefpcigoriu7.cloudfront.net/datasets/EfronMorrisBB.txt"
 
 # TODO: Remove broadcasting logic when support for `pyro.plate` is
 # available.
+#
+# Note that the current manual broadcasting logic is designed to
+# also work when the latent variables are batched along the leading
+# axis. This is useful for doing vectorized predictions, i.e. getting
+# the entire empirical distribution in one pass through the model.
+# This broadcasting logic can be removed when support for plates is
+# available.
+
 def fully_pooled(at_bats, hits=None):
     r"""
     Number of hits in $K$ at bats for each player has a Binomial

--- a/numpyro/examples/baseball.py
+++ b/numpyro/examples/baseball.py
@@ -1,0 +1,181 @@
+import argparse
+import numpyro.distributions as dist
+import jax.numpy as np
+import jax.random as random
+
+from numpyro.examples.datasets import load_dataset, BASEBALL
+from numpyro.handlers import sample, substitute, seed
+from numpyro.hmc_util import initialize_model
+from numpyro.mcmc import hmc
+from numpyro.util import fori_collect, control_flow_prims_disabled
+
+"""
+Original example from 
+
+Example has been adapted from [1]. It demonstrates how to do Bayesian inference using
+NUTS (or, HMC) in Pyro, and use of some common inference utilities.
+
+As in the Stan tutorial, this uses the small baseball dataset of Efron and Morris [2]
+to estimate players' batting average which is the fraction of times a player got a
+base hit out of the number of times they went up at bat.
+
+The dataset separates the initial 45 at-bats statistics from the remaining season.
+We use the hits data from the initial 45 at-bats to estimate the batting average
+for each player. We then use the remaining season's data to validate the predictions
+from our models.
+
+Three models are evaluated:
+ - Complete pooling model: The success probability of scoring a hit is shared
+     amongst all players.
+ - No pooling model: Each individual player's success probability is distinct and
+     there is no data sharing amongst players.
+ - Partial pooling model: A hierarchical model with partial data sharing.
+
+
+We recommend Radford Neal's tutorial on HMC ([3]) to users who would like to get a
+more comprehensive understanding of HMC and its variants, and to [4] for details on
+the No U-Turn Sampler, which provides an efficient and automated way (i.e. limited
+hyper-parameters) of running HMC on different problems.
+
+[1] Carpenter B. (2016), ["Hierarchical Partial Pooling for Repeated Binary Trials"]
+    (http://mc-stan.org/users/documentation/case-studies/pool-binary-trials.html).
+[2] Efron B., Morris C. (1975), "Data analysis using Stein's estimator and its
+    generalizations", J. Amer. Statist. Assoc., 70, 311-319.
+[3] Neal, R. (2012), "MCMC using Hamiltonian Dynamics",
+    (https://arxiv.org/pdf/1206.1901.pdf)
+[4] Hoffman, M. D. and Gelman, A. (2014), "The No-U-turn sampler: Adaptively setting
+    path lengths in Hamiltonian Monte Carlo", (https://arxiv.org/abs/1111.4246)
+"""
+
+
+DATA_URL = "https://d2fefpcigoriu7.cloudfront.net/datasets/EfronMorrisBB.txt"
+
+
+def fully_pooled(at_bats, hits=None):
+    r"""
+    Number of hits in $K$ at bats for each player has a Binomial
+    distribution with a common probability of success, $\phi$.
+
+    :param (np.DeviceArray) at_bats: Number of at bats for each player.
+    :param (np.DeviceArray) hits: Number of hits for the given at bats.
+    :return: Number of hits predicted by the model.
+    """
+    phi_prior = dist.Uniform(np.array([0.]), np.array([1.]))
+    phi = sample("phi", phi_prior)
+    return sample("obs", dist.Binomial(phi, at_bats), obs=hits)
+
+
+def not_pooled(at_bats, hits=None):
+    r"""
+    Number of hits in $K$ at bats for each player has a Binomial
+    distribution with independent probability of success, $\phi_i$.
+
+    :param (np.DeviceArray) at_bats: Number of at bats for each player.
+    :param (np.DeviceArray) hits: Number of hits for the given at bats.
+    :return: Number of hits predicted by the model.
+    """
+    num_players = at_bats.shape[0]
+    phi_prior = dist.Uniform(np.zeros((num_players,)),
+                             np.ones((num_players,)))
+    phi = sample("phi", phi_prior)
+    return sample("obs", dist.Binomial(phi, at_bats), obs=hits)
+
+
+def partially_pooled(at_bats, hits=None):
+    r"""
+    Number of hits has a Binomial distribution with independent
+    probability of success, $\phi_i$. Each $\phi_i$ follows a Beta
+    distribution with concentration parameters $c_1$ and $c_2$, where
+    $c_1 = m * kappa$, $c_2 = (1 - m) * kappa$, $m ~ Uniform(0, 1)$,
+    and $kappa ~ Pareto(1, 1.5)$.
+
+    :param (np.DeviceArray) at_bats: Number of at bats for each player.
+    :param (np.DeviceArray) hits: Number of hits for the given at bats.
+    :return: Number of hits predicted by the model.
+    """
+    num_players = at_bats.shape[0]
+    m = sample("m", dist.Uniform(np.array([0.]), np.array([1.])))
+    kappa = sample("kappa", dist.Pareto(np.array([1.]), np.array([1.5])))
+    shape = np.shape(kappa)[:np.ndim(kappa) - 1] + (num_players,)
+    phi_prior = dist.Beta(np.broadcast_to(m * kappa, shape),
+                          np.broadcast_to((1 - m) * kappa, shape))
+    phi = sample("phi", phi_prior)
+    return sample("obs", dist.Binomial(phi, at_bats), obs=hits)
+
+
+def partially_pooled_with_logit(at_bats, hits=None):
+    r"""
+    Number of hits has a Binomial distribution with a logit link function.
+    The logits $\alpha$ for each player is normally distributed with the
+    mean and scale parameters sharing a common prior.
+
+    :param (np.DeviceArray) at_bats: Number of at bats for each player.
+    :param (np.DeviceArray) hits: Number of hits for the given at bats.
+    :return: Number of hits predicted by the model.
+    """
+    num_players = at_bats.shape[0]
+    loc = sample("loc", dist.Normal(np.array([-1.]), np.array([1.])))
+    scale = sample("scale", dist.HalfCauchy(np.array([1.])))
+    shape = np.shape(loc)[:np.ndim(loc) - 1] + (num_players,)
+    alpha = sample("alpha", dist.Normal(np.broadcast_to(loc, shape),
+                                        np.broadcast_to(scale, shape)))
+    return sample("obs", dist.BinomialWithLogits(alpha, at_bats), obs=hits)
+
+
+def run_inference(model, at_bats, hits, rng, args):
+    init_params, potential_fn, transform_fn = initialize_model(rng, model,
+                                                               (at_bats, hits), {})
+    with control_flow_prims_disabled():
+        init_kernel, sample_kernel = hmc(potential_fn, algo='NUTS')
+        hmc_state = init_kernel(init_params, args.num_warmup_steps)
+        hmc_states = fori_collect(args.num_samples, sample_kernel, hmc_state,
+                                  transform=lambda hmc_state: transform_fn(hmc_state.z),
+                                  progbar=True)
+    return hmc_states
+
+
+def predict(model, at_bats, z, rng, player_names, hits):
+    model_name = model.__name__
+    model = substitute(seed(model, rng), z)
+    predictions = model(at_bats)
+    mean, std = np.mean(predictions, 0), np.std(predictions, 0)
+    print_out('=' * 15 + model_name + '=' * 15,
+              mean,
+              std,
+              player_names,
+              hits)
+
+
+def print_out(header, mean, std, player_names, hits):
+    columns = ['', 'Mean', 'Std', 'ActualHits']
+    header_format = '{:>20} {:>7} {:>7} {:>14}'
+    row_format = '{:>20} {:>7.2f} {:>7.2f} {:>14}'
+    print('\n\n')
+    print(header)
+    print(header_format.format(*columns))
+    for i, p in enumerate(player_names):
+        print(row_format.format(p, mean[i], std[i], hits[i]))
+    print('\n\n')
+
+
+def main(args):
+    _, fetch = load_dataset(BASEBALL, split='train', shuffle=False)
+    train, player_names = fetch(0)
+    at_bats, hits = train[:, 0], train[:, 1]
+    for i, model in enumerate((#fully_pooled,
+                               not_pooled,
+                               #partially_pooled,
+                               # partially_pooled_with_logit,
+                               )):
+        rng, rng_predict = random.split(random.PRNGKey(i))
+        zs = run_inference(model, at_bats, hits, random.PRNGKey(i), args)
+        predict(model, at_bats, zs, rng_predict, player_names, hits)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Baseball batting average using HMC")
+    parser.add_argument("-n", "--num-samples", nargs="?", default=20, type=int)
+    parser.add_argument("--num-warmup-steps", nargs='?', default=10, type=int)
+    parser.add_argument('--device', default='cpu', type=str, help='use "cpu" or "gpu".')
+    args = parser.parse_args()
+    main(args)

--- a/numpyro/examples/datasets.py
+++ b/numpyro/examples/datasets.py
@@ -114,7 +114,7 @@ def load_dataset(dset, batch_size=None, split='train', shuffle=True):
     def init():
         return num_records // batch_size, np.random.permutation(idxs) if shuffle else idxs
 
-    def get_batch(i, idxs=idxs):
+    def get_batch(i=0, idxs=idxs):
         ret_idx = lax.dynamic_slice_in_dim(idxs, (i + 1) * batch_size, batch_size)
         return tuple(lax.index_take(a, (ret_idx,), axes=(0,)) if isinstance(a, DeviceArray)
                      else np.take(a, ret_idx, axis=0) for a in arrays)

--- a/numpyro/examples/datasets.py
+++ b/numpyro/examples/datasets.py
@@ -1,3 +1,4 @@
+import csv
 import gzip
 import os
 import struct
@@ -8,6 +9,7 @@ from urllib.request import urlretrieve
 import numpy as np
 
 from jax import device_put, lax
+from jax.interpreters.xla import DeviceArray
 
 DATA_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__),
                                         '.data'))
@@ -22,6 +24,10 @@ MNIST = dset('mnist', [
     'https://d2fefpcigoriu7.cloudfront.net/datasets/mnist/train-labels-idx1-ubyte.gz',
     'https://d2fefpcigoriu7.cloudfront.net/datasets/mnist/t10k-images-idx3-ubyte.gz',
     'https://d2fefpcigoriu7.cloudfront.net/datasets/mnist/t10k-labels-idx1-ubyte.gz',
+])
+
+BASEBALL = dset('baseball', [
+    "https://d2fefpcigoriu7.cloudfront.net/datasets/EfronMorrisBB.txt",
 ])
 
 
@@ -56,9 +62,31 @@ def _load_mnist():
             'test': (read_img(files[2]), read_label(files[3]))}
 
 
+def _load_baseball():
+    _download(BASEBALL)
+
+    def train_test_split(file):
+        train, test, player_names = [], [], []
+        with open(file, 'r') as f:
+            csv_reader = csv.DictReader(f, delimiter='\t', quoting=csv.QUOTE_NONE)
+            for row in csv_reader:
+                player_names.append(row['FirstName'] + ' ' + row['LastName'])
+                at_bats, hits = row['At-Bats'], row['Hits']
+                train.append(np.array([int(at_bats), int(hits)]))
+                season_at_bats, season_hits = row['SeasonAt-Bats'], row['SeasonHits']
+                test.append(np.array([int(season_at_bats), int(season_hits)]))
+        return np.stack(train), np.stack(test), np.array(player_names)
+
+    train, test, player_names = train_test_split(os.path.join(DATA_DIR, 'EfronMorrisBB.txt'))
+    return {'train': (train, player_names),
+            'test': (test, player_names)}
+
+
 def _load(dset):
     if dset == MNIST:
         return _load_mnist()
+    elif dset == BASEBALL:
+        return _load_baseball()
     raise ValueError('Dataset - {} not found.'.format(dset.name))
 
 
@@ -86,8 +114,9 @@ def load_dataset(dset, batch_size=None, split='train', shuffle=True):
     def init():
         return num_records // batch_size, np.random.permutation(idxs) if shuffle else idxs
 
-    def get_batch(i, idxs):
+    def get_batch(i, idxs=idxs):
         ret_idx = lax.dynamic_slice_in_dim(idxs, (i + 1) * batch_size, batch_size)
-        return tuple(lax.index_take(a, (ret_idx,), axes=(0,)) for a in arrays)
+        return tuple(lax.index_take(a, (ret_idx,), axes=(0,)) if isinstance(a, DeviceArray)
+                     else np.take(a, ret_idx, axis=0) for a in arrays)
 
     return init, get_batch

--- a/numpyro/examples/datasets.py
+++ b/numpyro/examples/datasets.py
@@ -115,7 +115,7 @@ def load_dataset(dset, batch_size=None, split='train', shuffle=True):
         return num_records // batch_size, np.random.permutation(idxs) if shuffle else idxs
 
     def get_batch(i=0, idxs=idxs):
-        ret_idx = lax.dynamic_slice_in_dim(idxs, (i + 1) * batch_size, batch_size)
+        ret_idx = lax.dynamic_slice_in_dim(idxs, i * batch_size, batch_size)
         return tuple(lax.index_take(a, (ret_idx,), axes=(0,)) if isinstance(a, DeviceArray)
                      else np.take(a, ret_idx, axis=0) for a in arrays)
 

--- a/numpyro/examples/vae.py
+++ b/numpyro/examples/vae.py
@@ -21,7 +21,7 @@ def sigmoid(x):
 
 # TODO: move to JAX
 def _elemwise_no_params(fun, **kwargs):
-    def init_fun(input_shape): return input_shape, ()
+    def init_fun(rng, input_shape): return input_shape, ()
 
     def apply_fun(params, inputs, rng=None): return fun(inputs, **kwargs)
 
@@ -88,8 +88,9 @@ def main(args):
     train_init, train_fetch = load_dataset(MNIST, batch_size=args.batch_size, split='train')
     test_init, test_fetch = load_dataset(MNIST, batch_size=args.batch_size, split='test')
     num_train, train_idx = train_init()
-    _, encoder_params = encoder_init((args.batch_size, 28 * 28))
-    _, decoder_params = decoder_init((args.batch_size, args.z_dim))
+    rng, rng_enc, rng_dec = random.split(rng, 3)
+    _, encoder_params = encoder_init(rng_enc, (args.batch_size, 28 * 28))
+    _, decoder_params = decoder_init(rng_dec, (args.batch_size, args.z_dim))
     params = {'encoder': encoder_params, 'decoder': decoder_params}
     rng, sample_batch = binarize(rng, train_fetch(0, train_idx)[0])
     opt_state = svi_init(rng, (sample_batch,), (sample_batch,), params)

--- a/test/test_example_utils.py
+++ b/test/test_example_utils.py
@@ -1,7 +1,7 @@
 import jax.numpy as np
 from jax import lax
 
-from numpyro.examples.datasets import MNIST, load_dataset, BASEBALL
+from numpyro.examples.datasets import BASEBALL, MNIST, load_dataset
 
 
 def test_mnist_data_load():

--- a/test/test_example_utils.py
+++ b/test/test_example_utils.py
@@ -1,10 +1,10 @@
 import jax.numpy as np
 from jax import lax
 
-from numpyro.examples.datasets import MNIST, load_dataset
+from numpyro.examples.datasets import MNIST, load_dataset, BASEBALL
 
 
-def test_data_load():
+def test_mnist_data_load():
     def mean_pixels(i, mean_pix):
         batch, _ = fetch(i, idx)
         return mean_pix + np.sum(batch) / batch.size
@@ -12,3 +12,11 @@ def test_data_load():
     init, fetch = load_dataset(MNIST, batch_size=128, split='train')
     num_batches, idx = init()
     assert lax.fori_loop(0, num_batches, mean_pixels, np.float32(0.)) / num_batches < 0.15
+
+
+def test_baseball_data_load():
+    init, fetch = load_dataset(BASEBALL, split='train', shuffle=False)
+    num_batches, idx = init()
+    dataset = fetch(0, idx)
+    assert np.shape(dataset[0]) == (18, 2)
+    assert np.shape(dataset[1]) == (18,)


### PR DESCRIPTION
This adds the baseball example to numpyro, following pretty much the same style as in Pyro. I am seeing a speedup of ~20-40X speedup in some of these models.

Note that inference fails for the `no-pooling` model unless we disable fastmath mode, and I spent quite a long time trying to pinpoint where the bug lay. 

Addresses: #90. Note that I have not benchmarked against Stan, and will be doing that separately.