### PR TITLE
add ordered logistic distribution

### DIFF
--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -281,6 +281,14 @@ MultinomialProbs
     :show-inheritance:
     :member-order: bysource
 
+OrderedLogistic
+---------------
+.. autoclass:: numpyro.distributions.discrete.OrderedLogistic
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :member-order: bysource
+
 Poisson
 -------
 .. autoclass:: numpyro.distributions.discrete.Poisson
@@ -343,6 +351,10 @@ multinomial
 nonnegative_integer
 -------------------
 .. autodata:: numpyro.distributions.constraints.nonnegative_integer
+
+ordered_vector
+--------------
+.. autodata:: numpyro.distributions.constraints.ordered_vector
 
 positive
 --------
@@ -455,6 +467,14 @@ LowerCholeskyTransform
 MultivariateAffineTransform
 ---------------------------
 .. autoclass:: numpyro.distributions.transforms.MultivariateAffineTransform
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :member-order: bysource
+
+OrderedTransform
+----------------
+.. autoclass:: numpyro.distributions.transforms.OrderedTransform
     :members:
     :undoc-members:
     :show-inheritance:

--- a/numpyro/distributions/__init__.py
+++ b/numpyro/distributions/__init__.py
@@ -35,6 +35,7 @@ from numpyro.distributions.discrete import (
     Multinomial,
     MultinomialLogits,
     MultinomialProbs,
+    OrderedLogistic,
     Poisson,
     PRNGIdentity
 )
@@ -76,6 +77,7 @@ __all__ = [
     'MultinomialProbs',
     'MultivariateNormal',
     'Normal',
+    'OrderedLogistic',
     'Pareto',
     'Poisson',
     'PRNGIdentity',

--- a/numpyro/distributions/constraints.py
+++ b/numpyro/distributions/constraints.py
@@ -140,6 +140,11 @@ class _Multinomial(Constraint):
         return np.all(x >= 0, axis=-1) & (np.sum(x, -1) == self.upper_bound)
 
 
+class _OrderedVector(Constraint):
+    def __call__(self, x):
+        return np.all(x[..., 1:] > x[..., :-1], axis=-1)
+
+
 class _PositiveDefinite(Constraint):
     def __call__(self, x):
         # check for symmetric
@@ -178,6 +183,7 @@ interval = _Interval
 lower_cholesky = _LowerCholesky()
 multinomial = _Multinomial
 nonnegative_integer = _IntegerGreaterThan(0)
+ordered_vector = _OrderedVector()
 positive = _GreaterThan(0.)
 positive_definite = _PositiveDefinite()
 positive_integer = _IntegerGreaterThan(1)

--- a/numpyro/distributions/transforms.py
+++ b/numpyro/distributions/transforms.py
@@ -366,6 +366,31 @@ class MultivariateAffineTransform(Transform):
                                np.shape(x)[:-1])
 
 
+class OrderedTransform(Transform):
+    """
+    Transform a real vector to an ordered vector.
+
+    **References:**
+
+    1. *Stan Reference Manual v2.20, section 10.6*,
+       Stan Development Team
+    """
+    domain = constraints.real_vector
+    codomain = constraints.ordered_vector
+    event_dim = 1
+
+    def __call__(self, x):
+        z = np.concatenate([x[..., :1], np.exp(x[..., 1:])], axis=-1)
+        return cumsum(z)
+
+    def inv(self, y):
+        x = np.log(y[..., 1:] - y[..., :-1])
+        return np.concatenate([y[..., :1], x], axis=-1)
+
+    def log_abs_det_jacobian(self, x, y, intermediates=None):
+        return np.sum(x[..., 1:], -1)
+
+
 class PermuteTransform(Transform):
     domain = constraints.real_vector
     codomain = constraints.real_vector
@@ -538,6 +563,11 @@ def _transform_to_interval(constraint):
 @biject_to.register(constraints.lower_cholesky)
 def _transform_to_lower_cholesky(constraint):
     return LowerCholeskyTransform()
