### PR TITLE
Do not call random.split when sample site is observed

### DIFF
--- a/numpyro/handlers.py
+++ b/numpyro/handlers.py
@@ -330,7 +330,7 @@ class seed(Messenger):
         super(seed, self).__init__(fn)
 
     def process_message(self, msg):
-        if msg['type'] == 'sample':
+        if msg['type'] == 'sample' and not msg['is_observed']:
             self.rng, rng_sample = random.split(self.rng)
             msg['kwargs']['random_state'] = rng_sample
 

--- a/numpyro/infer_util.py
+++ b/numpyro/infer_util.py
@@ -7,7 +7,7 @@ from jax.tree_util import tree_flatten
 import numpyro
 import numpyro.distributions as dist
 from numpyro.distributions.constraints import ComposeTransform, biject_to, real
-from numpyro.handlers import block, seed, substitute, trace
+from numpyro.handlers import block, seed, substitute, trace, condition
 from numpyro.util import while_loop
 
 
@@ -278,7 +278,7 @@ def predictive(rng, model, posterior_samples, return_sites=None, *args, **kwargs
     """
     # TODO: consider to support `num_samples`, `return_traces`, `parallel` kwargs
     def single_prediction(rng, samples):
-        model_trace = trace(substitute(seed(model, rng), samples)).get_trace(*args, **kwargs)
+        model_trace = trace(seed(condition(model, samples), rng)).get_trace(*args, **kwargs)
         sites = model_trace.keys() - samples.keys() if return_sites is None else return_sites
         return {name: site['value'] for name, site in model_trace.items() if name in sites}
 

--- a/test/test_handlers.py
+++ b/test/test_handlers.py
@@ -48,3 +48,13 @@ def test_condition():
     # Raise ValueError when site is already observed.
     with pytest.raises(ValueError):
         handlers.condition(model, {'y': 3.})()
+
+
+def test_no_split_deterministic():
+    def model():
+        x = numpyro.sample('x', dist.Normal(0., 1.))
+        y = numpyro.sample('y', dist.Normal(0., 1.))
+        return x + y
+
+    model = handlers.condition(model, {'x': 1., 'y': 2.})
+    assert model() == 3.


### PR DESCRIPTION
This makes a minor optimization to seed to not call `random.split` if the site is already observed. This requires the following changes:
 - Using `condition` instead of `substitute` whenever possible, e.g. in the `predictive` utility.
 - Using `seed(condition(model, ..))` instead of `condition(seed(model, ..))`, the former being more efficient in that it will not call `random.split` for conditioned sites.