### PR TITLE
Expose energy for bfmi diagnostic

### DIFF
--- a/test/test_mcmc.py
+++ b/test/test_mcmc.py
@@ -31,7 +31,7 @@ def test_logistic_regression(algo):
     init_params, potential_fn, constrain_fn = initialize_model(random.PRNGKey(2), model, labels)
     samples = mcmc(warmup_steps, num_samples, init_params, sampler='hmc', algo=algo,
                    potential_fn=potential_fn, trajectory_length=10, constrain_fn=constrain_fn)
-    assert_allclose(np.mean(samples['coefs'], 0), true_coefs, atol=0.21)
+    assert_allclose(np.mean(samples['coefs'], 0), true_coefs, atol=0.22)
 
     if 'JAX_ENABLE_x64' in os.environ:
         assert samples['coefs'].dtype == np.float64


### PR DESCRIPTION
Resolves #349.

This PR exposes energy, which is required for [bfmi diagnostic](https://mc-stan.org/misc/warnings.html#bfmi-low), and [energy plot](https://nbviewer.jupyter.org/gist/fehiepsi/f65519d34526cce4f14b381c6a9a98f8#Energy-Plot). Because this is just a scalar, I think that storing this value to TreeInfo won't affect the performance.

@neerajprad This [gist](https://nbviewer.jupyter.org/gist/fehiepsi/f65519d34526cce4f14b381c6a9a98f8) illustrates how numpyro and arviz are integrated. With this PR, we fully support arviz (I need to make a PR to arviz with those updates after 0.2.1 is released)! Cheers, :D

I think it is good to make a tutorial which shows how simple it is to run MCMC in numpyro, and showcase the support for arviz. WDYT?