### PR TITLE
Remove some gross in arn and iaf

### DIFF
--- a/numpyro/contrib/nn/auto_reg_nn.py
+++ b/numpyro/contrib/nn/auto_reg_nn.py
@@ -58,7 +58,8 @@ def create_mask(input_dim, hidden_dims, permutation, output_dim_multiplier):
     return masks, mask_skip
 
 
-class AutoregressiveNN(object):
+def AutoregressiveNN(input_dim, hidden_dims, param_dims=[1, 1], permutation=None,
+                     skip_connections=False, nonlinearity=relu):
     """
     An implementation of a MADE-like auto-regressive neural network.
 
@@ -86,107 +87,96 @@ class AutoregressiveNN(object):
         nonlinearity is applied to the final network output, so the output is an unbounded real number.
         defaults to ReLU.
     :type nonlinearity: callable.
+    :return: a tuple (init_fun, apply_fun)
 
     Reference:
 
     MADE: Masked Autoencoder for Distribution Estimation [arXiv:1502.03509]
     Mathieu Germain, Karol Gregor, Iain Murray, Hugo Larochelle
     """
-    def __init__(self, input_dim, hidden_dims, param_dims=[1, 1], permutation=None,
-                 skip_connections=False, nonlinearity=relu):
-        self.input_dim = input_dim
-        self.hidden_dims = hidden_dims
-        self.masked_layers = None
-        self.param_dims = param_dims
-        self.permutation = permutation
-        self.skip_connections = skip_connections
-        self.nonlinearity = nonlinearity
-        self.all_ones = (np.array(param_dims) == 1).all()
+    output_multiplier = sum(param_dims)
+    all_ones = (np.array(param_dims) == 1).all()
 
-        # Calculate the indices on the output corresponding to each parameter
-        ends = np.cumsum(np.array(self.param_dims), axis=0)
-        starts = np.concatenate((np.zeros(1), ends[:-1]))
-        self.param_slices = [slice(int(s), int(e)) for s, e in zip(starts, ends)]
+    # Calculate the indices on the output corresponding to each parameter
+    ends = np.cumsum(np.array(param_dims), axis=0)
+    starts = np.concatenate((np.zeros(1), ends[:-1]))
+    param_slices = [slice(int(s), int(e)) for s, e in zip(starts, ends)]
 
-        self.count_params = len(self.param_dims)
-        self.output_multiplier = sum(self.param_dims)
+    # Hidden dimension must be not less than the input otherwise it isn't
+    # possible to connect to the outputs correctly
+    for h in hidden_dims:
+        if h < input_dim:
+            raise ValueError('Hidden dimension must not be less than input dimension.')
 
-        # Hidden dimension must be not less than the input otherwise it isn't
-        # possible to connect to the outputs correctly
-        for h in self.hidden_dims:
-            if h < self.input_dim:
-                raise ValueError('Hidden dimension must not be less than input dimension.')
+    skip_layer = None
+    masked_layers = []
 
-    def init_fun(self, rng, input_shape):
+    def init_fun(rng, input_shape):
         """
         :param rng: rng used to initialize parameters
         :param input_shape: input shape
         """
-        if self.permutation is None:
+        nonlocal permutation, skip_layer, masked_layers
+
+        if permutation is None:
             # By default set a random permutation of variables, which is
             # important for performance with multiple steps
             rng, rng_perm = random.split(rng)
-            self.permutation = random.shuffle(rng_perm, np.arange(self.input_dim))
+            permutation = random.shuffle(rng_perm, np.arange(input_dim))
 
         # Create masks
-        masks, mask_skip = create_mask(input_dim=self.input_dim, hidden_dims=self.hidden_dims,
-                                       permutation=self.permutation,
-                                       output_dim_multiplier=self.output_multiplier)
+        masks, mask_skip = create_mask(input_dim=input_dim, hidden_dims=hidden_dims,
+                                       permutation=permutation,
+                                       output_dim_multiplier=output_multiplier)
 
         init_params = []
-        if self.skip_connections:
+        if skip_connections:
             rng, rng_skip = random.split(rng)
-            self.skip_layer = MaskedDense(mask_skip, bias=False)
-            skip_init = self.skip_layer[0]
+            skip_init, skip_layer = MaskedDense(mask_skip, bias=False)
             _, param = skip_init(rng_skip, input_shape)
             init_params.append(param)
