### PR TITLE
add permute transform

### DIFF
--- a/numpyro/distributions/constraints.py
+++ b/numpyro/distributions/constraints.py
@@ -215,6 +215,8 @@ class AffineTransform(Transform):
     def codomain(self):
         if self.domain is real:
             return real
+        elif self.domain is real_vector:
+            return real_vector
         elif isinstance(self.domain, greater_than):
             return greater_than(self.__call__(self.domain.lower_bound))
         elif isinstance(self.domain, interval):
@@ -223,6 +225,10 @@ class AffineTransform(Transform):
         else:
             raise NotImplementedError
 
+    @property
+    def event_dim(self):
+        return 1 if self.domain is real_vector else 0
+
     def __call__(self, x):
         return self.loc + self.scale * x
 
@@ -230,7 +236,7 @@ class AffineTransform(Transform):
         return (y - self.loc) / self.scale
 
     def log_abs_det_jacobian(self, x, y):
-        return np.broadcast_to(np.log(np.abs(self.scale)), x.shape)
+        return sum_rightmost(np.broadcast_to(np.log(np.abs(self.scale)), x.shape), self.event_dim)
 
 
 class ComposeTransform(Transform):

--- a/numpyro/distributions/constraints.py
+++ b/numpyro/distributions/constraints.py
@@ -375,6 +375,7 @@ class IdentityTransform(Transform):
 
 
 class LowerCholeskyTransform(Transform):
+    domain = real_vector
     codomain = lower_cholesky
     event_dim = 1
 
@@ -448,6 +449,7 @@ class SigmoidTransform(Transform):
 
 
 class StickBreakingTransform(Transform):
+    domain = real_vector
     codomain = simplex
     event_dim = 1
 

--- a/numpyro/distributions/constraints.py
+++ b/numpyro/distributions/constraints.py
@@ -25,6 +25,7 @@
 import math
 
 import jax.numpy as np
