### PR TITLE
skip numpy warning error for constant values

### DIFF
--- a/numpyro/diagnostics.py
+++ b/numpyro/diagnostics.py
@@ -50,7 +50,7 @@ def gelman_rubin(x):
     assert x.shape[0] >= 2
     assert x.shape[1] >= 2
     var_within, var_estimator = _compute_chain_variance_stats(x)
-    with onp.errstate(invalid="ignore"):
+    with onp.errstate(invalid="ignore", divide="ignore"):
         rhat = onp.sqrt(var_estimator / var_within)
     return rhat
 
@@ -124,7 +124,7 @@ def autocorrelation(x, axis=0):
     # truncate and normalize the result, then transpose back to original shape
     autocorr = autocorr[..., :N]
     autocorr = autocorr / onp.arange(N, 0., -1)
-    with onp.errstate(invalid="ignore"):
+    with onp.errstate(invalid="ignore", divide="ignore"):
         autocorr = autocorr / autocorr[..., :1]
     return onp.swapaxes(autocorr, axis, -1)
 

--- a/numpyro/diagnostics.py
+++ b/numpyro/diagnostics.py
@@ -50,7 +50,8 @@ def gelman_rubin(x):
     assert x.shape[0] >= 2
     assert x.shape[1] >= 2
     var_within, var_estimator = _compute_chain_variance_stats(x)
-    rhat = onp.sqrt(var_estimator / var_within)
+    with onp.errstate(invalid="ignore"):
+        rhat = onp.sqrt(var_estimator / var_within)
     return rhat
 
 
@@ -123,7 +124,8 @@ def autocorrelation(x, axis=0):
     # truncate and normalize the result, then transpose back to original shape
     autocorr = autocorr[..., :N]
     autocorr = autocorr / onp.arange(N, 0., -1)
-    autocorr = autocorr / autocorr[..., :1]
+    with onp.errstate(invalid="ignore"):
+        autocorr = autocorr / autocorr[..., :1]
     return onp.swapaxes(autocorr, axis, -1)
 
 


### PR DESCRIPTION
For some priors such as LKJCholesky, the upper diagonal matrix will always be constant. When we print the summary, a numpy warning will be triggered due to (0 / 0) issue. This PR skips those warnings (this should be fine because we still have `NaN` displayed).

A quick test for this issue is:
```
summary(np.ones((2, 10))`
```