### PR TITLE
use map instead of vmap in constrain_fn

### DIFF
--- a/numpyro/infer/mcmc.py
+++ b/numpyro/infer/mcmc.py
@@ -744,7 +744,7 @@ class MCMC(object):
         states = dict(zip(collect_fields, states))
         # Apply constraints if number of samples is non-zero
         if len(tree_flatten(states['z'])[0]) > 0:
-            states['z'] = vmap(self.constrain_fn)(states['z'])
+            states['z'] = lax.map(self.constrain_fn, states['z'])
         return states
 
     def _single_chain_jit_args(self, init, collect_fields=('z',), collect_warmup=False):


### PR DESCRIPTION
In #465, I observed that using `vmap` is much slower than the native `lax.map`. This has been observed in the implementation of `find_initial_params` (where we use `lax.map` across chains instead of `vmap`).

I have tested that both give same performance in the examples in the tests.