-        else:
-            self.skip_layer = None
 
         # Create masked layers
-        self.masked_layers = [MaskedDense(mask) for mask in masks]
         rngs = random.split(rng, len(masks))
-        for i, mask in enumerate(self.masked_layers):
-            mask_init = mask[0]
-            input_shape, param = mask_init(rngs[i], input_shape)
+        for i, (rng, mask) in enumerate(zip(rngs, masks)):
+            mask_init, mask_apply = MaskedDense(mask)
+            masked_layers.append(mask_apply)
+            input_shape, param = mask_init(rng, input_shape)
             init_params.append(param)
 
         return input_shape, init_params
 
-    def apply_fun(self, params, inputs, **kwargs):
+    def apply_fun(params, inputs, **kwargs):
         """
         :param params: layer parameters
         :param inputs: layer inputs
         """
-        if self.skip_connections:
-            skip_apply = self.skip_layer[1]
-            skip_out = skip_apply(params[0], inputs)
+        if skip_connections:
+            skip_out = skip_layer(params[0], inputs)
             params = params[1:]
 
         out = inputs
-        for k, (mask, param) in enumerate(zip(self.masked_layers, params)):
-            mask_apply = mask[1]
+        for k, (mask_apply, param) in enumerate(zip(masked_layers, params)):
             out = mask_apply(param, out)
-            if k < len(self.masked_layers) - 1:
-                out = self.nonlinearity(out)
+            if k < len(masked_layers) - 1:
+                out = nonlinearity(out)
 
-        if self.skip_connections:
+        if skip_connections:
             out = out + skip_out
 
         # reshape output as necessary
-        if self.output_multiplier == 1:
-            return out
-        else:
-            # TODO: revise the following logic to have param_dims at axis 0
-            out = np.reshape(out, list(inputs.shape[:-1]) + [self.output_multiplier, self.input_dim])
+        out = np.reshape(out, inputs.shape[:-1] + (output_multiplier, input_dim))
+        # move param dims to the first dimension
+        out = np.swapaxes(out, 0, -2)
 
+        if all_ones:
             # Squeeze dimension if all parameters are one dimensional
-            if self.count_params == 1:
-                return out
-
-            elif self.all_ones:
-                return np.squeeze(out, axis=-2)
-
+            out = tuple([out[i] for i in range(output_multiplier)])
+        else:
             # If not all ones, then probably don't want to squeeze a single dimension parameter
-            else:
-                return tuple([out[..., s, :] for s in self.param_slices])
+            out = tuple([out[s] for s in param_slices])
+
+        # if len(param_dims) == 1, we return the array instead of a tuple of arrays
+        return out[0] if len(param_dims) == 1 else out
+
+    return init_fun, apply_fun

--- a/numpyro/distributions/util.py
+++ b/numpyro/distributions/util.py
@@ -357,10 +357,6 @@ def entr(p):
     return np.where(p < 0, -np.inf, -xlogy(p))
 
 
-def relu(x):
-    return np.maximum(x, 0.)
-
-
 def multigammaln(a, d):
     constant = 0.25 * d * (d - 1) * np.log(np.pi)
     res = np.sum(gammaln(np.expand_dims(a, axis=-1) - 0.5 * np.arange(d)), axis=-1)

--- a/test/contrib/test_auto_regressive_nn.py
+++ b/test/contrib/test_auto_regressive_nn.py
@@ -10,34 +10,39 @@ from numpyro.contrib.nn.auto_reg_nn import AutoregressiveNN, create_mask
 
 
 @pytest.mark.parametrize('input_dim', [5])
-@pytest.mark.parametrize('param_dims', [[1], [1, 1], [2, 3]])
+@pytest.mark.parametrize('param_dims', [[1], [1, 1], [2], [2, 3]])
 @pytest.mark.parametrize('hidden_dims', [[8], [6, 7]])
 @pytest.mark.parametrize('skip_connections', [True, False])
 def test_auto_reg_nn(input_dim, hidden_dims, param_dims, skip_connections):
-    arn = AutoregressiveNN(input_dim, hidden_dims, param_dims=param_dims,
-                           skip_connections=skip_connections)
+    arn_init, arn = AutoregressiveNN(input_dim, hidden_dims, param_dims=param_dims,
+                                     skip_connections=skip_connections)
 
     rng = random.PRNGKey(0)
     batch_size = 4
     input_shape = (batch_size, input_dim)
