### PR TITLE
Add compatibility module for pyro.generic

### DIFF
--- a/numpyro/compat/distributions.py
+++ b/numpyro/compat/distributions.py
@@ -1,0 +1,1 @@
+from numpyro.distributions import *  # noqa: F401, F403

--- a/numpyro/compat/handlers.py
+++ b/numpyro/compat/handlers.py
@@ -1,0 +1,11 @@
+from jax import random
+
+from numpyro.handlers import *  # noqa: F401, F403
+from numpyro.handlers import seed as _seed
+
+
+# This is so that users do not have to import PRNGKey from jax.random.
+# XXX: Should we make this the default?
+class seed(_seed):
+    def __init__(self, fn, rng):
+        super(seed, self).__init__(fn, random.PRNGKey(rng))

--- a/numpyro/compat/infer.py
+++ b/numpyro/compat/infer.py
@@ -1,0 +1,95 @@
+import math
+
+from jax import random
+
+from numpyro import mcmc
+
+
+class HMC(mcmc.HMC):
+    def __init__(self,
+                 model=None,
+                 potential_fn=None,
+                 step_size=1,
+                 adapt_step_size=True,
+                 adapt_mass_matrix=True,
+                 full_mass=False,
+                 use_multinomial_sampling=True,
+                 transforms=None,
+                 max_plate_nesting=None,
+                 jit_compile=False,
+                 jit_options=None,
+                 ignore_jit_warnings=False,
+                 trajectory_length=2 * math.pi,
+                 target_accept_prob=0.8):
+        super(HMC, self).__init__(model=model,
+                                  potential_fn=potential_fn,
+                                  step_size=step_size,
+                                  adapt_step_size=adapt_step_size,
+                                  adapt_mass_matrix=adapt_mass_matrix,
+                                  dense_mass=full_mass,
+                                  target_accept_prob=target_accept_prob,
+                                  trajectory_length=trajectory_length)
+
+
+class NUTS(mcmc.NUTS):
+    def __init__(self,
+                 model=None,
+                 potential_fn=None,
+                 step_size=1,
+                 adapt_step_size=True,
+                 adapt_mass_matrix=True,
+                 full_mass=False,
+                 use_multinomial_sampling=True,
+                 transforms=None,
+                 max_plate_nesting=None,
+                 jit_compile=False,
+                 jit_options=None,
+                 ignore_jit_warnings=False,
+                 trajectory_length=2 * math.pi,
+                 target_accept_prob=0.8,
+                 max_tree_depth=10):
+        if potential_fn is not None:
+            raise ValueError('Only `model` argument is supported in generic module;'
+                             ' `potential_fn` is not supported.')
+        super(NUTS, self).__init__(model=model,
+                                   potential_fn=potential_fn,
+                                   step_size=step_size,
+                                   adapt_step_size=adapt_step_size,
+                                   adapt_mass_matrix=adapt_mass_matrix,
+                                   dense_mass=full_mass,
+                                   target_accept_prob=target_accept_prob,
+                                   trajectory_length=trajectory_length,
+                                   max_tree_depth=max_tree_depth)
+
+
+class MCMC(object):
+    def __init__(self,
+                 kernel,
+                 num_samples,
+                 warmup_steps=None,
+                 initial_params=None,
+                 num_chains=1,
+                 hook_fn=None,
+                 mp_context=None,
+                 disable_progbar=False,
+                 disable_validation=True,
+                 transforms=None):
+        if warmup_steps is None:
+            warmup_steps = num_samples
+        self._initial_params = initial_params
+        self._mcmc = mcmc.MCMC(kernel,
+                               warmup_steps,
+                               num_samples,
+                               num_chains=num_chains,
+                               progress_bar=(not disable_progbar))
+
+    def run(self, *args, rng=random.PRNGKey(0), **kwargs):
+        self._mcmc.run(rng, *args, init_params=self._initial_params, **kwargs)
+
+    def get_samples(self, num_samples=None, group_by_chain=False):
+        if num_samples is not None:
+            raise ValueError('`num_samples` arg unsupported in NumPyro.')
+        return self._mcmc.get_samples(group_by_chain=group_by_chain)
+
+    def summary(self, prob=0.9):
+        self._mcmc.print_summary()

--- a/numpyro/compat/pyro.py
+++ b/numpyro/compat/pyro.py
@@ -1,0 +1,2 @@
+import numpyro.patch  # noqa: F401
+from numpyro.primitives import module, param, plate, sample  # noqa: F401

--- a/numpyro/handlers.py
+++ b/numpyro/handlers.py
@@ -84,6 +84,17 @@ from numpyro.distributions.constraints import ComposeTransform, biject_to, real
 from numpyro.primitives import Messenger
 
 
+__all__ = [
+    'block',
+    'condition',
+    'replay',
+    'scale',
+    'seed',
+    'substitute',
+    'trace',
+]
+
+
 class trace(Messenger):
     """
     Returns a handler that records the inputs and outputs at primitive calls

--- a/numpyro/mcmc.py
+++ b/numpyro/mcmc.py
@@ -785,7 +785,7 @@ class MCMC(object):
         get_items = itemgetter(*self._collect_fields)
         return get_items(self._samples) if group_by_chain else get_items(self._samples_flat)
 
-    def print_summary(self):
+    def print_summary(self, prob=0.9):
         if 'z' not in self._samples:
             raise ValueError('No latent samples `z` collected. Pass `z` to `collect_fields` arg.')
-        summary(self._samples['z'])
+        summary(self._samples['z'], prob=prob)


### PR DESCRIPTION
This seeds the `numpyro.compat` module with some basic wrappers for MCMC in preparation for #66. This will allow us to start testing the generic module in Pyro, and prepare for a more involved design discussion. Tests with the generic module will be in Pyro.