### PR TITLE
Fix a small bug at `rng` arg of mcmc

### DIFF
--- a/notebooks/source/bayesian_regression.ipynb
+++ b/notebooks/source/bayesian_regression.ipynb
@@ -7,6 +7,7 @@
     "# Bayesian Regression Using NumPyro\n",
     "\n",
     "In this tutorial, we will explore how to do bayesian regression in NumPyro, using a simple example adapted from Statistical Rethinking [[1](#References)]. In particular, we would like to explore the following:\n",
+    "\n",
     " - Write a simple model using the `sample` NumPyro primitive.\n",
     " - Run inference using MCMC in NumPyro, in particular, using the No U-Turn Sampler (NUTS) to get a posterior distribution over our regression parameters of interest.\n",
     " - Learn about utilities such as `initialize_model` that are useful for running HMC.\n",
@@ -1182,6 +1183,7 @@
    "metadata": {},
    "source": [
     "We write the NumPyro model as follows. While the code should largely be self-explanatory, take note of the following:\n",
+    "\n",
     " - In NumPyro, model code is any Python callable that can accept arguments and keywords. For HMC which we will be using for this tutorial, these arguments and keywords cannot change during model execution. This is convenient for passing in numpy arrays, or boolean arguments that might affect the execution path.\n",
     " - In addition to regular Python statements, the model code also contains primitives like `sample`. These primitives can be interpreted with various side-effects by effect handlers used by inference algorithms in NumPyro. For more on effect handlers, refer to [[3](#References)], [[4](#References)]. For now, just remember that a `sample` statement makes this a stochastic function by sampling from some distribution of interest.\n",
     " - The reason why we have kept our predictors as optional keyword arguments is to be able to reuse the same model as we vary the set of predictors. Likewise, the reason why the response variable is optional is that we would like to reuse this model to sample from the posterior predictive distribution. See the [section](#Posterior-Predictive-Distribution) on plotting the posterior predictive distribution, as an example."
@@ -1217,13 +1219,16 @@
     "\n",
     "\n",
     "Note the following requirements for running HMC and NUTS in NumPyro:\n",
+    "\n",
     " - The Hamiltonian Monte Carlo (or, the NUTS) implementation in Pyro takes in a potential energy function. This is the negative log joint density for the model. \n",
     " - The verlet integrator in HMC (or, NUTS) returns sample values simulated using Hamiltonian dynamics in the unconstrained space. As such, continuous variables with bounded support need to be transformed into unconstrained space using bijective transforms. We also need to transform these samples back to their constrained support before returning these values to the user.\n",
     " \n",
     "Thankfully, all of this is handled on the backend for us. Let us go through the steps one by one.\n",
+    "\n",
     " - JAX uses functional PRNGs. Unlike other languages / frameworks which maintain a global random state, in JAX, every call to a sampler requires an [explicit PRNGKey](https://github.com/google/jax#random-numbers-are-different). We will split our initial random seed for subsequent operations, so that we do not accidentally reuse the same seed.\n",
     " - The function [initialize_model](https://numpyro.readthedocs.io/en/latest/mcmc.html#numpyro.hmc_util.initialize_model) takes a model along with model arguments (and keyword arguments), and returns a tuple of initial parameters, potential energy function, and constrain function. The initial parameters are used to initiate the MCMC chain, the potential energy function is a callable that when given unconstrained sample values returns the potential energy at these sample values. This is used by the verlet integrator in HMC. Lastly, `constrain_fn` is a callable that transforms the unconstrained samples returned by HMC/NUTS to sample values that lie within the constrained support.\n",
     " - Finally, we use the [mcmc](https://numpyro.readthedocs.io/en/latest/mcmc.html#numpyro.mcmc.mcmc) function to run inference using the default `NUTS` sampler. Note that to run vanilla HMC, all you need to do is to pass `algo='HMC'` as argument to `mcmc` instead. This is a convenience utility that does all of the following:\n",
+    "\n",
     "   - Runs warmup - adapts steps size and mass matrix.\n",
     "   - Uses the sample from the warmup phase to start MCMC.\n",
     "   - Return samples from the posterior distribution and print diagnostic information."
@@ -1342,7 +1347,8 @@
     "\n",
     "Let us now look at the posterior predictive distribution to see how our predictive distribution looks with respect to the observed divorce rates. To get samples from the posterior predictive distribution, we need to run the model by substituting the latent parameters with samples from the posterior. This sounds complicated, but this can be easily achieved by using effect handlers from the [handlers module](https://numpyro.readthedocs.io/en/latest/handlers.html).\n",
     "\n",
-    "In particular, note the use of the `substitute`, `seed` and `trace` effect handlers in the `predict` function. \n",
+    "In particular, note the use of the `substitute`, `seed` and `trace` effect handlers in the `predict` function.\n",
+    "\n",
     " - The `seed` effect-handler is used to wrap a stochastic function with an initial `PRNGKey` seed. When a sample statement inside the model is called, it uses the existing seed to sample from a distribution but this effect-handler also splits the existing key to ensure that future `sample` calls in the model use the newly split key instead. This is to prevent us from having to explicitly pass in a `PRNGKey` to each `sample` statement.\n",
     " - The `substitute` effect handler simply substitutes the value for the site name present in the `post_samples` dict instead of sampling from the distribution, which can be useful for conditioning sample sites to certain values.\n",
     " - The `trace` effect handler runs the model and records the execution trace within an `OrderedDict`. This trace object contains execution metadata that is useful for computing quantities such as the log joint density.\n",
@@ -1452,6 +1458,7 @@
     "### Model 2: Predictor - Median Age of Marriage\n",
     "\n",
     "We will now model the divorce rate as a function of the median age of marriage. The computations are mostly a reproduction of what we did for Model 1. Notice the following:\n",
+    "\n",
     " - Divorce rate is inversely related to the age of marriage. Hence states where the median age of marriage is low will likely have a higher divorce rate.\n",
     " - We get a higher log likelihood of -60.92 as compared to -68.15 with Model 2, indicating that median age of marriage is likely a much better predictor of divorce rate. "
    ]

