### PR TITLE
Updates for jax 0.1.41

### DIFF
--- a/examples/baseball.py
+++ b/examples/baseball.py
@@ -5,9 +5,9 @@ import numpy as onp
 from jax.config import config as jax_config
 import jax.numpy as np
 import jax.random as random
-from jax.scipy.special import logsumexp
 
 import numpyro.distributions as dist
+from numpyro.distributions.util import logsumexp
 from numpyro.examples.datasets import BASEBALL, load_dataset
 from numpyro.handlers import sample, seed, substitute, trace
 from numpyro.hmc_util import initialize_model

--- a/examples/hmm.py
+++ b/examples/hmm.py
@@ -6,9 +6,9 @@ import numpy as onp
 from jax import lax, random
 from jax.config import config as jax_config
 import jax.numpy as np
-from jax.scipy.special import logsumexp
 
 import numpyro.distributions as dist
+from numpyro.distributions.util import logsumexp
 from numpyro.handlers import sample
 from numpyro.hmc_util import initialize_model
 from numpyro.mcmc import mcmc

--- a/examples/neutra.py
+++ b/examples/neutra.py
@@ -1,11 +1,11 @@
 import argparse
-import warnings
+import os
 
 from matplotlib.gridspec import GridSpec
 import matplotlib.pyplot as plt
 import seaborn as sns
 
-from jax import jit, random, vmap
+from jax import lax, random, vmap
 from jax.config import config as jax_config
 from jax.experimental import optimizers
 import jax.numpy as np
@@ -19,7 +19,10 @@ from numpyro.handlers import sample
 from numpyro.hmc_util import initialize_model
 from numpyro.mcmc import mcmc
 from numpyro.svi import elbo, svi
