### PR TITLE
implement scale messenger

### DIFF
--- a/numpyro/handlers.py
+++ b/numpyro/handlers.py
@@ -245,11 +245,12 @@ class scale(Messenger):
     This is typically used for data subsampling or for stratified sampling of data
     (e.g. in fraud detection where negatives vastly outnumber positives).
 
-    :param scale: a positive scaling factor
-    :type scale: float or numpy.ndarray
+    :param float scale_factor: a positive scaling factor
     """
-    def __init__(self, scale_value):
-        self.scale = scale_value
+    def __init__(self, scale_factor):
+        if scale_factor <= 0:
+            raise ValueError("scale factor should be a positive number.")
+        self.scale = scale_factor
         super(scale, self).__init__()
 
     def process_message(self, msg):

--- a/numpyro/handlers.py
+++ b/numpyro/handlers.py
@@ -238,6 +238,24 @@ class block(Messenger):
             msg['stop'] = True
 
 
+class scale(Messenger):
+    """
+    This messenger rescales the log probability score.
+
+    This is typically used for data subsampling or for stratified sampling of data
+    (e.g. in fraud detection where negatives vastly outnumber positives).
+
+    :param scale: a positive scaling factor
+    :type scale: float or numpy.ndarray
+    """
+    def __init__(self, scale_value):
+        self.scale = scale_value
+        super(scale, self).__init__()
+
+    def process_message(self, msg):
+        msg["scale"] = self.scale * msg.get('scale', 1)
+
+
 class seed(Messenger):
     """
     JAX uses a functional pseudo random number generator that requires passing

--- a/test/test_handlers.py
+++ b/test/test_handlers.py
@@ -1,0 +1,20 @@
+from numpy.testing import assert_allclose
+
+from jax import random
+
+import numpyro.distributions as dist
+from numpyro.handlers import sample, scale
+from numpyro.hmc_util import log_density
+
+
+def test_scale():
+    def model(data):
+        x = sample('x', dist.Normal(0, 1))
+        with scale(10):
+            sample('obs', dist.Normal(x, 1), obs=data)
+
+    data = random.normal(random.PRNGKey(0), (3,))
+    x = random.normal(random.PRNGKey(1))
+    log_joint = log_density(model, (data,), {}, {'x': x})[0]
+    expected = dist.Normal(0, 1).log_prob(x) + 10 * dist.Normal(x, 1).log_prob(data).sum()
+    assert_allclose(log_joint, expected)


### PR DESCRIPTION
This messenger is used to modify log density of sub-posteriors (rather reimplementing `potential_energy`, `initialize_model` for them),... One thing I concerned about is whether the logic at transform log_det is right, so I need your opinions about it.