### PR TITLE
Update to newer version of JAX

### DIFF
--- a/numpyro/distributions/continuous.py
+++ b/numpyro/distributions/continuous.py
@@ -203,10 +203,9 @@ class Chi2(Gamma):
 class GaussianRandomWalk(Distribution):
     arg_constraints = {'num_steps': constraints.positive_integer, 'scale': constraints.positive}
     support = constraints.real
-    # FIXME: cannot take grad through random.normal with dynamic shape
-    reparametrized_params = []
+    reparametrized_params = ['scale']
 
-    def __init__(self, num_steps=1, scale=1., validate_args=None):
+    def __init__(self, scale=1., num_steps=1, validate_args=None):
         assert np.shape(num_steps) == ()
         self.scale = scale
         self.num_steps = num_steps

--- a/numpyro/distributions/continuous.py
+++ b/numpyro/distributions/continuous.py
@@ -569,38 +569,6 @@ class StudentT(Distribution):
         return np.broadcast_to(var, self.batch_shape)
 
 
-class TruncatedCauchy(Distribution):
-    arg_constraints = {'low': constraints.dependent, 'high': constraints.dependent}
-    reparametrized_params = ['low', 'loc', 'scale']
-
-    # TODO: support `high` arg
-    def __init__(self, low, loc=0., scale=1., validate_args=None):
-        self.low, self.high = promote_shapes(low, high, loc, scale)
-        batch_shape = lax.broadcast_shapes(np.shape(low), np.shape(high))
-        super(Uniform, self).__init__(batch_shape=batch_shape, validate_args=validate_args)
-
-    def sample(self, key, size=()):
-        size = size + self.batch_shape
-        return self.low + random.uniform(key, shape=size) * (self.high - self.low)
-
-    def log_prob(self, value):
-        if self._validate_args:
-            self._validate_sample(value)
-        return - np.broadcast_to(np.log(self.high - self.low), np.shape(value))
-
-    @property
-    def mean(self):
-        return self.low + (self.high - self.low) / 2.
-
-    @property
-    def variance(self):
-        return (self.high - self.low) ** 2 / 12.
-
-    @property
-    def support(self):
-        return constraints.interval(self.low, self.high)
-
-
 class Uniform(Distribution):
     arg_constraints = {'low': constraints.dependent, 'high': constraints.dependent}
     reparametrized_params = ['low', 'high']

--- a/numpyro/distributions/util.py
+++ b/numpyro/distributions/util.py
@@ -6,7 +6,7 @@ import numpy as onp
 import scipy.special as osp_special
 
 import jax.numpy as np
-from jax import canonicalize_dtype, custom_transforms, jit, lax, random, vmap
+from jax import canonicalize_dtype, custom_transforms, device_get, jit, lax, random, vmap
 from jax.interpreters import ad
 from jax.numpy.lax_numpy import _promote_args_like
 from jax.scipy.special import gammaln
@@ -206,6 +206,7 @@ def _binomial(key, p, n=1, shape=()):
 
 
 def binomial(key, p, n=1, shape=()):
+    n = device_get(n)
     return _binomial(key, p, n, shape)
 
 
@@ -284,6 +285,7 @@ def _multinomial(key, p, n, shape=()):
 
 
 def multinomial(key, p, n, shape=()):
+    n = device_get(n)
     return _multinomial(key, p, n, shape)
 
 

--- a/numpyro/examples/baseball.py
+++ b/numpyro/examples/baseball.py
@@ -141,8 +141,7 @@ def run_inference(model, at_bats, hits, rng, args):
     init_kernel, sample_kernel = hmc(potential_fn, algo='NUTS')
     hmc_state = init_kernel(init_params, args.num_warmup_steps)
     hmc_states = fori_collect(args.num_samples, sample_kernel, hmc_state,
-                              transform=lambda hmc_state: transform_fn(hmc_state.z),
-                              progbar=True)
+                              transform=lambda hmc_state: transform_fn(hmc_state.z))
     return hmc_states
 
 

--- a/numpyro/examples/covtype.py
+++ b/numpyro/examples/covtype.py
@@ -76,8 +76,7 @@ def benchmark_hmc(args, features, labels):
     def transform(state): return {'coefs': state.z['coefs'],
                                   'num_steps': state.num_steps}
 
-    hmc_states = fori_collect(args.num_samples, sample_kernel, hmc_state, transform=transform,
-                              progbar=True)
+    hmc_states = fori_collect(args.num_samples, sample_kernel, hmc_state, transform=transform)
     num_leapfrogs = np.sum(hmc_states['num_steps'])
     print('number of leapfrog steps: ', num_leapfrogs)
     print('avg. time for each step: ', (time.time() - t1) / num_leapfrogs)

--- a/numpyro/examples/ucbadmit.py
+++ b/numpyro/examples/ucbadmit.py
@@ -75,8 +75,7 @@ def run_inference(dept, male, applications, admit, rng, args):
     init_kernel, sample_kernel = hmc(potential_fn, algo='NUTS')
     hmc_state = init_kernel(init_params, args.num_warmup_steps)
     hmc_states = fori_collect(args.num_samples, sample_kernel, hmc_state,
-                              transform=lambda hmc_state: transform_fn(hmc_state.z),
-                              progbar=True)
+                              transform=lambda hmc_state: transform_fn(hmc_state.z))
     return hmc_states
 
 

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,8 @@ setup(
     author='Uber AI Labs',
     author_email='npradhan@uber.com',
     install_requires=[
-        'jax==0.1.26',
-        'jaxlib==0.1.14',
+        'jax>=0.1.26',
+        'jaxlib>=0.1.14',
         'tqdm',
     ],
     extras_require={


### PR DESCRIPTION
Fixes #146

Originally, this PR is to implement TruncatedCauchy (to port local global trend to new distribution API) but it seems that we can fix #146 by casting device array to onp.array. Given that it is more urgent (to make our tests faster), I push the fix instead.

In addition, I also add default args to our distribution interface.