### PR TITLE
More compatibility tweaks for pyro-api

### DIFF
--- a/numpyro/compat/infer.py
+++ b/numpyro/compat/infer.py
@@ -132,7 +132,7 @@ class SVI(svi.SVI):
                                 'dicts of arrays.')
             else:
                 raise e
-        params = super(SVI, self).get_params(self.svi_state)
+        params = jit(super(SVI, self).get_params)(self.svi_state)
         get_param_store().update(params)
         return loss
 

--- a/numpyro/compat/infer.py
+++ b/numpyro/compat/infer.py
@@ -4,6 +4,7 @@ from jax import jit
 
 import numpyro
 import numpyro.distributions as dist
+from numpyro.compat.pyro import get_param_store
 from numpyro.infer import elbo, mcmc, svi
 
 
@@ -131,6 +132,8 @@ class SVI(svi.SVI):
                                 'dicts of arrays.')
             else:
                 raise e
+        params = super(SVI, self).get_params(self.svi_state)
+        get_param_store().update(params)
         return loss
 
     def get_params(self):

--- a/numpyro/compat/ops.py
+++ b/numpyro/compat/ops.py
@@ -1,3 +1,34 @@
+import numpy as onp
+
+import jax.numpy as np
 from jax.numpy import *  # noqa: F401, F403
 
 tensor = array  # noqa: F405
+
+randn = onp.random.randn
+
+
+# Provide wrappers to initialize ones/zeros using the pytorch convention
+# of using *sizes. e.g. ops.ones(2, 3) as well as ops.ones((2, 3)) can
+# be used to initialize an array of ones with shape (2, 3).
+
+def ones(*sizes, **kwargs):
+    if len(sizes) == 0:
+        raise ValueError('Positional `size` argument not provided.')
+    elif len(sizes) == 1:
+        if isinstance(sizes[0], (tuple, list)):
+            sizes = sizes[0]
+    if not all([isinstance(s, int) for s in sizes]):
+        raise ValueError('Invalid data type for `size` provided.')
+    return np.ones(sizes, **kwargs)
+
+
+def zeros(*sizes, **kwargs):
+    if len(sizes) == 0:
+        raise ValueError('Positional `size` argument not provided.')
+    elif len(sizes) == 1:
+        if isinstance(sizes[0], (tuple, list)):
+            sizes = sizes[0]
+    if not all([isinstance(s, int) for s in sizes]):
+        raise ValueError('Invalid data type for `size` provided.')
+    return np.ones(sizes, **kwargs)

--- a/numpyro/compat/optim.py
+++ b/numpyro/compat/optim.py
@@ -13,4 +13,9 @@ def ClippedAdam(kwargs):
     b1, b2 = kwargs.pop('betas', (0.9, 0.999))
     eps = kwargs.pop('eps', 1.e-8)
     clip_norm = kwargs.pop('clip_norm', 10.)
+    lrd = kwargs.pop('lrd', None)
+    init_lr = step_size
+    if lrd is not None:
+        def step_size(i):
+            return init_lr * lrd ** i
     return optim.ClippedAdam(step_size=step_size, b1=b1, b2=b2, eps=eps, clip_norm=clip_norm)

--- a/numpyro/compat/optim.py
+++ b/numpyro/compat/optim.py
@@ -6,3 +6,11 @@ def Adam(kwargs):
     b1, b2 = kwargs.pop('betas', (0.9, 0.999))
     eps = kwargs.pop('eps', 1.e-8)
     return optim.Adam(step_size=step_size, b1=b1, b2=b2, eps=eps)
+
+
+def ClippedAdam(kwargs):
+    step_size = kwargs.pop('lr')
+    b1, b2 = kwargs.pop('betas', (0.9, 0.999))
+    eps = kwargs.pop('eps', 1.e-8)
+    clip_norm = kwargs.pop('clip_norm', 10.)
+    return optim.ClippedAdam(step_size=step_size, b1=b1, b2=b2, eps=eps, clip_norm=clip_norm)

--- a/numpyro/compat/pyro.py
+++ b/numpyro/compat/pyro.py
@@ -1,13 +1,30 @@
 import warnings
 
 from numpyro.compat.util import UnsupportedAPIWarning
-from numpyro.primitives import module, param, plate, sample  # noqa: F401
+from numpyro.primitives import module, param as _param, plate, sample  # noqa: F401
+
+
+_PARAM_STORE = {}
 
 
 def get_param_store():
