### PR TITLE
Support batching rule for gamma

### DIFF
--- a/notebooks/logistic_regression.ipynb
+++ b/notebooks/logistic_regression.ipynb
@@ -343,7 +343,7 @@
    ],
    "source": [
     "t0 = time.time()\n",
-    "hmc_states = fori_collect(100, sample_kernel, hmc_state,\n",
+    "hmc_states = fori_collect(0, 100, sample_kernel, hmc_state,\n",
     "                          transform=lambda state: {'coefs': state.z['coefs'],\n",
     "                                                   'num_steps': state.num_steps})\n",
     "t1 = time.time()\n",

--- a/numpyro/distributions/continuous.py
+++ b/numpyro/distributions/continuous.py
@@ -128,10 +128,9 @@ class Dirichlet(Distribution):
     def log_prob(self, value):
         if self._validate_args:
             self._validate_sample(value)
-        concentration = lax.convert_element_type(self.concentration, value.dtype)
-        normalize_term = (np.sum(gammaln(concentration), axis=-1) -
-                          gammaln(np.sum(concentration, axis=-1)))
-        return np.sum(np.log(value) * (concentration - 1.), axis=-1) - normalize_term
+        normalize_term = (np.sum(gammaln(self.concentration), axis=-1) -
+                          gammaln(np.sum(self.concentration, axis=-1)))
+        return np.sum(np.log(value) * (self.concentration - 1.), axis=-1) - normalize_term
 
     @property
     def mean(self):

--- a/test/test_distributions_util.py
+++ b/test/test_distributions_util.py
@@ -169,6 +169,14 @@ def test_standard_gamma_batch():
     for i in range(3):
         assert_allclose(samples[i], standard_gamma(rngs[i], alphas[i]))
 
+    samples = vmap(lambda rng: standard_gamma(rng, alphas[:2]))(rngs)
+    for i in range(3):
+        assert_allclose(samples[i], standard_gamma(rngs[i], alphas[:2]))
+
+    samples = vmap(lambda alpha: standard_gamma(rng, alpha))(alphas)
+    for i in range(3):
+        assert_allclose(samples[i], standard_gamma(rng, alphas[i]))
+
 
 @pytest.mark.parametrize('prim', [
     xlogy,


### PR DESCRIPTION
This PR covers other usage cases of gamma batching rule:
+ key is batched, alpha is not batched
+ key is not batched, alpha is batched

Note that the previous version only works for batched key and batched alpha.

In addition, because `gammaln` supports int dtype, we don't need to use `lax.convert_element_type` at various places.