### PR TITLE
Tweak docs and change the default value of parallel arg in Predictive

### DIFF
--- a/docs/source/autoguide.rst
+++ b/docs/source/autoguide.rst
@@ -3,6 +3,14 @@ Automatic Guide Generation
 
 .. automodule:: numpyro.contrib.autoguide
 
+AutoContinuous
+--------------
+.. autoclass:: numpyro.contrib.autoguide.AutoContinuous
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :member-order: bysource
+
 AutoDiagonalNormal
 ------------------
 .. autoclass:: numpyro.contrib.autoguide.AutoDiagonalNormal

--- a/docs/source/utilities.rst
+++ b/docs/source/utilities.rst
@@ -19,6 +19,8 @@ set_host_device_count
 ---------------------
 .. autofunction:: numpyro.util.set_host_device_count
 
+.. _inference_utilities:
+
 Inference Utilities
 ===================
 

--- a/docs/source/utilities.rst
+++ b/docs/source/utilities.rst
@@ -19,8 +19,6 @@ set_host_device_count
 ---------------------
 .. autofunction:: numpyro.util.set_host_device_count
 
-.. _inference_utilities:
-
 Inference Utilities
 ===================
 
@@ -58,22 +56,27 @@ find_valid_initial_params
 -------------------------
 .. autofunction:: numpyro.infer.util.find_valid_initial_params
 
+.. _init_strategy:
+
+Initialization Strategies
+-------------------------
+
 init_to_median
---------------
+^^^^^^^^^^^^^^
 .. autofunction:: numpyro.infer.util.init_to_median
 
 init_to_prior
--------------
+^^^^^^^^^^^^^
 .. autofunction:: numpyro.infer.util.init_to_prior
 
 init_to_uniform
----------------
+^^^^^^^^^^^^^^^
 .. autofunction:: numpyro.infer.util.init_to_uniform
 
 init_to_feasible
-----------------
+^^^^^^^^^^^^^^^^
 .. autofunction:: numpyro.infer.util.init_to_feasible
 
 init_to_value
--------------
+^^^^^^^^^^^^^
 .. autofunction:: numpyro.infer.util.init_to_value

--- a/numpyro/compat/infer.py
+++ b/numpyro/compat/infer.py
@@ -3,8 +3,8 @@ import math
 from jax import jit
 
 import numpyro
-import numpyro.distributions as dist
 from numpyro.compat.pyro import get_param_store
+import numpyro.distributions as dist
 from numpyro.infer import elbo, mcmc, svi
 
 

--- a/numpyro/contrib/autoguide/__init__.py
+++ b/numpyro/contrib/autoguide/__init__.py
@@ -105,10 +105,12 @@ class AutoContinuous(AutoGuide):
     variables are continuous.
 
     .. note::
-        We recommend to use :class:`AutoContinuousELBO` as the
+        We recommend using :class:`AutoContinuousELBO` as the
         objective function `loss` in :class:`~numpyro.infer.svi.SVI`.
-        In addition, to get posterior samples from this autoguide, it
-        is better to use the :meth:`sample_posterior` method.
+        In addition, we recommend using :meth:`sample_posterior` method
+        for drawing posterior samples from the autoguide as it will
+        automatically do any unpacking and transformations required
+        to constrain the samples to the support of the latent sites.
 
     **Reference:**
 
@@ -119,7 +121,7 @@ class AutoContinuous(AutoGuide):
     :param callable model: A NumPyro model.
     :param str prefix: a prefix that will be prefixed to all param internal sites.
     :param callable init_strategy: A per-site initialization function.
-        See :ref:`inference_utilities` section for available functions.
+        See :ref:`init_strategy` section for available functions.
     """
     def __init__(self, model, prefix="auto", init_strategy=init_to_uniform()):
         self.init_strategy = init_strategy

--- a/numpyro/contrib/autoguide/__init__.py
+++ b/numpyro/contrib/autoguide/__init__.py
@@ -99,23 +99,27 @@ class AutoContinuous(AutoGuide):
     Base class for implementations of continuous-valued Automatic
     Differentiation Variational Inference [1].
 
-    Each derived class implements its own :meth:`get_posterior` method.
+    Each derived class implements its own :meth:`_get_transform` method.
 
     Assumes model structure and latent dimension are fixed, and all latent
     variables are continuous.
 
-    Reference:
+    .. note::
+        We recommend to use :class:`AutoContinuousELBO` as the
+        objective function `loss` in :class:`~numpyro.infer.svi.SVI`.
+        In addition, to get posterior samples from this autoguide, it
+        is better to use the :meth:`sample_posterior` method.
 
-    [1] `Automatic Differentiation Variational Inference`,
-        Alp Kucukelbir, Dustin Tran, Rajesh Ranganath, Andrew Gelman, David M.
-        Blei
+    **Reference:**
 
-    :param jax.random.PRNGKey rng_key: random key to be used as the source of randomness
-        to initialize the guide.
+    1. *Automatic Differentiation Variational Inference*,
+       Alp Kucukelbir, Dustin Tran, Rajesh Ranganath, Andrew Gelman, David M.
+       Blei
+
     :param callable model: A NumPyro model.
     :param str prefix: a prefix that will be prefixed to all param internal sites.
     :param callable init_strategy: A per-site initialization function.
-        See :ref:`autoguide-initialization` section for available functions.
+        See :ref:`inference_utilities` section for available functions.
     """
     def __init__(self, model, prefix="auto", init_strategy=init_to_uniform()):
         self.init_strategy = init_strategy
