### PR TITLE
pip jaxlib to 0.1.27

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     install_requires=[
         # TODO: pin to a specific version for the next release (unless JAX's API becomes stable)
         'jax==0.1.43',
-        'jaxlib==0.1.26',
+        'jaxlib==0.1.27',
         'tqdm',
     ],
     extras_require={

--- a/test/test_mcmc_interface.py
+++ b/test/test_mcmc_interface.py
@@ -94,7 +94,8 @@ def test_uniform_normal():
     data = true_coef + random.normal(random.PRNGKey(0), (1000,))
     kernel = NUTS(model=model)
     mcmc = MCMC(kernel, num_warmup=num_warmup, num_samples=num_samples)
-    mcmc.run(random.PRNGKey(2), data, collect_warmup=True, collect_fields=('z', 'num_steps'))
+    mcmc.run(random.PRNGKey(2), data, collect_warmup=True,
+             collect_fields=('z', 'num_steps', 'adapt_state.step_size'))
     samples = mcmc.get_samples()
     assert len(samples[0]['loc']) == num_warmup + num_samples
     assert_allclose(np.mean(samples[0]['loc'], 0), true_coef, atol=0.05)


### PR DESCRIPTION
For some reasons, numpyro is failing in Travis, saying that jaxlib 0.1.26 is not available. So we ping to a newer version.