-from numpyro.util import fori_collect
+
+# TODO: remove when the issue https://github.com/google/jax/issues/939 is fixed upstream
+# The behaviour when training guide under fast math mode is unstable.
+os.environ["XLA_FLAGS"] = "--xla_cpu_enable_fast_math=false"
 
 """
 This example illustrates how to use a trained AutoIAFNormal autoguide to transform a posterior to a
@@ -64,26 +67,19 @@ def main(args):
     svi_init, svi_update, _ = svi(dual_moon_model, guide, elbo, opt_init, opt_update, get_params)
     opt_state, _ = svi_init(rng_init)
 
-    def body_fn(val):
-        i, loss, opt_state_, rng_ = val
+    def body_fn(val, i):
+        opt_state_, rng_ = val
         loss, opt_state_, rng_ = svi_update(i, rng_, opt_state_)
-        return i + 1, loss, opt_state_, rng_
+        return (opt_state_, rng_), loss
 
     print("Start training guide...")
-    # TODO: remove the warning when the issue is fixed upstream
-    warnings.warn('Due to the bug https://github.com/google/jax/issues/939, to'
-                  ' train AutoIAFNormal we should set the environment flag'
-                  ' "XLA_FLAGS=--xla_cpu_enable_fast_math=false".')
-    losses, opt_states = fori_collect(0, args.num_iters, jit(body_fn),
-                                      (0, 0., opt_state, rng_train),
-                                      transform=lambda x: (x[1], x[2]), progbar=False)
-    last_state = tree_map(lambda x: x[-1], opt_states)
+    (last_state, _), losses = lax.scan(body_fn, (opt_state, rng_train), np.arange(args.num_iters))
     print("Finish training guide. Extract samples...")
     guide_samples = guide.sample_posterior(random.PRNGKey(0), last_state,
                                            sample_shape=(args.num_samples,))
 
     transform = guide.get_transform(last_state)
-    unpack_fn = lambda u: guide.unpack_latent(u, transform=False)  # noqa: E731
+    unpack_fn = guide.unpack_latent
 
     _, potential_fn, constrain_fn = initialize_model(random.PRNGKey(0), dual_moon_model)
     transformed_potential_fn = make_transformed_pe(potential_fn, transform, unpack_fn)

--- a/examples/neutra.py
+++ b/examples/neutra.py
@@ -9,12 +9,12 @@ from jax import jit, random, vmap
 from jax.config import config as jax_config
 from jax.experimental import optimizers
 import jax.numpy as np
-from jax.scipy.special import logsumexp
 from jax.tree_util import tree_map
 
 from numpyro.contrib.autoguide import AutoIAFNormal
 from numpyro.diagnostics import summary
 import numpyro.distributions as dist
+from numpyro.distributions.util import logsumexp
 from numpyro.handlers import sample
 from numpyro.hmc_util import initialize_model
 from numpyro.mcmc import mcmc

--- a/numpyro/contrib/distributions/discrete.py
+++ b/numpyro/contrib/distributions/discrete.py
@@ -11,11 +11,11 @@ import numpy as onp
 from jax import device_put, random
 import jax.numpy as np
 from jax.numpy.lax_numpy import _promote_dtypes
-from jax.scipy.special import expit, gammaln
+from jax.scipy.special import entr, expit, gammaln
 
 from numpyro.contrib.distributions.distribution import jax_discrete
 from numpyro.distributions import constraints
-from numpyro.distributions.util import binary_cross_entropy_with_logits, entr, xlog1py, xlogy
+from numpyro.distributions.util import binary_cross_entropy_with_logits, xlog1py, xlogy
 
 
 class bernoulli_gen(jax_discrete):

--- a/numpyro/contrib/distributions/multivariate.py
+++ b/numpyro/contrib/distributions/multivariate.py
@@ -10,13 +10,12 @@ from jax import lax
 from jax.experimental.stax import softmax
 import jax.numpy as np
 from jax.numpy.lax_numpy import _promote_dtypes
-from jax.scipy.special import digamma, gammaln, logsumexp
+from jax.scipy.special import digamma, entr, gammaln, logsumexp
 
 from numpyro.contrib.distributions.discrete import binom
 from numpyro.contrib.distributions.distribution import jax_continuous, jax_discrete, jax_multivariate
 from numpyro.distributions import constraints
 from numpyro.distributions.util import categorical as categorical_rvs
-from numpyro.distributions.util import entr
 from numpyro.distributions.util import multinomial as multinomial_rvs
 from numpyro.distributions.util import standard_gamma, xlogy
 

--- a/numpyro/distributions/continuous.py
+++ b/numpyro/distributions/continuous.py
@@ -27,7 +27,7 @@ from jax import lax, ops
 import jax.numpy as np
 import jax.random as random
 from jax.scipy.linalg import solve_triangular
-from jax.scipy.special import gammaln, log_ndtr, ndtr, ndtri
+from jax.scipy.special import gammaln, log_ndtr, multigammaln, ndtr, ndtri
 
 from numpyro.distributions import constraints
 from numpyro.distributions.constraints import AffineTransform, ExpTransform, PowerTransform
@@ -37,7 +37,6 @@ from numpyro.distributions.util import (
     cumsum,
     lazy_property,
     matrix_to_tril_vec,
-    multigammaln,
     promote_shapes,
     signed_stick_breaking_tril,
     standard_gamma,

--- a/numpyro/distributions/discrete.py
+++ b/numpyro/distributions/discrete.py
@@ -27,7 +27,7 @@ from jax import lax
 from jax.lib import xla_bridge
 import jax.numpy as np
 import jax.random as random
-from jax.scipy.special import gammaln, logsumexp
+from jax.scipy.special import gammaln
 
 from numpyro.distributions import constraints
 from numpyro.distributions.distribution import Distribution
@@ -38,6 +38,7 @@ from numpyro.distributions.util import (
     clamp_probs,
     get_dtypes,
     lazy_property,
+    logsumexp,
     multinomial,
     poisson,
     promote_shapes,

--- a/numpyro/distributions/util.py
+++ b/numpyro/distributions/util.py
@@ -454,6 +454,12 @@ def signed_stick_breaking_tril(t):
     return y
 
 
+def logsumexp(x, axis=0, keepdims=False):
+    x_max = np.max(x, axis=axis, keepdims=True)
+    result = np.log(np.sum(np.exp(x - x_max), axis=axis, keepdims=True)) + x_max
+    return result if keepdims else np.squeeze(result, axis=axis)
+
+
 # The is sourced from: torch.distributions.util.py
 #
 # Copyright (c) 2016-     Facebook, Inc            (Adam Paszke)

--- a/numpyro/distributions/util.py
+++ b/numpyro/distributions/util.py
@@ -2,7 +2,6 @@ from functools import update_wrapper
 import math
 from numbers import Number
 
-import numpy as onp
 import scipy.special as osp_special
 
 from jax import canonicalize_dtype, custom_transforms, defjvp, device_get, jit, lax, random, vmap
@@ -10,7 +9,6 @@ from jax.lib import xla_bridge
 import jax.numpy as np
 from jax.numpy.lax_numpy import _promote_args_like
 from jax.scipy.linalg import solve_triangular
-from jax.scipy.special import gammaln
 from jax.util import partial
 
 
@@ -351,16 +349,6 @@ def cholesky_inverse(matrix):
     return solve_triangular(tril_inv, identity, lower=True)
 
 
-def entr(p):
-    return np.where(p < 0, -np.inf, -xlogy(p))
-
-
-def multigammaln(a, d):
-    constant = 0.25 * d * (d - 1) * np.log(np.pi)
-    res = np.sum(gammaln(np.expand_dims(a, axis=-1) - 0.5 * np.arange(d)), axis=-1)
-    return res + constant
-
-
 def binary_cross_entropy_with_logits(x, y):
     # compute -y * log(sigmoid(x)) - (1 - y) * log(1 - sigmoid(x))
     # Ref: https://www.tensorflow.org/api_docs/python/tf/nn/sigmoid_cross_entropy_with_logits
@@ -402,7 +390,7 @@ def promote_shapes(*args, shape=()):
 
 
 def get_dtypes(*args):
-    return [canonicalize_dtype(onp.result_type(arg)) for arg in args]
+    return [canonicalize_dtype(lax.dtype(arg)) for arg in args]
 
 
 def sum_rightmost(x, dim):
@@ -415,7 +403,7 @@ def sum_rightmost(x, dim):
 
 
 def matrix_to_tril_vec(x, diagonal=0):
-    idxs = onp.tril_indices(x.shape[-1], diagonal)
+    idxs = np.tril_indices(x.shape[-1], diagonal)
     return x[..., idxs[0], idxs[1]]
 
 
@@ -423,7 +411,7 @@ def vec_to_tril_matrix(t, diagonal=0):
     # NB: the following formula only works for diagonal <= 0
     n = round((math.sqrt(1 + 8 * t.shape[-1]) - 1) / 2) - diagonal
     n2 = n * n
-    idx = np.reshape(np.arange(n2), (n, n))[onp.tril_indices(n, diagonal)]
+    idx = np.reshape(np.arange(n2), (n, n))[np.tril_indices(n, diagonal)]
     x = lax.scatter_add(np.zeros(t.shape[:-1] + (n2,)), np.expand_dims(idx, axis=-1), t,
                         lax.ScatterDimensionNumbers(update_window_dims=range(t.ndim - 1),
                                                     inserted_window_dims=(t.ndim - 1,),

--- a/numpyro/infer_util.py
+++ b/numpyro/infer_util.py
@@ -119,8 +119,7 @@ def init_to_median(site, num_samples=15, skip_param=False):
         else:
             fn = site['fn']
         samples = sample('_init', fn, sample_shape=(num_samples,))
-        # TODO: use np.median when it is available upstream
-        return np.mean(samples, axis=0)
+        return np.median(samples, axis=0)
 
     if site['type'] == 'param' and not skip_param:
         # return base value of param site

--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -58,7 +58,6 @@ def while_loop(cond_fun, body_fun, init_val):
             val = body_fun(val)
         return val
     else:
-        # TODO: consider jitting while_loop similar to fori_loop
         return lax.while_loop(cond_fun, body_fun, init_val)
 
 
@@ -69,7 +68,7 @@ def fori_loop(lower, upper, body_fun, init_val):
             val = body_fun(i, val)
         return val
     else:
-        return jit(lax.fori_loop, static_argnums=(2,))(lower, upper, body_fun, init_val)
+        return lax.fori_loop(lower, upper, body_fun, init_val)
 
 
 def identity(x):

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -9,8 +9,8 @@ EXAMPLES_DIR = os.path.join(os.path.dirname(TESTS_DIR), 'examples')
 
 
 EXAMPLES = [
-    # 'baseball.py --num-samples 100 --num-warmup 100 --num-chains 2',
-    # 'covtype.py --algo HMC --num-samples 10',
+    'baseball.py --num-samples 100 --num-warmup 100 --num-chains 2',
+    'covtype.py --algo HMC --num-samples 10',
     'hmm.py --num-samples 100 --num-warmup 100 --num-chains 2',
     'bnn.py --num-samples 10 --num-warmup 10 --num-data 7 --num-chains 2',
     'sparse_regression.py --num-samples 10 --num-warmup 10 --num-data 10 --num-dimensions 10',
@@ -28,9 +28,6 @@ EXAMPLES = [
 def test_cpu(example):
     print('Running:\npython examples/{}'.format(example))
     example = example.split()
-    if example[0] == 'hmm.py':
-        pytest.skip('FIXME: Could not find valid initial params'
-                    ' (https://github.com/pyro-ppl/numpyro/issues/279).')
     filename, args = example[0], example[1:]
     filename = os.path.join(EXAMPLES_DIR, filename)
     check_call([sys.executable, filename] + args)

--- a/test/test_hmc_util.py
+++ b/test/test_hmc_util.py
@@ -14,7 +14,6 @@ from numpyro.distributions.constraints import biject_to
 from numpyro.handlers import sample, seed
 from numpyro.hmc_util import (
     AdaptWindow,
-    _cov,
     _is_iterative_turning,
     _leaf_idx_to_ckpt_idxs,
     build_adaptation_schedule,
@@ -512,7 +511,7 @@ def test_gaussian_subposterior(method, diagonal):
     if diagonal:
         assert_allclose(np.var(draws, axis=0), np.diag(cov), atol=0.05)
     else:
-        assert_allclose(_cov(draws), cov, atol=0.05)
+        assert_allclose(np.cov(draws.T), cov, atol=0.05)
 
 
 @pytest.mark.parametrize('method', [consensus, parametric_draws])


### PR DESCRIPTION
This PR fixes some issues at the examples involving `logsumexp`. It seems that there is some issues of the upstream `logsumexp` under fastmath mode.

In addition, this incorporates various cleanup at #276.

Fix #279.