### PR TITLE
Add to_event to Distribution to change batch-event dim boundary

### DIFF
--- a/numpyro/distributions/__init__.py
+++ b/numpyro/distributions/__init__.py
@@ -36,7 +36,7 @@ from numpyro.distributions.discrete import (
     Poisson,
     PRNGIdentity
 )
-from numpyro.distributions.distribution import Distribution, TransformedDistribution
+from numpyro.distributions.distribution import Distribution, Independent, TransformedDistribution
 
 __all__ = [
     'Bernoulli',
@@ -59,6 +59,7 @@ __all__ = [
     'GaussianRandomWalk',
     'HalfCauchy',
     'HalfNormal',
+    'Independent',
     'InverseGamma',
     'LKJCholesky',
     'LogNormal',


### PR DESCRIPTION
Fixes #357. 

I think we had a work-arounds in the code for the absence of this facility, that can be addressed as follow-up PRs once this merges.