### PR TITLE
Remove laxtuple

### DIFF
--- a/examples/vae.py
+++ b/examples/vae.py
@@ -83,7 +83,6 @@ def main(args):
     opt_init, opt_update, get_params = optimizers.adam(args.learning_rate)
     svi_init, svi_update, svi_eval = svi(model, guide, elbo, opt_init, opt_update, get_params,
                                          encode=encode, decode=decode, z_dim=args.z_dim)
-    svi_update = jit(svi_update)
     rng = PRNGKey(0)
     train_init, train_fetch = load_dataset(MNIST, batch_size=args.batch_size, split='train')
     test_init, test_fetch = load_dataset(MNIST, batch_size=args.batch_size, split='test')

--- a/numpyro/hmc_util.py
+++ b/numpyro/hmc_util.py
@@ -1,3 +1,5 @@
+from collections import namedtuple
+
 import jax
 from jax import grad, jit, partial, random, value_and_grad, vmap
 from jax.flatten_util import ravel_pytree
@@ -10,18 +12,18 @@ from numpyro.distributions.constraints import biject_to, real
 from numpyro.distributions.util import cholesky_inverse
 from numpyro.handlers import seed, trace
 from numpyro.infer_util import log_density, transform_fn
-from numpyro.util import cond, laxtuple, while_loop
+from numpyro.util import cond, while_loop
 
-AdaptWindow = laxtuple("AdaptWindow", ["start", "end"])
-AdaptState = laxtuple("AdaptState", ["step_size", "inverse_mass_matrix", "mass_matrix_sqrt",
-                                     "ss_state", "mm_state", "window_idx", "rng"])
-IntegratorState = laxtuple("IntegratorState", ["z", "r", "potential_energy", "z_grad"])
+AdaptWindow = namedtuple('AdaptWindow', ['start', 'end'])
+AdaptState = namedtuple('AdaptState', ['step_size', 'inverse_mass_matrix', 'mass_matrix_sqrt',
+                                       'ss_state', 'mm_state', 'window_idx', 'rng'])
+IntegratorState = namedtuple('IntegratorState', ['z', 'r', 'potential_energy', 'z_grad'])
 
-TreeInfo = laxtuple('TreeInfo', ['z_left', 'r_left', 'z_left_grad',
-                                 'z_right', 'r_right', 'z_right_grad',
-                                 'z_proposal', 'z_proposal_pe', 'z_proposal_grad',
-                                 'depth', 'weight', 'r_sum', 'turning', 'diverging',
-                                 'sum_accept_probs', 'num_proposals'])
+TreeInfo = namedtuple('TreeInfo', ['z_left', 'r_left', 'z_left_grad',
+                                   'z_right', 'r_right', 'z_right_grad',
+                                   'z_proposal', 'z_proposal_pe', 'z_proposal_grad',
+                                   'depth', 'weight', 'r_sum', 'turning', 'diverging',
+                                   'sum_accept_probs', 'num_proposals'])
 
 
 def dual_averaging(t0=10, kappa=0.75, gamma=0.05):

--- a/numpyro/mcmc.py
+++ b/numpyro/mcmc.py
@@ -10,7 +10,7 @@ from jax.flatten_util import ravel_pytree
 from jax.lib import xla_bridge
 import jax.numpy as np
 from jax.random import PRNGKey
-from jax.tree_util import register_pytree_node, tree_map, tree_multimap
+from jax.tree_util import tree_map, tree_multimap
 
 from numpyro.diagnostics import summary
 from numpyro.hmc_util import (
@@ -50,16 +50,6 @@ A :func:`~collections.namedtuple` consisting of the following fields:
 
  - **rng** - random number generator seed used for the iteration.
 """
-
-
-register_pytree_node(
-    HMCState,
-    lambda xs: (tuple(xs), None),
-    lambda _, xs: HMCState(*xs)
-)
-
-
-HMCState.update = HMCState._replace
 
 
 def _get_num_steps(step_size, trajectory_length):
@@ -270,7 +260,8 @@ def hmc(potential_fn, kinetic_fn=None, algo='NUTS'):
                                  max_tree_depth=max_treedepth)
         accept_prob = binary_tree.sum_accept_probs / binary_tree.num_proposals
         num_steps = binary_tree.num_proposals
-        vv_state = vv_state.update(z=binary_tree.z_proposal,
+        vv_state = IntegratorState(z=binary_tree.z_proposal,
+                                   r=vv_state.r,
                                    potential_energy=binary_tree.z_proposal_pe,
                                    z_grad=binary_tree.z_proposal_grad)
         return vv_state, num_steps, accept_prob


### PR DESCRIPTION
The new version of JAX supports namedtuple out of box, so we can drop laxtuple for now. :)

The slowness of `np.stack/np.concatenate` is also solved. So we can use it in `fori_collect`.