--- a/notebooks/source/time_series_forecasting.ipynb
+++ b/notebooks/source/time_series_forecasting.ipynb
@@ -147,6 +147,7 @@
    "metadata": {},
    "source": [
     "A more detailed explanation for SGT model can be found in [this vignette](https://cran.r-project.org/web/packages/Rlgt/vignettes/GT_models.html) from the authors of Rlgt package. Here we summarize the core ideas of this model:\n",
+    "\n",
     "+ [Student's t-distribution](https://en.wikipedia.org/wiki/Student%27s_t-distribution), which has heavier tails than normal distribution, is used for the likelihood.\n",
     "+ The expected value `exp_val` consists of a trending component and a seasonal component:\n",
     "  - The trend is governed by the map $x \\mapsto x + ax^b$, where $x$ is `level`, $a$ is `coef_trend`, and $b$ is `pow_trend`. Note that when $b \\sim 0$, the trend is linear with $a$ is the slope, and when $b \\sim 1$, the trend is exponential with $a$ is the rate. So that function can cover a large family of trend.\n",

--- a/numpyro/infer_util.py
+++ b/numpyro/infer_util.py
@@ -1,3 +1,30 @@
+import jax.numpy as np
+
+from numpyro.handlers import substitute, trace
+
+
+def log_density(model, model_args, model_kwargs, params):
+    """
+    Computes log of joint density for the model given latent values ``params``.
+
+    :param model: Python callable containing Pyro primitives.
+    :param tuple model_args: args provided to the model.
+    :param dict model_kwargs`: kwargs provided to the model.
+    :param dict params: dictionary of current parameter values keyed by site
+        name.
+    :return: log of joint density and a corresponding model trace
+    """
+    model = substitute(model, params)
+    model_trace = trace(model).get_trace(*model_args, **model_kwargs)
+    log_joint = 0.
+    for site in model_trace.values():
+        if site['type'] == 'sample':
+            log_prob = np.sum(site['fn'].log_prob(site['value']))
+            if 'scale' in site:
+                log_prob = site['scale'] * log_prob
+            log_joint = log_joint + log_prob
+    return log_joint, model_trace
+
 
 def transform_fn(transforms, params, invert=False):
     """

--- a/numpyro/svi.py
+++ b/numpyro/svi.py
@@ -6,7 +6,7 @@ from jax import random, value_and_grad
 from numpyro.distributions import constraints
 from numpyro.distributions.constraints import biject_to
 from numpyro.handlers import replay, seed, substitute, trace
-from numpyro.hmc_util import log_density
+from numpyro.infer_util import log_density
 
 
 def _seed(model, guide, rng):


### PR DESCRIPTION
If users provide `rng` to `mcmc` with single chain, the current code will throw error because it expected that `rng` will have `batch_size = 1`. This bug comes from my last rng PR and this PR fixes that.

In addition, I
+ move `log_density` to `infer_util` because it is not specific to `hmc`,
+ move euclidean ke to `hmc_util`
+ fix [tutorial](http://pyro.ai/numpyro/bayesian_regression.html#Bayesian-Regression-Using-NumPyro) not render list of items. We need an empty line before each markdown list. 