### PR TITLE
Support for prior predictive

### DIFF
--- a/numpyro/infer_util.py
+++ b/numpyro/infer_util.py
@@ -280,7 +280,7 @@ def find_valid_initial_params(rng, model, *model_args, init_strategy=init_to_uni
 def predictive(rng, model, posterior_samples, *args, num_samples=None, return_sites=None, **kwargs):
     """
     Run model by sampling latent parameters from `posterior_samples`, and return
-    values at sample sites from the forward run. By default, only non-plate sites not contained in
+    values at sample sites from the forward run. By default, only sample sites not contained in
     `posterior_samples` are returned. This can be modified by changing the `return_sites`
     keyword argument.
 
@@ -292,7 +292,7 @@ def predictive(rng, model, posterior_samples, *args, num_samples=None, return_si
     :param model: Python callable containing Pyro primitives.
     :param dict posterior_samples: dictionary of samples from the posterior.
     :param args: model arguments.
-    :param list return_sites: sites to return; by default only non-plate sites not present
+    :param list return_sites: sites to return; by default only sample sites not present
         in `posterior_samples` are returned.
     :param int num_samples: number of samples
     :param kwargs: model kwargs.

--- a/numpyro/infer_util.py
+++ b/numpyro/infer_util.py
@@ -259,10 +259,10 @@ def find_valid_initial_params(rng, model, *model_args, init_strategy=init_to_uni
     return init_params, is_valid
 
 
-def predictive(rng, model, posterior_samples={}, num_samples=None, return_sites=None, *args, **kwargs):
+def predictive(rng, model, posterior_samples, *args, num_samples=None, return_sites=None, **kwargs):
     """
     Run model by sampling latent parameters from `posterior_samples`, and return
-    values at sample sites from the forward run. By default, only sites not contained in
+    values at sample sites from the forward run. By default, only non-plate sites not contained in
     `posterior_samples` are returned. This can be modified by changing the `return_sites`
     keyword argument.
 
@@ -273,16 +273,20 @@ def predictive(rng, model, posterior_samples={}, num_samples=None, return_sites=
     :param jax.random.PRNGKey rng: seed to draw samples
     :param model: Python callable containing Pyro primitives.
     :param dict posterior_samples: dictionary of samples from the posterior.
-    :param int num_samples: number of samples
-    :param list return_sites: sites to return; by default only sample sites not present
-        in `posterior_samples` are returned.
     :param args: model arguments.
+    :param list return_sites: sites to return; by default only non-plate sites not present
+        in `posterior_samples` are returned.
+    :param int num_samples: number of samples
     :param kwargs: model kwargs.
     :return: dict of samples from the predictive distribution.
     """
     def single_prediction(rng, samples):
         model_trace = trace(seed(condition(model, samples), rng)).get_trace(*args, **kwargs)
-        sites = model_trace.keys() - samples.keys() if return_sites is None else return_sites
+        if return_sites is not None:
+            sites = return_sites
+        else:
+            sites = {k for k, site in model_trace.items()
+                     if site['type'] != 'plate' and k not in samples}
         return {name: site['value'] for name, site in model_trace.items() if name in sites}
 
     if posterior_samples:

--- a/numpyro/primitives.py
+++ b/numpyro/primitives.py
@@ -198,7 +198,6 @@ class plate(Messenger):
     def _validate_and_set_dim(self):
         msg = {
             'type': 'plate',
-            'is_observed': False,
             'fn': identity,
             'name': self.name,
             'args': (None,),

--- a/test/test_infer_util.py
+++ b/test/test_infer_util.py
@@ -16,7 +16,8 @@ def beta_bernoulli():
 
     def model(data=None):
         beta = numpyro.sample("beta", dist.Beta(np.ones(5), np.ones(5)))
-        numpyro.sample("obs", dist.Bernoulli(beta), obs=data, sample_shape=(1000,))
+        with numpyro.plate("plate", 1000):
+            numpyro.sample("obs", dist.Bernoulli(beta), obs=data)
 
     return model, data, true_probs
 
@@ -43,7 +44,7 @@ def test_predictive():
 
 def test_prior_predictive():
     model, data, _ = beta_bernoulli()
-    predictive_samples = predictive(random.PRNGKey(1), model, num_samples=100)
+    predictive_samples = predictive(random.PRNGKey(1), model, {}, num_samples=100)
     assert predictive_samples.keys() == {"beta", "obs"}
 
     # check shapes

--- a/test/test_infer_util.py
+++ b/test/test_infer_util.py
@@ -39,3 +39,13 @@ def test_predictive():
 
     # check sample mean
     assert_allclose(predictive_samples["obs"].reshape([-1, 5]).mean(0), true_probs, rtol=0.1)
+
+
+def test_prior_predictive():
+    model, data, _ = beta_bernoulli()
+    predictive_samples = predictive(random.PRNGKey(1), model, num_samples=100)
+    assert predictive_samples.keys() == {"beta", "obs"}
+
+    # check shapes
+    assert predictive_samples["beta"].shape == (100, 5)
+    assert predictive_samples["obs"].shape == (100, 1000, 5)


### PR DESCRIPTION
This PR adds `num_samples` arg to `predictive` utility to allow to draw samples from priors. This is useful for #337 and #349.

### TODO
- [x] make sure that we won't record plate sites