### PR TITLE
Make isort independent of import type within sections

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -3,6 +3,10 @@ import sys
 
 import sphinx_rtd_theme
 
+# HACK: This is to ensure that local functions are documented by sphinx.
+from numpyro.mcmc import hmc  # noqa: E402
+from numpyro.svi import svi  # noqa: E402
+
 # import pkg_resources
 
 # -*- coding: utf-8 -*-
@@ -21,9 +25,6 @@ import sphinx_rtd_theme
 #
 sys.path.insert(0, os.path.abspath('../..'))
 
-# HACK: This is to ensure that local functions are documented by sphinx.
-from numpyro.mcmc import hmc  # noqa: E402
-from numpyro.svi import svi  # noqa: E402
 
 os.environ['SPHINX_BUILD'] = '1'
 hmc(None, None)

--- a/examples/baseball.py
+++ b/examples/baseball.py
@@ -2,9 +2,9 @@ import argparse
 
 import numpy as onp
 
+from jax.config import config as jax_config
 import jax.numpy as np
 import jax.random as random
-from jax.config import config as jax_config
 from jax.scipy.special import logsumexp
 
 import numpyro.distributions as dist

--- a/examples/bnn.py
+++ b/examples/bnn.py
@@ -10,10 +10,10 @@ import matplotlib
 import matplotlib.pyplot as plt
 import numpy as onp
 
-import jax.numpy as np
-import jax.random as random
 from jax import vmap
 from jax.config import config as jax_config
+import jax.numpy as np
+import jax.random as random
 
 import numpyro.distributions as dist
 from numpyro.handlers import sample, seed, substitute, trace

--- a/examples/covtype.py
+++ b/examples/covtype.py
@@ -3,9 +3,9 @@ import time
 
 import numpy as onp
 
-import jax.numpy as np
 from jax import random
 from jax.config import config as jax_config
+import jax.numpy as np
 
 import numpyro.distributions as dist
 from numpyro.examples.datasets import COVTYPE, load_dataset

--- a/examples/gp.py
+++ b/examples/gp.py
@@ -6,10 +6,10 @@ import matplotlib.pyplot as plt
 import numpy as onp
 
 import jax
-import jax.numpy as np
-import jax.random as random
 from jax import vmap
 from jax.config import config as jax_config
+import jax.numpy as np
+import jax.random as random
 
 import numpyro.distributions as dist
 from numpyro.handlers import sample

--- a/examples/hmm.py
+++ b/examples/hmm.py
@@ -3,9 +3,9 @@ import time
 
 import numpy as onp
 
-import jax.numpy as np
 from jax import lax, random
 from jax.config import config as jax_config
+import jax.numpy as np
 from jax.scipy.special import logsumexp
 
 import numpyro.distributions as dist

--- a/examples/minipyro.py
+++ b/examples/minipyro.py
@@ -1,8 +1,8 @@
 import argparse
 
-import jax.numpy as np
 from jax import lax, random
 from jax.experimental import optimizers
+import jax.numpy as np
 from jax.random import PRNGKey
 
 import numpyro.distributions as dist

--- a/examples/stochastic_volatility.py
+++ b/examples/stochastic_volatility.py
@@ -2,9 +2,9 @@ import argparse
 
 import numpy as onp
 
+from jax.config import config as jax_config
 import jax.numpy as np
 import jax.random as random
-from jax.config import config as jax_config
 
 import numpyro.distributions as dist
 from numpyro.examples.datasets import SP500, load_dataset

--- a/examples/ucbadmit.py
+++ b/examples/ucbadmit.py
@@ -2,9 +2,9 @@ import argparse
 
 import numpy as onp
 
-import jax.numpy as np
 from jax import random, vmap
 from jax.config import config as jax_config
+import jax.numpy as np
 
 import numpyro.distributions as dist
 from numpyro.examples.datasets import UCBADMIT, load_dataset

--- a/examples/vae.py
+++ b/examples/vae.py
@@ -4,9 +4,9 @@ import time
 
 import matplotlib.pyplot as plt
 
-import jax.numpy as np
 from jax import jit, lax, random
 from jax.experimental import optimizers, stax
