### PR TITLE
Allow seed handler to be used as a context manager

### DIFF
--- a/numpyro/handlers.py
+++ b/numpyro/handlers.py
@@ -312,7 +312,9 @@ class seed(Messenger):
     so that we use a fresh seed for each subsequent call without having to
     explicitly pass in a `PRNGKey` to each `sample` call.
     """
-    def __init__(self, fn, rng):
+    def __init__(self, fn=None, rng=None):
+        if isinstance(rng, int):
+            rng = random.PRNGKey(rng)
         self.rng = rng
         super(seed, self).__init__(fn)
 

--- a/numpyro/handlers.py
+++ b/numpyro/handlers.py
@@ -311,6 +311,28 @@ class seed(Messenger):
     primitive inside the function results in a splitting of this initial seed
     so that we use a fresh seed for each subsequent call without having to
     explicitly pass in a `PRNGKey` to each `sample` call.
+
+    **Example:**
+
+    .. testsetup::
+
+      from jax import random
+      import numpyro
+      import numpyro.handlers
+      import numpyro.distributions as dist
+
+    .. doctest::
+
+       >>> # as context manager
+       >>> with handlers.seed(rng=1):
+       ...     x = numpyro.sample('x', dist.Normal(0., 1.))
+
+       >>> def model():
+       ...     return numpyro.sample('y', dist.Normal(0., 1.))
+
+       >>> # as function decorator (/modifier)
+       >>> y = seed(model, rng=1)()
+       >>> assert x == y
     """
     def __init__(self, fn=None, rng=None):
         if isinstance(rng, int):

--- a/numpyro/handlers.py
+++ b/numpyro/handlers.py
@@ -312,6 +312,13 @@ class seed(Messenger):
     so that we use a fresh seed for each subsequent call without having to
     explicitly pass in a `PRNGKey` to each `sample` call.
 
+    .. note::
+
+        Unlike in Pyro, `numpyro.sample` primitive cannot be used without wrapping
+        it in seed handler since there is no global random state. As such,
+        users need to use `seed` as a contextmanager to generate samples from
+        distributions or as a decorator for their model callable (See below).
+
     **Example:**
 
     .. testsetup::

--- a/numpyro/handlers.py
+++ b/numpyro/handlers.py
@@ -79,6 +79,7 @@ from __future__ import absolute_import, division, print_function
 from collections import OrderedDict
 
 from jax import random
+import jax.numpy as np
 
 from numpyro.distributions.constraints import ComposeTransform, biject_to, real
 from numpyro.primitives import Messenger
@@ -342,7 +343,7 @@ class seed(Messenger):
        >>> assert x == y
     """
     def __init__(self, fn=None, rng=None):
-        if isinstance(rng, int):
+        if isinstance(rng, int) or np.size(rng) == 1:
             rng = random.PRNGKey(rng)
         self.rng = rng
         super(seed, self).__init__(fn)

--- a/test/test_handlers.py
+++ b/test/test_handlers.py
@@ -35,6 +35,14 @@ def test_substitute():
     assert handlers.substitute(model, {'x': 3.})() == 12.
 
 
+def test_seed():
+    with handlers.seed(rng=11):
+        x = numpyro.sample('x', dist.Normal(0., 1.))
+
+    y = handlers.seed(lambda: numpyro.sample('y', dist.Normal(0., 1.)), 11)()
+    assert_allclose(x, y)
+
+
 def test_condition():
     def model():
         x = numpyro.sample('x', dist.Delta(0.))

--- a/test/test_handlers.py
+++ b/test/test_handlers.py
@@ -49,7 +49,7 @@ def test_seed():
     xs = np.stack(xs)
 
     ys = vmap(lambda rng: handlers.seed(lambda: _sample(), rng)())(np.arange(100))
-    assert_allclose(xs, ys)
+    assert_allclose(xs, ys, atol=1e-6)
 
 
 def test_condition():


### PR DESCRIPTION
This allows for usage like the following:

```python
with handlers.seed(rng=1):
  numpyro.sample('x', dist.Normal(0., 1.))
```

**Changes:**
 - Allows for using `seed` as a contextmanager, so that we don't need to wrap things in a callable.
 - Changes the seed handler to take in Python ints so that we don't have to do `seed(random.PRNGKey(1)` and can instead just write `seed(1)`.

cc. @martinjankowiak 