### PR TITLE
Add diagnostic information to progress bar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ branches:
 jobs:
     include:
         - stage: lint / docs
+          before_install: pip install .[doc]
           python: 3.6
           script:
             - make lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,12 @@ branches:
 
 jobs:
     include:
-        - stage: lint
+        - stage: lint / docs
           python: 3.6
-          script: make lint
+          script:
+            - make lint
+            - make docs
+            - make doctest
         - stage: unit
           name: "unit tests"
           python: 3.6

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -64,13 +64,13 @@ extensions = [
 
 autodoc_inherit_docstrings = False
 
-autodoc_default_options = {
-    'member-order': 'bysource',
-    'show-inheritance': True,
-    'special-members': True,
-    'undoc-members': True,
-    # 'exclude-members': '__dict__,__module__,__weakref__',
-}
+# autodoc_default_options = {
+#     'member-order': 'bysource',
+#     'show-inheritance': True,
+#     'special-members': True,
+#     'undoc-members': True,
+#     'exclude-members': '__dict__,__module__,__weakref__',
+# }
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/source/mcmc.rst
+++ b/docs/source/mcmc.rst
@@ -1,6 +1,8 @@
 Markov Chain Monte Carlo (MCMC)
 ===============================
 
+.. autofunction:: numpyro.mcmc.mcmc
+
 .. autofunction:: numpyro.mcmc.hmc
 
 .. autofunction:: numpyro.mcmc.hmc.init_kernel

--- a/examples/baseball.py
+++ b/examples/baseball.py
@@ -11,8 +11,7 @@ import numpyro.distributions as dist
 from numpyro.examples.datasets import BASEBALL, load_dataset
 from numpyro.handlers import sample, seed, substitute, trace
 from numpyro.hmc_util import initialize_model
-from numpyro.mcmc import hmc
-from numpyro.util import fori_collect
+from numpyro.mcmc import mcmc
 
 """
 Original example from Pyro:
@@ -137,10 +136,8 @@ def partially_pooled_with_logit(at_bats, hits=None):
 
 def run_inference(model, at_bats, hits, rng, args):
     init_params, potential_fn, constrain_fn = initialize_model(rng, model, at_bats, hits)
-    init_kernel, sample_kernel = hmc(potential_fn, algo='NUTS')
-    hmc_state = init_kernel(init_params, args.num_warmup)
-    hmc_states = fori_collect(args.num_samples, sample_kernel, hmc_state,
-                              transform=lambda hmc_state: constrain_fn(hmc_state.z))
+    hmc_states = mcmc(args.num_warmup, args.num_samples, init_params,
+                      sampler='hmc', potential_fn=potential_fn, constrain_fn=constrain_fn)
     return hmc_states
 
 

--- a/numpyro/mcmc.py
+++ b/numpyro/mcmc.py
@@ -133,7 +133,7 @@ def hmc(potential_fn, kinetic_fn=None, algo='NUTS'):
         ...                         num_warmup=300)
         >>> hmc_states = fori_collect(500, sample_kernel, hmc_state,
         ...                           transform=lambda x: constrain_fn(x.z))
-        >>> print(np.mean(hmc_states['beta'], axis=0))
+        >>> print(np.mean(hmc_states['beta'], axis=0))  # doctest: +SKIP
         [0.9153987 2.0754058 2.9621222]
     """
     if kinetic_fn is None:

--- a/numpyro/mcmc.py
+++ b/numpyro/mcmc.py
@@ -294,7 +294,9 @@ def mcmc(num_warmup, num_samples, init_samples, sampler='hmc',
     :param init_samples: Initial parameters to begin sampling. The type can
         must be consistent with the input type to `potential_fn`.
     :param sampler: currently, only `hmc` is implemented (default).
-    :param constrain_fn: When given a
+    :param constrain_fn: Callable that converts a collection of unconstrained
+        sample values returned from the sampler to constrained values that
+        lie within the support of the sample sites.
     :param print_summary: Whether to print diagnostics summary for
         each sample site. Default is ``True``.
     :param `**sampler_kwargs`: Sampler specific keyword arguments.

--- a/numpyro/mcmc.py
+++ b/numpyro/mcmc.py
@@ -19,21 +19,21 @@ HMCState = namedtuple('HMCState', ['i', 'z', 'z_grad', 'potential_energy', 'num_
                                    'mean_accept_prob', 'step_size', 'inverse_mass_matrix', 'rng'])
 """
 A :func:`~collections.namedtuple` consisting of the following fields:
- - ``i`` - iteration. This is reset to 0 after warmup.
- - ``z`` - Python collection representing values (unconstrained samples from 
+ - **i** - iteration. This is reset to 0 after warmup.
+ - **z** - Python collection representing values (unconstrained samples from 
    the posterior) at latent sites.
- - ``z_grad`` - Gradient of potential energy w.r.t. latent sample sites.
- - ``potential_energy`` - Potential energy computed at the given value of ``z``.
- - ``num_steps`` - Number of steps in the Hamiltonian trajectory (for diagnostics).
- - ``accept_prob`` - Acceptance probability of the proposal. Note that ``z``
+ - **z_grad** - Gradient of potential energy w.r.t. latent sample sites.
+ - **potential_energy** - Potential energy computed at the given value of ``z``.
+ - **num_steps** - Number of steps in the Hamiltonian trajectory (for diagnostics).
+ - **accept_prob** - Acceptance probability of the proposal. Note that ``z``
    does not correspond to the proposal if it is rejected.
- - ``mean_accept_prob`` - Mean acceptance probability until current iteration 
+ - **mean_accept_prob** - Mean acceptance probability until current iteration 
    during warmup adaptation or sampling (for diagnostics).
- - ``step_size`` - Step size to be used by the integrator in the next iteration.
+ - **step_size** - Step size to be used by the integrator in the next iteration.
    This is adapted during warmup.   
- - ``inverse_mass_matrix`` - The inverse mass matrix to be be used for the next 
+ - **inverse_mass_matrix** - The inverse mass matrix to be be used for the next 
    iteration. This is adapted during warmup. 
- - ``rng`` - random number generator seed used for the iteration.   
+ - **rng** - random number generator seed used for the iteration.   
 """
 
 
@@ -159,8 +159,8 @@ def hmc(potential_fn, kinetic_fn=None, algo='NUTS'):
         """
         Initializes the HMC sampler.
 
-        :param init_params: Initial parameters to begin sampling. The type can
-            must be consistent with the input type to `potential_fn`.
+        :param init_params: Initial parameters to begin sampling. The type must
+            be consistent with the input type to `potential_fn`.
         :param int num_warmup_steps: Number of warmup steps; samples generated
             during warmup are discarded.
         :param float step_size: Determines the size of a single step taken by the

--- a/numpyro/mcmc.py
+++ b/numpyro/mcmc.py
@@ -130,7 +130,7 @@ def hmc(potential_fn, kinetic_fn=None, algo='NUTS'):
         >>> init_kernel, sample_kernel = hmc(potential_fn, algo='NUTS')
         >>> hmc_state = init_kernel(init_params,
         ...                         trajectory_length=10,
-        ...                         num_warmup_steps=300)
+        ...                         num_warmup=300)
         >>> hmc_states = fori_collect(500, sample_kernel, hmc_state,
         ...                           transform=lambda x: constrain_fn(x.z))
         >>> print(np.mean(hmc_states['beta'], axis=0))

--- a/numpyro/mcmc.py
+++ b/numpyro/mcmc.py
@@ -20,20 +20,20 @@ HMCState = namedtuple('HMCState', ['i', 'z', 'z_grad', 'potential_energy', 'num_
 """
 A :func:`~collections.namedtuple` consisting of the following fields:
  - **i** - iteration. This is reset to 0 after warmup.
- - **z** - Python collection representing values (unconstrained samples from 
+ - **z** - Python collection representing values (unconstrained samples from
    the posterior) at latent sites.
  - **z_grad** - Gradient of potential energy w.r.t. latent sample sites.
  - **potential_energy** - Potential energy computed at the given value of ``z``.
  - **num_steps** - Number of steps in the Hamiltonian trajectory (for diagnostics).
  - **accept_prob** - Acceptance probability of the proposal. Note that ``z``
    does not correspond to the proposal if it is rejected.
- - **mean_accept_prob** - Mean acceptance probability until current iteration 
+ - **mean_accept_prob** - Mean acceptance probability until current iteration
    during warmup adaptation or sampling (for diagnostics).
  - **step_size** - Step size to be used by the integrator in the next iteration.
-   This is adapted during warmup.   
- - **inverse_mass_matrix** - The inverse mass matrix to be be used for the next 
-   iteration. This is adapted during warmup. 
- - **rng** - random number generator seed used for the iteration.   
+   This is adapted during warmup.
+ - **inverse_mass_matrix** - The inverse mass matrix to be be used for the next
+   iteration. This is adapted during warmup.
+ - **rng** - random number generator seed used for the iteration.
 """
 
 

--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -96,11 +96,11 @@ def fori_loop(lower, upper, body_fun, init_val):
         return lax.fori_loop(lower, upper, body_fun, init_val)
 
 
-def _identity(x):
+def identity(x):
     return x
 
 
-def fori_collect(n, body_fun, init_val, transform=_identity, progbar=True, **progbar_opts):
+def fori_collect(n, body_fun, init_val, transform=identity, progbar=True, **progbar_opts):
     # works like lax.fori_loop but ignores i in body_fn, supports
     # postprocessing `transform`, and collects values during the loop
     init_val_flat, unravel_fn = ravel_pytree(transform(init_val))

--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -105,8 +105,6 @@ def fori_collect(n, body_fun, init_val, transform=_identity, progbar=True, **pro
     # postprocessing `transform`, and collects values during the loop
     init_val_flat, unravel_fn = ravel_pytree(transform(init_val))
     ravel_fn = lambda x: ravel_pytree(transform(x))[0]  # noqa: E731
-    diagnostics_fn = progbar_opts.pop('diagnostics_fn', None)
-    progbar_desc = progbar_opts.pop('progbar_desc', '')
 
     if not progbar:
         collection = np.zeros((n,) + init_val_flat.shape, dtype=init_val_flat.dtype)
@@ -120,6 +118,8 @@ def fori_collect(n, body_fun, init_val, transform=_identity, progbar=True, **pro
         _, collection = jit(lax.fori_loop, static_argnums=(2,))(0, n, _body_fn,
                                                                 (init_val, collection))
     else:
+        diagnostics_fn = progbar_opts.pop('diagnostics_fn', None)
+        progbar_desc = progbar_opts.pop('progbar_desc', '')
         collection = []
 
         val = init_val

--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -100,7 +100,7 @@ def _identity(x):
     return x
 
 
-def fori_collect(n, body_fun, init_val, transform=_identity, progbar=True):
+def fori_collect(n, body_fun, init_val, transform=_identity, progbar=True, diagnostics_fn=None):
     # works like lax.fori_loop but ignores i in body_fn, supports
     # postprocessing `transform`, and collects values during the loop
     init_val_flat, unravel_fn = ravel_pytree(transform(init_val))

--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -128,7 +128,7 @@ def fori_collect(n, body_fun, init_val, transform=_identity, progbar=True, **pro
                 val = body_fun(val)
                 collection.append(jit(ravel_fn)(val))
                 if diagnostics_fn:
-                    t.set_postfix(diagnostics_fn(val))
+                    t.set_postfix_str(diagnostics_fn(val), refresh=True)
 
         # XXX: jax.numpy.stack/concatenate is currently so slow
         collection = onp.stack(collection)

--- a/test/test_mcmc.py
+++ b/test/test_mcmc.py
@@ -9,7 +9,7 @@ from jax.scipy.special import logit
 import numpyro.distributions as dist
 from numpyro.handlers import sample
 from numpyro.hmc_util import initialize_model
-from numpyro.mcmc import hmc
+from numpyro.mcmc import hmc, mcmc
 from numpyro.util import fori_collect
 
 
@@ -48,12 +48,8 @@ def test_logistic_regression(algo):
         return sample('obs', dist.Bernoulli(logits=logits), obs=labels)
 
     init_params, potential_fn, constrain_fn = initialize_model(random.PRNGKey(2), model, labels)
-    init_kernel, sample_kernel = hmc(potential_fn, algo=algo)
-    hmc_state = init_kernel(init_params,
-                            trajectory_length=10,
-                            num_warmup=warmup_steps)
-    hmc_states = fori_collect(num_samples, sample_kernel, hmc_state,
-                              transform=lambda x: constrain_fn(x.z))
+    hmc_states = mcmc(warmup_steps, num_samples, init_params, sampler='hmc',
+                      potential_fn=potential_fn, trajectory_length=10, constrain_fn=constrain_fn)
     assert_allclose(np.mean(hmc_states['coefs'], 0), true_coefs, atol=0.2)
 
 

--- a/test/test_mcmc.py
+++ b/test/test_mcmc.py
@@ -23,8 +23,8 @@ def test_unnormalized_normal(algo):
         return 0.5 * np.sum(((z - true_mean) / true_std) ** 2)
 
     init_kernel, sample_kernel = hmc(potential_fn, algo=algo)
-    init_samples = np.array(0.)
-    hmc_state = init_kernel(init_samples,
+    init_params = np.array(0.)
+    hmc_state = init_kernel(init_params,
                             trajectory_length=10,
                             num_warmup=warmup_steps)
     hmc_states = fori_collect(num_samples, sample_kernel, hmc_state,


### PR DESCRIPTION
This adds more information to the progress bar that can be useful when debugging. Currently, includes number of steps, step size and mean accept probability (see below). I think the most important is probability of acceptance, so we can remove the other two if there isn't much space (we can do that dynamically as well in a later PR).

Also added a convenience `mcmc` wrapper function to minimize boiler-plate code, specially with having to pass progress bar options. See usage in `baseball` and `test_mcmc`.


e.g. 

```
  $ python examples/baseball.py
warmup: 100%|████| 1500/1500 [00:07<00:00, 196.23it/s, 1 steps of size 1.05. E[p(acc.)]=0.79]
sample: 100%|███| 3000/3000 [00:02<00:00, 1284.08it/s, 3 steps of size 1.05. E[p(acc.)]=0.88]
```