+import jax.numpy as np
 from jax.random import PRNGKey
 
 import numpyro.distributions as dist

--- a/numpyro/contrib/distributions/continuous.py
+++ b/numpyro/contrib/distributions/continuous.py
@@ -7,8 +7,8 @@
 # All rights reserved.
 
 import jax.numpy as np
-import jax.random as random
 from jax.numpy.lax_numpy import _promote_dtypes
+import jax.random as random
 from jax.scipy.special import digamma, gammaln, log_ndtr, ndtr, ndtri
 
 from numpyro.contrib.distributions.distribution import jax_continuous

--- a/numpyro/contrib/distributions/discrete.py
+++ b/numpyro/contrib/distributions/discrete.py
@@ -8,8 +8,8 @@
 
 import numpy as onp
 
-import jax.numpy as np
 from jax import device_put, random
+import jax.numpy as np
 from jax.numpy.lax_numpy import _promote_dtypes
 from jax.scipy.special import expit, gammaln
 

--- a/numpyro/contrib/distributions/distribution.py
+++ b/numpyro/contrib/distributions/distribution.py
@@ -7,12 +7,12 @@
 # All rights reserved.
 from contextlib import contextmanager
 
-import scipy.stats as osp_stats
 from scipy._lib._util import getargspec_no_self
+import scipy.stats as osp_stats
 from scipy.stats._distn_infrastructure import instancemethod, rv_frozen, rv_generic
 
-import jax.numpy as np
 from jax import lax
+import jax.numpy as np
 from jax.random import _is_prng_key
 from jax.scipy import stats
 

--- a/numpyro/contrib/distributions/multivariate.py
+++ b/numpyro/contrib/distributions/multivariate.py
@@ -6,9 +6,9 @@
 # Copyright (c) 2003-2019 SciPy Developers.
 # All rights reserved.
 
-import jax.numpy as np
 from jax import lax
 from jax.experimental.stax import softmax
+import jax.numpy as np
 from jax.numpy.lax_numpy import _promote_dtypes
 from jax.scipy.special import digamma, gammaln, logsumexp
 

--- a/numpyro/contrib/nn/__init__.py
+++ b/numpyro/contrib/nn/__init__.py
@@ -1,4 +1,4 @@
-from numpyro.contrib.nn.masked_dense import MaskedDense
 from numpyro.contrib.nn.auto_reg_nn import AutoRegressiveNN
+from numpyro.contrib.nn.masked_dense import MaskedDense
 
 __all__ = ['MaskedDense', 'AutoRegressiveNN']

--- a/numpyro/contrib/nn/auto_reg_nn.py
+++ b/numpyro/contrib/nn/auto_reg_nn.py
@@ -7,7 +7,7 @@ import numpy as onp
 from jax import random
 import jax.numpy as np
 
-from numpyro.contrib.nn import MaskedDense
+from numpyro.contrib.nn.masked_dense import MaskedDense
 
 
 def sample_mask_indices(input_dim, hidden_dim):

--- a/numpyro/contrib/nn/auto_reg_nn.py
+++ b/numpyro/contrib/nn/auto_reg_nn.py
@@ -3,8 +3,10 @@
 from __future__ import absolute_import, division, print_function
 
 import numpy as onp
-import jax.numpy as np
+
 from jax import random
+import jax.numpy as np
+
 from numpyro.contrib.nn import MaskedDense
 
 

--- a/numpyro/contrib/nn/masked_dense.py
+++ b/numpyro/contrib/nn/masked_dense.py
@@ -1,6 +1,6 @@
-import jax.numpy as np
-from jax.experimental.stax import glorot, randn
 from jax import random
+from jax.experimental.stax import glorot, randn
+import jax.numpy as np
 
 
 def MaskedDense(mask, W_init=glorot(), b_init=randn()):

--- a/numpyro/distributions/continuous.py
+++ b/numpyro/distributions/continuous.py
@@ -23,9 +23,9 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 
+from jax import lax, ops
 import jax.numpy as np
 import jax.random as random
-from jax import lax, ops
 from jax.scipy.linalg import solve_triangular
 from jax.scipy.special import gammaln, log_ndtr, ndtr, ndtri
 

