### PR TITLE
Convert TruncatedCauchy, TruncatedNormal, Uniform to transformed distribution

### DIFF
--- a/numpyro/distributions/continuous.py
+++ b/numpyro/distributions/continuous.py
@@ -715,35 +715,44 @@ class StudentT(Distribution):
         return np.broadcast_to(var, self.batch_shape)
 
 
-@copy_docs_from(Distribution)
-class TruncatedCauchy(Distribution):
-    arg_constraints = {'low': constraints.real, 'loc': constraints.real,
-                       'scale': constraints.positive}
-    reparametrized_params = ['low', 'loc', 'scale']
+class _BaseTruncatedCauchy(Distribution):
+    # NB: this is a truncated cauchy with low=0, scale=1
+    support = constraints.positive
 
-    def __init__(self, low=0., loc=0., scale=1., validate_args=None):
-        self.low, self.loc, self.scale = promote_shapes(low, loc, scale)
-        batch_shape = lax.broadcast_shapes(np.shape(low), np.shape(loc), np.shape(scale))
-        super(TruncatedCauchy, self).__init__(batch_shape=batch_shape, validate_args=validate_args)
+    def __init__(self, base_loc):
+        self.base_loc = base_loc
+        super(_BaseTruncatedCauchy, self).__init__(batch_shape=np.shape(base_loc))
 
     def sample(self, key, sample_shape=()):
         # We use inverse transform method:
         # z ~ inv_cdf(U), where U ~ Uniform(cdf(low), cdf(high)).
         #                         ~ Uniform(arctan(low), arctan(high)) / pi + 1/2
         size = sample_shape + self.batch_shape
-        low = (self.low - self.loc) / self.scale
-        minval = np.arctan(low)
+        minval = -np.arctan(self.base_loc)
         maxval = np.pi / 2
         u = minval + random.uniform(key, shape=size) * (maxval - minval)
-        return self.loc + np.tan(u) * self.scale
+        return self.base_loc + np.tan(u)
 
     def log_prob(self, value):
         if self._validate_args:
             self._validate_sample(value)
-        low = (self.low - self.loc) / self.scale
         # pi / 2 is arctan of self.high when that arg is supported
-        normalize_term = np.log(np.pi / 2 - np.arctan(low)) + np.log(self.scale)
-        return - np.log1p(((value - self.loc) / self.scale) ** 2) - normalize_term
+        normalize_term = np.log(np.pi / 2 + np.arctan(self.base_loc))
+        return - np.log1p((value - self.base_loc) ** 2) - normalize_term
+
+
+@copy_docs_from(Distribution)
+class TruncatedCauchy(TransformedDistribution):
+    arg_constraints = {'low': constraints.real, 'loc': constraints.real,
+                       'scale': constraints.positive}
+    reparametrized_params = ['low', 'loc', 'scale']
+
+    def __init__(self, low=0., loc=0., scale=1., validate_args=None):
+        self.low, self.loc, self.scale = promote_shapes(low, loc, scale)
+        base_loc = (loc - low) / scale
+        base_dist = _BaseTruncatedCauchy(base_loc)
+        super(TruncatedCauchy, self).__init__(base_dist, AffineTransform(low, scale),
+                                              validate_args=validate_args)
 
     # NB: these stats do not apply when arg `high` is supported
     @property
@@ -754,13 +763,35 @@ class TruncatedCauchy(Distribution):
     def variance(self):
         return np.full(self.batch_shape, np.nan)
 
-    @property
-    def support(self):
-        return constraints.greater_than(self.low)
+
+class _BaseTruncatedNormal(Distribution):
+    # NB: this is a truncated normal with low=0, scale=1
+    support = constraints.positive
+
+    def __init__(self, base_loc):
+        self.base_loc = base_loc
+        self._normal = Normal(base_loc, 1.)
+        super(_BaseTruncatedNormal, self).__init__(batch_shape=np.shape(base_loc))
+
+    def sample(self, key, sample_shape=()):
+        size = sample_shape + self.batch_shape
+        # We use inverse transform method:
+        # z ~ icdf(U), where U ~ Uniform(0, 1).
+        u = random.uniform(key, shape=size)
+        # Ref: https://en.wikipedia.org/wiki/Truncated_normal_distribution#Simulating
+        # icdf[cdf_a + u * (1 - cdf_a)] = icdf[1 - (1 - cdf_a)(1 - u)]
+        #                                 = - icdf[(1 - cdf_a)(1 - u)]
+        return self.base_loc - ndtri(ndtr(self.base_loc) * (1 - u))
+
+    def log_prob(self, value):
+        if self._validate_args:
+            self._validate_sample(value)
+        # log(cdf(high) - cdf(low)) = log(1 - cdf(low)) = log(cdf(-low))
+        return self._normal.log_prob(value) - log_ndtr(self.base_loc)
 
 
 @copy_docs_from(Distribution)
-class TruncatedNormal(Distribution):
+class TruncatedNormal(TransformedDistribution):
     arg_constraints = {'low': constraints.real, 'loc': constraints.real,
                        'scale': constraints.positive}
     reparametrized_params = ['low', 'loc', 'scale']
