### PR TITLE
swap loss and optim in svi

### DIFF
--- a/examples/minipyro.py
+++ b/examples/minipyro.py
@@ -32,7 +32,7 @@ def main(args):
     # model/guide pair.
     adam = optim.Adam(args.learning_rate)
 
-    svi = SVI(model, guide, ELBO(num_particles=100), adam)
+    svi = SVI(model, guide, adam, ELBO(num_particles=100))
     svi_state = svi.init(PRNGKey(0), data)
 
     # Training loop

--- a/examples/neutra.py
+++ b/examples/neutra.py
@@ -66,7 +66,7 @@ def main(args):
     # TODO: it is hard to find good hyperparameters such that IAF guide can learn this model.
     # We will use BNAF instead!
     guide = AutoIAFNormal(dual_moon_model, num_flows=2, hidden_dims=[args.num_hidden, args.num_hidden])
-    svi = SVI(dual_moon_model, guide, AutoContinuousELBO(), adam)
+    svi = SVI(dual_moon_model, guide, adam, AutoContinuousELBO())
     svi_state = svi.init(random.PRNGKey(1))
 
     print("Start training guide...")

--- a/examples/vae.py
+++ b/examples/vae.py
@@ -63,7 +63,7 @@ def main(args):
     encoder_nn = encoder(args.hidden_dim, args.z_dim)
     decoder_nn = decoder(args.hidden_dim, 28 * 28)
     adam = optim.Adam(args.learning_rate)
-    svi = SVI(model, guide, ELBO(), adam, hidden_dim=args.hidden_dim, z_dim=args.z_dim)
+    svi = SVI(model, guide, adam, ELBO(), hidden_dim=args.hidden_dim, z_dim=args.z_dim)
     rng = PRNGKey(0)
     train_init, train_fetch = load_dataset(MNIST, batch_size=args.batch_size, split='train')
     test_init, test_fetch = load_dataset(MNIST, batch_size=args.batch_size, split='test')

--- a/numpyro/infer/svi.py
+++ b/numpyro/infer/svi.py
@@ -134,13 +134,13 @@ class SVI(object):
     :param model: Python callable with Pyro primitives for the model.
     :param guide: Python callable with Pyro primitives for the guide
         (recognition network).
-    :param loss: ELBO loss, i.e. negative Evidence Lower Bound, to minimize.
     :param optim: an instance of :class:`~numpyro.optim._NumpyroOptim`.