+
+
+@biject_to.register(constraints.ordered_vector)
+def _transform_to_ordered_vector(constraint):
+    return OrderedTransform()
 
 
 @biject_to.register(constraints.positive_definite)

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -156,6 +156,8 @@ DISCRETE = [
     T(dist.MultinomialProbs, np.array([0.2, 0.7, 0.1]), 10),
     T(dist.MultinomialProbs, np.array([0.2, 0.7, 0.1]), np.array([5, 8])),
     T(dist.MultinomialLogits, np.array([-1., 3.]), np.array([[5], [8]])),
+    T(dist.OrderedLogistic, -2, np.array([-10., 4., 9.])),
+    T(dist.OrderedLogistic, np.array([-4, 3, 4, 5]), np.array([-1.5])),
     T(dist.Poisson, 2.),
     T(dist.Poisson, np.array([2., 3., 5.])),
 ]
@@ -201,6 +203,9 @@ def gen_values_within_bounds(constraint, size, key=random.PRNGKey(11)):
     elif isinstance(constraint, constraints._PositiveDefinite):
         x = random.normal(key, size)
         return np.matmul(x, np.swapaxes(x, -2, -1))
+    elif isinstance(constraint, constraints._OrderedVector):
+        x = np.cumsum(random.exponential(key, size), -1)
+        return x - random.normal(key, size[:-1])
     else:
         raise NotImplementedError('{} not implemented.'.format(constraint))
 
@@ -237,6 +242,9 @@ def gen_values_outside_bounds(constraint, size, key=random.PRNGKey(11)):
         return random.uniform(key, size)
     elif isinstance(constraint, constraints._PositiveDefinite):
         return random.normal(key, size)
+    elif isinstance(constraint, constraints._OrderedVector):
+        x = np.cumsum(random.exponential(key, size), -1)
+        return x[..., ::-1]
     else:
         raise NotImplementedError('{} not implemented.'.format(constraint))
 
@@ -667,12 +675,13 @@ def test_constraints(constraint, x, expected):
     constraints.greater_than(2),
     constraints.interval(-3, 5),
     constraints.lower_cholesky,
+    constraints.ordered_vector,
     constraints.positive,
     constraints.positive_definite,
     constraints.real,
     constraints.simplex,
     constraints.unit_interval,
-])
+], ids=lambda x: x.__class__)
 @pytest.mark.parametrize('shape', [(), (1,), (3,), (6,), (3, 1), (1, 3), (5, 3)])
 def test_biject_to(constraint, shape):
     transform = biject_to(constraint)
@@ -709,6 +718,9 @@ def test_biject_to(constraint, shape):
         if constraint is constraints.simplex:
             expected = onp.linalg.slogdet(jax.jacobian(transform)(x)[:-1, :])[1]
             inv_expected = onp.linalg.slogdet(jax.jacobian(transform.inv)(y)[:, :-1])[1]
+        elif constraint is constraints.ordered_vector:
+            expected = onp.linalg.slogdet(jax.jacobian(transform)(x))[1]
+            inv_expected = onp.linalg.slogdet(jax.jacobian(transform.inv)(y))[1]
         elif constraint in [constraints.corr_cholesky, constraints.corr_matrix]:
             vec_transform = lambda x: matrix_to_tril_vec(transform(x), diagonal=-1)  # noqa: E731
             y_tril = matrix_to_tril_vec(y, diagonal=-1)


### PR DESCRIPTION
This together with #405 solves #402.

This distribution is useful for problems with ordered categorical outcomes: https://en.wikipedia.org/wiki/Ordinal_regression

References:

+ https://mc-stan.org/docs/2_20/functions-reference/ordered-logistic-distribution.html
+ https://mc-stan.org/docs/2_20/reference-manual/ordered-vector.html