### PR TITLE
use fori + vmap instead of vmap + fori for vectorized method

### DIFF
--- a/numpyro/hmc_util.py
+++ b/numpyro/hmc_util.py
@@ -861,7 +861,6 @@ def parametric(subposteriors, diagonal=False):
 
     submeans = np.mean(joined_subposteriors, axis=1)
     if diagonal:
-        # NB: jax.numpy.var does not support ddof=1, so we do it manually
         weights = vmap(lambda x: 1 / np.var(x, ddof=1, axis=0))(joined_subposteriors)
         var = 1 / np.sum(weights, axis=0)
         normalized_weights = var * weights

--- a/numpyro/mcmc.py
+++ b/numpyro/mcmc.py
@@ -543,6 +543,7 @@ class HMC(MCMCKernel):
 
     @copy_docs_from(MCMCKernel.init)
     def init(self, rng, num_warmup, init_params=None, model_args=(), model_kwargs={}):
+        constrain_fn = None
         if self.model is not None:
             if rng.ndim == 1:
                 rng, rng_init_model = random.split(rng)

--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -128,7 +128,7 @@ def fori_collect(lower, upper, body_fun, init_val, transform=identity, progbar=T
                 val = jit(body_fun)(val)
                 if i >= lower:
                     collection.append(jit(ravel_fn)(val))
-                t.set_description(progbar_desc(val), refresh=False)
+                t.set_description(progbar_desc(i), refresh=False)
                 if diagnostics_fn:
                     t.set_postfix_str(diagnostics_fn(val), refresh=False)
 

--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -8,7 +8,7 @@ import tqdm
 from jax import jit, lax, ops, vmap
 from jax.lib.xla_bridge import canonicalize_dtype
 import jax.numpy as np
-from jax.tree_util import tree_flatten, tree_map, tree_multimap, tree_unflatten
+from jax.tree_util import tree_flatten, tree_map, tree_unflatten
 
 _DATA_TYPES = {}
 _DISABLE_CONTROL_FLOW_PRIM = False
@@ -70,20 +70,6 @@ def fori_loop(lower, upper, body_fun, init_val):
         return val
     else:
         return lax.fori_loop(lower, upper, body_fun, init_val)
-
-
-def lax_map(f, xs):
-    n = tree_flatten(xs)[0][0].shape[0]
-
-    def get_value_from_index(i):
-        return tree_map(lambda x: x[i], xs)
-
-    ys = []
-    for i in range(n):
-        x = jit(get_value_from_index)(i)
-        ys.append(f(x))
-
-    return tree_multimap(lambda *args: np.stack(args), *ys)
 
 
 def identity(x):

--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -8,7 +8,7 @@ import tqdm
 from jax import jit, lax, ops, vmap
 from jax.lib.xla_bridge import canonicalize_dtype
 import jax.numpy as np
-from jax.tree_util import tree_flatten, tree_map, tree_unflatten
+from jax.tree_util import tree_flatten, tree_map, tree_multimap, tree_unflatten
 
 _DATA_TYPES = {}
 _DISABLE_CONTROL_FLOW_PRIM = False
@@ -70,6 +70,20 @@ def fori_loop(lower, upper, body_fun, init_val):
         return val
     else:
         return lax.fori_loop(lower, upper, body_fun, init_val)
+
+
+def lax_map(f, xs):
+    n = tree_flatten(xs)[0][0].shape[0]
+
+    def get_value_from_index(i):
+        return tree_map(lambda x: x[i], xs)
+
+    ys = []
+    for i in range(n):
+        x = jit(get_value_from_index)(i)
+        ys.append(f(x))
+
+    return tree_multimap(lambda *args: np.stack(args), *ys)
 
 
 def identity(x):

--- a/test/test_mcmc_interface.py
+++ b/test/test_mcmc_interface.py
@@ -347,7 +347,8 @@ def test_chain_inside_jit(kernel_cls, chain_method):
     def get_samples(rng, data, step_size, trajectory_length, target_accept_prob):
         kernel = kernel_cls(model, step_size=step_size, trajectory_length=trajectory_length,
                             target_accept_prob=target_accept_prob)
-        mcmc = MCMC(kernel, warmup_steps, num_samples, num_chains=2, chain_method=chain_method)
+        mcmc = MCMC(kernel, warmup_steps, num_samples, num_chains=2, chain_method=chain_method,
+                    progress_bar=False)
         mcmc.run(rng, data)
         return mcmc.get_samples()
 


### PR DESCRIPTION
Addresses #341 and #309. We can have progress_bar with sequential and vectorized now. I also added a note that sampling will be faster when progress_bar=False.

Test already covers the change. An illustration can be found in
https://nbviewer.jupyter.org/gist/fehiepsi/b9ff5cb6df8b110172471084df1cbe99