### PR TITLE
Rename transform_to to constrain_to

### DIFF
--- a/examples/baseball.py
+++ b/examples/baseball.py
@@ -136,11 +136,11 @@ def partially_pooled_with_logit(at_bats, hits=None):
 
 
 def run_inference(model, at_bats, hits, rng, args):
-    init_params, potential_fn, transform_fn = initialize_model(rng, model, at_bats, hits)
+    init_params, potential_fn, constrain_fn = initialize_model(rng, model, at_bats, hits)
     init_kernel, sample_kernel = hmc(potential_fn, algo='NUTS')
     hmc_state = init_kernel(init_params, args.num_warmup)
     hmc_states = fori_collect(args.num_samples, sample_kernel, hmc_state,
-                              transform=lambda hmc_state: transform_fn(hmc_state.z))
+                              transform=lambda hmc_state: constrain_fn(hmc_state.z))
     return hmc_states
 
 

--- a/examples/hmm.py
+++ b/examples/hmm.py
@@ -118,7 +118,7 @@ def semi_supervised_hmm(transition_prior, emission_prior,
 
 def run_inference(transition_prior, emission_prior, supervised_categories, supervised_words,
                   unsupervised_words, rng, args):
-    init_params, potential_fn, transform_fn = initialize_model(
+    init_params, potential_fn, constrain_fn = initialize_model(
         rng,
         semi_supervised_hmm,
         transition_prior, emission_prior, supervised_categories,
@@ -127,7 +127,7 @@ def run_inference(transition_prior, emission_prior, supervised_categories, super
     init_kernel, sample_kernel = hmc(potential_fn, algo='NUTS')
     hmc_state = init_kernel(init_params, args.num_warmup)
     hmc_states = fori_collect(args.num_samples, sample_kernel, hmc_state,
-                              transform=lambda state: transform_fn(state.z))
+                              transform=lambda state: constrain_fn(state.z))
     return hmc_states
 
 

--- a/examples/stochastic_volatility.py
+++ b/examples/stochastic_volatility.py
@@ -68,11 +68,11 @@ def main(args):
     _, fetch = load_dataset(SP500, shuffle=False)
     dates, returns = fetch()
     init_rng, sample_rng = random.split(random.PRNGKey(args.rng))
-    init_params, potential_fn, transform_fn = initialize_model(init_rng, model, returns)
+    init_params, potential_fn, constrain_fn = initialize_model(init_rng, model, returns)
     init_kernel, sample_kernel = hmc(potential_fn, algo='NUTS')
     hmc_state = init_kernel(init_params, args.num_warmup, rng=sample_rng)
     hmc_states = fori_collect(args.num_samples, sample_kernel, hmc_state,
-                              transform=lambda hmc_state: transform_fn(hmc_state.z))
+                              transform=lambda hmc_state: constrain_fn(hmc_state.z))
     print_results(hmc_states, dates)
 
 

--- a/examples/ucbadmit.py
+++ b/examples/ucbadmit.py
@@ -70,12 +70,12 @@ def glmm(dept, male, applications, admit):
 
 
 def run_inference(dept, male, applications, admit, rng, args):
-    init_params, potential_fn, transform_fn = initialize_model(
+    init_params, potential_fn, constrain_fn = initialize_model(
         rng, glmm, dept, male, applications, admit)
     init_kernel, sample_kernel = hmc(potential_fn, algo='NUTS')
     hmc_state = init_kernel(init_params, args.num_warmup_steps)
     hmc_states = fori_collect(args.num_samples, sample_kernel, hmc_state,
-                              transform=lambda hmc_state: transform_fn(hmc_state.z))
+                              transform=lambda hmc_state: constrain_fn(hmc_state.z))
     return hmc_states
 
 

--- a/numpyro/hmc_util.py
+++ b/numpyro/hmc_util.py
@@ -554,7 +554,7 @@ def potential_energy(model, model_args, model_kwargs, inv_transforms):
     def _potential_energy(params):
         params_constrained = constrain_fn(inv_transforms, params)
         log_joint = jax.partial(log_density, model, model_args, model_kwargs)(params_constrained)[0]
-        for name, t in transforms.items():
+        for name, t in inv_transforms.items():
             log_joint = log_joint + np.sum(t.log_abs_det_jacobian(params[name], params_constrained[name]))
         return - log_joint
 

--- a/numpyro/hmc_util.py
+++ b/numpyro/hmc_util.py
@@ -550,9 +550,9 @@ def log_density(model, model_args, model_kwargs, params):
     return log_joint, model_trace
 
 
-def potential_energy(model, model_args, model_kwargs, transforms):
+def potential_energy(model, model_args, model_kwargs, inv_transforms):
     def _potential_energy(params):
-        params_constrained = {k: transforms[k](v) for k, v in params.items()}
+        params_constrained = constrain_fn(inv_transforms, params)
         log_joint = jax.partial(log_density, model, model_args, model_kwargs)(params_constrained)[0]
         for name, t in transforms.items():
             log_joint = log_joint + np.sum(t.log_abs_det_jacobian(params[name], params_constrained[name]))
@@ -561,8 +561,8 @@ def potential_energy(model, model_args, model_kwargs, transforms):
     return _potential_energy
 
 
-def transform_fn(inv_transforms, params, constrain=True):
-    return {k: inv_transforms[k](v) if constrain else inv_transforms[k].inv(v)
+def constrain_fn(inv_transforms, params, invert=False):
+    return {k: inv_transforms[k](v) if not invert else inv_transforms[k].inv(v)
             for k, v in params.items()}
 
 
@@ -580,9 +580,9 @@ def initialize_model(rng, model, *model_args, **model_kwargs):
     :param model: Python callable containing Pyro primitives.
     :param `*model_args`: args provided to the model.
     :param `**model_kwargs`: kwargs provided to the model.
-    :return: tuple of (`init_params`, `potential_fn`, `inv_transform_fn`)
+    :return: tuple of (`init_params`, `potential_fn`, `constrain_fn`)
         `init_params` are values from the prior used to initiate MCMC.
-        `inv_transform_fn` is a callable that uses inverse transforms
+        `constrain_fn` is a callable that uses inverse transforms
         to convert unconstrained HMC samples to constrained values that
         lie within the site's support.
     """
@@ -590,6 +590,6 @@ def initialize_model(rng, model, *model_args, **model_kwargs):
     model_trace = trace(model).get_trace(*model_args, **model_kwargs)
     sample_sites = {k: v for k, v in model_trace.items() if v['type'] == 'sample' and not v['is_observed']}
     inv_transforms = {k: biject_to(v['fn'].support) for k, v in sample_sites.items()}
-    init_params = transform_fn(inv_transforms, {k: v['value'] for k, v in sample_sites.items()}, constrain=False)
+    init_params = constrain_fn(inv_transforms, {k: v['value'] for k, v in sample_sites.items()}, invert=True)
     return init_params, potential_energy(model, model_args, model_kwargs, inv_transforms), \
-        jax.partial(transform_fn, inv_transforms, constrain=True)
+        jax.partial(constrain_fn, inv_transforms)

--- a/numpyro/mcmc.py
+++ b/numpyro/mcmc.py
@@ -89,13 +89,13 @@ def hmc(potential_fn, kinetic_fn=None, algo='NUTS'):
         ...     coefs = sample('beta', dist.Normal(coefs_mean, np.ones(3)))
         ...     return sample('y', dist.Bernoulli(logits=(coefs * data).sum(-1)), obs=labels)
         >>>
-        >>> init_params, potential_fn, transform_fn = initialize_model(random.PRNGKey(0), model, data, labels)
+        >>> init_params, potential_fn, constrain_fn = initialize_model(random.PRNGKey(0), model, data, labels)
         >>> init_kernel, sample_kernel = hmc(potential_fn, algo='NUTS')
         >>> hmc_state = init_kernel(init_params,
         ...                         trajectory_length=10,
         ...                         num_warmup_steps=300)
         >>> hmc_states = fori_collect(500, sample_kernel, hmc_state,
-        ...                           transform=lambda x: transform_fn(x.z))
+        ...                           transform=lambda x: constrain_fn(x.z))
         >>> print(np.mean(hmc_states['beta'], axis=0))
         [0.9153987 2.0754058 2.9621222]
     """


### PR DESCRIPTION
The change is to avoid confusion. The logic is much clearer now. :D A (positive) little side effect: users can import `constrain_to` with custom `inv_transforms` (a dict of callable) to use with their custom potential_fn.