### PR TITLE
Fix the bug of computing transformed potential energy in neutra example

### DIFF
--- a/examples/neutra.py
+++ b/examples/neutra.py
@@ -1,4 +1,5 @@
 import argparse
+from functools import partial
 import os
 
 from matplotlib.gridspec import GridSpec
@@ -18,7 +19,7 @@ from numpyro.diagnostics import summary
 import numpyro.distributions as dist
 from numpyro.distributions import constraints
 from numpyro.hmc_util import initialize_model
-from numpyro.infer_util import transformed_potential_fn
+from numpyro.infer_util import transformed_potential_energy
 from numpyro.mcmc import MCMC, NUTS
 from numpyro.svi import SVI, elbo
 
@@ -62,8 +63,9 @@ def main(args):
     print("Start vanilla HMC...")
     nuts_kernel = NUTS(dual_moon_model)
     mcmc = MCMC(nuts_kernel, args.num_warmup, args.num_samples)
-    mcmc.run(random.PRNGKey(0), init_params=np.array([2., 0.]))
-    vanilla_samples = mcmc.get_samples()
+    mcmc.run(random.PRNGKey(0))
+    mcmc.print_summary()
+    vanilla_samples = mcmc.get_samples()['x'].copy()
 
     adam = optim.Adam(0.001)
     guide = AutoIAFNormal(dual_moon_model, hidden_dims=[args.num_hidden], skip_connections=True)
@@ -75,35 +77,34 @@ def main(args):
     params = svi.get_params(last_state)
     print("Finish training guide. Extract samples...")
     guide_samples = guide.sample_posterior(random.PRNGKey(0), params,
-                                           sample_shape=(args.num_samples,))
+                                           sample_shape=(args.num_samples,))['x'].copy()
 
     transform = guide.get_transform(params)
-    unpack_fn = guide.unpack_latent
-
     _, potential_fn, constrain_fn = initialize_model(random.PRNGKey(2), dual_moon_model)
-    transformed_potential_fn = make_transformed_pe(potential_fn, transform, unpack_fn)
-    transformed_constrain_fn = lambda x: constrain_fn(unpack_fn(transform(x)))  # noqa: E731
+    transformed_potential_fn = partial(transformed_potential_energy, potential_fn, transform)
+    transformed_constrain_fn = lambda x: constrain_fn(transform(x))  # noqa: E731
 
-    init_params = np.zeros(guide.latent_size)
     print("\nStart NeuTra HMC...")
     nuts_kernel = NUTS(potential_fn=transformed_potential_fn)
     mcmc = MCMC(nuts_kernel, args.num_warmup, args.num_samples)
+    init_params = np.zeros(guide.latent_size)
     mcmc.run(random.PRNGKey(3), init_params=init_params)
+    mcmc.print_summary()
     zs = mcmc.get_samples()
     print("Transform samples into unwarped space...")
-    samples = vmap(transformed_constrain_fn)(zs)
+    samples = vmap(transformed_constrain_fn)(zs)['x'].copy()
     summary(tree_map(lambda x: x[None, ...], samples))
 
     # make plots
 
-    # IAF guide samples (for plotting)
-    iaf_base_samples = dist.Normal(np.zeros(2), 1.).sample(random.PRNGKey(0), (1000,))
-    iaf_trans_samples = vmap(transformed_constrain_fn)(iaf_base_samples)['x']
+    # guide samples (for plotting)
+    guide_base_samples = dist.Normal(np.zeros(2), 1.).sample(random.PRNGKey(4), (1000,))
+    guide_trans_samples = vmap(transformed_constrain_fn)(guide_base_samples)['x']
 
     x1 = np.linspace(-3, 3, 100)
     x2 = np.linspace(-3, 3, 100)
     X1, X2 = np.meshgrid(x1, x2)
-    P = np.clip(np.exp(-dual_moon_pe(np.stack([X1, X2], axis=-1))), a_min=0.)
+    P = np.exp(DualMoonDistribution().log_prob(np.stack([X1, X2], axis=-1)))
 
     fig = plt.figure(figsize=(12, 16), constrained_layout=True)
     gs = GridSpec(3, 2, figure=fig)
