### PR TITLE
Remove test_example marker from tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,12 +36,12 @@ jobs:
           name: "unit tests"
           python: 3.6
           script:
-              - pytest -vs -m "not test_examples" --deselect test/contrib/test_distributions_contrib.py --durations=100
+              - pytest -vs -k "not test_example" --deselect test/contrib/test_distributions_contrib.py --durations=100
               - JAX_ENABLE_x64=1 pytest -vs test/test_mcmc.py
               - XLA_FLAGS="--xla_force_host_platform_device_count=2" pytest -vs test/test_mcmc.py -k pmap
               - XLA_FLAGS="--xla_force_host_platform_device_count=2" pytest -vs test/test_mcmc_interface.py -k chain
         - name: "examples"
           python: 3.6
           script:
-              - pytest -vs -m test_examples
-              - XLA_FLAGS="--xla_force_host_platform_device_count=2" pytest -vs -m test_examples
+              - pytest -vs -k test_example
+              - XLA_FLAGS="--xla_force_host_platform_device_count=2" pytest -vs -k test_example

--- a/test/test_example_utils.py
+++ b/test/test_example_utils.py
@@ -6,7 +6,6 @@ from numpyro.examples.datasets import BASEBALL, COVTYPE, MNIST, SP500, load_data
 from numpyro.util import fori_loop
 
 
-@pytest.mark.test_examples
 def test_baseball_data_load():
     init, fetch = load_dataset(BASEBALL, split='train', shuffle=False)
     num_batches, idx = init()
@@ -15,7 +14,6 @@ def test_baseball_data_load():
     assert np.shape(dataset[1]) == (18,)
 
 
-@pytest.mark.test_examples
 def test_covtype_data_load():
     _, fetch = load_dataset(COVTYPE, shuffle=False)
     x, y = fetch()
@@ -23,7 +21,6 @@ def test_covtype_data_load():
     assert np.shape(y) == (581012,)
 
 
-@pytest.mark.test_examples
 def test_mnist_data_load():
     def mean_pixels(i, mean_pix):
         batch, _ = fetch(i, idx)
@@ -34,7 +31,6 @@ def test_mnist_data_load():
     assert fori_loop(0, num_batches, mean_pixels, np.float32(0.)) / num_batches < 0.15
 
 
-@pytest.mark.test_examples
 def test_sp500_data_load():
     _, fetch = load_dataset(SP500, split='train', shuffle=False)
     date, value = fetch()

--- a/test/test_example_utils.py
+++ b/test/test_example_utils.py
@@ -1,5 +1,3 @@
-import pytest
-
 import jax.numpy as np
 
 from numpyro.examples.datasets import BASEBALL, COVTYPE, MNIST, SP500, load_dataset

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -23,7 +23,6 @@ EXAMPLES = [
 
 
 @pytest.mark.parametrize('example', EXAMPLES)
-@pytest.mark.test_examples
 @pytest.mark.filterwarnings("ignore:There are not enough devices:UserWarning")
 def test_cpu(example):
     print('Running:\npython examples/{}'.format(example))


### PR DESCRIPTION
I was getting a PytestUnknownMarkerWarning locally, which was getting caught as an error. If we want to use this as a marker, we will need to register it as such in `conftest.py`. I think using a marker is currently overkill, and we can just use the `-k` option instead. If we have multiple stages, then we might need to have a marker. 

I am still not sure why our travis builds were not failing. 

```
    PytestUnknownMarkWarning,
E   pytest.PytestUnknownMarkWarning: Unknown pytest.mark.test_examples - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
```