### PR TITLE
Update to newer jax version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ sudo: false
 env:
     global:
         - PYTHONPATH=$PWD:$PYTHONPATH
-        - XLA_FLAGS=--xla_cpu_enable_fast_math=false
 
 cache:
     directories:

--- a/numpyro/examples/minipyro.py
+++ b/numpyro/examples/minipyro.py
@@ -29,8 +29,8 @@ def main(args):
 
     # Construct an SVI object so we can do variational inference on our
     # model/guide pair.
-    opt_init, opt_update = optimizers.adam(args.learning_rate)
-    svi_init, svi_update, _ = svi(model, guide, elbo, opt_init, opt_update)
+    opt_init, opt_update, get_params = optimizers.adam(args.learning_rate)
+    svi_init, svi_update, _ = svi(model, guide, elbo, opt_init, opt_update, get_params)
     rng = PRNGKey(0)
     opt_state = svi_init(rng, model_args=(data,))
 
@@ -46,7 +46,7 @@ def main(args):
 
     # Report the final values of the variational parameters
     # in the guide after training.
-    params = optimizers.get_params(opt_state)
+    params = get_params(opt_state)
     for name, value in params.items():
         print("{} = {}".format(name, value))
 

--- a/numpyro/examples/vae.py
+++ b/numpyro/examples/vae.py
@@ -80,8 +80,8 @@ def binarize(rng, batch):
 def main(args):
     encoder_init, encode = encoder(args.hidden_dim, args.z_dim)
     decoder_init, decode = decoder(args.hidden_dim, 28 * 28)