@@ -118,28 +119,29 @@ def main(args):
     ax1.set_title('Autoguide training log loss (after 1000 steps)')
 
     ax2.contourf(X1, X2, P, cmap='OrRd')
-    sns.kdeplot(guide_samples['x'][:, 0].copy(), guide_samples['x'][:, 1].copy(), n_levels=30, ax=ax2)
+    sns.kdeplot(guide_samples['x'][:, 0], guide_samples['x'][:, 1], n_levels=30, ax=ax2)
     ax2.set(xlim=[-3, 3], ylim=[-3, 3],
             xlabel='x0', ylabel='x1', title='Posterior using AutoIAFNormal guide')
 
-    sns.scatterplot(iaf_base_samples[:, 0], iaf_base_samples[:, 1], ax=ax3, hue=iaf_trans_samples[:, 0] < 0.)
+    sns.scatterplot(guide_base_samples[:, 0], guide_base_samples[:, 1], ax=ax3,
+                    hue=guide_trans_samples[:, 0] < 0.)
     ax3.set(xlim=[-3, 3], ylim=[-3, 3],
             xlabel='x0', ylabel='x1', title='AutoIAFNormal base samples (True=left moon; False=right moon)')
 
     ax4.contourf(X1, X2, P, cmap='OrRd')
-    sns.kdeplot(vanilla_samples[:, 0].copy(), vanilla_samples[:, 1].copy(), n_levels=30, ax=ax4)
+    sns.kdeplot(vanilla_samples[:, 0], vanilla_samples[:, 1], n_levels=30, ax=ax4)
     ax4.plot(vanilla_samples[-50:, 0], vanilla_samples[-50:, 1], 'bo-', alpha=0.5)
     ax4.set(xlim=[-3, 3], ylim=[-3, 3],
             xlabel='x0', ylabel='x1', title='Posterior using vanilla HMC sampler')
 
-    sns.scatterplot(zs[:, 0], zs[:, 1], ax=ax5, hue=samples['x'][:, 0] < 0.,
+    sns.scatterplot(zs[:, 0], zs[:, 1], ax=ax5, hue=samples[:, 0] < 0.,
                     s=30, alpha=0.5, edgecolor="none")
     ax5.set(xlim=[-5, 5], ylim=[-5, 5],
             xlabel='x0', ylabel='x1', title='Samples from the warped posterior - p(z)')
 
     ax6.contourf(X1, X2, P, cmap='OrRd')
-    sns.kdeplot(samples['x'][:, 0].copy(), samples['x'][:, 1].copy(), n_levels=30, ax=ax6)
-    ax6.plot(samples['x'][-50:, 0], samples['x'][-50:, 1], 'bo-', alpha=0.2)
+    sns.kdeplot(samples[:, 0], samples[:, 1], n_levels=30, ax=ax6)
+    ax6.plot(samples[-50:, 0], samples[-50:, 1], 'bo-', alpha=0.2)
     ax6.set(xlim=[-3, 3], ylim=[-3, 3],
             xlabel='x0', ylabel='x1', title='Posterior using NeuTra HMC sampler')
 
@@ -150,8 +152,8 @@ def main(args):
 if __name__ == "__main__":
     assert numpyro.__version__.startswith('0.2.0')
     parser = argparse.ArgumentParser(description="NeuTra HMC")
-    parser.add_argument('-n', '--num-samples', nargs='?', default=20000, type=int)
-    parser.add_argument('--num-warmup', nargs='?', default=0, type=int)
+    parser.add_argument('-n', '--num-samples', nargs='?', default=10000, type=int)
+    parser.add_argument('--num-warmup', nargs='?', default=1000, type=int)
     parser.add_argument('--num-hidden', nargs='?', default=20, type=int)
     parser.add_argument('--num-iters', nargs='?', default=200000, type=int)
     parser.add_argument('--device', default='cpu', type=str, help='use "cpu" or "gpu".')

--- a/examples/neutra.py
+++ b/examples/neutra.py
@@ -67,8 +67,10 @@ def main(args):
     mcmc.print_summary()
     vanilla_samples = mcmc.get_samples()['x'].copy()
 
-    adam = optim.Adam(0.001)
-    guide = AutoIAFNormal(dual_moon_model, hidden_dims=[args.num_hidden], skip_connections=True)
+    adam = optim.Adam(0.01)
+    # TODO: it is hard to find good hyperparameters such that IAF guide can learn this model.
+    # We will use BNAF instead!
+    guide = AutoIAFNormal(dual_moon_model, num_flows=2, hidden_dims=[args.num_hidden, args.num_hidden])
     svi = SVI(dual_moon_model, guide, elbo, adam)
     svi_state = svi.init(random.PRNGKey(1))
 
@@ -119,7 +121,7 @@ def main(args):
     ax1.set_title('Autoguide training log loss (after 1000 steps)')
 
     ax2.contourf(X1, X2, P, cmap='OrRd')
-    sns.kdeplot(guide_samples['x'][:, 0], guide_samples['x'][:, 1], n_levels=30, ax=ax2)
+    sns.kdeplot(guide_samples[:, 0], guide_samples[:, 1], n_levels=30, ax=ax2)
     ax2.set(xlim=[-3, 3], ylim=[-3, 3],
             xlabel='x0', ylabel='x1', title='Posterior using AutoIAFNormal guide')
 
@@ -154,8 +156,8 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="NeuTra HMC")
     parser.add_argument('-n', '--num-samples', nargs='?', default=10000, type=int)
     parser.add_argument('--num-warmup', nargs='?', default=1000, type=int)