+    :param loss: ELBO loss, i.e. negative Evidence Lower Bound, to minimize.
     :param static_kwargs: static arguments for the model / guide, i.e. arguments
         that remain constant during fitting.
     :return: tuple of `(init_fn, update_fn, evaluate)`.
     """
-    def __init__(self, model, guide, loss, optim, **static_kwargs):
+    def __init__(self, model, guide, optim, loss, **static_kwargs):
         self.model = model
         self.guide = guide
         self.loss = loss

--- a/test/contrib/test_autoguide.py
+++ b/test/contrib/test_autoguide.py
@@ -44,7 +44,7 @@ def test_beta_bernoulli(auto_class):
 
     adam = optim.Adam(0.01)
     guide = auto_class(model, init_strategy=init_strategy)
-    svi = SVI(model, guide, AutoContinuousELBO(), adam)
+    svi = SVI(model, guide, adam, AutoContinuousELBO())
     svi_state = svi.init(random.PRNGKey(1), data)
 
     def body_fn(i, val):
@@ -80,7 +80,7 @@ def test_logistic_regression(auto_class):
     adam = optim.Adam(0.01)
     rng_init = random.PRNGKey(1)
     guide = auto_class(model, init_strategy=init_strategy)
-    svi = SVI(model, guide, AutoContinuousELBO(), adam)
+    svi = SVI(model, guide, adam, AutoContinuousELBO())
     svi_state = svi.init(rng_init, data, labels)
 
     def body_fn(i, val):
@@ -117,7 +117,7 @@ def test_iaf():
     adam = optim.Adam(0.01)
     rng_init = random.PRNGKey(1)
     guide = AutoIAFNormal(model)
-    svi = SVI(model, guide, AutoContinuousELBO(), adam)
+    svi = SVI(model, guide, adam, AutoContinuousELBO())
     svi_state = svi.init(rng_init, data, labels)
     params = svi.get_params(svi_state)
 
@@ -160,7 +160,7 @@ def test_uniform_normal():
     adam = optim.Adam(0.01)
     rng_init = random.PRNGKey(1)
     guide = AutoDiagonalNormal(model)
-    svi = SVI(model, guide, AutoContinuousELBO(), adam)
+    svi = SVI(model, guide, adam, AutoContinuousELBO())
     svi_state = svi.init(rng_init, data)
 
     def body_fn(i, val):
@@ -199,7 +199,7 @@ def test_param():
     adam = optim.Adam(0.01)
     rng_init = random.PRNGKey(1)
     guide = _AutoGuide(model)
-    svi = SVI(model, guide, AutoContinuousELBO(), adam)
+    svi = SVI(model, guide, adam, AutoContinuousELBO())
     svi_state = svi.init(rng_init)
 
     params = svi.get_params(svi_state)
@@ -232,7 +232,7 @@ def test_dynamic_supports():
     rng_init = random.PRNGKey(1)
 
     guide = AutoDiagonalNormal(actual_model)
-    svi = SVI(actual_model, guide, AutoContinuousELBO(), adam)
+    svi = SVI(actual_model, guide, adam, AutoContinuousELBO())
     svi_state = svi.init(rng_init, data)
     actual_opt_params = adam.get_params(svi_state.optim_state)
     actual_params = svi.get_params(svi_state)
@@ -240,7 +240,7 @@ def test_dynamic_supports():
     actual_loss = svi.evaluate(svi_state, data)
 
     guide = AutoDiagonalNormal(expected_model)
-    svi = SVI(expected_model, guide, AutoContinuousELBO(), adam)
+    svi = SVI(expected_model, guide, adam, AutoContinuousELBO())
     svi_state = svi.init(rng_init, data)
     expected_opt_params = adam.get_params(svi_state.optim_state)
     expected_params = svi.get_params(svi_state)
@@ -270,7 +270,7 @@ def test_elbo_dynamic_support():
 
     adam = optim.Adam(0.01)
     guide = _AutoGuide(model)
-    svi = SVI(model, guide, AutoContinuousELBO(), adam)
+    svi = SVI(model, guide, adam, AutoContinuousELBO())
     svi_state = svi.init(random.PRNGKey(0))
     actual_loss = svi.evaluate(svi_state)
     assert np.isfinite(actual_loss)

--- a/test/test_svi.py
+++ b/test/test_svi.py
@@ -29,7 +29,7 @@ def test_beta_bernoulli():
         numpyro.sample("beta", dist.Beta(alpha_q, beta_q))
 
     adam = optim.Adam(0.05)
-    svi = SVI(model, guide, ELBO(), adam)
+    svi = SVI(model, guide, adam, ELBO())
     svi_state = svi.init(random.PRNGKey(1), data)
     assert_allclose(adam.get_params(svi_state.optim_state)['alpha_q'], 0.)
 
@@ -57,7 +57,7 @@ def test_jitted_update_fn():
         numpyro.sample("beta", dist.Beta(alpha_q, beta_q))
 
     adam = optim.Adam(0.05)
-    svi = SVI(model, guide, ELBO(), adam)
+    svi = SVI(model, guide, adam, ELBO())
     svi_state = svi.init(random.PRNGKey(1), data)
     expected = svi.get_params(svi.update(svi_state, data)[0])
 
@@ -89,7 +89,7 @@ def test_param():
         numpyro.sample('y', dist.Normal(c, d), obs=obs)
 
     adam = optim.Adam(0.01)
-    svi = SVI(model, guide, ELBO(), adam)
+    svi = SVI(model, guide, adam, ELBO())
     svi_state = svi.init(random.PRNGKey(0))
 
     params = svi.get_params(svi_state)
@@ -120,7 +120,7 @@ def test_elbo_dynamic_support():
     # set base value of x_guide is 0.9
     x_base = 0.9
     guide = substitute(guide, base_param_map={'x': x_base})
-    svi = SVI(model, guide, ELBO(), adam)
+    svi = SVI(model, guide, adam, ELBO())
     svi_state = svi.init(random.PRNGKey(0))
     actual_loss = svi.evaluate(svi_state)
     assert np.isfinite(actual_loss)


### PR DESCRIPTION
Why working on compat submodule, I noticed this inconsistency. I think that it is better to swap the order to match Pyro pattern.