-    opt_init, opt_update = optimizers.adam(args.learning_rate)
-    svi_init, svi_update, svi_eval = svi(model, guide, elbo, opt_init, opt_update,
+    opt_init, opt_update, get_params = optimizers.adam(args.learning_rate)
+    svi_init, svi_update, svi_eval = svi(model, guide, elbo, opt_init, opt_update, get_params,
                                          encode=encode, decode=decode, z_dim=args.z_dim)
     svi_update = jit(svi_update)
     rng = PRNGKey(0)
@@ -125,7 +125,7 @@ def main(args):
         img = test_fetch(0, test_idx)[0][0]
         plt.imsave(os.path.join(RESULTS_DIR, 'original_epoch={}.png'.format(epoch)), img, cmap='gray')
         _, test_sample = binarize(rng, img)
-        params = optimizers.get_params(opt_state)
+        params = get_params(opt_state)
         z_mean, z_var = encode(params['encoder'], test_sample.reshape([1, -1]))
         z = dist.Normal(z_mean, z_var).sample(rng)
         img_loc = decode(params['decoder'], z).reshape([28, 28])

--- a/numpyro/patch.py
+++ b/numpyro/patch.py
@@ -1,8 +1,3 @@
-import jax
-import jax.interpreters.partial_eval as pe
-import jax.linear_util as lu
-
-
 def patch_dependency(target, root_module):
     parts = target.split('.')
     assert parts[0] == root_module.__name__
@@ -20,9 +15,3 @@ def patch_dependency(target, root_module):
         return new_fn
 
     return decorator
-
-
-# TODO: Remove with jax v0.1.26
-@patch_dependency('jax.interpreters.partial_eval.trace_unwrapped_to_jaxpr', jax)
-def _trace_unwrapped_to_jaxpr(fun, pvals, **kwargs):
-    return pe.trace_to_jaxpr(lu.wrap_init(fun, kwargs), pvals)

--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -8,7 +8,7 @@ import tqdm
 import jax.numpy as np
 from jax import jit, lax, ops, vmap
 from jax.flatten_util import ravel_pytree
-from jax.tree_util import register_pytree_node, tree_flatten, tree_map, tree_multimap
+from jax.tree_util import register_pytree_node
 
 _DATA_TYPES = {}
 _DISABLE_CONTROL_FLOW_PRIM = False

--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -96,27 +96,11 @@ def fori_loop(lower, upper, body_fun, init_val):
         return lax.fori_loop(lower, upper, body_fun, init_val)
 
 
-def scan(f, a, bs):
-    if _DISABLE_CONTROL_FLOW_PRIM:
-        length = tree_flatten(bs)[0][0].shape[0]
-        for i in range(length):
-            b = tree_map(lambda x: x[i], bs)
-            a = f(a, b)
-            a_out = tree_map(lambda x: np.expand_dims(x, axis=0), a)
-            if i == 0:
-                out = a_out
-            else:
-                out = tree_multimap(lambda x, y: np.concatenate((x, y)), out, a_out)
-        return out
-    else:
-        return lax.scan(f, a, bs)
-
-
 def _identity(x):
     return x
 
 
-def fori_collect(n, body_fun, init_val, transform=_identity, progbar=False):
+def fori_collect(n, body_fun, init_val, transform=_identity, progbar=True):
     # works like lax.fori_loop but ignores i in body_fn, supports
     # postprocessing `transform`, and collects values during the loop
     init_val_flat, unravel_fn = ravel_pytree(transform(init_val))

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,8 @@ setup(
     author='Uber AI Labs',
     author_email='npradhan@uber.com',
     install_requires=[
-        'jax>=0.1.25',
-        'jaxlib>=0.1.12',
+        'jax>=0.1.26',
+        'jaxlib>=0.1.13',
         'tqdm',
     ],
     extras_require={

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -81,7 +81,7 @@ CONTINUOUS = [
     T(dist.Pareto, np.array([0.3, 2.]), np.array([1., 0.5])),
     T(dist.Pareto, np.array([1., 0.5]), np.array([[1.], [3.]])),
     T(dist.StudentT, 1., 1., 0.5),
-    T(dist.StudentT, 1.5, np.array([1., 2.]), 2.),
+    T(dist.StudentT, 2., np.array([1., 2.]), 2.),
     T(dist.StudentT, np.array([3, 5]), np.array([[1.], [2.]]), 2.),
     T(dist.Uniform, 0., 2.),
     T(dist.Uniform, 1., np.array([2., 3.])),

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -422,7 +422,7 @@ def test_biject_to(constraint, shape):
 
     # test inv
     z = transform.inv(y)
-    assert_allclose(x, z, atol=1e-6)
+    assert_allclose(x, z, atol=1e-6, rtol=1e-6)
 
     # test domain, currently all is constraints.real
     assert_array_equal(transform.domain(z), np.ones(shape))

--- a/test/test_mcmc.py
+++ b/test/test_mcmc.py
@@ -74,9 +74,11 @@ def test_beta_bernoulli(algo):
     init_kernel, sample_kernel = hmc(potential_fn, algo=algo)
     hmc_state = init_kernel(init_params,
                             trajectory_length=1.,
-                            num_warmup_steps=warmup_steps)
+                            num_warmup_steps=warmup_steps,
+                            progbar=False)
     hmc_states = fori_collect(num_samples, sample_kernel, hmc_state,
-                              transform=lambda x: transform_fn(x.z))
+                              transform=lambda x: transform_fn(x.z),
+                              progbar=False)
     assert_allclose(np.mean(hmc_states['p_latent'], 0), true_probs, atol=0.05)
 
 
@@ -96,9 +98,11 @@ def test_dirichlet_categorical(algo):
     init_kernel, sample_kernel = hmc(potential_fn, algo=algo)
     hmc_state = init_kernel(init_params,
                             trajectory_length=1.,
-                            num_warmup_steps=warmup_steps)
+                            num_warmup_steps=warmup_steps,
+                            progbar=False)
     hmc_states = fori_collect(num_samples, sample_kernel, hmc_state,
-                              transform=lambda x: transform_fn(x.z))
+                              transform=lambda x: transform_fn(x.z),
+                              progbar=False)
     assert_allclose(np.mean(hmc_states['p_latent'], 0), true_probs, atol=0.02)
 
 
@@ -125,11 +129,9 @@ def test_change_point():
     init_params, potential_fn, transform_fn = initialize_model(random.PRNGKey(2), model,
                                                                (count_data,), {})
     init_kernel, sample_kernel = hmc(potential_fn)
-    hmc_state = init_kernel(init_params, num_warmup_steps=warmup_steps,
-                            progbar=True)
+    hmc_state = init_kernel(init_params, num_warmup_steps=warmup_steps)
     hmc_states = fori_collect(num_samples, sample_kernel, hmc_state,
-                              transform=lambda x: transform_fn(x.z),
-                              progbar=True)
+                              transform=lambda x: transform_fn(x.z))
     tau_posterior = (hmc_states['tau'] * len(count_data)).astype("int")
     tau_values, counts = onp.unique(tau_posterior, return_counts=True)
     mode_ind = np.argmax(counts)
