### PR TITLE
Make numpyro jit-free

### DIFF
--- a/numpyro/mcmc.py
+++ b/numpyro/mcmc.py
@@ -8,7 +8,7 @@ import warnings
 
 import tqdm
 
-from jax import jit, lax, partial, pmap, random, vmap
+from jax import lax, partial, pmap, random, vmap
 from jax.flatten_util import ravel_pytree
 from jax.lib import xla_bridge
 import jax.numpy as np
@@ -279,7 +279,6 @@ def hmc(potential_fn, kinetic_fn=None, algo='NUTS'):
 
     _next = _nuts_next if algo == 'NUTS' else _hmc_next
 
-    @jit
     def sample_kernel(hmc_state):
         """
         Given an existing :data:`~numpyro.mcmc.HMCState`, run HMC with fixed (possibly adapted)

--- a/numpyro/mcmc.py
+++ b/numpyro/mcmc.py
@@ -8,7 +8,7 @@ import warnings
 
 import tqdm
 
-from jax import lax, partial, pmap, random, vmap
+from jax import jit, lax, partial, pmap, random, vmap
 from jax.flatten_util import ravel_pytree
 from jax.lib import xla_bridge
 import jax.numpy as np
@@ -245,7 +245,7 @@ def hmc(potential_fn, kinetic_fn=None, algo='NUTS'):
             else:
                 with tqdm.trange(num_warmup, desc='warmup') as t:
                     for i in t:
-                        hmc_state = sample_kernel(hmc_state)
+                        hmc_state = jit(sample_kernel)(hmc_state)
                         t.set_postfix_str(get_diagnostics_str(hmc_state), refresh=False)
         return hmc_state
 

--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -125,7 +125,7 @@ def fori_collect(lower, upper, body_fun, init_val, transform=identity, progbar=T
         val = init_val
         with tqdm.trange(upper) as t:
             for i in t:
-                val = body_fun(val)
+                val = jit(body_fun)(val)
                 if i >= lower:
                     collection.append(jit(ravel_fn)(val))
                 t.set_description(progbar_desc(val), refresh=False)


### PR DESCRIPTION
Historically, we jit `sample_kernel` because it is used in both `init` and `fori_collect` (to avoid 2-time compiling). Now, we move to the new API, which always have `run_warmup=False`, so we don't need to jit sample_kernel (of course, we need to jit fori_collect body_fn). Given that we have a PR to avoid two time compiling after 0.1 release, so this PR causes no regression for the old interface (w.r.t. 0.1 version).

The main benefit of this PR is it will be easier to debug (we don't need to use `jax.disable_jit`).