### PR TITLE
Respect unnormalized logits input in Categorical/Multinomial dist

### DIFF
--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -360,7 +360,7 @@ def test_log_prob_gradient(jax_dist, sp_dist, params):
     actual_grad = jax.grad(fn)(params, value)
     assert len(actual_grad) == len(params)
 
-    eps = 1e-4
+    eps = 1e-3
     for i in range(len(params)):
         if np.result_type(params[i]) in (np.int32, np.int64):
             continue
@@ -371,7 +371,7 @@ def test_log_prob_gradient(jax_dist, sp_dist, params):
         # finite diff approximation
         expected_grad = (fn_rhs - fn_lhs) / (2. * eps)
         assert np.shape(actual_grad[i]) == np.shape(params[i])
-        assert_allclose(np.sum(actual_grad[i]), expected_grad, rtol=0.10, atol=1e-3)
+        assert_allclose(np.sum(actual_grad[i]), expected_grad, rtol=0.01, atol=1e-3)
 
 
 @pytest.mark.parametrize('jax_dist, sp_dist, params', CONTINUOUS + DISCRETE)


### PR DESCRIPTION
Currently, logits of these distributions are normalized. The changes in this PR have the following folds
+ Removes the unexpected behaviour for users when `logits` input values are modified at __init__ 
+ Removes the unnecessary logsumexp op when only sampling is necessary
+ Matches with `tensorflow` definition of `logits` ([ref](https://www.tensorflow.org/probability/api_docs/python/tfp/distributions/Multinomial#args))
+ (personally) allow me inject a custom log_prob term to joint density (by setting value=0)

This PR also fixes the bug of missing `axis=-1` for `logsumexp` in previous PRs.
