### PR TITLE
Make behavior of nested seed handler consistent with Pyro

### DIFF
--- a/numpyro/handlers.py
+++ b/numpyro/handlers.py
@@ -348,7 +348,8 @@ class seed(Messenger):
         super(seed, self).__init__(fn)
 
     def process_message(self, msg):
-        if msg['type'] == 'sample' and not msg['is_observed']:
+        if msg['type'] == 'sample' and not msg['is_observed'] and \
+                msg['kwargs']['random_state'] is None:
             self.rng, rng_sample = random.split(self.rng)
             msg['kwargs']['random_state'] = rng_sample
 


### PR DESCRIPTION
Refer to https://github.com/pyro-ppl/pyro-api/pull/6 for details.

The current behavior of the seed handler is that the outermost context determines the rng seed, i.e. in `seed(seed(fn, ..), 1)`, the seed used is always 1. This is because of the order in which the effect handlers are applied. This is in contrast to Pyro where seeding happens in `__enter__` and therefore the innermost context determines the seed used. This changes the behavior to match that of Pyro. More importantly, this will let us use the pattern in https://github.com/pyro-ppl/pyro-api/pull/6, so that we can have default seeding in an external context manager which will can be overridden by individual tests. 

cc. @fritzo. 