### PR TITLE
Add a simplified plate context manager

### DIFF
--- a/docs/source/primitives.rst
+++ b/docs/source/primitives.rst
@@ -11,6 +11,10 @@ sample
 ------
 .. autofunction:: numpyro.primitives.sample
 
+plate
+-----
+.. autoclass:: numpyro.primitives.plate
+
 module
 ------
 .. autofunction:: numpyro.primitives.module

--- a/numpyro/__init__.py
+++ b/numpyro/__init__.py
@@ -1,3 +1,3 @@
 import numpyro.patch  # noqa: F401
-from numpyro.primitives import module, param, sample  # noqa: F401
+from numpyro.primitives import module, param, plate, sample  # noqa: F401
 from numpyro.version import __version__  # noqa: F401

--- a/numpyro/handlers.py
+++ b/numpyro/handlers.py
@@ -77,35 +77,11 @@ need to loop over all the data points.
 from __future__ import absolute_import, division, print_function
 
 from collections import OrderedDict
-import functools
 
 from jax import random
 
 from numpyro.distributions.constraints import ComposeTransform, biject_to, real
-from numpyro.primitives import _PYRO_STACK
-
-
-class Messenger(object):
-    def __init__(self, fn=None):
-        self.fn = fn
-        functools.update_wrapper(self, fn, updated=[])
-
-    def __enter__(self):
-        _PYRO_STACK.append(self)
-
-    def __exit__(self, *args, **kwargs):
-        assert _PYRO_STACK[-1] is self
-        _PYRO_STACK.pop()
-
-    def process_message(self, msg):
-        pass
-
-    def postprocess_message(self, msg):
-        pass
-
-    def __call__(self, *args, **kwargs):
-        with self:
-            return self.fn(*args, **kwargs)
+from numpyro.primitives import Messenger
 
 
 class trace(Messenger):

--- a/numpyro/infer_util.py
+++ b/numpyro/infer_util.py
@@ -7,7 +7,7 @@ from jax.tree_util import tree_flatten
 import numpyro
 import numpyro.distributions as dist
 from numpyro.distributions.constraints import ComposeTransform, biject_to, real
-from numpyro.handlers import block, seed, substitute, trace, condition
+from numpyro.handlers import block, condition, seed, substitute, trace
 from numpyro.util import while_loop
 
 

--- a/numpyro/primitives.py
+++ b/numpyro/primitives.py
@@ -1,9 +1,17 @@
+import functools
+from collections import namedtuple
+
 import jax
+from jax import lax
+
 
 import numpyro
 from numpyro.distributions.discrete import PRNGIdentity
 
 _PYRO_STACK = []
+
+
+CondIndepStackFrame = namedtuple('CondIndepStackFrame', ['name', 'dim', 'size'])
 
 
 def apply_stack(msg):
@@ -30,6 +38,29 @@ def apply_stack(msg):
     return msg
 
 
