### PR TITLE
Update travis to use JAX master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ dist: xenial
 install:
     - pip install -U pip
     - pip install jaxlib
-    - pip install jax
+    - pip install -e git+https://github.com/google/jax.git@5861e37edd82ec5bd737fdb33b1ac6f2684e4827#egg=jax
     - pip install .[examples,test]
     - pip freeze
 

--- a/examples/neutra.py
+++ b/examples/neutra.py
@@ -56,9 +56,8 @@ def main(args):
     jax_config.update('jax_platform_name', args.device)
 
     print("Start vanilla HMC...")
-    # TODO: set progbar=True when https://github.com/google/jax/issues/939 is resolved
     vanilla_samples = mcmc(args.num_warmup, args.num_samples, init_params=np.array([2., 0.]),
-                           potential_fn=dual_moon_pe, progbar=False)
+                           potential_fn=dual_moon_pe, progbar=True)
 
     opt_init, opt_update, get_params = optimizers.adam(0.001)
     rng_guide, rng_init, rng_train = random.split(random.PRNGKey(1), 3)

--- a/numpyro/distributions/continuous.py
+++ b/numpyro/distributions/continuous.py
@@ -214,7 +214,7 @@ class Chi2(Gamma):
 @copy_docs_from(Distribution)
 class GaussianRandomWalk(Distribution):
     arg_constraints = {'num_steps': constraints.positive_integer, 'scale': constraints.positive}
-    support = constraints.real
+    support = constraints.real_vector
     reparametrized_params = ['scale']
 
     def __init__(self, scale=1., num_steps=1, validate_args=None):

--- a/numpyro/distributions/util.py
+++ b/numpyro/distributions/util.py
@@ -229,12 +229,12 @@ def categorical(key, p, shape=()):
     return _categorical(key, p, shape)
 
 
-@partial(jit, static_argnums=(2,))
-def _poisson(key, rate, shape):
+@partial(jit, static_argnums=(2, 3))
+def _poisson(key, rate, shape, dtype):
     # Ref: https://en.wikipedia.org/wiki/Poisson_distribution#Generating_Poisson-distributed_random_variables
     shape = shape or np.shape(rate)
     L = np.exp(-rate)
-    k = np.zeros(shape)
+    k = np.zeros(shape, dtype=dtype)
     p = np.ones(shape)
 
     def body_fn(val):
@@ -249,8 +249,8 @@ def _poisson(key, rate, shape):
     return k - 1
 
 
-def poisson(key, rate, shape):
-    return _poisson(key, rate, shape)
+def poisson(key, rate, shape, dtype=np.int64):
+    return _poisson(key, rate, shape, dtype)
 
 
 def _scatter_add_one(operand, indices, updates):

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     install_requires=[
         # TODO: pin to a specific version for the next release (unless JAX's API becomes stable)
         'jax @ git+https://github.com/google/jax.git@5861e37edd82ec5bd737fdb33b1ac6f2684e4827#egg=jax',
-        'jaxlib>=0.1.18',
+        'jaxlib>=0.1.22',
         'tqdm',
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     author_email='npradhan@uber.com',
     install_requires=[
         # TODO: pin to a specific version for the next release (unless JAX's API becomes stable)
-        'jax>=0.1.37',
+        'jax @ git+https://github.com/google/jax.git@5861e37edd82ec5bd737fdb33b1ac6f2684e4827#egg=jax',
         'jaxlib>=0.1.18',
         'tqdm',
     ],

--- a/test/contrib/test_autoguide.py
+++ b/test/contrib/test_autoguide.py
@@ -1,7 +1,7 @@
 from numpy.testing import assert_allclose
 import pytest
 
-from jax import lax, random
+from jax import random
 from jax.experimental import optimizers
 import jax.numpy as np
 
@@ -35,7 +35,7 @@ def test_beta_bernoulli(auto_class):
         loss, opt_state_, rng_ = svi_update(i, rng_, opt_state_, model_args=(data,), guide_args=(data,))
         return opt_state_, rng_
 
-    opt_state, _ = lax.fori_loop(0, 1000, body_fn, (opt_state, rng_train))
+    opt_state, _ = fori_loop(0, 1000, body_fn, (opt_state, rng_train))
     true_coefs = (np.sum(data, axis=0) + 1) / (data.shape[0] + 2)
     # test .sample_posterior method
     posterior_samples = guide.sample_posterior(random.PRNGKey(1), opt_state, sample_shape=(1000,))


### PR DESCRIPTION
This is to fix and unblock various issues and PRs: fixes #241, #251, unblock #235, #237

The new jaxlib version `0.1.22` makes it impossible for me to train AutoIAFNormal (or AutoDiagonalNormal) on dual moon model under fastmath mode. So I add a warning for it.

I have tuned NeutraHMC args a bit so we get a better guide (see image below). However, the NeuTra samples are not good, so I added this issue to #256.

[neutra.pdf](https://github.com/pyro-ppl/numpyro/files/3445521/neutra.pdf)
