### PR TITLE
Upgrade minimum jax versions to run examples

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,8 @@ setup(
     author_email='npradhan@uber.com',
     install_requires=[
         # TODO: pin to a specific version for the next release (unless JAX's API becomes stable)
-        'jax>=0.1.44',
-        'jaxlib>=0.1.27',
+        'jax>=0.1.46',
+        'jaxlib>=0.1.28',
         'tqdm',
     ],
     extras_require={


### PR DESCRIPTION
If we don't bump up the versions, `pip install -e .` will not force an upgrade and our examples will throw errors like `jax.nn does not exist`.