### PR TITLE
Resive summary format to match pyro summary

### DIFF
--- a/numpyro/diagnostics.py
+++ b/numpyro/diagnostics.py
@@ -195,41 +195,47 @@ def hpdi(x, prob=0.89, axis=0):
     return onp.concatenate([hpd_left, hpd_right], axis=axis)
 
 
-def summary(samples, prob=0.89):
+def summary(samples, prob=0.90):
     """
     Prints a summary table displaying diagnostics of ``samples`` from the
     posterior. The diagnostics displayed are mean, standard deviation,
-    the 89% Credibility Interval, :func:`~numpyro.diagnostics.effective_sample_size`
+    the 90% Credibility Interval, :func:`~numpyro.diagnostics.effective_sample_size`
     :func:`~numpyro.diagnostics.split_gelman_rubin`.
 
     :param samples: a collection of input samples with left most dimension is chain
         dimension and second to left most dimension is draw dimension.
     :param float prob: the probability mass of samples within the HPDI interval.
     """
-    # FIXME: handle variable with str len > 20
-    header_format = '{:>20} {:>10} {:>10} {:>10} {:>10} {:>10} {:>10}'
-    columns = ['', 'mean', 'sd', '{:.1f}%'.format(50 * (1 - prob)),
-               '{:.1f}%'.format(50 * (1 + prob)), 'n_eff', 'Rhat']
+    if not isinstance(samples, dict):
+        samples = {'Param:{}'.format(i): v for i, v in enumerate(tree_flatten(samples)[0])}
+
+    row_names = {k: k + '[' + ','.join(map(lambda x: str(x - 1), v.shape[2:])) + ']'
+                 for k, v in samples.items()}
+    max_len = max(max(map(lambda x: len(x), row_names.values())), 10)
+    name_format = '{:>' + str(max_len) + '}'
+    header_format = name_format + ' {:>9} {:>9} {:>9} {:>9} {:>9} {:>9} {:>9}'
+    columns = ['', 'mean', 'std', 'median', '{:.1f}%'.format(50 * (1 - prob)),
+               '{:.1f}%'.format(50 * (1 + prob)), 'n_eff', 'r_hat']
     print('\n')
     print(header_format.format(*columns))
 
     # FIXME: maybe allow a `digits` arg to set how many floatting points are needed?
-    row_format = '{:>20} {:>10.2f} {:>10.2f} {:>10.2f} {:>10.2f} {:>10.2f} {:>10.2f}'
-    if not isinstance(samples, dict):
-        samples = {'Param:{}'.format(i): v for i, v in enumerate(tree_flatten(samples)[0])}
+    row_format = name_format + ' {:>9.2f} {:>9.2f} {:>9.2f} {:>9.2f} {:>9.2f} {:>9.2f} {:>9.2f}'
     for name, value in samples.items():
         value = device_get(value)
         value_flat = onp.reshape(value, (-1,) + value.shape[2:])
         mean = value_flat.mean(axis=0)
         sd = value_flat.std(axis=0, ddof=1)
+        median = onp.median(value_flat, axis=0)
         hpd = hpdi(value_flat, prob=prob)
         n_eff = effective_sample_size(value)
         r_hat = split_gelman_rubin(value)
         shape = value_flat.shape[1:]
         if len(shape) == 0:
-            print(row_format.format(name, mean, sd, hpd[0], hpd[1], n_eff, r_hat))
+            print(row_format.format(name, mean, sd, median, hpd[0], hpd[1], n_eff, r_hat))
         else:
             for idx in product(*map(range, shape)):
                 idx_str = '[{}]'.format(','.join(map(str, idx)))
-                print(row_format.format(name + idx_str, mean[idx], sd[idx],
+                print(row_format.format(name + idx_str, mean[idx], sd[idx], median[idx],
                                         hpd[0][idx], hpd[1][idx], n_eff[idx], r_hat[idx]))
+    print('\n')

--- a/numpyro/mcmc.py
+++ b/numpyro/mcmc.py
@@ -293,9 +293,7 @@ def hmc(potential_fn, kinetic_fn=None, algo='NUTS'):
 
         itr = hmc_state.i + 1
         n = np.where(hmc_state.i < wa_steps, itr, itr - wa_steps)
-        # Reset `mean_accept_prob` for fresh diagnostics.
-        mean_accept_prob = np.where(hmc_state.i == wa_steps, 0., hmc_state.mean_accept_prob)
-        mean_accept_prob = mean_accept_prob + (accept_prob - mean_accept_prob) / n
+        mean_accept_prob = hmc_state.mean_accept_prob + (accept_prob - hmc_state.mean_accept_prob) / n
 
         return HMCState(itr, vv_state.z, vv_state.z_grad, vv_state.potential_energy, num_steps,
                         accept_prob, mean_accept_prob, adapt_state, rng)


### PR DESCRIPTION
This PR revises the format of summary to make it have each row length = 80 (when variable's name are short).