### PR TITLE
mask log prob of univariate distribution

### DIFF
--- a/numpyro/distributions/discrete.py
+++ b/numpyro/distributions/discrete.py
@@ -82,7 +82,7 @@ class BernoulliProbs(Distribution):
         if self._validate_args:
             self._validate_sample(value)
         logprob = xlogy(value, self.probs) + xlog1py(1 - value, -self.probs)
-        return np.where(np.bitwise_or(x == 0, x == 1), logprob, -np.inf)
+        return np.where(np.bitwise_or(value == 0, value == 1), logprob, -np.inf)
 
     @property
     def mean(self):


### PR DESCRIPTION
Addresses #373.

At first, I thought that we need a general approach to this issue. However, when plotting out the log_prob of all distributions, we can see that there are just a few distributions that have this issue. So I go ahead and do the masking job for each of them, instead of trying to think of a general solution.

Affected distributions:
+ Exponential
+ HalfNormal/HalfCauchy/TruncatedNormal/TruncatedCauchy
+ Uniform
+ Bernoulli
+ Categorical

Not tested distributions:
+ all multivariate ones