### PR TITLE
make some utils to set JAX flags

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -56,7 +56,7 @@ NumPyro documentation
 .. toctree::
    :glob:
    :maxdepth: 2
-   :caption: Inference Utilities:
+   :caption: Utilities:
 
    utilities
 

--- a/docs/source/utilities.rst
+++ b/docs/source/utilities.rst
@@ -1,10 +1,23 @@
+Utilities
+=========
+
+.. automodule:: numpyro.util
+
+set_platform
+------------
+.. autofunction:: numpyro.util.set_platform
+
+set_host_devices
+----------------
+.. autofunction:: numpyro.util.set_host_devices
+
 Inference Utilities
 ===================
 
 .. automodule:: numpyro.infer_util
 
 predictive
------------
+----------
 .. autofunction:: numpyro.infer_util.predictive
 
 log_density
@@ -23,6 +36,14 @@ potential_energy
 ----------------
 .. autofunction:: numpyro.infer_util.potential_energy
 
+log_likelihood
+--------------
+.. autofunction:: numpyro.infer_util.log_likelihood
+
+find_valid_initial_params
+-------------------------
+.. autofunction:: numpyro.infer_util.find_valid_initial_params
+
 init_to_median
 --------------
 .. autofunction:: numpyro.infer_util.init_to_median
@@ -38,7 +59,3 @@ init_to_uniform
 init_to_feasible
 ----------------
 .. autofunction:: numpyro.infer_util.init_to_feasible
-
-find_valid_initial_params
--------------------------
-.. autofunction:: numpyro.infer_util.find_valid_initial_params

--- a/numpyro/__init__.py
+++ b/numpyro/__init__.py
@@ -3,6 +3,4 @@ from numpyro.primitives import module, param, plate, sample  # noqa: F401
 from numpyro.version import __version__  # noqa: F401
 import numpyro.util as util
 
-# TODO: set defaults to numpyro
-# import os
-# set_host_devices(os.cpu_count())
+util.set_platform('cpu')

--- a/numpyro/__init__.py
+++ b/numpyro/__init__.py
@@ -1,3 +1,6 @@
 import numpyro.patch  # noqa: F401
 from numpyro.primitives import module, param, plate, sample  # noqa: F401
 from numpyro.version import __version__  # noqa: F401
+import numpyro.util as util
+
+# TODO: set defaults to numpyro

--- a/numpyro/__init__.py
+++ b/numpyro/__init__.py
@@ -4,3 +4,5 @@ from numpyro.version import __version__  # noqa: F401
 import numpyro.util as util
 
 # TODO: set defaults to numpyro
+# import os
+# set_host_devices(os.cpu_count())

--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -58,8 +58,7 @@ def set_host_devices(n):
     :param int n: number of CPU devices to use.
     """
     xla_flags = os.getenv('XLA_FLAGS', '').lstrip('--')
-    xla_flags = re.sub(re.compile(r'xla_force_host_platform_device_count=.+\s'),
-                       '', xla_flags).split()
+    xla_flags = re.sub(r'xla_force_host_platform_device_count=.+\s', '', xla_flags).split()
     os.environ['XLA_FLAGS'] = ' '.join(['--xla_force_host_platform_device_count={}'.format(n)]
                                        + xla_flags)
 

--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -23,7 +23,10 @@ def set_rng_seed(rng_seed):
 
 def set_platform(platform=None):
     """
-    :param str platform: either 'cpu', 'gpu', 'tpu'.
+    Changes platform to CPU, GPU, or TPU. This utility only takes
+    effect at the beginning of your program.
+
+    :param str platform: either 'cpu', 'gpu', or 'tpu'.
     """
     if platform is None:
         platform = os.getenv('JAX_PLATFORM_NAME', 'cpu')
@@ -32,6 +35,25 @@ def set_platform(platform=None):
 
 def set_host_devices(n):
     """
+    By default, XLA considers all CPU cores as one device. This utility tells XLA
+    that there are `n` host (CPU) devices available to use. As a consequence, this
+    allows parallel mapping in JAX :func:`jax.pmap` to work in CPU platform.
+
+    .. note:: This utility only takes effect at the beginning of your program.
+        Under the sence, this sets the environment variable
+        `XLA_FLAGS=--xla_force_host_platform_device_count=[num_devices]`, where
+        `[num_device]` is the desired number of CPU devices `n`.
+
+    .. warning:: We do not understand much the side effects when using
+        `xla_force_host_platform_device_count` flag. If you observe some strange
+        phenomenon when using this utility, please let us know through our issue
+        or forum page. Here we quote from XLA source code the meaning of this flag:
+        "Force the host platform to pretend that there are these many host
+        'devices'. All of these host devices are backed by the same threadpool.
+        Setting this to anything other than 1 can increase overhead from context
+        switching but we let the user override this behavior to help run tests
+        on the host that run models in parallel across multiple devices."
+
     :param int n: number of CPU devices to use.
     """
     xla_flags = os.getenv('XLA_FLAGS', '--xla_force_host_platform_device_count={}'.format(n))

--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -1,10 +1,12 @@
 from collections import namedtuple
 from contextlib import contextmanager
+import os
 import random
 
 import numpy as onp
 import tqdm
 
+import jax
 from jax import jit, lax, ops, vmap
 from jax.lib.xla_bridge import canonicalize_dtype
 import jax.numpy as np
@@ -17,6 +19,23 @@ _DISABLE_CONTROL_FLOW_PRIM = False
 def set_rng_seed(rng_seed):
     random.seed(rng_seed)
     onp.random.seed(rng_seed)
+
+
+def set_platform(platform=None):
+    """
+    :param str device: either 'cpu', 'gpu', 'tpu'.
+    """
+    if platform is None:
+        platform = os.getenv('JAX_PLATFORM_NAME', 'cpu')
+    jax.config.update('jax_platform_name', platform)
+
+
+def set_host_devices(n):
+    """
+    :param int n: number of CPU devices to use.
+    """
+    xla_flags = os.getenv('XLA_FLAGS', '--xla_force_host_platform_device_count={}'.format(n))
+    os.environ['XLA_FLAGS'] = xla_flags
 
 
 @contextmanager

--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -58,7 +58,8 @@ def set_host_devices(n):
     :param int n: number of CPU devices to use.
     """
     xla_flags = os.getenv('XLA_FLAGS', '').lstrip('--')