-    parser.add_argument('--num-hidden', nargs='?', default=20, type=int)
-    parser.add_argument('--num-iters', nargs='?', default=200000, type=int)
+    parser.add_argument('--num-hidden', nargs='?', default=10, type=int)
+    parser.add_argument('--num-iters', nargs='?', default=20000, type=int)
     parser.add_argument('--device', default='cpu', type=str, help='use "cpu" or "gpu".')
     args = parser.parse_args()
     main(args)

--- a/examples/neutra.py
+++ b/examples/neutra.py
@@ -94,8 +94,9 @@ def main(args):
     mcmc.print_summary()
     zs = mcmc.get_samples()
     print("Transform samples into unwarped space...")
-    samples = vmap(transformed_constrain_fn)(zs)['x'].copy()
+    samples = vmap(transformed_constrain_fn)(zs)
     summary(tree_map(lambda x: x[None, ...], samples))
+    samples = samples['x'].copy()
 
     # make plots
 

--- a/numpyro/contrib/autoguide/__init__.py
+++ b/numpyro/contrib/autoguide/__init__.py
@@ -135,7 +135,7 @@ class AutoContinuous(AutoGuide):
                     self._inv_transforms[name] = transform
                     unconstrained_sites[name] = transform.inv(site['value'])
 
-        self._init_latent, self.unpack_latent = ravel_pytree(init_params)
+        self._init_latent, self._unpack_latent = ravel_pytree(init_params)
         self.latent_size = np.size(self._init_latent)
         if self.base_dist is None:
             self.base_dist = _Normal(np.zeros(self.latent_size), 1.)
@@ -169,7 +169,7 @@ class AutoContinuous(AutoGuide):
         # unpack continuous latent samples
         result = {}
 
-        for name, unconstrained_value in self.unpack_latent(latent).items():
+        for name, unconstrained_value in self._unpack_latent(latent).items():
             transform = self._inv_transforms[name]
             site = self.prototype_trace[name]
             value = transform(unconstrained_value)
@@ -196,7 +196,7 @@ class AutoContinuous(AutoGuide):
         model_kwargs = self._kwargs
 
         def unpack_single_latent(latent):
-            unpacked_samples = self.unpack_latent(latent)
+            unpacked_samples = self._unpack_latent(latent)
             if self._has_transformed_dist:
                 # first, substitute to `param` statements in model
                 model = handlers.substitute(self.model, params)
