### PR TITLE
Add some more plots to the NeutraHMC example

### DIFF
--- a/examples/neutra.py
+++ b/examples/neutra.py
@@ -137,13 +137,14 @@ def main(args):
     ax4.set(xlim=[-3, 3], ylim=[-3, 3],
             xlabel='x0', ylabel='x1', title='Posterior using vanilla HMC sampler')
 
-    sns.scatterplot(zs[:, 0], zs[:, 1], ax=ax5, hue=samples['x'][:, 0] < 0.)
+    sns.scatterplot(zs[:, 0], zs[:, 1], ax=ax5, hue=samples['x'][:, 0] < 0.,
+                    s=30, alpha=0.5, edgecolor="none")
     ax5.set(xlim=[-5, 5], ylim=[-5, 5],
             xlabel='x0', ylabel='x1', title='Samples from the warped posterior - p(z)')
 
     ax6.contourf(X1, X2, P, cmap='OrRd')
     sns.kdeplot(samples['x'][:, 0].copy(), samples['x'][:, 1].copy(), n_levels=30, ax=ax6)
-    ax6.plot(samples['x'][-50:, 0], samples['x'][-50:, 1], 'bo-', alpha=0.5)
+    ax6.plot(samples['x'][-50:, 0], samples['x'][-50:, 1], 'bo-', alpha=0.2)
     ax6.set(xlim=[-3, 3], ylim=[-3, 3],
             xlabel='x0', ylabel='x1', title='Posterior using NeuTra HMC sampler')
 


### PR DESCRIPTION
This makes a few changes and adds some plots for debugging the half moons example:
 - Changed the prior to `Unif(-4, 4)` from `Unif(-10, 10)` which seems easier to sample for NeutraHMC. I also tried other priors like Normal and Cauchy, but none were notably better as to warrant the change.
 - Also changed the number of samples to 20k, since we were getting biased results for NeutraHMC with 10k samples.
 - Added some more plots to debug - inc. a plot of the warped posterior (see below).

[neutra.pdf](https://github.com/pyro-ppl/numpyro/files/3458679/neutra.pdf)

**Some observations:**

 - Even though the above measures help NeutraHMC, Vanilla HMC still seems a better choice on this example in terms of the quality of the generated posterior.
 - Not sure how much we can generalize from this example, but the posterior in the warped space isn't very gaussian, definitely more so than the unwarped posterior distribution but it has more of a butterfly shape. Changing the prior has an effect on the shape and can be very far from gaussian.
 - For some reason, NeutraHMC is placing a bulk of the posterior mass lower than where you would expect. Not sure why that's the case.