-    xla_flags = re.sub('xla_force_host_platform_device_count=.+\s', '', xla_flags).split()
+    xla_flags = re.sub(re.compile(r'xla_force_host_platform_device_count=.+\s'),
+                       '', xla_flags).split()
     os.environ['XLA_FLAGS'] = ' '.join(['--xla_force_host_platform_device_count={}'.format(n)]
                                        + xla_flags)
 

--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -2,6 +2,7 @@ from collections import namedtuple
 from contextlib import contextmanager
 import os
 import random
+import re
 
 import numpy as onp
 import tqdm
@@ -40,7 +41,7 @@ def set_host_devices(n):
     allows parallel mapping in JAX :func:`jax.pmap` to work in CPU platform.
 
     .. note:: This utility only takes effect at the beginning of your program.
-        Under the sence, this sets the environment variable
+        Under the hood, this sets the environment variable
         `XLA_FLAGS=--xla_force_host_platform_device_count=[num_devices]`, where
         `[num_device]` is the desired number of CPU devices `n`.
 
@@ -56,8 +57,10 @@ def set_host_devices(n):
 
     :param int n: number of CPU devices to use.
     """
-    xla_flags = os.getenv('XLA_FLAGS', '--xla_force_host_platform_device_count={}'.format(n))
-    os.environ['XLA_FLAGS'] = xla_flags
+    xla_flags = os.getenv('XLA_FLAGS', '').lstrip('--')
+    xla_flags = re.sub('xla_force_host_platform_device_count=.+\s', '', xla_flags).split()
+    os.environ['XLA_FLAGS'] = ' '.join(['--xla_force_host_platform_device_count={}'.format(n)]
+                                       + xla_flags)
 
 
 @contextmanager

--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -23,7 +23,7 @@ def set_rng_seed(rng_seed):
 
 def set_platform(platform=None):
     """
-    :param str device: either 'cpu', 'gpu', 'tpu'.
+    :param str platform: either 'cpu', 'gpu', 'tpu'.
     """
     if platform is None:
         platform = os.getenv('JAX_PLATFORM_NAME', 'cpu')

--- a/test/test_mcmc.py
+++ b/test/test_mcmc.py
@@ -31,7 +31,7 @@ def test_logistic_regression(algo):
     init_params, potential_fn, constrain_fn = initialize_model(random.PRNGKey(2), model, labels)
     samples = mcmc(warmup_steps, num_samples, init_params, sampler='hmc', algo=algo,
                    potential_fn=potential_fn, trajectory_length=10, constrain_fn=constrain_fn)
-    assert_allclose(np.mean(samples['coefs'], 0), true_coefs, atol=0.21)
+    assert_allclose(np.mean(samples['coefs'], 0), true_coefs, atol=0.22)
 
     if 'JAX_ENABLE_x64' in os.environ:
         assert samples['coefs'].dtype == np.float64

--- a/test/test_mcmc_interface.py
+++ b/test/test_mcmc_interface.py
@@ -77,7 +77,7 @@ def test_logistic_regression(kernel_cls):
     mcmc = MCMC(kernel, warmup_steps, num_samples)
     mcmc.run(random.PRNGKey(2), labels)
     samples = mcmc.get_samples()
-    assert_allclose(np.mean(samples['coefs'], 0), true_coefs, atol=0.21)
+    assert_allclose(np.mean(samples['coefs'], 0), true_coefs, atol=0.22)
 
     if 'JAX_ENABLE_x64' in os.environ:
         assert samples['coefs'].dtype == np.float64


### PR DESCRIPTION
Addresses #364. I have only changed the default platform to `cpu` (instead of `gpu`). I think it is better to not change the default cpu count = 1. If users want to run 4 chains parallelly in CPU, they should use `numpyro.util.set_host_devices(4)`.

Some facts which I collected:
+ By default, JAX uses `gpu`.
+ If we set XLA_FLAGS host device_count to a number, then CPU platform will be used by default.
+ We can change platform multi times using `jax.config.update('jax_platform_name', platform)`. The last one will take effect as long as no `np.ones(3)` is called.
+ Changing XLA_FLAGS host device_count will not affect the number of GPU device counts. No matter which value host (CPU) device_count takes, if we change platform to `gpu`, then `xla_bridge.device_count()` will list the number of GPUs which we have.

So `set_host_devices` only affects the number of CPUs available to us.

TODO (after this PR):
+ update examples to use these utils