### PR TITLE
Add predictive utility

### DIFF
--- a/numpyro/infer_util.py
+++ b/numpyro/infer_util.py
@@ -1,7 +1,10 @@
+import warnings
+
 import jax
-from jax import random, value_and_grad
+from jax import random, value_and_grad, vmap
 from jax.flatten_util import ravel_pytree
 import jax.numpy as np
+from jax.tree_util import tree_flatten
 
 import numpyro
 import numpyro.distributions as dist
@@ -253,3 +256,49 @@ def find_valid_initial_params(rng, model, *model_args, init_strategy=init_to_uni
         init_state = body_fn((0, rng, None, None))
     _, _, init_params, is_valid = while_loop(cond_fn, body_fn, init_state)
     return init_params, is_valid
+
+
+def _predictive_sequential(model, posterior_samples, model_args, model_kwargs,
+                           num_samples, sample_sites, return_trace=False):
+    collected = []
+    samples = [{k: v[i] for k, v in posterior_samples.items()} for i in range(num_samples)]
+    for i in range(num_samples):
+        trace = poutine.trace(poutine.condition(model, samples[i])).get_trace(*model_args, **model_kwargs)
+        if return_trace:
+            collected.append(trace)
+        else:
+            collected.append({site: trace.nodes[site]['value'] for site in sample_sites})
+
+    return collected if return_trace else {site: torch.stack([s[site] for s in collected])
+                                           for site in sample_sites}
+
+
+def predictive(rng, model, posterior_samples, return_sites=None, *args, **kwargs):
+    """
+    Run model by sampling latent parameters from `posterior_samples`, and return
+    values at sample sites from the forward run. By default, only sites not contained in
+    `posterior_samples` are returned. This can be modified by changing the `return_sites`
+    keyword argument.
+
+    .. warning::
+        The interface for the `predictive` function is experimental, and
+        might change in the future.
+
+    :param jax.random.PRNGKey rng: seed to draw samples
+    :param model: Python callable containing Pyro primitives.
+    :param dict posterior_samples: dictionary of samples from the posterior.
+    :param list return_sites: sites to return; by default only sample sites not present
+        in `posterior_samples` are returned.
+    :param args: model arguments.
+    :param kwargs: model kwargs.
+    :return: dict of samples from the predictive distribution.
+    """
+    # TODO: consider to support `num_samples`, `return_traces`, `parallel` kwargs
+    def single_prediction(rng, samples):
+        model_trace = trace(substitute(seed(model, rng), samples)).get_trace(*args, **kwargs)
+        sites = model_trace.keys() - samples.keys() if return_sites is None else return_sites
+        return {name: site['value'] for name, site in model_trace.items() if name in sites}
+
+    num_samples = tree_flatten(posterior_samples)[0][0].shape[0]
+    rngs = random.split(rng, num_samples)
+    return vmap(single_prediction)(rngs, posterior_samples)

--- a/test/test_infer_util.py
+++ b/test/test_infer_util.py
@@ -1,0 +1,41 @@
+from numpy.testing import assert_allclose
+
+import jax.numpy as np
+from jax import random
+
+import numpyro
+import numpyro.distributions as dist
+from numpyro.mcmc import MCMC, NUTS
+from numpyro.infer_util import predictive
+
+
+def beta_bernoulli():
+    N = 1000
+    true_probs = np.array([0.2, 0.3, 0.4, 0.8, 0.5])
+    data = dist.Bernoulli(true_probs).sample(random.PRNGKey(0), (N,))
+
+    def model(data=None):
+        beta = numpyro.sample("beta", dist.Beta(np.ones(5), np.ones(5)))
+        numpyro.sample("obs", dist.Bernoulli(beta), obs=data, sample_shape=(1000,))
+
+    return model, data, true_probs
+
+
+def test_predictive():
+    model, data, true_probs = beta_bernoulli()
+    mcmc = MCMC(NUTS(model), num_warmup=100, num_samples=100)
+    mcmc.run(random.PRNGKey(0), data)
+    samples = mcmc.get_samples()
+
+    predictive_samples = predictive(random.PRNGKey(1), model, samples)
+    assert predictive_samples.keys() == {"obs"}
+
+    predictive_samples = predictive(random.PRNGKey(1), model, samples,
+                                    return_sites=["beta", "obs"])
+
+    # check shapes
+    assert predictive_samples["beta"].shape == (100, 5)
+    assert predictive_samples["obs"].shape == (100, 1000, 5)
+
+    # check sample mean
+    assert_allclose(predictive_samples["obs"].reshape([-1, 5]).mean(0), true_probs, rtol=0.1)


### PR DESCRIPTION
Because we don't have `plate` yet, users need to explicitly put `sample_shape` arg to observation sites if they want to draw a batch of obs. Looking like the best example to illustrate this utility is bayesian regression tutorial, so based on comments, I'll make corresponding changes on that tutorial (or in some examples such as `bnn`).