### PR TITLE
[do not merge] Sparse reg example for profiling

### DIFF
--- a/numpyro/infer/mcmc.py
+++ b/numpyro/infer/mcmc.py
@@ -744,7 +744,7 @@ class MCMC(object):
         states = dict(zip(collect_fields, states))
         # Apply constraints if number of samples is non-zero
         if len(tree_flatten(states['z'])[0]) > 0:
-            states['z'] = vmap(self.constrain_fn)(states['z'])
+            states['z'] = lax.map(self.constrain_fn, states['z'])
         return states
 
     def _single_chain_jit_args(self, init, collect_fields=('z',), collect_warmup=False):


### PR DESCRIPTION
The two models should be exactly the same now. With regard to the Stan code from the paper, the following are some of the differences:

 - `sigma` and `var_obs` are modeled separately as in our example - this makes the inference problem much easier.
 - Non-centered parametrization should only really be needed for `eta1` which depends on `phi`, but the Stan code uses it for `m_sq` too, which I have removed. 
 - Added more parameters `alpha_1, beta_1, alpha_2, beta_2`, which replace the more constrained `half_slab_df` and `slab_scale` parameters.

With these changes, the results look much more reasonable:

**pystan**
```
            mean se_mean     sd   2.5%    25%    50%    75%  97.5%  n_eff   Rhat
lambda[1]  294.66    80.4 1465.3  10.26  32.29  60.39 134.81 2112.4    332   1.01
lambda[2]  136.88    17.5 277.25   8.06  27.84  51.64 109.99 905.24    251    1.0
lambda[3]   53.02     9.4 163.07   6.37   17.1  28.68  51.02 193.21    301   1.01
lambda[4]    0.88    0.05   0.98   0.03   0.23   0.55   1.08   3.77    465    1.0
lambda[5]    0.85    0.04   0.98 7.4e-3   0.22   0.53   1.12    3.6    592    1.0
lambda[6]    0.89    0.05   1.09 9.8e-3   0.23   0.58   1.11   4.63    461    1.0
lambda[7]    0.98    0.06   1.33   0.02   0.23   0.58    1.3   3.77    532    1.0
lambda[8]     0.8    0.04   1.14   0.02   0.21   0.48   0.95   3.25    683    1.0
lambda[9]    0.81    0.05   1.03   0.02   0.18   0.49    1.0   3.83    480    1.0
lambda[10]   0.89    0.05   1.17   0.03   0.22   0.57   1.04   4.08    643    1.0
m_sq         1.45    0.07    1.3   0.39   0.76   1.13   1.73   4.61    326    1.0
eta_1_base    2.1    0.14   2.36   0.29   0.82   1.41   2.47   8.41    275   1.01
sigma        0.94    0.03    0.6   0.11   0.48   0.81   1.28   2.35    441    1.0
psi_sq       0.32  9.8e-3   0.21   0.11   0.19   0.26   0.38   0.81    438   1.01
var_obs      0.02  1.2e-4 3.3e-3   0.02   0.02   0.02   0.02   0.03    719    1.0
eta_1        0.02  7.8e-4   0.01 2.6e-3 7.6e-3   0.01   0.02   0.05    288    1.0
eta_2      2.0e-4  2.2e-5 4.1e-4 2.9e-6 2.4e-5 6.8e-5 1.7e-4 1.6e-3    359    1.0
psi          0.54  6.7e-3   0.16   0.33   0.44   0.51   0.62    0.9    538    1.0
kappa[1]    1.1e4  1624.3  3.1e4  85.32 733.03 2211.5 7380.9  7.6e4    372   1.01
kappa[2]   9807.2  1795.3  3.6e4  57.84 606.34 1698.0 5671.7  7.4e4    408    1.0
kappa[3]   2807.9  414.18 7494.0  37.33 260.82 712.93 2119.5  2.1e4    327   1.01
kappa[4]     1.74     0.2   4.25 8.8e-4   0.05   0.31   1.17  14.21    438    1.0
kappa[5]     1.69    0.22   4.99 5.5e-5   0.05   0.28   1.25  12.93    523    1.0
kappa[6]     1.99    0.33   6.47 9.7e-5   0.05   0.34   1.23  21.46    386    1.0
kappa[7]     2.73    0.71  15.53 5.1e-4   0.05   0.33   1.68  14.18    482    1.0
kappa[8]     1.92    0.44  10.08 3.6e-4   0.05   0.23   0.91  10.57    534    1.0
kappa[9]     1.72     0.3   5.94 3.0e-4   0.03   0.24    1.0  14.63    381    1.0
kappa[10]    2.15    0.35   8.17 8.6e-4   0.05   0.32   1.09   16.6    533    1.0
lp__        97.44    0.27   3.47  90.09  95.22  97.72 100.16 103.02    166    1.0

Samples were drawn using NUTS at Tue Nov 26 23:18:20 2019.
For each parameter, n_eff is a crude measure of effective sample size,
and Rhat is the potential scale reduction factor on split chains (at
convergence, Rhat=1).

MCMC (stan) elapsed time: 64.45611023902893
num leapfrogs 15676.0
time per leapfrog 0.004111770237243489
```

**numpyro**
```
                mean       std    median      5.0%     95.0%     n_eff     r_hat
      eta1      0.02      0.01      0.01      0.00      0.03    182.79      1.01
 lambda[0]    155.21    504.57     52.98      4.27    264.94    184.97      1.02
 lambda[1]    103.98    204.53     47.85      3.18    203.78    251.16      1.00
 lambda[2]     44.56     93.28     28.42      2.79     80.58    262.45      1.00
 lambda[3]      0.75      0.91      0.47      0.00      1.79    468.40      1.00
 lambda[4]      0.85      0.99      0.56      0.00      1.86    515.83      1.01
 lambda[5]      0.81      1.03      0.51      0.00      1.72    382.63      1.00
 lambda[6]      0.82      1.43      0.51      0.00      1.83    463.52      1.00
 lambda[7]      0.83      0.89      0.54      0.00      1.77    648.92      1.00
 lambda[8]      0.83      0.97      0.55      0.00      1.91    518.58      1.00
 lambda[9]      0.92      1.53      0.58      0.02      1.82    255.58      1.00
      m_sq      1.32      0.99      1.03      0.24      2.49    201.70      1.01
    psi_sq      0.29      0.15      0.25      0.12      0.53    305.63      1.00
     sigma      0.92      0.56      0.83      0.05      1.73    278.99      1.00
   var_obs      0.02      0.00      0.02      0.02      0.03    389.88      1.00

Number of divergences: 0

MCMC (numpyro) elapsed time: 51.200181007385254
num leapfrogs 20764
time per leapfrog 0.0024658148
```