### PR TITLE
fix CategoricalLogits log_prob

### DIFF
--- a/numpyro/distributions/discrete.py
+++ b/numpyro/distributions/discrete.py
@@ -265,10 +265,11 @@ class CategoricalLogits(Distribution):
 
     @validate_sample
     def log_prob(self, value):
+        batch_shape = lax.broadcast_shapes(np.shape(value), self.batch_shape)
         value = np.expand_dims(value, -1)
+        value = np.broadcast_to(value, batch_shape + (1,))
         log_pmf = self.logits - logsumexp(self.logits, axis=-1, keepdims=True)
-        value, log_pmf = promote_shapes(value, log_pmf)
-        value = value[..., :1]
+        log_pmf = np.broadcast_to(log_pmf, batch_shape + np.shape(log_pmf)[-1:])
         return np.take_along_axis(log_pmf, value, -1)[..., 0]
 
     @lazy_property

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -594,6 +594,22 @@ def test_distribution_constraints(jax_dist, sp_dist, params, prepend_shape):
         d.log_prob(oob_samples)
 
 
+def test_categorical_log_prob_grad():
+    data = np.repeat(np.arange(3), 10)
+
+    def f(x):
+        return dist.Categorical(jax.nn.softmax(x * np.arange(1, 4))).log_prob(data).sum()
+
+    def g(x):
+        return dist.Categorical(logits=x * np.arange(1, 4)).log_prob(data).sum()
+
+    x = 0.5
+    fx, grad_fx = jax.value_and_grad(f)(x)
+    gx, grad_gx = jax.value_and_grad(g)(x)
+    assert_allclose(fx, gx)
+    assert_allclose(grad_fx, grad_gx)
+
+
 ########################################
 # Tests for constraints and transforms #
 ########################################


### PR DESCRIPTION
The current implementation of CategoricalLogits log_prob gives the wrong gradient value. This PR fixes the issue and adds a corresponding test, which failed under the current implementation.

Upstream issue: https://github.com/google/jax/issues/1521. In summary, we should broadcast the first argument of np.take_along_axis.