### PR TITLE
improve turning condition

### DIFF
--- a/numpyro/infer/hmc_util.py
+++ b/numpyro/infer/hmc_util.py
@@ -456,8 +456,9 @@ def _is_turning(inverse_mass_matrix, r_left, r_right, r_sum):
         v_right = np.multiply(inverse_mass_matrix, r_right)
 
     # This implements dynamic termination criterion (ref [2], section A.4.2).
-    turning_at_left = np.dot(v_left, r_sum - r_left) <= 0
-    turning_at_right = np.dot(v_right, r_sum - r_right) <= 0
+    r_sum = r_sum - (r_left + r_right) / 2
+    turning_at_left = np.dot(v_left, r_sum) <= 0
+    turning_at_right = np.dot(v_right, r_sum) <= 0
     return turning_at_left | turning_at_right
 
 

--- a/test/test_hmc_util.py
+++ b/test/test_hmc_util.py
@@ -346,7 +346,7 @@ def test_is_iterative_turning(ckpt_idxs, expected_turning):
     r = 1.
     r_sum = 3.
     r_ckpts = np.array([1., 2., 3., -2.])
-    r_sum_ckpts = r_ckpts + 1
+    r_sum_ckpts = np.array([2., 4., 4., -1.])
 
     actual_turning = _is_iterative_turning(inverse_mass_matrix, r, r_sum, r_ckpts, r_sum_ckpts,
                                            *ckpt_idxs)


### PR DESCRIPTION
This PR tries to address #393.

### Context

To check the turning condition, we need to compute `dot(v_left, z_right - z_left)` and `dot(v_right, z_right - z_left)`. Then we approximate `z_right - z_left` by `r_sum - r_left` or `r_sum - r_right`. As pointed out by the user **nhuurre** at [this thread](https://discourse.mc-stan.org/t/nuts-misses-u-turns-runs-in-circles-until-max-treedepth/9727/58), it is better to approximate `z_right - z_left` by
`r_sum - (r_left + r_right) / 2`.

### Test
On the model #393 

```
from jax import numpy as np, random
import numpyro as npyro; npyro.set_host_device_count(4)
import numpyro.distributions as dist
from numpyro.infer import NUTS, MCMC

def model():
    b = npyro.sample('b', dist.Normal(0, 1))
    sigma = npyro.sample('sigma', dist.Uniform(0, 1))
    npyro.sample('y', dist.Normal(b, sigma), obs=np.array([0, 0.1, 1]))

for i in range(5):
    mcmc = MCMC(NUTS(model), 1000, 1000, num_chains=4, chain_method='vectorized')
    mcmc.run(random.PRNGKey(i))
    mcmc.print_summary()
```
gives us
```
sample: 100%|██████████| 2000/2000 [00:07<00:00, 266.53it/s]



                mean       std    median      5.0%     95.0%     n_eff     r_hat
         b      0.31      0.34      0.31     -0.29      0.84   8105.90      0.99
     sigma      0.63      0.19      0.62      0.35      0.95   8135.58      0.99


sample: 100%|██████████| 2000/2000 [00:07<00:00, 274.86it/s]



                mean       std    median      5.0%     95.0%     n_eff     r_hat
         b      0.32      0.35      0.33     -0.29      0.84   8780.48      1.00
     sigma      0.63      0.19      0.62      0.33      0.95   7681.27      1.01


sample: 100%|██████████| 2000/2000 [00:07<00:00, 273.77it/s]



                mean       std    median      5.0%     95.0%     n_eff     r_hat
         b      0.32      0.35      0.32     -0.26      0.89   8724.73      0.99
     sigma      0.63      0.19      0.61      0.34      0.95   7996.22      1.00


sample: 100%|██████████| 2000/2000 [00:07<00:00, 270.22it/s]



                mean       std    median      5.0%     95.0%     n_eff     r_hat
         b      0.32      0.35      0.33     -0.28      0.87   7574.28      1.01
     sigma      0.63      0.19      0.63      0.34      0.95   7719.02      1.01


sample: 100%|██████████| 2000/2000 [00:07<00:00, 270.19it/s]



                mean       std    median      5.0%     95.0%     n_eff     r_hat
         b      0.32      0.36      0.32     -0.32      0.87   7915.71      0.99
     sigma      0.63      0.19      0.63      0.37      0.98   7461.49      1.02


```