### PR TITLE
Use intermediate values for TransformedDistribution.log_prob

### DIFF
--- a/numpyro/handlers.py
+++ b/numpyro/handlers.py
@@ -80,7 +80,6 @@ from __future__ import absolute_import, division, print_function
 from collections import OrderedDict
 
 from jax import random
-import jax.numpy as np
 
 _PYRO_STACK = []
 

--- a/numpyro/handlers.py
+++ b/numpyro/handlers.py
@@ -373,6 +373,7 @@ def sample(name, fn, obs=None, sample_shape=()):
         'kwargs': {'sample_shape': sample_shape},
         'value': obs,
         'is_observed': obs is not None,
+        'intermediates': [],
     }
 
     # ...and use apply_stack to send it to the Messengers
@@ -411,21 +412,8 @@ def param(name, init_value, **kwargs):
         'args': (init_value,),
         'kwargs': kwargs,
         'value': None,
-        'intermediates': [],
     }
 
     # ...and use apply_stack to send it to the Messengers
     msg = apply_stack(initial_msg)
     return msg['value']
-
-
-def log_density(trace):
-    log_probs = []
-    for site in trace.values():
-        if site["type"] == "sample":
-            value = site["value"]
-            intermediates = site["intermediates"]
-            log_prob = site["fn"].logpdf(value, intermediates) if intermediates \
-                else site["fn"].logpdf(value)
-            log_probs.append(log_prob)
-    return np.sum(log_probs)

--- a/numpyro/infer_util.py
+++ b/numpyro/infer_util.py
@@ -19,7 +19,10 @@ def log_density(model, model_args, model_kwargs, params):
     log_joint = 0.
     for site in model_trace.values():
         if site['type'] == 'sample':
-            log_prob = np.sum(site['fn'].log_prob(site['value']))
+            value = site['value']
+            intermediates = site['intermediates']
+            log_prob = np.sum(site['fn'].log_prob(value, intermediates) if intermediates
+                              else site['fn'].log_prob(value))
             if 'scale' in site:
                 log_prob = site['scale'] * log_prob
             log_joint = log_joint + log_prob

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -705,3 +705,15 @@ def test_bijective_transforms(transform, event_shape, batch_shape):
 
         assert_allclose(actual, expected, atol=1e-6)
         assert_allclose(actual, -inv_expected, atol=1e-6)
+
+
+@pytest.mark.parametrize('transformed_dist', [
+    dist.TransformedDistribution(dist.Normal(np.array([2., 3.]), 1.), constraints.ExpTransform()),
+    dist.TransformedDistribution(dist.Exponential(np.ones(2)), [
+        constraints.PowerTransform(0.7),
+        constraints.AffineTransform(0., np.ones(2) * 3)
+    ]),
+])
+def test_transformed_distribution_intermediates(transformed_dist):
+    sample, intermediates = transformed_dist.sample_with_intermediates(random.PRNGKey(1))
+    assert_allclose(transformed_dist.log_prob(sample, intermediates), transformed_dist.log_prob(sample))


### PR DESCRIPTION
This tries to offer one possible solution to #238, i.e. reusing intermediate values from the forward computation in `TransformedDistribution.log_prob`. I am not completely sure if this will help with the caching issue in #234, but opening this up for discussion. 