-    warnings.warn('NumPyro does not have a parameter store. '
-                  'Value of SVI parameters can be obtained via '
-                  'SVI.get_params() method.',
+    warnings.warn('A limited parameter store is provided for compatibility with Pyro. '
+                  'Value of SVI parameters should be obtained via SVI.get_params() method.',
                   category=UnsupportedAPIWarning)
     # Return an empty dict for compatibility
-    return {}
+    return _PARAM_STORE
+
+
+def clear_param_store():
+    return _PARAM_STORE.clear()
+
+
+def param(name, *args, **kwargs):
+    # Get value assuming statement is wrapped in a substitute handler.
+    val = _param(name, *args, **kwargs)
+    # If no value is found, check param store.
+    if val is None:
+        param_store = get_param_store()
+        if name in param_store:
+            val = param_store[name]
+    return val

--- a/numpyro/compat/pyro.py
+++ b/numpyro/compat/pyro.py
@@ -24,7 +24,7 @@ def param(name, *args, **kwargs):
     val = _param(name, *args, **kwargs)
     # If no value is found, check param store.
     if val is None:
-        # If other arguments are provided. e.g. for initialization raise error.
+        # If other arguments are provided, e.g. for initialization, raise error.
         if args or kwargs:
             raise NotImplementedError
         param_store = get_param_store()

--- a/numpyro/compat/pyro.py
+++ b/numpyro/compat/pyro.py
@@ -24,6 +24,9 @@ def param(name, *args, **kwargs):
     val = _param(name, *args, **kwargs)
     # If no value is found, check param store.
     if val is None:
+        # If other arguments are provided. e.g. for initialization raise error.
+        if args or kwargs:
+            raise NotImplementedError
         param_store = get_param_store()
         if name in param_store:
             val = param_store[name]

--- a/numpyro/optim.py
+++ b/numpyro/optim.py
@@ -81,13 +81,16 @@ class ClippedAdam(_NumpyroOptim):
     """
     :class:`~numpyro.optim.Adam` optimizer with gradient clipping.
 
+    :param float clip_norm: All gradient values will be clipped between
+    [-`clip_norm`, `clip_norm`].
+
     **Reference:**
 
     `A Method for Stochastic Optimization`, Diederik P. Kingma, Jimmy Ba
     https://arxiv.org/abs/1412.6980
     """
-    def __init__(self, *args, **kwargs):
-        self.clip_norm = kwargs.pop('clip_norm', 10.)
+    def __init__(self, *args, clip_norm=10., **kwargs):
+        self.clip_norm = clip_norm
         super(ClippedAdam, self).__init__(optimizers.adam, *args, **kwargs)
 
     def update(self, g, state):

--- a/numpyro/optim.py
+++ b/numpyro/optim.py
@@ -7,6 +7,8 @@ suited for working with NumPyro inference algorithms.
 from typing import Callable, Tuple, TypeVar
 
 from jax.experimental import optimizers
+import jax.numpy as np
+from jax.tree_util import tree_map
 
 __all__ = [
     'Adam',
@@ -73,6 +75,27 @@ def _add_doc(fn):
 class Adam(_NumpyroOptim):
     def __init__(self, *args, **kwargs):
         super(Adam, self).__init__(optimizers.adam, *args, **kwargs)
+
+
+class ClippedAdam(_NumpyroOptim):
+    """
+    :class:`~numpyro.optim.Adam` optimizer with gradient clipping.
+
+    **Reference:**
+
+    `A Method for Stochastic Optimization`, Diederik P. Kingma, Jimmy Ba
+    https://arxiv.org/abs/1412.6980
+    """
+    def __init__(self, *args, **kwargs):
+        self.clip_norm = kwargs.pop('clip_norm', 10.)
+        super(ClippedAdam, self).__init__(optimizers.adam, *args, **kwargs)
+
+    def update(self, g, state):
+        i, opt_state = state
+        # clip norm
+        g = tree_map(lambda g_: np.clip(g_, a_min=-self.clip_norm, a_max=self.clip_norm), g)
+        opt_state = self.update_fn(i, g, opt_state)
+        return i + 1, opt_state
 
 
 @_add_doc(optimizers.adagrad)

--- a/test/pyroapi/test_pyroapi.py
+++ b/test/pyroapi/test_pyroapi.py
@@ -1,6 +1,7 @@
+import pytest
+
 from pyroapi import pyro_backend
 from pyroapi.tests import *  # noqa F401
-import pytest
 
 pytestmark = pytest.mark.filterwarnings("ignore::numpyro.compat.util.UnsupportedAPIWarning")
 

--- a/test/test_optimizers.py
+++ b/test/test_optimizers.py
@@ -19,6 +19,7 @@ def step(opt_state, optim):
 
 @pytest.mark.parametrize('optim_class, args', [
     (optim.Adam, (1e-2,)),
+    (optim.ClippedAdam, (1e-2,)),
     (optim.Adagrad, (1e-1,)),
     (optim.Momentum, (1e-2, 0.5,)),
     (optim.RMSProp, (1e-2, 0.95)),


### PR DESCRIPTION
Follow up on https://github.com/pyro-ppl/pyro-api/pull/8 in pyro-api, this increases the coverage of tests with the following changes to the compatibility wrapper:

 - Added support for `ClippedAdam` optimizer.
 - Wrappers to allow for torch style zeros/ones array initializers. i.e. in pytorch, `torch.ones(2, 3)`, `torch.ones((2, 3))` and `torch.ones([2, 3])` can all be used to initialize a tensor of size (2, 3). In NumPy, the first invocation isn't allowed.
 - Allow accessing SVI parameters via the global param store when `pyro.param` is used outside an inference context. This doesn't support the full param store API e.g. initializing using constraints etc., which are handled by inference algorithms directly in NumPyro. This simply updates the global param store when `svi.step` is called. 

With these fixes, all tests pass expect `test_mean_field ` which isn't implemented.