@@ -231,7 +231,7 @@ class AutoContinuous(AutoGuide):
         :rtype: :class:`~numpyro.distributions.constraints.Transform`
         """
         return ComposeTransform([handlers.substitute(self._get_transform, params)(),
-                                 UnpackTransform(self.unpack_latent)])
+                                 UnpackTransform(self._unpack_latent)])
 
     def sample_posterior(self, rng, params, sample_shape=()):
         """

--- a/numpyro/contrib/autoguide/__init__.py
+++ b/numpyro/contrib/autoguide/__init__.py
@@ -12,7 +12,13 @@ from numpyro import handlers
 from numpyro.contrib.nn.auto_reg_nn import AutoregressiveNN
 import numpyro.distributions as dist
 from numpyro.distributions import constraints
-from numpyro.distributions.constraints import AffineTransform, ComposeTransform, PermuteTransform, UnpackTransform, biject_to
+from numpyro.distributions.constraints import (
+    AffineTransform,
+    ComposeTransform,
+    PermuteTransform,
+    UnpackTransform,
+    biject_to
+)
 from numpyro.distributions.flows import InverseAutoregressiveTransform
 from numpyro.distributions.util import sum_rightmost
 from numpyro.infer_util import constrain_fn, find_valid_initial_params, init_to_median, transform_fn

--- a/numpyro/handlers.py
+++ b/numpyro/handlers.py
@@ -83,7 +83,6 @@ from jax import random
 from numpyro.distributions.constraints import ComposeTransform, biject_to, real
 from numpyro.primitives import Messenger
 
