### PR TITLE
Reinstate earlier logic to compute ELBO in SVI

### DIFF
--- a/numpyro/handlers.py
+++ b/numpyro/handlers.py
@@ -195,7 +195,7 @@ class replay(Messenger):
 
     def process_message(self, msg):
         if msg['name'] in self.guide_trace:
-            msg['value'] = self.guide_trace[msg['name']]
+            msg['value'] = self.guide_trace[msg['name']]['value']
 
 
 class block(Messenger):

--- a/numpyro/handlers.py
+++ b/numpyro/handlers.py
@@ -195,13 +195,7 @@ class replay(Messenger):
 
     def process_message(self, msg):
         if msg['name'] in self.guide_trace:
-            guide_site = self.guide_trace[msg['name']]
-            if msg['type'] == 'sample':
-                value, intermediates = guide_site['value'], guide_site['intermediates']
-                base_value = intermediates[0][0] if intermediates else value
-                msg['value'], msg['intermediates'] = msg['fn'].transform_with_intermediates(base_value)
-            elif msg['type'] == 'param':
-                msg['value'] = guide_site['value']
+            msg['value'] = self.guide_trace[msg['name']]
 
 
 class block(Messenger):


### PR DESCRIPTION
This reverts the changes in replay messenger and the svi class in #284 which, as pointed out by @fehiepsi, will lead to wrong ELBO computation for certain examples.


