### PR TITLE
Fix docs build in travis

### DIFF
--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -27,7 +27,7 @@ TransformedDistribution
 
 Unit
 ----
-.. autoclass:: pyro.distributions.distribution.Unit
+.. autoclass:: numpyro.distributions.distribution.Unit
     :members:
     :undoc-members:
     :show-inheritance:

--- a/numpyro/primitives.py
+++ b/numpyro/primitives.py
@@ -254,7 +254,7 @@ class plate(Messenger):
 def factor(name, log_factor):
     """
     Factor statement to add arbitrary log probability factor to a
-    probabilisitic model.
+    probabilistic model.
 
     :param str name: Name of the trivial sample.
     :param numpy.ndarray log_factor: A possibly batched log probability factor.


### PR DESCRIPTION
~For some reason the previous builds seem to have passed.~ This only raises a warning, turns out that there was a lint error with #456. 