+class Messenger(object):
+    def __init__(self, fn=None):
+        self.fn = fn
+        functools.update_wrapper(self, fn, updated=[])
+
+    def __enter__(self):
+        _PYRO_STACK.append(self)
+
+    def __exit__(self, *args, **kwargs):
+        assert _PYRO_STACK[-1] is self
+        _PYRO_STACK.pop()
+
+    def process_message(self, msg):
+        pass
+
+    def postprocess_message(self, msg):
+        pass
+
+    def __call__(self, *args, **kwargs):
+        with self:
+            return self.fn(*args, **kwargs)
+
+
 def sample(name, fn, obs=None, sample_shape=()):
     """
     Returns a random sample from the stochastic function `fn`. This can have
@@ -54,8 +85,10 @@ def sample(name, fn, obs=None, sample_shape=()):
         'args': (),
         'kwargs': {'sample_shape': sample_shape},
         'value': obs,
+        'scale': 1.0,
         'is_observed': obs is not None,
         'intermediates': [],
+        'cond_indep_stack': [],
     }
 
     # ...and use apply_stack to send it to the Messengers
@@ -94,6 +127,8 @@ def param(name, init_value=None, **kwargs):
         'args': (init_value,),
         'kwargs': kwargs,
         'value': None,
+        'scale': 1.0,
+        'cond_indep_stack': [],
     }
 
     # ...and use apply_stack to send it to the Messengers
@@ -126,3 +161,74 @@ def module(name, nn, input_shape=None):
         _, nn_params = nn_init(rng, input_shape)
         param(module_key, nn_params)
     return jax.partial(nn_apply, nn_params)
+
+
+class plate(Messenger):
+    """
+    Construct for annotating conditionally independent variables. Within a
+    `plate` context manager, `sample` sites will be automatically broadcasted to
+    the size of the plate. Additionally, a scale factor might be applied by
+    certain inference algorithms if `subsample_size` is specified.
+
+    :param str name: Name of the plate.
+    :param int size: Size of the plate.
+    :param int subsample_size: Optional argument denoting the size of the mini-batch.
+        This can be used to apply a scaling factor by inference algorithms. e.g.
+        when computing ELBO using a mini-batch.
+    :param int dim: Optional argument to specify which dimension in the tensor
+        is used as the plate dim. If `None` (default), the leftmost available dim
+        is allocated.
+    """
+    def __init__(self, name, size, subsample_size=None, dim=None):
+        self.name = name
+        self.size = size
+        self.subsample_size = size if subsample_size is None else subsample_size
+        if dim is not None and dim >= 0:
+            raise ValueError('dim arg must be negative.')
+        self.dim = dim
+        self._validate_and_set_dim()
+        super(plate, self).__init__()
+
+    def _validate_and_set_dim(self):
+        msg = {
+            'type': 'plate',
+            'is_observed': False,
+            'fn': identity,
+            'name': self.name,
+            'args': (None,),
+            'kwargs': {},
+            'value': None,
+            'scale': 1.0,
+            'cond_indep_stack': [],
+        }
+        apply_stack(msg)
+        cond_indep_stack = msg['cond_indep_stack']
+        occupied_dims = {f.dim for f in cond_indep_stack}
+        dim = -1
+        while True:
+            if dim not in occupied_dims:
+                break
+            dim -= 1
+        if self.dim is None:
+            self.dim = dim
+        else:
+            assert self.dim not in occupied_dims
+
+    @staticmethod
+    def _get_batch_shape(cond_indep_stack):
+        n_dims = max(-f.dim for f in cond_indep_stack)
+        batch_shape = [1] * n_dims
+        for f in cond_indep_stack:
+            batch_shape[f.dim] = f.size
+        return tuple(batch_shape)
+
+    def process_message(self, msg):
+        cond_indep_stack = msg['cond_indep_stack']
+        frame = CondIndepStackFrame(self.name, self.dim, self.subsample_size)
+        cond_indep_stack.append(frame)
+        batch_shape = self._get_batch_shape(cond_indep_stack)
+        if 'sample_shape' in msg['kwargs']:
+            batch_shape = lax.broadcast_shapes(msg['kwargs']['sample_shape'], batch_shape)
+        msg['kwargs']['sample_shape'] = batch_shape
+        msg['scale'] = msg['scale'] * self.size / self.subsample_size
+

--- a/numpyro/primitives.py
+++ b/numpyro/primitives.py
@@ -1,9 +1,8 @@
-import functools
 from collections import namedtuple
+import functools
 
 import jax
 from jax import lax
-
 
 import numpyro
 from numpyro.distributions.discrete import PRNGIdentity
@@ -231,4 +230,3 @@ class plate(Messenger):
             batch_shape = lax.broadcast_shapes(msg['kwargs']['sample_shape'], batch_shape)
         msg['kwargs']['sample_shape'] = batch_shape
         msg['scale'] = msg['scale'] * self.size / self.subsample_size
-

--- a/test/test_handlers.py
+++ b/test/test_handlers.py
@@ -1,6 +1,3 @@
-import functools
-from operator import mul
-
 from numpy.testing import assert_allclose
 import pytest
 

--- a/test/test_handlers.py
+++ b/test/test_handlers.py
@@ -4,7 +4,7 @@ from operator import mul
 from numpy.testing import assert_allclose
 import pytest
 
-from jax import random, jit
+from jax import jit, random
 
 import numpyro
 from numpyro import handlers

--- a/test/test_handlers.py
+++ b/test/test_handlers.py
@@ -115,4 +115,8 @@ def model_subsample_1():
     model_subsample_1,
 ])
 def test_plate(model):
-    jit(handlers.seed(model, random.PRNGKey(1)))
+    trace = handlers.trace(handlers.seed(model, random.PRNGKey(1))).get_trace()
+    jit_trace = handlers.trace(jit(handlers.seed(model, random.PRNGKey(1)))).get_trace()
+    for name, site in trace.items():
+        if site['type'] == 'sample':
+            assert_allclose(jit_trace[name]['value'], site['value'])


### PR DESCRIPTION
Fixes #41. Additionally, this is a blocker for #66. 

This adds a simplified version of the context manager used in Pyro models. This has the same broadcasting and scaling semantics as Pyro's plate context manager. 

There are a few simplifications - `size` argument is mandatory, there is no `subsample` argument and the context manager does not return indices like `arange` or samples from a categorical distribution. If needed, we can support these arguments later, but it is unclear if our simple interface for SVI/HMC without enumeration would require a more complex implementation.