@@ -768,43 +799,20 @@ class TruncatedNormal(Distribution):
     # TODO: support `high` arg
     def __init__(self, low=0., loc=0., scale=1., validate_args=None):
         self.low, self.loc, self.scale = promote_shapes(low, loc, scale)
-        batch_shape = lax.broadcast_shapes(np.shape(low), np.shape(loc), np.shape(scale))
-        self._normal = Normal(self.loc, self.scale)
-        super(TruncatedNormal, self).__init__(batch_shape=batch_shape, validate_args=validate_args)
-
-    def sample(self, key, sample_shape=()):
-        size = sample_shape + self.batch_shape
-        # We use inverse transform method:
-        # z ~ icdf(U), where U ~ Uniform(0, 1).
-        u = random.uniform(key, shape=size)
-        low = (self.low - self.loc) / self.scale
-        # Ref: https://en.wikipedia.org/wiki/Truncated_normal_distribution#Simulating
-        # icdf[cdf_a + u * (1 - cdf_a)] = icdf[1 - (1 - cdf_a)(1 - u)]
-        #                                 = - icdf[(1 - cdf_a)(1 - u)]
-        return self.loc - ndtri(ndtr(-low) * (1 - u)) * self.scale
-
-    def log_prob(self, value):
-        if self._validate_args:
-            self._validate_sample(value)
-        # log(cdf(high) - cdf(low)) = log(1 - cdf(low)) = log(cdf(-low))
-        low = (self.low - self.loc) / self.scale
-        return self._normal.log_prob(value) - log_ndtr(-low)
+        base_loc = (loc - low) / scale
+        base_dist = _BaseTruncatedNormal(base_loc)
+        super(TruncatedNormal, self).__init__(base_dist, AffineTransform(low, scale),
+                                              validate_args=validate_args)
 
     @property
     def mean(self):
-        low = (self.low - self.loc) / self.scale
-        low_prob_scaled = np.exp(self._normal.log_prob(self.low)) * self.scale / ndtr(-low)
+        low_prob_scaled = np.exp(self.base_dist.log_prob(0.))
         return self.loc + low_prob_scaled * self.scale
 
     @property
     def variance(self):
-        low = (self.low - self.loc) / self.scale
-        low_prob_scaled = np.exp(self._normal.log_prob(self.low)) * self.scale / ndtr(-low)
-        return self._normal.variance * (1 + low * low_prob_scaled - low_prob_scaled ** 2)
-
-    @property
-    def support(self):
-        return constraints.greater_than(self.low)
+        low_prob_scaled = np.exp(self.base_dist.log_prob(0.))
+        return (self.scale ** 2) * (1 - self.base_dist.base_loc * low_prob_scaled - low_prob_scaled ** 2)
 
 
 class _BaseUniform(Distribution):

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -721,9 +721,9 @@ def test_transformed_distribution_intermediates(transformed_dist):
 
 def test_transformed_transformed_distribution():
     loc, scale = -2, 3
-    dist1 = dist.TransformedDistribution(dist.Uniform(2, 3), constraints.PowerTransform(2.))
+    dist1 = dist.TransformedDistribution(dist.Normal(2, 3), constraints.PowerTransform(2.))
     dist2 = dist.TransformedDistribution(dist1, constraints.AffineTransform(-2, 3))
-    assert isinstance(dist2.base_dist, dist.Uniform)
+    assert isinstance(dist2.base_dist, dist.Normal)
     assert len(dist2.transforms) == 2
     assert isinstance(dist2.transforms[0], constraints.PowerTransform)
     assert isinstance(dist2.transforms[1], constraints.AffineTransform)

--- a/test/test_hmc_util.py
+++ b/test/test_hmc_util.py
@@ -396,7 +396,7 @@ def test_build_tree(step_size):
 
 
 def test_model_with_transformed_distribution():
-    x_prior = dist.Uniform(2, 3)
+    x_prior = dist.HalfNormal(2)
     y_prior = dist.LogNormal(scale=3.)  # transformed distribution
 
     def model():

--- a/test/test_mcmc.py
+++ b/test/test_mcmc.py
@@ -89,9 +89,7 @@ def test_uniform_normal():
 
     def model(data):
         alpha = sample('alpha', dist.Uniform(0, 1))
-        # TODO: use dist.Uniform when it is reimplemented as a transformed distribution
-        loc = sample('loc', dist.TransformedDistribution(
-            dist.Uniform(0, 1), constraints.AffineTransform(0, alpha)))
+        loc = sample('loc', dist.Uniform(0, alpha))
         sample('obs', dist.Normal(loc, 0.1), obs=data)
 
     data = true_coef + random.normal(random.PRNGKey(0), (1000,))


### PR DESCRIPTION
As a follow-up PR of #265, currently, only these distributions have dynamic support.

Because Abs is not a bijective transform, I have converted HalfNormal, HalfCauchy to a subclass of Distribution, not TransformedDistribution.