@@ -236,7 +240,7 @@ class AutoContinuous(AutoGuide):
 
         :param dict params: Current parameters of model and autoguide.
         :return: the transform of posterior distribution
-        :rtype: :class:`~numpyro.distributions.constraints.Transform`
+        :rtype: :class:`~numpyro.distributions.transforms.Transform`
         """
         return ComposeTransform([handlers.substitute(self._get_transform, params)(),
                                  UnpackTransform(self._unpack_latent)])
@@ -271,9 +275,8 @@ class AutoContinuous(AutoGuide):
 
             print(guide.quantiles(opt_state, [0.05, 0.5, 0.95]))
 
-        :param opt_state: Current state of the optimizer.
-        :param quantiles: A list of requested quantiles between 0 and 1.
-        :type quantiles: torch.Tensor or list
+        :param dict params: A dict containing parameter values.
+        :param list quantiles: A list of requested quantiles between 0 and 1.
         :return: A dict mapping sample site name to a list of quantile values.
         :rtype: dict
         """

--- a/numpyro/distributions/__init__.py
+++ b/numpyro/distributions/__init__.py
@@ -1,5 +1,5 @@
-import numpyro.distributions.constraints  # noqa: F401
 from numpyro.distributions.conjugate import BetaBinomial, GammaPoisson
+import numpyro.distributions.constraints  # noqa: F401
 from numpyro.distributions.continuous import (
     LKJ,
     Beta,
@@ -14,8 +14,8 @@ from numpyro.distributions.continuous import (
     InverseGamma,
     LKJCholesky,
     LogNormal,
-    MultivariateNormal,
     LowRankMultivariateNormal,
+    MultivariateNormal,
     Normal,
     Pareto,
     StudentT,

--- a/numpyro/distributions/conjugate.py
+++ b/numpyro/distributions/conjugate.py
@@ -3,10 +3,9 @@ import jax.numpy as np
 from jax.scipy.special import gammaln
 
 from numpyro.distributions import constraints
-from numpyro.distributions.distribution import Distribution
-
 from numpyro.distributions.continuous import Beta, Gamma
 from numpyro.distributions.discrete import Binomial, Poisson
+from numpyro.distributions.distribution import Distribution
 from numpyro.distributions.util import promote_shapes, validate_sample
 
 

--- a/numpyro/handlers.py
+++ b/numpyro/handlers.py
@@ -75,8 +75,8 @@ need to loop over all the data points.
 
 from __future__ import absolute_import, division, print_function
 
-import warnings
 from collections import OrderedDict
+import warnings
 
 from jax import random
 import jax.numpy as np

--- a/numpyro/infer/util.py
+++ b/numpyro/infer/util.py
@@ -457,11 +457,12 @@ class Predictive(object):
     :param list return_sites: sites to return; by default only sample sites not present
         in `posterior_samples` are returned.
     :param bool parallel: whether to predict in parallel using JAX vectorized map :func:`jax.vmap`.
+        Defaults to False.
 
     :return: dict of samples from the predictive distribution.
     """
     def __init__(self, model, posterior_samples=None, guide=None, params=None, num_samples=None,
-                 return_sites=None, parallel=True):
+                 return_sites=None, parallel=False):
         if posterior_samples is None and num_samples is None:
             raise ValueError("Either posterior_samples or num_samples must be specified.")
 

--- a/test/pyroapi/test_pyroapi.py
+++ b/test/pyroapi/test_pyroapi.py
@@ -1,7 +1,6 @@
-import pytest
-
 from pyroapi import pyro_backend
 from pyroapi.tests import *  # noqa F401
+import pytest
 
 pytestmark = pytest.mark.filterwarnings("ignore::numpyro.compat.util.UnsupportedAPIWarning")
 

--- a/test/test_infer_util.py
+++ b/test/test_infer_util.py
@@ -9,7 +9,7 @@ import jax.numpy as np
 import numpyro
 from numpyro import handlers
 import numpyro.distributions as dist
-from numpyro.distributions import transforms, constraints
+from numpyro.distributions import constraints, transforms
 from numpyro.distributions.transforms import biject_to
 from numpyro.infer import ELBO, MCMC, NUTS, SVI
 from numpyro.infer.util import (

--- a/test/test_svi.py
+++ b/test/test_svi.py
@@ -1,9 +1,10 @@
 from numpy.testing import assert_allclose
+import pytest
 
 from jax import jit, random, value_and_grad
 import jax.numpy as np
 from jax.test_util import check_eq
-import pytest
+
 import numpyro
 from numpyro import optim
 import numpyro.distributions as dist


### PR DESCRIPTION
This PR exposes `AutoContinuous` to docs and adds a note about the best way to use it in SVI and get posterior samples.

In addition, per discussion, I changed `parallel` arg of Predictive class to False, which is still fast and has less memory requirement.