### PR TITLE
Fix issues with new version of JAX

### DIFF
--- a/numpyro/distributions/util.py
+++ b/numpyro/distributions/util.py
@@ -417,7 +417,7 @@ def cumsum(x):
     return np.cumsum(x, axis=-1)
 
 
-defjvp(cumsum, lambda g, x: np.cumsum(g, axis=-1))
+defjvp(cumsum, lambda g, ans, x: np.cumsum(g, axis=-1))
 
 
 # XXX work around the issue: batching rule for 'reduce_window' not implemented

--- a/numpyro/distributions/util.py
+++ b/numpyro/distributions/util.py
@@ -315,25 +315,6 @@ def xlogy(x, y):
     return lax._safe_mul(x, np.log(y))
 
 
-def _xlogy_batching_rule(batched_args, batch_dims):
-    x, y = batched_args
-    bx, by = batch_dims
-    # promote shapes
-    sx, sy = np.shape(x), np.shape(y)
-    nx = len(sx) + int(bx is None)
-    ny = len(sy) + int(by is None)
-    nd = max(nx, ny)
-    x = np.reshape(x, (1,) * (nd - len(sx)) + sx)
-    y = np.reshape(y, (1,) * (nd - len(sy)) + sy)
-    # correct bx, by due to promoting
-    bx = bx + nd - len(sx) if bx is not None else nd - len(sx) - 1
-    by = by + nd - len(sy) if by is not None else nd - len(sy) - 1
-    # move bx, by to front
-    x = batching.move_dim_to_front(x, bx)
-    y = batching.move_dim_to_front(y, by)
-    return xlogy(x, y), 0
-
-
 defjvp(xlogy, _xlogy_jvp_lhs, _xlogy_jvp_rhs)
 
 
@@ -351,25 +332,6 @@ def _xlog1py_jvp_rhs(g, ans, x, y):
     x = np.broadcast_to(x, shape)
     x, y = _promote_args_like(osp_special.xlog1py, x, y)
     return g * lax._safe_mul(x, np.reciprocal(1 + y))
-
-
-def _xlog1py_batching_rule(batched_args, batch_dims):
-    x, y = batched_args
-    bx, by = batch_dims
-    # promote shapes
-    sx, sy = np.shape(x), np.shape(y)
-    nx = len(sx) + int(bx is None)
-    ny = len(sy) + int(by is None)
-    nd = max(nx, ny)
-    x = np.reshape(x, (1,) * (nd - len(sx)) + sx)
-    y = np.reshape(y, (1,) * (nd - len(sy)) + sy)
-    # correct bx, by due to promoting
-    bx = bx + nd - len(sx) if bx is not None else nd - len(sx) - 1
-    by = by + nd - len(sy) if by is not None else nd - len(sy) - 1
-    # move bx, by to front
-    x = batching.move_dim_to_front(x, bx)
-    y = batching.move_dim_to_front(y, by)
-    return xlog1py(x, y), 0
 
 
 @custom_transforms

--- a/numpyro/mcmc.py
+++ b/numpyro/mcmc.py
@@ -241,13 +241,8 @@ def hmc(potential_fn, kinetic_fn=None, algo='NUTS'):
         if run_warmup and num_warmup > 0:
             # JIT if progress bar updates not required
             if not progbar:
-                # TODO: keep jit version and remove non-jit version for the next jax release
-                if progbar is None:  # NB: if progbar=None, we jit fori_loop
-                    hmc_state = jit(fori_loop, static_argnums=(2,))(
-                        0, num_warmup, lambda *args: sample_kernel(args[1]), hmc_state)
-                else:
-                    hmc_state = fori_loop(
-                        0, num_warmup, lambda *args: sample_kernel(args[1]), hmc_state)
+                hmc_state = jit(fori_loop, static_argnums=(2,))(
+                    0, num_warmup, lambda *args: sample_kernel(args[1]), hmc_state)
             else:
                 with tqdm.trange(num_warmup, desc='warmup') as t:
                     for i in t:

--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -140,8 +140,7 @@ def fori_collect(lower, upper, body_fun, init_val, transform=identity, progbar=T
             collection = ops.index_update(collection, i, ravel_fn(val))
             return val, collection
 
-        # TODO: keep jit version and remove non-jit version for the next jax release
-        if progbar is None:  # NB: if progbar=None, we jit fori_loop
+        if progbar is None:
             _, collection = jit(fori_loop, static_argnums=(2,))(0, upper, _body_fn,
                                                                 (init_val, collection))
         else:

--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -140,11 +140,8 @@ def fori_collect(lower, upper, body_fun, init_val, transform=identity, progbar=T
             collection = ops.index_update(collection, i, ravel_fn(val))
             return val, collection
 
-        if progbar is None:
-            _, collection = jit(fori_loop, static_argnums=(2,))(0, upper, _body_fn,
-                                                                (init_val, collection))
-        else:
-            _, collection = fori_loop(0, upper, _body_fn, (init_val, collection))
+        _, collection = jit(fori_loop, static_argnums=(2,))(0, upper, _body_fn,
+                                                            (init_val, collection))
     else:
         diagnostics_fn = progbar_opts.pop('diagnostics_fn', None)
         progbar_desc = progbar_opts.pop('progbar_desc', '')

--- a/test/test_mcmc.py
+++ b/test/test_mcmc.py
@@ -125,9 +125,7 @@ def test_dirichlet_categorical(algo, dense_mass):
     true_probs = np.array([0.1, 0.6, 0.3])
     data = dist.Categorical(true_probs).sample(random.PRNGKey(1), (2000,))
     init_params, potential_fn, constrain_fn = initialize_model(random.PRNGKey(2), model, data)
-    # TODO: having progbar=None just to test if that value works,
-    # change it to False when jit fori_loop issue is resolved
-    samples = mcmc(warmup_steps, num_samples, init_params, constrain_fn=constrain_fn, progbar=None,
+    samples = mcmc(warmup_steps, num_samples, init_params, constrain_fn=constrain_fn, progbar=False,
                    print_summary=False, potential_fn=potential_fn, algo=algo, trajectory_length=1.,
                    dense_mass=dense_mass)
     assert_allclose(np.mean(samples['p_latent'], 0), true_probs, atol=0.02)


### PR DESCRIPTION
Addresses #201. New version of custom_transforms simplifies our implementation in that we don't need to define batching_rule for various operator. But it introduced an issue at `cumprod` because batching rule for 'reduce_window' (used by np.cumprod) is not implemented.

In addition, the bug `jit(jit(fori_loop))` is fixed with the new version, so this PR drops the case `progbar=None` and always `jit(fori_loop)`.

Other PRs will be blocked until this is merged.

**Note:** What I have not tested is if `jit(fori_loop)` affects `pmap`. And will address it in  #198.