### PR TITLE
add gitattribute to correct repo language

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ipynb linguist-documentation


### PR DESCRIPTION
As title. Currently, `numpyro` is reported as a jupyter notebook repo.