### PR TITLE
bump version in notebooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Probabilistic programming with NumPy powered by [JAX](https://github.com/google/jax) for autograd and JIT compilation to GPU/CPU.
 
-[Docs](https://numpyro.readthedocs.io/en/v0.1.0/) | [Examples](https://pyro.ai/numpyro/) | [Forum](https://forum.pyro.ai/)
+[Docs](https://numpyro.readthedocs.io/en/stable/) | [Examples](https://pyro.ai/numpyro/) | [Forum](https://forum.pyro.ai/)
 
 ----------------------------------------------------------------------------------------------------
 

--- a/notebooks/source/conf.py
+++ b/notebooks/source/conf.py
@@ -68,7 +68,7 @@ author = u'Uber AI Labs'
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 
-version = '0.1.0'
+version = '0.2.0'
 
 # release version
 release = version  # eg Numpyro 0.1.2


### PR DESCRIPTION
missed one in #328, also use the canonical url for docs