@@ -154,10 +156,8 @@ def test_binomial_stable(with_logits):
     data = {'n': 5000000, 'x': 3849}
     init_params, potential_fn, transform_fn = initialize_model(random.PRNGKey(2), model, (data,), {})
     init_kernel, sample_kernel = hmc(potential_fn)
-    hmc_state = init_kernel(init_params, num_warmup_steps=warmup_steps,
-                            progbar=True)
+    hmc_state = init_kernel(init_params, num_warmup_steps=warmup_steps)
     hmc_states = fori_collect(num_samples, sample_kernel, hmc_state,
-                              transform=lambda x: transform_fn(x.z),
-                              progbar=True)
+                              transform=lambda x: transform_fn(x.z))
 
     assert_allclose(np.mean(hmc_states['p'], 0), data['x'] / data['n'], rtol=0.05)

--- a/test/test_optimizers.py
+++ b/test/test_optimizers.py
@@ -8,17 +8,17 @@ def loss(params):
     return np.sum(params['x'] ** 2 + params['y'] ** 2)
 
 
-def step(i, opt_state, opt_update):
-    params = optimizers.get_params(opt_state)
+def step(i, opt_state, opt_update, get_params):
+    params = get_params(opt_state)
     g = grad(loss)(params)
     return opt_update(i, g, opt_state)
 
 
 def test_optim_multi_params():
     params = {'x': np.array([1., 1., 1.]), 'y': np.array([-1, -1., -1.])}
-    opt_init, opt_update = optimizers.adam(step_size=1e-2)
+    opt_init, opt_update, get_params = optimizers.adam(step_size=1e-2)
     opt_state = opt_init(params)
     for i in range(1000):
-        opt_state = step(i, opt_state, opt_update)
-    for _, param in optimizers.get_params(opt_state).items():
+        opt_state = step(i, opt_state, opt_update, get_params)
+    for _, param in get_params(opt_state).items():
         assert np.allclose(param, np.zeros(3))

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1,8 +1,5 @@
-from numpy.testing import assert_allclose
-
 import jax.numpy as np
 from jax.test_util import check_eq
-from jax.tree_util import tree_map
 
 from numpyro.util import fori_collect
 

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1,11 +1,10 @@
 from numpy.testing import assert_allclose
 
 import jax.numpy as np
-from jax import lax
 from jax.test_util import check_eq
 from jax.tree_util import tree_map
 
-from numpyro.util import control_flow_prims_disabled, fori_collect, laxtuple, scan
+from numpyro.util import fori_collect
 
 
 def test_fori_collect():
@@ -13,27 +12,6 @@ def test_fori_collect():
         return {'i': x['i'] + x['j'], 'j': x['i'] - x['j']}
 
     a = {'i': np.array([0.]), 'j': np.array([1.])}
-    scan_tree = lax.scan(lambda x, y: f(x), a, np.arange(3))
-    expected_tree = {'i': scan_tree['i']}
+    expected_tree = {'i': np.array([[1.], [0.], [2.]])}
     actual_tree = fori_collect(3, f, a, transform=lambda a: {'i': a['i']})
     check_eq(actual_tree, expected_tree)
-
-
-def test_scan_prims_disabled():
-    def f(tree, yz):
-        y, z = yz
-        return tree_map(lambda x: (x + y) * z, tree)
-
-    Tree = laxtuple("Tree", ["x", "y", "z"])
-    a = Tree(np.array([1., 2.]),
-             np.array(3., dtype=np.float32),
-             np.array(4., dtype=np.float32))
-    bs = (np.array([1., 2., 3., 4.]),
-          np.array([4., 3., 2., 1.]))
-
-    expected_tree = lax.scan(f, a, bs)
-    with control_flow_prims_disabled():
-        actual_tree = scan(f, a, bs)
-    assert_allclose(actual_tree.x, expected_tree.x)
-    assert_allclose(actual_tree.y, expected_tree.y)
-    assert_allclose(actual_tree.z, expected_tree.z)


### PR DESCRIPTION
This PR makes our repo work for newer jax version (which has just been released). One of the new feature of jax is the unstable of fast-math has been resolved. So I guess it is safe to enable fastmath again in Travis now.

For some reasons, statistics mean_var test for StudentT fails (rtol is a bit higher than before) with new version so I changed parameters of that test to make tests pass.

`lax.scan` is removed in the newer version. In addition, I set `progbar=True` to make it consistence with `init_kernel`.

`optimizers` now returns 3 functions: init, update, and get_params (instead of `optimizers.get_params`) as previously.