### PR TITLE
ping to a working jax version for 0.2 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ dist: xenial
 install:
     - pip install -U pip
     - pip install jaxlib
-    - pip install jax==0.1.41
+    - pip install jax
     - pip install .[examples,test]
     - pip freeze
 

--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,8 @@ setup(
     author_email='npradhan@uber.com',
     install_requires=[
         # TODO: pin to a specific version for the next release (unless JAX's API becomes stable)
-        'jax==0.1.41',
-        'jaxlib>=0.1.22',
+        'jax==0.1.43',
+        'jaxlib==0.1.26',
         'tqdm',
     ],
     extras_require={


### PR DESCRIPTION
@neerajprad This version is stable and fix the `lax.scan` bug. It is also much faster than previous versions. Let's target to have 0.2 released with this version.