-    _, init_params = arn.init_fun(rng, input_shape)
+    _, init_params = arn_init(rng, input_shape)
 
-    output = arn.apply_fun(init_params, onp.random.rand(*input_shape))
+    output = arn(init_params, onp.random.rand(*input_shape))
 
     if param_dims == [1]:
         assert output.shape == (batch_size, input_dim)
-        jac = jacfwd(lambda x: arn.apply_fun(init_params, x))(onp.random.rand(input_dim))
+        jac = jacfwd(lambda x: arn(init_params, x))(onp.random.rand(input_dim))
     elif param_dims == [1, 1]:
-        assert output.shape == (batch_size, 2, input_dim)
-        jac = jacfwd(lambda x: arn.apply_fun(init_params, x))(onp.random.rand(input_dim))
+        assert output[0].shape == (batch_size, input_dim)
+        assert output[1].shape == (batch_size, input_dim)
+        jac = jacfwd(lambda x: arn(init_params, x)[0])(onp.random.rand(input_dim))
+    elif param_dims == [2]:
+        assert output.shape == (2, batch_size, input_dim)
+        jac = jacfwd(lambda x: arn(init_params, x))(onp.random.rand(input_dim))
     elif param_dims == [2, 3]:
-        assert output[0].shape == (batch_size, 2, input_dim)
-        assert output[1].shape == (batch_size, 3, input_dim)
-        jac = jacfwd(lambda x: arn.apply_fun(init_params, x)[0])(onp.random.rand(input_dim))
+        assert output[0].shape == (2, batch_size, input_dim)
+        assert output[1].shape == (3, batch_size, input_dim)
+        jac = jacfwd(lambda x: arn(init_params, x)[0])(onp.random.rand(input_dim))
 
     # permute jacobian as necessary
     permuted_jac = onp.zeros(jac.shape)
-    perm = arn.permutation
+    _, rng_perm = random.split(rng)
+    perm = random.shuffle(rng_perm, onp.arange(input_dim))
 
     for j in range(input_dim):
         for k in range(input_dim):

--- a/test/test_flows.py
+++ b/test/test_flows.py
@@ -40,9 +40,9 @@ def test_flows(flow_class, flow_args, input_dim, batch_shape):
 
         # make sure jacobian is triangular, first permute jacobian as necessary
         if isinstance(transform, InverseAutoregressiveTransform):
-            arn = flow_args[0]
             permuted_jac = onp.zeros(jac.shape)
-            perm = arn.permutation
+            _, rng_perm = random.split(random.PRNGKey(0))
+            perm = random.shuffle(rng_perm, onp.arange(input_dim))
 
             for j in range(input_dim):
                 for k in range(input_dim):

--- a/test/test_flows.py
+++ b/test/test_flows.py
@@ -9,8 +9,8 @@ from numpyro.distributions.flows import InverseAutoregressiveTransform
 
 
 def _make_iaf_args(input_dim, hidden_dims):
-    arn = AutoregressiveNN(input_dim, hidden_dims, param_dims=[1, 1])
-    _, init_params = arn.init_fun(random.PRNGKey(0), (input_dim,))
+    arn_init, arn = AutoregressiveNN(input_dim, hidden_dims, param_dims=[1, 1])
+    _, init_params = arn_init(random.PRNGKey(0), (input_dim,))
     return arn, init_params
 
 


### PR DESCRIPTION
Per requested by @martinjankowiak, I revise these classes.

Beside cleaning the code, here are some usage changes:
+ AutoregressiveNN is implemented as a function, instead of a class. This is to match stax module.
+ `param_dims` are moved to the leading dimension, instead of second to last dimension.
+ In case `param_dims=[1, 1]`, we return a tuple of arrays which leading dims are 1 (instead of an array with leading dim is 2). Users can still get the later behaviour by setting `param_dims=[2]`.

There is one regression:
+ When computing the inverse, the update `x = ops.index_update(x, (..., idx), (y[..., idx] - mean) * inverse_scale)` operated at index `idx` will be replaced by `x = (y - mean) * inverse_scale`, hence might be a bit slower. But this regression is pretty small comparing to the forward pass of arn `self.arn(self.params, x)`. The reason is with functional style, we don't have access to `arn`'s `permutation`.