### PR TITLE
fix bug at constraint

### DIFF
--- a/numpyro/distributions/constraints.py
+++ b/numpyro/distributions/constraints.py
@@ -408,8 +408,9 @@ def _transform_to_greater_than(constraint):
 
 @biject_to.register(interval)
 def _transform_to_interval(constraint):
+    scale = constraint.upper_bound - constraint.lower_bound
     return ComposeTransform([SigmoidTransform(),
-                             AffineTransform(constraint.lower_bound, constraint.upper_bound,
+                             AffineTransform(constraint.lower_bound, scale,
                                              domain=unit_interval)])
 
 


### PR DESCRIPTION
Hopefully, this fixes the bug at #154. Looking like in PyTorch, AffineTransform does not work with various constraint domain, so the transforms of bounded parameters in Pyro will be wrong??? We should fix the issue in PyTorch.