--- a/numpyro/distributions/discrete.py
+++ b/numpyro/distributions/discrete.py
@@ -23,9 +23,9 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 
+from jax import lax
 import jax.numpy as np
 import jax.random as random
-from jax import lax
 from jax.scipy.special import gammaln, logsumexp
 
 from numpyro.distributions import constraints

--- a/numpyro/distributions/util.py
+++ b/numpyro/distributions/util.py
@@ -1,14 +1,14 @@
-import math
 from functools import update_wrapper
+import math
 from numbers import Number
 
 import numpy as onp
 import scipy.special as osp_special
 
-import jax.numpy as np
 from jax import canonicalize_dtype, core, custom_transforms, defjvp, device_get, jit, lax, random, vmap
 from jax.interpreters import ad, batching, partial_eval, xla
 from jax.lib import xla_bridge
+import jax.numpy as np
 from jax.numpy.lax_numpy import _promote_args_like
 from jax.scipy.linalg import solve_triangular
 from jax.scipy.special import gammaln

--- a/numpyro/examples/datasets.py
+++ b/numpyro/examples/datasets.py
@@ -1,8 +1,8 @@
+from collections import namedtuple
 import csv
 import gzip
 import os
 import struct
-from collections import namedtuple
 from urllib.parse import urlparse
 from urllib.request import urlretrieve
 

--- a/numpyro/hmc_util.py
+++ b/numpyro/hmc_util.py
@@ -1,7 +1,7 @@
 import jax
-import jax.numpy as np
 from jax import grad, jit, partial, random, value_and_grad, vmap
 from jax.flatten_util import ravel_pytree
+import jax.numpy as np
 from jax.ops import index_update
 from jax.scipy.special import expit
 from jax.tree_util import tree_multimap

--- a/numpyro/mcmc.py
+++ b/numpyro/mcmc.py
@@ -1,14 +1,14 @@
+from collections import namedtuple
 import math
 import os
 import warnings
-from collections import namedtuple
 
 import tqdm
 
-import jax.numpy as np
 from jax import jit, partial, pmap, random, vmap
 from jax.flatten_util import ravel_pytree
 from jax.lib import xla_bridge
+import jax.numpy as np
 from jax.random import PRNGKey
 from jax.tree_util import register_pytree_node, tree_map, tree_multimap
 

--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -1,13 +1,13 @@
-import random
 from collections import namedtuple
 from contextlib import contextmanager
+import random
 
 import numpy as onp
 import tqdm
 
-import jax.numpy as np
 from jax import jit, lax, ops, vmap
 from jax.flatten_util import ravel_pytree
+import jax.numpy as np
 from jax.tree_util import register_pytree_node
 
 _DATA_TYPES = {}

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,7 @@ known_first_party = numpyro, test
 known_third_party = opt_einsum
 known_jax = jax
 sections = FUTURE, STDLIB, THIRDPARTY, JAX, FIRSTPARTY, LOCALFOLDER
+force_sort_within_sections = true
 multi_line_output = 3
 
 [tool:pytest]

--- a/test/contrib/test_auto_regressive_nn.py
+++ b/test/contrib/test_auto_regressive_nn.py
@@ -1,10 +1,12 @@
 # lightly adapted from https://github.com/pyro-ppl/pyro/blob/dev/tests/nn/test_autoregressive.py
 
-import pytest
 import numpy as onp
 from numpy.testing import assert_array_equal
-from numpyro.contrib.nn.auto_reg_nn import create_mask, AutoRegressiveNN
-from jax import random, jacfwd
+import pytest
+
+from jax import jacfwd, random
+
+from numpyro.contrib.nn.auto_reg_nn import AutoRegressiveNN, create_mask
 
 
 @pytest.mark.parametrize('input_dim', [5])

--- a/test/contrib/test_masked_dense.py
+++ b/test/contrib/test_masked_dense.py
@@ -1,9 +1,11 @@
-import pytest
 import numpy as onp
-from numpyro.contrib.nn.auto_reg_nn import create_mask
-from numpyro.contrib.nn import MaskedDense
-from jax.experimental.stax import serial
+import pytest
+
 from jax import random