-
 __all__ = [
     'block',
     'condition',

--- a/numpyro/infer_util.py
+++ b/numpyro/infer_util.py
@@ -97,7 +97,7 @@ def constrain_fn(model, model_args, model_kwargs, transforms, params):
 
 def potential_energy(model, model_args, model_kwargs, inv_transforms, params):
     """
-    Makes a callable which computes potential energy of a model given unconstrained params.
+    Computes potential energy of a model given unconstrained params.
     The `inv_transforms` is used to transform these unconstrained parameters to base values
     of the corresponding priors in `model`. If a prior is a transformed distribution,
     the corresponding base value lies in the support of base distribution. Otherwise,
@@ -107,7 +107,8 @@ def potential_energy(model, model_args, model_kwargs, inv_transforms, params):
     :param tuple model_args: args provided to the model.
     :param dict model_kwargs`: kwargs provided to the model.
     :param dict inv_transforms: dictionary of transforms keyed by names.
-    :return: a callable that computes potential energy given unconstrained parameters.
+    :param dict params: unconstrained parameters of `model`.
+    :return: potential energy given unconstrained parameters.
     """
     params_constrained = transform_fn(inv_transforms, params)
     log_joint, model_trace = log_density(model, model_args, model_kwargs, params_constrained,
@@ -120,29 +121,21 @@ def potential_energy(model, model_args, model_kwargs, inv_transforms, params):
     return - log_joint
 
 
-def transformed_potential_fn(potential_fn, transform, z):
+def transformed_potential_energy(potential_energy, inv_transform, z):
     """
-    Given a potential function `p(x)`, compute potential energy of `p(t(z))`
-    where `t` is a transform from `z` to `x`. 
+    Given a potential energy `p(x)`, compute potential energy of `p(z)`
+    with `z = transform(x)` (i.e. `x = inv_transform(z)`).
 
-    :param z: [description]
-    :type z: [type]
-    :param potential_fn: [description]
-    :type potential_fn: [type]
-    :param ~numpyro.distributions.constraints.Transform transform: a
-    :type transform: [type]
-    :param unpack_fn: [description]
-    :type unpack_fn: [type]
-    :return: [description]
-    :rtype: [type]
+    :param potential_energy: a callable to compute potential energy of original
+        variable `x`.
+    :param ~numpyro.distributions.constraints.Transform inv_transform: a
+        transform from the new variable `z` to `x`.
+    :param z: new variable to compute potential energy
+    :return: potential energy of `z`.
     """
-
-    def transformed_potential_fn(z):
-        u, intermediates = transform.call_with_intermediates(z)
-        logdet = transform.log_abs_det_jacobian(z, u, intermediates=intermediates)
-        return potential_fn(unpack_fn(u)) + logdet
-
-    return transformed_potential_fn
+    x, intermediates = inv_transform.call_with_intermediates(z)
+    logdet = inv_transform.log_abs_det_jacobian(z, x, intermediates=intermediates)
+    return potential_energy(inv_transform(x)) - logdet
 
 
 def init_to_median(site, num_samples=15, skip_param=False):

--- a/numpyro/infer_util.py
+++ b/numpyro/infer_util.py
@@ -135,7 +135,7 @@ def transformed_potential_energy(potential_energy, inv_transform, z):
     """
     x, intermediates = inv_transform.call_with_intermediates(z)
     logdet = inv_transform.log_abs_det_jacobian(z, x, intermediates=intermediates)
-    return potential_energy(inv_transform(x)) - logdet
+    return potential_energy(x) - logdet
 
 
 def init_to_median(site, num_samples=15, skip_param=False):

--- a/numpyro/infer_util.py
+++ b/numpyro/infer_util.py
@@ -120,6 +120,31 @@ def potential_energy(model, model_args, model_kwargs, inv_transforms, params):
     return - log_joint
 
 
+def transformed_potential_fn(potential_fn, transform, z):
+    """
+    Given a potential function `p(x)`, compute potential energy of `p(t(z))`
+    where `t` is a transform from `z` to `x`. 
+
+    :param z: [description]
+    :type z: [type]
+    :param potential_fn: [description]
+    :type potential_fn: [type]
+    :param ~numpyro.distributions.constraints.Transform transform: a
+    :type transform: [type]
+    :param unpack_fn: [description]
+    :type unpack_fn: [type]
+    :return: [description]
+    :rtype: [type]
+    """
+
+    def transformed_potential_fn(z):
+        u, intermediates = transform.call_with_intermediates(z)
+        logdet = transform.log_abs_det_jacobian(z, u, intermediates=intermediates)
+        return potential_fn(unpack_fn(u)) + logdet
+
+    return transformed_potential_fn
+
+
 def init_to_median(site, num_samples=15, skip_param=False):
     """
     Initialize to the prior median.

--- a/test/contrib/test_autoguide.py
+++ b/test/contrib/test_autoguide.py
@@ -123,15 +123,16 @@ def test_iaf():
                                                nonlinearity=guide._nonlinearity)
         arn = partial(arn_apply, params['auto_arn__{}$params'.format(i)])
         flows.append(InverseAutoregressiveTransform(arn))
+    flows.append(constraints.UnpackTransform(guide.unpack_latent))
 
     transform = constraints.ComposeTransform(flows)
     rng_seed, rng_sample = random.split(rng)
-    expected_sample = guide.unpack_latent(transform(dist.Normal(np.zeros(dim + 1), 1).sample(rng_sample)))
+    expected_sample = transform(dist.Normal(np.zeros(dim + 1), 1).sample(rng_sample))
     expected_output = transform(x)
     assert_allclose(actual_sample['coefs'], expected_sample['coefs'])
     assert_allclose(actual_sample['offset'],
                     constraints.biject_to(constraints.interval(-1, 1))(expected_sample['offset']))
-    assert_allclose(actual_output, expected_output)
+    check_eq(actual_output, expected_output)
 
 
 def test_uniform_normal():

--- a/test/contrib/test_autoguide.py
+++ b/test/contrib/test_autoguide.py
@@ -123,7 +123,7 @@ def test_iaf():
                                                nonlinearity=guide._nonlinearity)
         arn = partial(arn_apply, params['auto_arn__{}$params'.format(i)])
         flows.append(InverseAutoregressiveTransform(arn))
