### PR TITLE
Generic compatibility wrapper for seed handler

### DIFF
--- a/numpyro/compat/handlers.py
+++ b/numpyro/compat/handlers.py
@@ -1,1 +1,7 @@
 from numpyro.handlers import *  # noqa: F401, F403
+from numpyro.handlers import seed as numpyro_seed
+
+
+# Compatibility wrapper for matching arg names
+def seed(fn=None, rng_seed=None):
+    return numpyro_seed(fn=fn, rng=rng_seed)


### PR DESCRIPTION
This is needed to align the names for the `rng_seed` argument. It is possible that we can remove this once #377 is resolved and we use `rng_seed` instead of `rng_key`, but either ways, I am happy with having this in `compat`. 