+from jax.experimental.stax import serial
+
+from numpyro.contrib.nn import MaskedDense
+from numpyro.contrib.nn.auto_reg_nn import create_mask
 
 
 @pytest.mark.parametrize('input_dim', [5, 7])

--- a/test/test_diagnostics.py
+++ b/test/test_diagnostics.py
@@ -1,6 +1,6 @@
 import numpy as onp
-import pytest
 from numpy.testing import assert_allclose
+import pytest
 from scipy.fftpack import next_fast_len
 
 from numpyro.diagnostics import (

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -1,15 +1,15 @@
-import inspect
 from collections import namedtuple
+import inspect
 
 import numpy as onp
+from numpy.testing import assert_allclose, assert_array_equal
 import pytest
 import scipy.stats as osp
-from numpy.testing import assert_allclose, assert_array_equal
 
 import jax
+from jax import grad, jacfwd, lax, vmap
 import jax.numpy as np
 import jax.random as random
-from jax import grad, jacfwd, lax, vmap
 
 import numpyro.distributions as dist
 import numpyro.distributions.constraints as constraints

--- a/test/test_distributions_contrib.py
+++ b/test/test_distributions_contrib.py
@@ -2,13 +2,13 @@ from functools import reduce
 from operator import mul
 
 import numpy as onp
+from numpy.testing import assert_allclose
 import pytest
 import scipy.stats as osp_stats
-from numpy.testing import assert_allclose
 
 import jax
-import jax.numpy as np
 from jax import grad, lax, random
+import jax.numpy as np
 from jax.scipy.special import logit
 
 import numpyro.contrib.distributions as dist

--- a/test/test_distributions_util.py
+++ b/test/test_distributions_util.py
@@ -1,13 +1,13 @@
 from numbers import Number
 
 import numpy as onp
+from numpy.testing import assert_allclose
 import pytest
 import scipy.special as osp_special
 import scipy.stats as osp_stats
-from numpy.testing import assert_allclose
 
-import jax.numpy as np
 from jax import grad, jacobian, jit, lax, random, vmap
+import jax.numpy as np
 from jax.scipy.special import expit
 from jax.util import partial
 

--- a/test/test_example_utils.py
+++ b/test/test_example_utils.py
@@ -1,5 +1,5 @@
-import jax.numpy as np
 from jax import lax
+import jax.numpy as np
 
 from numpyro.examples.datasets import BASEBALL, COVTYPE, MNIST, SP500, load_dataset
 

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -1,6 +1,6 @@
 import os
-import sys
 from subprocess import check_call
+import sys
 
 import pytest
 

--- a/test/test_hmc_util.py
+++ b/test/test_hmc_util.py
@@ -1,12 +1,12 @@
-import logging
 from collections import namedtuple
+import logging
 
 import numpy as onp
-import pytest
 from numpy.testing import assert_allclose
+import pytest
 
-import jax.numpy as np
 from jax import device_put, disable_jit, grad, jit, lax, random, tree_map
+import jax.numpy as np
 
 import numpyro.distributions as dist
 from numpyro.handlers import sample

--- a/test/test_mcmc.py
+++ b/test/test_mcmc.py
@@ -1,12 +1,12 @@
 import os
 
 import numpy as onp
-import pytest
 from numpy.testing import assert_allclose
+import pytest
 
-import jax.numpy as np
 from jax import pmap, random
 from jax.lib import xla_bridge
+import jax.numpy as np
 from jax.scipy.special import logit
 
 import numpyro.distributions as dist

--- a/test/test_optimizers.py
+++ b/test/test_optimizers.py
@@ -1,6 +1,6 @@
-import jax.numpy as np
 from jax import grad, jit
 from jax.experimental import optimizers
+import jax.numpy as np
 
 
 @jit


### PR DESCRIPTION
This makes a config change to isort to ensure that packages are not sorted by import type which can result in confusing layout, i.e. all modules from a package are not grouped together (see below):

Current:
```
import numpy as onp
import pytest
import scipy.stats as osp_stats
from numpy.testing import assert_allclose
```

Proposed:
```
import numpy as onp
from numpy.testing import assert_allclose
import pytest
import scipy.stats as osp_stats
```