+from jax import ops
 from jax.scipy.special import expit, logit
 
 from numpyro.distributions.util import (
@@ -134,6 +135,11 @@ class _Real(Constraint):
         return np.isfinite(x)
 
 
+class _RealVector(Constraint):
+    def __call__(self, x):
+        return np.all(np.isfinite(x), axis=-1)
+
+
 class _Simplex(Constraint):
     def __call__(self, x):
         x_sum = np.sum(x, axis=-1)
@@ -156,6 +162,7 @@ positive_integer = _IntegerGreaterThan(1)
 positive = _GreaterThan(0.)
 positive_definite = _PositiveDefinite()
 real = _Real()
+real_vector = _RealVector()
 simplex = _Simplex()
 unit_interval = _Interval(0., 1.)
 
@@ -354,6 +361,9 @@ class ExpTransform(Transform):
 
 class IdentityTransform(Transform):
 
+    def __init__(self, event_dim=0):
+        self.event_dim = event_dim
+
     def __call__(self, x):
         return x
 
@@ -361,7 +371,7 @@ class IdentityTransform(Transform):
         return y
 
     def log_abs_det_jacobian(self, x, y):
-        return np.full(np.shape(x), 0.)
+        return np.full(np.shape(x) if self.event_dim == 0 else np.shape(x)[:-1], 0.)
 
 
 class LowerCholeskyTransform(Transform):
@@ -382,6 +392,28 @@ class LowerCholeskyTransform(Transform):
         # the jacobian is diagonal, so logdet is the sum of diagonal `exp` transform
         n = round((math.sqrt(1 + 8 * x.shape[-1]) - 1) / 2)
         return x[..., -n:].sum(-1)
+
+
+class PermuteTransform(Transform):
+    domain = real_vector
+    codomain = real_vector
+    event_dim = 1
+
+    def __init__(self, permutation):
+        self.permutation = permutation
+
+    def __call__(self, x):
+        return x[..., self.permutation]
+
+    def inv(self, y):
+        size = self.permutation.size
+        permutation_inv = ops.index_update(np.zeros(size, dtype=np.int64),
+                                           self.permutation,
+                                           np.arange(size))
+        return y[..., permutation_inv]
+
+    def log_abs_det_jacobian(self, x, y):
+        return np.full(np.shape(x)[:-1], 0.)
 
 
 class PowerTransform(Transform):
@@ -507,6 +539,11 @@ def _transform_to_lower_cholesky(constraint):
 @biject_to.register(real)
 def _transform_to_real(constraint):
     return IdentityTransform()
+
+
+@biject_to.register(real_vector)
+def _transform_to_real_vector(constraint):
+    return IdentityTransform(event_dim=1)
 
 
 @biject_to.register(simplex)

--- a/numpyro/distributions/constraints.py
+++ b/numpyro/distributions/constraints.py
@@ -293,6 +293,7 @@ class CorrCholeskyTransform(Transform):
         c. Applies :math:`s_i = StickBreakingTransform(z_i)`.
         d. Transforms back into signed domain: :math:`y_i = (sign(r_i), 1) * \sqrt{s_i}`.
     """
+    domain = real_vector
     codomain = corr_cholesky
     event_dim = 1
 

--- a/numpyro/distributions/continuous.py
+++ b/numpyro/distributions/continuous.py
@@ -553,11 +553,11 @@ def _batch_mahalanobis(bL, bx):
 
 @copy_docs_from(Distribution)
 class MultivariateNormal(Distribution):
-    arg_constraints = {'loc': constraints.real,
+    arg_constraints = {'loc': constraints.real_vector,
                        'covariance_matrix': constraints.positive_definite,
                        'precision_matrix': constraints.positive_definite,
                        'scale_tril': constraints.lower_cholesky}
-    support = constraints.real
+    support = constraints.real_vector
     reparametrized_params = ['loc', 'covariance_matrix', 'precision_matrix', 'scale_tril']
 
     def __init__(self, loc=0., covariance_matrix=None, precision_matrix=None, scale_tril=None,
@@ -627,7 +627,7 @@ class Normal(Distribution):
         super(Normal, self).__init__(batch_shape=batch_shape, validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
-        eps = random.normal(key, shape=sample_shape + self.batch_shape)
+        eps = random.normal(key, shape=sample_shape + self.batch_shape + self.event_shape)
         return self.loc + eps * self.scale
 
     def log_prob(self, value):

--- a/numpyro/distributions/distribution.py
+++ b/numpyro/distributions/distribution.py
@@ -185,10 +185,6 @@ class TransformedDistribution(Distribution):
             domain = t.codomain
         return domain
 
-    @property
-    def is_reparametrized(self):
-        return self.base_dist.reparametrized
-
     def sample(self, key, sample_shape=()):
         x = self.base_dist.sample(key, sample_shape)
         for transform in self.transforms:

--- a/numpyro/distributions/util.py
+++ b/numpyro/distributions/util.py
@@ -418,6 +418,9 @@ def get_dtypes(*args):
 
 
 def sum_rightmost(x, dim):
+    """
+    Sum out ``dim`` many rightmost dimensions of a given tensor.
+    """
     out_dim = np.ndim(x) - dim
     x = np.reshape(x[..., np.newaxis], np.shape(x)[:out_dim] + (-1,))
     return np.sum(x, axis=-1)

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -640,8 +640,8 @@ def test_biject_to(constraint, shape):
     z = transform.inv(y)
     assert_allclose(x, z, atol=1e-6, rtol=1e-6)
 
-    # test domain, currently all is constraints.real
-    assert_array_equal(transform.domain(z), np.ones(shape))
+    # test domain, currently all is constraints.real or constraints.real_vector
+    assert_array_equal(transform.domain(z), np.ones(batch_shape))
 
     # test log_abs_det_jacobian
     actual = transform.log_abs_det_jacobian(x, y)

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -672,7 +672,7 @@ def test_biject_to(constraint, shape):
 
 # NB: skip transforms which are tested in `test_biject_to`
 @pytest.mark.parametrize('transform, event_shape', [
-    (PermuteTransform(np.array([3, 1, 4, 0, 2])), (5,)),
+    (PermuteTransform(np.array([3, 0, 4, 1, 2])), (5,)),
     (PowerTransform(2.), ()),
 ])
 @pytest.mark.parametrize('batch_shape', [(), (1,), (3,), (6,), (3, 1), (1, 3), (5, 3)])


### PR DESCRIPTION
This PR adds PermuteTransform, which is useful to permute dimensions between normalization flows. `real_vector` constraint is added to correct the domain and codomain of several transforms, including PermuteTransform. It is easy to get things wrong e.g. in case
```
d = dist.MultivariateNormal(loc=np.zeros(3), covariance_matrix=np.identity(3))
x = d.sample()
t  = biject_to(d.support)
unconstrained_value = t.inv(x)
log_prob = d.log_prob(x) + t.log_abs_det_jacobian(unconstrained_value, x)
```
`log_prob` will have shape `3` (which is wrong) if `d.support = real`.

I have checked our current algorithm in hmc/svi/autoguide regarding logdet of transforms. Their logic seems correct so no need to change any of them.