### PR TITLE
Defer to autodelta if hessian of laplace approximation is singular

### DIFF
--- a/numpyro/contrib/autoguide/__init__.py
+++ b/numpyro/contrib/autoguide/__init__.py
@@ -366,6 +366,7 @@ class AutoLaplaceApproximation(AutoContinuous):
         loc = params['{}_loc'.format(self.prefix)]
         precision = hessian(loss_fn)(loc)
         scale_tril = cholesky_inverse(precision)
+        scale_tril = np.where(np.isnan(scale_tril), 0., scale_tril)
         return MultivariateAffineTransform(loc, scale_tril)
 
     def sample_posterior(self, rng, params, sample_shape=()):

--- a/numpyro/handlers.py
+++ b/numpyro/handlers.py
@@ -83,6 +83,7 @@ import jax.numpy as np
 from numpyro.distributions.constraints import real
 from numpyro.distributions.transforms import ComposeTransform, biject_to
 from numpyro.primitives import Messenger
+from numpyro.util import not_jax_tracer
 
 __all__ = [
     'block',
@@ -293,8 +294,9 @@ class scale(Messenger):
     :param float scale_factor: a positive scaling factor
     """
     def __init__(self, fn=None, scale_factor=1.):
-        if scale_factor <= 0:
-            raise ValueError("scale factor should be a positive number.")
+        if not_jax_tracer(scale_factor):
+            if scale_factor <= 0:
+                raise ValueError("scale factor should be a positive number.")
         self.scale = scale_factor
         super(scale, self).__init__(fn)
 


### PR DESCRIPTION
When hessian is singular, we will get NaN samples because the transform `scale_tril` is NaN. But there are problems where there is no (or little) uncertainty about MAP point. This PR masks out `scale_tril` by zero if hessian is singular, hence gives us MAP point as posterior samples.

In addition, I wrap `scale_factor` positive check in `scale` handler by `not_jax_tracer` to be able to jit models with scale handler.