### PR TITLE
add factor primitive

### DIFF
--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -25,6 +25,14 @@ TransformedDistribution
     :show-inheritance:
     :member-order: bysource
 
+Unit
+----
+.. autoclass:: pyro.distributions.distribution.Unit
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :member-order: bysource
+
 
 Continuous Distributions
 ========================

--- a/docs/source/primitives.rst
+++ b/docs/source/primitives.rst
@@ -15,6 +15,10 @@ plate
 -----
 .. autoclass:: numpyro.primitives.plate
 
+factor
+------
+.. autoclass:: numpyro.primitives.factor
+
 module
 ------
 .. autofunction:: numpyro.primitives.module

--- a/examples/hmm.py
+++ b/examples/hmm.py
@@ -110,8 +110,7 @@ def semi_supervised_hmm(transition_prior, emission_prior,
                                 transition_log_prob, emission_log_prob)
     log_prob = logsumexp(log_prob, axis=0, keepdims=True)
     # inject log_prob to potential function
-    # NB: This is a trick to add an additional term to potential energy.
-    numpyro.sample('forward_log_prob', dist.Delta(log_density=log_prob), obs=0.)
+    numpyro.factor('forward_log_prob', log_prob)
 
 
 def print_results(posterior, transition_prob, emission_prob):

--- a/numpyro/__init__.py
+++ b/numpyro/__init__.py
@@ -1,7 +1,7 @@
 from numpyro import compat, diagnostics, distributions, handlers, infer, optim
 from numpyro.distributions.distribution import enable_validation, validation_enabled
 import numpyro.patch  # noqa: F401
-from numpyro.primitives import module, param, plate, sample
+from numpyro.primitives import factor, module, param, plate, sample
 from numpyro.util import set_host_device_count, set_platform
 from numpyro.version import __version__
 
