### PR TITLE
Make it possible to JIT compile model args/kwargs

### DIFF
--- a/numpyro/contrib/autoguide/__init__.py
+++ b/numpyro/contrib/autoguide/__init__.py
@@ -219,8 +219,8 @@ class AutoContinuous(AutoGuide):
             if self._has_transformed_dist:
                 # first, substitute to `param` statements in model
                 model = handlers.substitute(self.model, params)
-                return constrain_fn(model, model_args, model_kwargs,
-                                    self._inv_transforms, unpacked_samples)
+                return constrain_fn(model, self._inv_transforms, model_args,
+                                    model_kwargs, unpacked_samples)
             else:
                 return transform_fn(self._inv_transforms, unpacked_samples)
 

--- a/test/test_infer_util.py
+++ b/test/test_infer_util.py
@@ -159,8 +159,8 @@ def test_model_with_transformed_distribution():
 
     base_inv_transforms = {'x': biject_to(x_prior.support), 'y': biject_to(y_prior.base_dist.support)}
     actual_samples = constrain_fn(
-        handlers.seed(model, random.PRNGKey(0)), (), {}, base_inv_transforms, params)
-    actual_potential_energy = potential_energy(model, (), {}, base_inv_transforms, params)
+        handlers.seed(model, random.PRNGKey(0)), base_inv_transforms,  (), {}, params)
+    actual_potential_energy = potential_energy(model, base_inv_transforms, (), {}, params)
 
     assert_allclose(expected_samples['x'], actual_samples['x'])
     assert_allclose(expected_samples['y'], actual_samples['y'])

--- a/test/test_mcmc.py
+++ b/test/test_mcmc.py
@@ -445,7 +445,8 @@ def test_functional_map(algo, map_fn):
 
 
 def test_reuse_mcmc_run():
-    y_obs = onp.random.normal(3, 1, (100,))
+    y1 = onp.random.normal(3, 0.1, (100,))
+    y2 = onp.random.normal(-3, 0.1, (100,))
 
     def model(y_obs):
         mu = numpyro.sample('mu', dist.Normal(0., 1.))
@@ -454,9 +455,39 @@ def test_reuse_mcmc_run():
 
     # Run MCMC on zero observations.
     kernel = NUTS(model)
-    mcmc = MCMC(kernel, 500, 1000)
-    mcmc.run(random.PRNGKey(32), np.zeros((0,)))
+    mcmc = MCMC(kernel, 200, 200)
+    mcmc.run(random.PRNGKey(32), y1)
 
     # Run on data, re-using `mcmc`.
-    mcmc.run(random.PRNGKey(32), y_obs)
-    assert_allclose(mcmc.get_samples()['mu'].mean(), 3., atol=0.1)
+    mcmc.run(random.PRNGKey(32), y2)
+    assert_allclose(mcmc.get_samples()['mu'].mean(), -3., atol=0.1)
+
+
+def test_reuse_mcmc_pe_gen():
+    y1 = onp.random.normal(3, 0.1, (100,))
+    y2 = onp.random.normal(-3, 0.1, (100,))
+
+    def model(y_obs):
+        mu = numpyro.sample('mu', dist.Normal(0., 1.))
+        sigma = numpyro.sample("sigma", dist.HalfCauchy(3.))
+        numpyro.sample("y", dist.Normal(mu, sigma), obs=y_obs)
+
+    init_params, potential_fn, constrain_fn = initialize_model(random.PRNGKey(0), model,
+                                                               y1, dynamic_args=True)
+    init_kernel, sample_kernel = hmc(potential_fn_gen=potential_fn)
+    init_state = init_kernel(init_params, num_warmup=300, model_args=(y1,))
+
+    @jit
+    def _sample(state_and_args):
+        hmc_state, model_args = state_and_args
+        return sample_kernel(hmc_state, (model_args,)), model_args
+
+    samples = fori_collect(0, 500, _sample, (init_state, y1),
+                           transform=lambda state: constrain_fn(y1)(state[0].z))
+    assert_allclose(samples['mu'].mean(), 3., atol=0.1)
+
+    # Run on data, re-using `mcmc` - this should be much faster.
+    init_state = init_kernel(init_params, num_warmup=300, model_args=(y2,))
+    samples = fori_collect(0, 500, _sample, (init_state, y2),
+                           transform=lambda state: constrain_fn(y2)(state[0].z))
+    assert_allclose(samples['mu'].mean(), -3., atol=0.1)


### PR DESCRIPTION
Partially addresses #441, by allowing for a `potential_fn_gen` argument to `hmc`, which returns a `potential_fn` when provided model args/kwargs. This does not change the higher-level MCMC/NUTS APIs, but simply provides the functionality to exist in the lower level API. This can be seen in `test_reuse_mcmc_pe_gen`, where the second run is almost free. This requires corresponding changes in `initialize_model`. 

The code can be slightly simplified if we make this the default (i.e. `hmc` taking in only `potential_fn_gen`), but we can do that in the future, if needed. In later PRs, we can start using this in MCMC/NUTS so that once the `sample_kernel` is compiled we can use `MCMC.run` multiple times with other data.