### PR TITLE
Add mv affine transform

### DIFF
--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -424,6 +424,14 @@ LowerCholeskyTransform
     :show-inheritance:
     :member-order: bysource
 
+MultivariateAffineTransform
+---------------------------
+.. autoclass:: numpyro.distributions.constraints.MultivariateAffineTransform
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :member-order: bysource
+
 PermuteTransform
 ----------------
 .. autoclass:: numpyro.distributions.constraints.PermuteTransform

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -15,7 +15,7 @@ import jax.random as random
 from numpyro.contrib.nn import AutoregressiveNN
 import numpyro.distributions as dist
 import numpyro.distributions.constraints as constraints
-from numpyro.distributions.constraints import PermuteTransform, PowerTransform, biject_to
+from numpyro.distributions.constraints import MultivariateAffineTransform, PermuteTransform, PowerTransform, biject_to
 from numpyro.distributions.discrete import _to_probs_bernoulli, _to_probs_multinom
 from numpyro.distributions.flows import InverseAutoregressiveTransform
 from numpyro.distributions.util import (
@@ -678,6 +678,7 @@ def test_biject_to(constraint, shape):
 @pytest.mark.parametrize('transform, event_shape', [
     (PermuteTransform(np.array([3, 0, 4, 1, 2])), (5,)),
     (PowerTransform(2.), ()),
+    (MultivariateAffineTransform(np.array([1., 2.]), np.array([[0.6, 0.], [1.5, 0.4]])), (2,))
 ])
 @pytest.mark.parametrize('batch_shape', [(), (1,), (3,), (6,), (3, 1), (1, 3), (5, 3)])
 def test_bijective_transforms(transform, event_shape, batch_shape):
@@ -700,7 +701,7 @@ def test_bijective_transforms(transform, event_shape, batch_shape):
     actual = transform.log_abs_det_jacobian(x, y)
     assert np.shape(actual) == batch_shape
     if len(shape) == transform.event_dim:
-        if isinstance(transform, PermuteTransform):
+        if len(event_shape) == 1:
             expected = onp.linalg.slogdet(jax.jacobian(transform)(x))[1]
             inv_expected = onp.linalg.slogdet(jax.jacobian(transform.inv)(y))[1]
         else:


### PR DESCRIPTION
In preparation for having mvn guide, this PR adds multivariate affine transform.

This transform is useful to create transformed distribution with univariate base_dist, as long as we can declare dependent dimension (issue #357) for base_dist. In particular, `TransformedDistribution(Normal(0, 1).to_event(1), MultivariateAffineTransform(loc, scale_tril))` is equivalent to `MVN(loc, scale_tril)`.