### PR TITLE
Revise seeds in mcmc to make it easy to reproduce result

### DIFF
--- a/numpyro/mcmc.py
+++ b/numpyro/mcmc.py
@@ -6,7 +6,7 @@ from collections import namedtuple
 import tqdm
 
 import jax.numpy as np
-from jax import jit, partial, pmap, random
+from jax import jit, partial, pmap, random, vmap
 from jax.flatten_util import ravel_pytree
 from jax.lib import xla_bridge
 from jax.random import PRNGKey

--- a/numpyro/mcmc.py
+++ b/numpyro/mcmc.py
@@ -405,11 +405,12 @@ def mcmc(num_warmup, num_samples, init_params, num_chains=1, sampler='hmc',
         potential_fn = sampler_kwargs.pop('potential_fn')
         kinetic_fn = sampler_kwargs.pop('kinetic_fn', None)
         algo = sampler_kwargs.pop('algo', 'NUTS')
-        rng = sampler_kwargs.pop('rng', PRNGKey(0))
+        rngs = sampler_kwargs.pop('rng', vmap(PRNGKey)(np.arange(num_chains)))
 
         init_kernel, sample_kernel = hmc(potential_fn, kinetic_fn, algo)
         if progbar:
-            hmc_state = init_kernel(init_params, num_warmup, progbar=progbar, **sampler_kwargs)
+            hmc_state = init_kernel(init_params, num_warmup, progbar=progbar, rng=rngs[0],
+                                    **sampler_kwargs)
             samples_flat = fori_collect(0, num_samples, sample_kernel, hmc_state,
                                         transform=lambda x: constrain_fn(x.z),
                                         progbar=progbar,
@@ -418,18 +419,17 @@ def mcmc(num_warmup, num_samples, init_params, num_chains=1, sampler='hmc',
             samples = tree_map(lambda x: x[np.newaxis, ...], samples_flat)
         else:
             def single_chain_mcmc(rng, init_params):
-                sampler_kwargs['rng'] = rng
-                hmc_state = init_kernel(init_params, num_warmup, run_warmup=False, **sampler_kwargs)
+                hmc_state = init_kernel(init_params, num_warmup, run_warmup=False, rng=rng,
+                                        **sampler_kwargs)
                 samples = fori_collect(num_warmup, num_warmup + num_samples, sample_kernel, hmc_state,
                                        transform=lambda x: constrain_fn(x.z),
                                        progbar=progbar)
                 return samples
 
             if num_chains == 1:
-                samples_flat = single_chain_mcmc(rng, init_params)
+                samples_flat = single_chain_mcmc(rngs[0], init_params)
                 samples = tree_map(lambda x: x[np.newaxis, ...], samples_flat)
             else:
-                rngs = random.split(rng, num_chains)
                 if sequential_chain:
                     samples = []
                     for i in range(num_chains):


### PR DESCRIPTION
Currently, with `num_chains > 1`, we split the default `rng`. This way makes it a bit complicated to compare the results of single chain and 1 chain. This PR forces
+ users have to provide `rng` with correct batch size = num_chains
+ or the default keys are the stack of `[PRNGKey(0), PRNGKey(1),...]`

Typically, we want to make sure that the following procedures are equivalent
```
def single(rng_param, rng_mcmc):
    init_params, potential_fn, constrain_fn = initialize_model(rng_param, model, data)
    return mcmc(num_warmup=4000, num_samples=4000, init_params=init_params, num_chains=4,
                   potential_fn=potential_fn, constrain_fn=constrain_fn, rng=rng_mcmc)

vmap(single)(rngs_param, rngs_mcmc)
```
and
```
init_params, potential_fn, constrain_fn = initialize_model(rngs_param, model, data)
samples = mcmc(num_warmup=4000, num_samples=4000, init_params=init_params, num_chains=4,
                   potential_fn=potential_fn, constrain_fn=constrain_fn, rng=rngs_mcmc)
```
with
```
rngs_param = random.split(PRNGKey(0), 4)
rngs_mcmc = random.split(PRNGKey(1), 4)
```

This way, it is also easy to verify the consistence by comparing the result of `num_chains=1` and `num_chains=4` because the first default rng with `num_chains=4` is `PRNGKey(0)`.