-    flows.append(constraints.UnpackTransform(guide.unpack_latent))
+    flows.append(constraints.UnpackTransform(guide._unpack_latent))
 
     transform = constraints.ComposeTransform(flows)
     rng_seed, rng_sample = random.split(rng)

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -766,7 +766,7 @@ def test_compose_transform_with_intermediates(transforms):
 def test_unpack_transform():
     value = np.ones(3)
     x = {'key': value}
-    unpack_fn = lambda x: x['key']
+    unpack_fn = lambda x: x['key']  # noqa: E731
     transform = constraints.UnpackTransform(unpack_fn)
     y = transform(x)
     z = transform.inv(y)

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -557,7 +557,7 @@ def test_distribution_constraints(jax_dist, sp_dist, params, prepend_shape):
             expected = sp_dist(*valid_params).logpdf(valid_samples)
         except AttributeError:
             expected = sp_dist(*valid_params).logpmf(valid_samples)
-        assert_allclose(d.log_prob(valid_samples), expected, atol=1e-5)
+        assert_allclose(d.log_prob(valid_samples), expected, atol=1e-5, rtol=1e-5)
 
     # Out of support samples throw ValueError
     oob_samples = gen_values_outside_bounds(d.support, size=prepend_shape + d.batch_shape + d.event_shape)
@@ -764,11 +764,10 @@ def test_compose_transform_with_intermediates(transforms):
 
 
 def test_unpack_transform():
-    value = np.ones(3)
-    x = {'key': value}
-    unpack_fn = lambda x: x['key']  # noqa: E731
+    x = np.ones(3)
+    unpack_fn = lambda x: {'key': x}  # noqa: E731
     transform = constraints.UnpackTransform(unpack_fn)
     y = transform(x)
     z = transform.inv(y)
-    assert_allclose(y, value)
-    assert_allclose(z['key'], x['key'])
+    assert_allclose(y['key'], x)
+    assert_allclose(z, x)

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -535,8 +535,8 @@ def test_distribution_constraints(jax_dist, sp_dist, params, prepend_shape):
             dependent_constraint = True
             break
         key, key_gen = random.split(key)
-        oob_params[i] = gen_values_outside_bounds(constraint, np.shape(params[i]), key)
-        valid_params[i] = gen_values_within_bounds(constraint, np.shape(params[i]), key)
+        oob_params[i] = gen_values_outside_bounds(constraint, np.shape(params[i]), key_gen)
+        valid_params[i] = gen_values_within_bounds(constraint, np.shape(params[i]), key_gen)
 
     assert jax_dist(*oob_params)
 
@@ -761,3 +761,14 @@ def test_compose_transform_with_intermediates(transforms):
     logdet = transform.log_abs_det_jacobian(x, y, intermediates)
     assert_allclose(y, transform(x))
     assert_allclose(logdet, transform.log_abs_det_jacobian(x, y))
+
+
+def test_unpack_transform():
+    value = np.ones(3)
+    x = {'key': value}
+    unpack_fn = lambda x: x['key']
+    transform = constraints.UnpackTransform(unpack_fn)
+    y = transform(x)
+    z = transform.inv(y)
+    assert_allclose(y, value)
+    assert_allclose(z['key'], x['key'])

--- a/test/test_infer_util.py
+++ b/test/test_infer_util.py
@@ -49,6 +49,6 @@ def test_transformed_potential_energy():
 
     z = random.normal(random.PRNGKey(0), (5,))
     pe_expected = -dist.TransformedDistribution(beta_dist, transform).log_prob(z)
-    potential_fn = lambda x: -beta_dist.log_prob(x)
+    potential_fn = lambda x: -beta_dist.log_prob(x)  # noqa: E731
     pe_actual = transformed_potential_energy(potential_fn, inv_transform, z)
     assert_allclose(pe_actual, pe_expected)


### PR DESCRIPTION
This PR fixes the error at #256 due to . In addition, I moved transformed_pe to `infer_util` because it is useful for various purposes (as explained at #343).

A transform UnpackTransform is introduced to reflect better the purpose of `get_transform` in autoguide.

### issue

it is hard to fit AuroIAFNormal to this potential function when we remove x's prior. :( I'll use BNAF instead when #230 is merged.