### PR TITLE
Out of support mask

### DIFF
--- a/docs/source/utilities.rst
+++ b/docs/source/utilities.rst
@@ -1,6 +1,14 @@
 Utilities
 =========
 
+enable_validation
+-----------------
+.. autofunction:: numpyro.distributions.distribution.enable_validation
+
+validation_enabled
+------------------
+.. autofunction:: numpyro.distributions.distribution.validation_enabled
+
 .. automodule:: numpyro.util
 
 set_platform

--- a/numpyro/__init__.py
+++ b/numpyro/__init__.py
@@ -1,4 +1,5 @@
 from numpyro import compat, diagnostics, distributions, handlers, infer, optim
+from numpyro.distributions.distribution import enable_validation, validation_enabled
 import numpyro.patch  # noqa: F401
 from numpyro.primitives import module, param, plate, sample
 from numpyro.util import set_host_device_count, set_platform
@@ -12,6 +13,7 @@ __all__ = [
     'compat',
     'diagnostics',
     'distributions',
+    'enable_validation',
     'handlers',
     'infer',
     'module',
@@ -21,4 +23,5 @@ __all__ = [
     'sample',
     'set_host_device_count',
     'set_platform',
+    'validation_enabled',
 ]

--- a/numpyro/distributions/continuous.py
+++ b/numpyro/distributions/continuous.py
@@ -39,6 +39,7 @@ from numpyro.distributions.util import (
     matrix_to_tril_vec,
     promote_shapes,
     signed_stick_breaking_tril,
+    validate_sample,
     vec_to_tril_matrix
 )
 from numpyro.util import copy_docs_from
@@ -60,9 +61,8 @@ class Beta(Distribution):
     def sample(self, key, sample_shape=()):
         return self._dirichlet.sample(key, sample_shape)[..., 0]
 
+    @validate_sample
     def log_prob(self, value):
-        if self._validate_args:
-            self._validate_sample(value)
         return self._dirichlet.log_prob(np.stack([value, 1. - value], -1))
 
     @property
@@ -90,9 +90,8 @@ class Cauchy(Distribution):
         eps = random.cauchy(key, shape=sample_shape + self.batch_shape)
         return self.loc + eps * self.scale
 
+    @validate_sample
     def log_prob(self, value):
-        if self._validate_args:
-            self._validate_sample(value)
         return - np.log(np.pi) - np.log(self.scale) - np.log1p(((value - self.loc) / self.scale) ** 2)
 
     @property
@@ -123,9 +122,8 @@ class Dirichlet(Distribution):
         gamma_samples = random.gamma(key, self.concentration, shape=shape)
         return gamma_samples / np.sum(gamma_samples, axis=-1, keepdims=True)
 
+    @validate_sample
     def log_prob(self, value):
-        if self._validate_args:
-            self._validate_sample(value)
         normalize_term = (np.sum(gammaln(self.concentration), axis=-1) -
                           gammaln(np.sum(self.concentration, axis=-1)))
         return np.sum(np.log(value) * (self.concentration - 1.), axis=-1) - normalize_term
@@ -153,9 +151,8 @@ class Exponential(Distribution):
     def sample(self, key, sample_shape=()):
         return random.exponential(key, shape=sample_shape + self.batch_shape) / self.rate
 
+    @validate_sample
     def log_prob(self, value):
-        if self._validate_args:
-            self._validate_sample(value)
         return np.log(self.rate) - self.rate * value
 
     @property
@@ -184,9 +181,8 @@ class Gamma(Distribution):
         shape = sample_shape + self.batch_shape + self.event_shape
         return random.gamma(key, self.concentration, shape=shape) / self.rate
 
+    @validate_sample
     def log_prob(self, value):
-        if self._validate_args:
-            self._validate_sample(value)
         normalize_term = (gammaln(self.concentration) -
                           self.concentration * np.log(self.rate))
         return (self.concentration - 1) * np.log(value) - self.rate * value - normalize_term
@@ -227,9 +223,8 @@ class GaussianRandomWalk(Distribution):
         walks = random.normal(key, shape=shape)
         return cumsum(walks) * np.expand_dims(self.scale, axis=-1)
 
+    @validate_sample
     def log_prob(self, value):
-        if self._validate_args:
-            self._validate_sample(value)
         init_prob = Normal(0., self.scale).log_prob(value[..., 0])
         scale = np.expand_dims(self.scale, -1)
         step_probs = Normal(value[..., :-1], scale).log_prob(value[..., 1:])
@@ -259,9 +254,8 @@ class HalfCauchy(Distribution):
     def sample(self, key, sample_shape=()):
         return np.abs(self._cauchy.sample(key, sample_shape))
 
+    @validate_sample
     def log_prob(self, value):
-        if self._validate_args:
-            self._validate_sample(value)
         return self._cauchy.log_prob(value) + np.log(2)
 
     @property
@@ -287,9 +281,8 @@ class HalfNormal(Distribution):
     def sample(self, key, sample_shape=()):
         return np.abs(self._normal.sample(key, sample_shape))
 
+    @validate_sample
     def log_prob(self, value):
-        if self._validate_args:
-            self._validate_sample(value)
         return self._normal.log_prob(value) + np.log(2)
 
     @property
@@ -491,9 +484,8 @@ class LKJCholesky(Distribution):
         else:
             return self._cvine(key, sample_shape)
 
+    @validate_sample
     def log_prob(self, value):
-        if self._validate_args:
-            self._validate_sample(value)
         # Note about computing Jacobian of the transformation from Cholesky factor to
         # correlation matrix:
         #
@@ -633,9 +625,8 @@ class MultivariateNormal(Distribution):
         eps = random.normal(key, shape=sample_shape + self.batch_shape + self.event_shape)
         return self.loc + np.squeeze(np.matmul(self.scale_tril, eps[..., np.newaxis]), axis=-1)
 
+    @validate_sample
     def log_prob(self, value):
-        if self._validate_args:
-            self._validate_sample(value)
         M = _batch_mahalanobis(self.scale_tril, value - self.loc)
         half_log_det = np.log(np.diagonal(self.scale_tril, axis1=-2, axis2=-1)).sum(-1)
         normalize_term = half_log_det + 0.5 * self.scale_tril.shape[-1] * np.log(2 * np.pi)
@@ -675,9 +666,8 @@ class Normal(Distribution):
         eps = random.normal(key, shape=sample_shape + self.batch_shape + self.event_shape)
         return self.loc + eps * self.scale
 
+    @validate_sample
     def log_prob(self, value):
-        if self._validate_args:
-            self._validate_sample(value)
         normalize_term = np.log(np.sqrt(2 * np.pi) * self.scale)
         value_scaled = (value - self.loc) / self.scale
         return -0.5 * value_scaled ** 2 - normalize_term
@@ -743,9 +733,8 @@ class StudentT(Distribution):
         y = std_normal * np.sqrt(self.df / z)
         return self.loc + self.scale * y
 
+    @validate_sample
     def log_prob(self, value):
-        if self._validate_args:
-            self._validate_sample(value)
         y = (value - self.loc) / self.scale
         z = (np.log(self.scale) + 0.5 * np.log(self.df) + 0.5 * np.log(np.pi) +
              gammaln(0.5 * self.df) - gammaln(0.5 * (self.df + 1.)))
@@ -781,9 +770,8 @@ class _BaseTruncatedCauchy(Distribution):
         u = minval + random.uniform(key, shape=size) * (maxval - minval)
         return self.base_loc + np.tan(u)
 
+    @validate_sample
     def log_prob(self, value):
-        if self._validate_args:
-            self._validate_sample(value)
         # pi / 2 is arctan of self.high when that arg is supported
         normalize_term = np.log(np.pi / 2 + np.arctan(self.base_loc))
         return - np.log1p((value - self.base_loc) ** 2) - normalize_term
@@ -831,9 +819,8 @@ class _BaseTruncatedNormal(Distribution):
         #                                 = - icdf[(1 - cdf_a)(1 - u)]
         return self.base_loc - ndtri(ndtr(self.base_loc) * (1 - u))
 
+    @validate_sample
     def log_prob(self, value):
-        if self._validate_args:
-            self._validate_sample(value)
         # log(cdf(high) - cdf(low)) = log(1 - cdf(low)) = log(cdf(-low))
         return self._normal.log_prob(value) - log_ndtr(self.base_loc)
 
@@ -873,9 +860,8 @@ class _BaseUniform(Distribution):
         size = sample_shape + self.batch_shape
         return random.uniform(key, shape=size)
 
+    @validate_sample
     def log_prob(self, value):
-        if self._validate_args:
-            self._validate_sample(value)
         batch_shape = lax.broadcast_shapes(self.batch_shape, np.shape(value))
         return - np.zeros(batch_shape)
 

--- a/numpyro/distributions/discrete.py
+++ b/numpyro/distributions/discrete.py
@@ -42,6 +42,7 @@ from numpyro.distributions.util import (
     poisson,
     promote_shapes,
     sum_rightmost,
+    validate_sample,
     xlog1py,
     xlogy
 )
@@ -78,9 +79,8 @@ class BernoulliProbs(Distribution):
     def sample(self, key, sample_shape=()):
         return random.bernoulli(key, self.probs, shape=sample_shape + self.batch_shape)
 
+    @validate_sample
     def log_prob(self, value):
-        if self._validate_args:
-            self._validate_sample(value)
         return xlogy(value, self.probs) + xlog1py(1 - value, -self.probs)
 
     @property
@@ -104,9 +104,8 @@ class BernoulliLogits(Distribution):
     def sample(self, key, sample_shape=()):
         return random.bernoulli(key, self.probs, shape=sample_shape + self.batch_shape)
 
+    @validate_sample
     def log_prob(self, value):
-        if self._validate_args:
-            self._validate_sample(value)
         return -binary_cross_entropy_with_logits(self.logits, value)
 
     @lazy_property
@@ -144,9 +143,8 @@ class BinomialProbs(Distribution):
     def sample(self, key, sample_shape=()):
         return binomial(key, self.probs, n=self.total_count, shape=sample_shape + self.batch_shape)
 
+    @validate_sample
     def log_prob(self, value):
-        if self._validate_args:
-            self._validate_sample(value)
         log_factorial_n = gammaln(self.total_count + 1)
         log_factorial_k = gammaln(value + 1)
         log_factorial_nmk = gammaln(self.total_count - value + 1)
@@ -179,9 +177,8 @@ class BinomialLogits(Distribution):
     def sample(self, key, sample_shape=()):
         return binomial(key, self.probs, n=self.total_count, shape=sample_shape + self.batch_shape)
 
+    @validate_sample
     def log_prob(self, value):
-        if self._validate_args:
-            self._validate_sample(value)
         log_factorial_n = gammaln(self.total_count + 1)
         log_factorial_k = gammaln(value + 1)
         log_factorial_nmk = gammaln(self.total_count - value + 1)
@@ -230,9 +227,8 @@ class CategoricalProbs(Distribution):
     def sample(self, key, sample_shape=()):
         return categorical(key, self.probs, shape=sample_shape + self.batch_shape)
 
+    @validate_sample
     def log_prob(self, value):
-        if self._validate_args:
-            self._validate_sample(value)
         batch_shape = lax.broadcast_shapes(np.shape(value), self.batch_shape)
         value = np.expand_dims(value, axis=-1)
         value = np.broadcast_to(value, batch_shape + (1,))
@@ -267,9 +263,8 @@ class CategoricalLogits(Distribution):
     def sample(self, key, sample_shape=()):
         return categorical(key, self.probs, shape=sample_shape + self.batch_shape)
 
+    @validate_sample
     def log_prob(self, value):
-        if self._validate_args:
-            self._validate_sample(value)
         value = np.expand_dims(value, -1)
         log_pmf = self.logits - logsumexp(self.logits, axis=-1, keepdims=True)
         value, log_pmf = promote_shapes(value, log_pmf)
@@ -323,10 +318,9 @@ class Delta(Distribution):
         shape = sample_shape + self.batch_shape + self.event_shape
         return np.broadcast_to(self.value, shape)
 
-    def log_prob(self, x):
-        if self._validate_args:
-            self._validate_sample(x)
-        log_prob = np.log(x == self.value)
+    @validate_sample
+    def log_prob(self, value):
+        log_prob = np.log(value == self.value)
         log_prob = sum_rightmost(log_prob, len(self.event_shape))
         return log_prob + self.log_density
 
@@ -371,6 +365,7 @@ class MultinomialProbs(Distribution):
     def sample(self, key, sample_shape=()):
         return multinomial(key, self.probs, self.total_count, shape=sample_shape + self.batch_shape)
 
+    @validate_sample
     def log_prob(self, value):
         if self._validate_args:
             self._validate_sample(value)
@@ -408,6 +403,7 @@ class MultinomialLogits(Distribution):
     def sample(self, key, sample_shape=()):
         return multinomial(key, self.probs, self.total_count, shape=sample_shape + self.batch_shape)
 
+    @validate_sample
     def log_prob(self, value):
         if self._validate_args:
             self._validate_sample(value)
@@ -453,6 +449,7 @@ class Poisson(Distribution):
     def sample(self, key, sample_shape=()):
         return poisson(key, self.rate, shape=sample_shape + self.batch_shape)
 
+    @validate_sample
     def log_prob(self, value):
         if self._validate_args:
             self._validate_sample(value)

--- a/numpyro/distributions/distribution.py
+++ b/numpyro/distributions/distribution.py
@@ -22,6 +22,8 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+import warnings
+
 import jax.numpy as np
 
 from numpyro.distributions.constraints import is_dependent
@@ -157,8 +159,8 @@ class Distribution(object):
 
     def _validate_sample(self, value):
         if not np.all(self.support(value)):
-            raise ValueError('Invalid values provided to log prob method. '
-                             'The value argument must be within the support.')
+            warnings.warn('Out-of-support values provided to log prob method. '
+                          'The value argument should be within the support.')
 
     def __call__(self, *args, **kwargs):
         key = kwargs.pop('random_state')

--- a/numpyro/distributions/util.py
+++ b/numpyro/distributions/util.py
@@ -303,9 +303,10 @@ class lazy_property(object):
 
 
 def validate_sample(log_prob_fn):
-    def wrapper(self, value):
-        log_prob = log_prob_fn(self, value)
+    def wrapper(self, *args, **kwargs):
+        log_prob = log_prob_fn(self, *args, *kwargs)
         if self._validate_args:
+            value = kwargs['value'] if 'value' in kwargs else args[0]
             mask = self._validate_sample(value)
             log_prob = np.where(mask, log_prob, -np.inf)
         return log_prob

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -590,7 +590,7 @@ def test_distribution_constraints(jax_dist, sp_dist, params, prepend_shape):
 
     # Out of support samples throw ValueError
     oob_samples = gen_values_outside_bounds(d.support, size=prepend_shape + d.batch_shape + d.event_shape)
-    with pytest.raises(ValueError):
+    with pytest.warns(UserWarning):
         d.log_prob(oob_samples)
 
 


### PR DESCRIPTION
Follow up the discussion at #385. This PR adds `validate_sample` decorator to mask out-of-support values as `-np.inf`. @neerajprad What do you think about this way?