@@ -14,6 +14,7 @@ __all__ = [
     'diagnostics',
     'distributions',
     'enable_validation',
+    'factor',
     'handlers',
     'infer',
     'module',

--- a/numpyro/distributions/__init__.py
+++ b/numpyro/distributions/__init__.py
@@ -42,7 +42,7 @@ from numpyro.distributions.discrete import (
     PRNGIdentity,
     ZeroInflatedPoisson
 )
-from numpyro.distributions.distribution import Distribution, Independent, TransformedDistribution
+from numpyro.distributions.distribution import Distribution, Independent, TransformedDistribution, Unit
 import numpyro.distributions.transforms  # noqa: F401
 from numpyro.distributions.transforms import biject_to
 
@@ -92,5 +92,6 @@ __all__ = [
     'TruncatedCauchy',
     'TruncatedNormal',
     'Uniform',
+    'Unit',
     'ZeroInflatedPoisson',
 ]

--- a/numpyro/distributions/distribution.py
+++ b/numpyro/distributions/distribution.py
@@ -26,6 +26,7 @@ from contextlib import contextmanager
 import warnings
 
 import jax.numpy as np
+from jax import lax
 
 from numpyro.distributions.constraints import is_dependent
 from numpyro.distributions.transforms import Transform
@@ -386,3 +387,28 @@ class TransformedDistribution(Distribution):
     @property
     def variance(self):
         raise NotImplementedError
+
+
+class Unit(Distribution):
+    """
+    Trivial nonnormalized distribution representing the unit type.
+
+    The unit type has a single value with no data, i.e. ``value.size == 0``.
+
+    This is used for :func:`numpyro.factor` statements.
+    """
+    arg_constraints = {'log_factor': constraints.real}
+    support = constraints.real
+
+    def __init__(self, log_factor, validate_args=None):
+        batch_shape = np.shape(log_factor)
+        event_shape = (0,)  # This satisfies .size == 0.
+        self.log_factor = log_factor
+        super(Unit, self).__init__(batch_shape, event_shape, validate_args=validate_args)
+
+    def sample(self, key, sample_shape=()):
+        return np.empty(sample_shape + self.batch_shape + self.event_shape)
+
+    def log_prob(self, value):
+        shape = lax.broadcast_shape(self.batch_shape, np.shape(value)[:-1])
+        return np.broadcast_to(self.log_factor, shape)

--- a/numpyro/distributions/distribution.py
+++ b/numpyro/distributions/distribution.py
@@ -28,7 +28,7 @@ import warnings
 import jax.numpy as np
 from jax import lax
 
-from numpyro.distributions.constraints import is_dependent
+from numpyro.distributions.constraints import is_dependent, real
 from numpyro.distributions.transforms import Transform
 from numpyro.distributions.util import lazy_property, sum_rightmost, validate_sample
 from numpyro.util import not_jax_tracer
@@ -397,8 +397,8 @@ class Unit(Distribution):
 
     This is used for :func:`numpyro.factor` statements.
     """
-    arg_constraints = {'log_factor': constraints.real}
-    support = constraints.real
+    arg_constraints = {'log_factor': real}
+    support = real
 
     def __init__(self, log_factor, validate_args=None):
         batch_shape = np.shape(log_factor)
@@ -410,5 +410,5 @@ class Unit(Distribution):
         return np.empty(sample_shape + self.batch_shape + self.event_shape)
 
     def log_prob(self, value):
-        shape = lax.broadcast_shape(self.batch_shape, np.shape(value)[:-1])
+        shape = lax.broadcast_shapes(self.batch_shape, np.shape(value)[:-1])
         return np.broadcast_to(self.log_factor, shape)

--- a/numpyro/primitives.py
+++ b/numpyro/primitives.py
@@ -249,3 +249,16 @@ class plate(Messenger):
             batch_shape = lax.broadcast_shapes(msg['kwargs']['sample_shape'], batch_shape)
         msg['kwargs']['sample_shape'] = batch_shape
         msg['scale'] = msg['scale'] * self.size / self.subsample_size
+
+
+def factor(name, log_factor):
+    """
+    Factor statement to add arbitrary log probability factor to a
+    probabilisitic model.
+
+    :param str name: Name of the trivial sample.
+    :param numpy.ndarray log_factor: A possibly batched log probability factor.
+    """
+    unit_dist = numpyro.distributions.distribution.Unit(log_factor)
+    unit_value = unit_dist.sample()
+    sample(name, unit_dist, obs=unit_value)

--- a/numpyro/primitives.py
+++ b/numpyro/primitives.py
@@ -260,5 +260,5 @@ def factor(name, log_factor):
     :param numpy.ndarray log_factor: A possibly batched log probability factor.
     """
     unit_dist = numpyro.distributions.distribution.Unit(log_factor)
-    unit_value = unit_dist.sample()
+    unit_value = unit_dist.sample(None)
     sample(name, unit_dist, obs=unit_value)

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -286,6 +286,16 @@ def test_dist_shape(jax_dist, sp_dist, params, prepend_shape):
         assert np.shape(sp_samples) == expected_shape
 
 
+@pytest.mark.parametrize('batch_shape', [(), (4,), (3, 2)])
+def test_unit(batch_shape):
+    log_factor = random.normal(random.PRNGKey(0), batch_shape)
+
+    d = dist.Unit(log_factor=log_factor)
+    x = d.sample(random.PRNGKey(1))
+    assert x.shape == batch_shape + (0,)
+    assert (d.log_prob(x) == log_factor).all()
+
+
 @pytest.mark.parametrize('jax_dist, sp_dist, params', CONTINUOUS)
 def test_sample_gradient(jax_dist, sp_dist, params):
     if not jax_dist.reparametrized_params:


### PR DESCRIPTION
Addresses #449. Ported from Pyro to here.

The main purpose to have this is to match Pyro API. As in Pyro, this is a little bit cheaper than using `dist.Delta`.

TODO:
- [x] add tests
- [x] update some examples which are using dist.Delta for this purpose.