### PR TITLE
Ability to start MCMC sampling from the same warmup state

### DIFF
--- a/numpyro/infer/mcmc.py
+++ b/numpyro/infer/mcmc.py
@@ -688,6 +688,7 @@ class MCMC(object):
         self._jit_model_args = jit_model_args
         self._states = None
         self._states_flat = None
+        self._init_state = None
         self._cache = {}
 
     def _get_cached_fn(self):
@@ -723,22 +724,32 @@ class MCMC(object):
                 self._cache[key] = fn
         return fn
 
-    def _single_chain_mcmc(self, rng_key, init_params, args, kwargs, collect_fields=('z',), collect_warmup=False):
-        init_state = self.sampler.init(rng_key, self.num_warmup, init_params,
-                                       model_args=args, model_kwargs=kwargs)
+    def _single_chain_mcmc(self, rng_key, init_params, args, kwargs,
+                           collect_fields=('z',), collect_warmup=False, reuse_warmup=False):
+        num_warmup = self.num_warmup
+        if reuse_warmup:
+            if self._init_state is None:
+                raise ValueError('No `init_state` found; warmup results cannot be reused.')
+            num_warmup = 0
+            init_state = self._init_state
+        else:
+            init_state = self.sampler.init(rng_key, self.num_warmup, init_params,
+                                           model_args=args, model_kwargs=kwargs)
         if self.constrain_fn is None:
             self.constrain_fn = self.sampler.constrain_fn(args, kwargs)
         collect_fn = attrgetter(*collect_fields)
-        lower = 0 if collect_warmup else self.num_warmup
+        lower = 0 if collect_warmup else num_warmup
         diagnostics = lambda x: get_diagnostics_str(x[0]) if rng_key.ndim == 1 else None   # noqa: E731
         init_val = (init_state, args, kwargs) if self._jit_model_args else (init_state,)
-        states = fori_collect(lower, self.num_warmup + self.num_samples,
-                              self._get_cached_fn(),
-                              init_val,
-                              transform=lambda x: collect_fn(x[0]),  # noqa: E731
-                              progbar=self.progress_bar,
-                              progbar_desc=functools.partial(get_progbar_desc_str, self.num_warmup),
-                              diagnostics_fn=diagnostics)
+        collect_vals = fori_collect(lower, num_warmup + self.num_samples,
+                                    self._get_cached_fn(),
+                                    init_val,
+                                    transform=lambda x: collect_fn(x[0]),  # noqa: E731
+                                    progbar=self.progress_bar,
+                                    return_init_state=True,
+                                    progbar_desc=functools.partial(get_progbar_desc_str, self.num_warmup),
+                                    diagnostics_fn=diagnostics)
+        states, self._init_state = collect_vals
         if len(collect_fields) == 1:
             states = (states,)
         states = dict(zip(collect_fields, states))
@@ -747,15 +758,19 @@ class MCMC(object):
             states['z'] = lax.map(self.constrain_fn, states['z'])
         return states
 
-    def _single_chain_jit_args(self, init, collect_fields=('z',), collect_warmup=False):
-        return self._single_chain_mcmc(*init, collect_fields=collect_fields, collect_warmup=collect_warmup)
+    def _single_chain_jit_args(self, init, collect_fields=('z',), collect_warmup=False, reuse_warmup=False):
+        return self._single_chain_mcmc(*init, collect_fields=collect_fields,
+                                       collect_warmup=collect_warmup, reuse_warmup=reuse_warmup)
 
-    def _single_chain_nojit_args(self, init, model_args, model_kwargs, collect_fields=('z',), collect_warmup=False):
+    def _single_chain_nojit_args(self, init, model_args, model_kwargs, collect_fields=('z',),
+                                 collect_warmup=False, reuse_warmup=False):
         return self._single_chain_mcmc(*init, model_args, model_kwargs,
                                        collect_fields=collect_fields,
-                                       collect_warmup=collect_warmup)
+                                       collect_warmup=collect_warmup,
+                                       reuse_warmup=reuse_warmup)
 
-    def run(self, rng_key, *args, extra_fields=(), collect_warmup=False, init_params=None, **kwargs):
+    def run(self, rng_key, *args, extra_fields=(), collect_warmup=False,
+            init_params=None, reuse_warmup=False, **kwargs):
         """
         Run the MCMC samplers and collect samples.
 
@@ -769,6 +784,8 @@ class MCMC(object):
             to `False`.
         :param init_params: Initial parameters to begin sampling. The type must be consistent
             with the input type to `potential_fn`.
+        :param bool reuse_warmup: If `True`, sampling would make use of the initial state and
+            adaptation parameters from the last warmup run.
         :param kwargs: Keyword arguments to be provided to the :meth:`numpyro.infer.mcmc.MCMCKernel.init`
             method. These are typically the keyword arguments needed by the `model`.
         """
@@ -798,13 +815,15 @@ class MCMC(object):
             if self._jit_model_args:
                 partial_map_fn = partial(self._single_chain_jit_args,
                                          collect_fields=collect_fields,
-                                         collect_warmup=collect_warmup)
+                                         collect_warmup=collect_warmup,
+                                         reuse_warmup=reuse_warmup)
             else:
                 partial_map_fn = partial(self._single_chain_nojit_args,
                                          model_args=args,
                                          model_kwargs=kwargs,
                                          collect_fields=collect_fields,
-                                         collect_warmup=collect_warmup)
+                                         collect_warmup=collect_warmup,
+                                         reuse_warmup=reuse_warmup)
             if chain_method == 'sequential':
                 if self.progress_bar:
                     map_fn = partial(_laxmap, partial_map_fn)

--- a/numpyro/infer/mcmc.py
+++ b/numpyro/infer/mcmc.py
@@ -751,7 +751,11 @@ class MCMC(object):
                                     progbar_desc=functools.partial(get_progbar_desc_str, num_warmup),
                                     diagnostics_fn=diagnostics)
         states, warmup_state = collect_vals
-        self._warmup_state = warmup_state[0]._replace(i=0)
+        # Get first argument of type `HMCState`
+        warmup_state = warmup_state[0]
+        # Note that setting i = 0 may result in recompilation due to python integers having
+        # weak type
+        self._warmup_state = warmup_state._replace(i=np.zeros_like(warmup_state.i))
         if len(collect_fields) == 1:
             states = (states,)
         states = dict(zip(collect_fields, states))

--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -183,8 +183,7 @@ def fori_collect(lower, upper, body_fun, init_val, transform=identity,
         progbar_desc = progbar_opts.pop('progbar_desc', lambda x: '')
         collection = []
 
-        val = init_val
-        start_state = None
+        val, start_state = init_val, init_val
         with tqdm.trange(upper) as t:
             for i in t:
                 val = jit(body_fun)(val)
@@ -199,7 +198,7 @@ def fori_collect(lower, upper, body_fun, init_val, transform=identity,
         collection = np.stack(collection)
 
     unravel_collection = vmap(unravel_fn)(collection)
-    return unravel_collection, start_state if return_init_state else start_state
+    return (unravel_collection, start_state) if return_init_state else unravel_collection
 
 
 def copy_docs_from(source_class, full_text=False):

--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -149,6 +149,9 @@ def fori_collect(lower, upper, body_fun, init_val, transform=identity,
         be any Python collection type containing `np.ndarray` objects.
     :param transform: a callable to post-process the values returned by `body_fn`.
     :param progbar: whether to post progress bar updates.
+    :param bool return_init_state: If `True`, the state at iteration `lower-1`,
+        where the collection begins, is also returned. This has the same type
+        as `init_val`.
     :param `**progbar_opts`: optional additional progress bar arguments. A
         `diagnostics_fn` can be supplied which when passed the current value
         from `body_fun` returns a string that is used to update the progress

--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -160,7 +160,7 @@ def fori_collect(lower, upper, body_fun, init_val, transform=identity,
     :return: collection with the same type as `init_val` with values
         collected along the leading axis of `np.ndarray` objects.
     """
-    assert lower < upper
+    assert lower <= upper
     init_val_flat, unravel_fn = ravel_pytree(transform(init_val))
     ravel_fn = lambda x: ravel_pytree(transform(x))[0]  # noqa: E731
 
@@ -195,7 +195,8 @@ def fori_collect(lower, upper, body_fun, init_val, transform=identity,
                 if diagnostics_fn:
                     t.set_postfix_str(diagnostics_fn(val), refresh=False)
 
-        collection = np.stack(collection)
+        collection = np.stack(collection) if len(collection) > 0 else \
+            np.zeros((upper - lower,) + init_val_flat.shape)
 
     unravel_collection = vmap(unravel_fn)(collection)
     return (unravel_collection, start_state) if return_init_state else unravel_collection

--- a/test/test_mcmc.py
+++ b/test/test_mcmc.py
@@ -238,7 +238,7 @@ def test_improper_prior():
     data = dist.Normal(true_mean, true_std).sample(random.PRNGKey(1), (2000,))
     kernel = NUTS(model=model)
     # num_samples must be >= 1; otherwise we'll get an error
-    mcmc = MCMC(kernel, num_warmup, num_samples=1, progress_bar=False)
+    mcmc = MCMC(kernel, num_warmup)
     mcmc.run(random.PRNGKey(2), data)
     mcmc.num_samples = num_samples
     mcmc.run(random.PRNGKey(2), data, reuse_warmup=True)

--- a/test/test_mcmc.py
+++ b/test/test_mcmc.py
@@ -237,8 +237,11 @@ def test_improper_prior():
 
     data = dist.Normal(true_mean, true_std).sample(random.PRNGKey(1), (2000,))
     kernel = NUTS(model=model)
-    mcmc = MCMC(kernel, num_warmup, num_samples)
+    # num_samples must be >= 1; otherwise we'll get an error
+    mcmc = MCMC(kernel, num_warmup, num_samples=1, progress_bar=False)
     mcmc.run(random.PRNGKey(2), data)
+    mcmc.num_samples = num_samples
+    mcmc.run(random.PRNGKey(2), data, reuse_warmup=True)
     samples = mcmc.get_samples()
     assert_allclose(np.mean(samples['mean']), true_mean, rtol=0.05)
     assert_allclose(np.mean(samples['std']), true_std, rtol=0.05)
@@ -392,7 +395,7 @@ def test_chain_smoke(chain_method, compile_args):
         return p_latent
 
     data = dist.Categorical(np.array([0.1, 0.6, 0.3])).sample(random.PRNGKey(1), (2000,))
-    kernel = NUTS(model, )
+    kernel = NUTS(model)
     mcmc = MCMC(kernel, 2, 5, num_chains=2, chain_method=chain_method, jit_model_args=compile_args)
     mcmc.run(random.PRNGKey(0), data)
 

--- a/test/test_mcmc.py
+++ b/test/test_mcmc.py
@@ -241,7 +241,7 @@ def test_improper_prior():
     mcmc = MCMC(kernel, num_warmup)
     mcmc.run(random.PRNGKey(2), data)
     mcmc.num_samples = num_samples
-    mcmc.run(random.PRNGKey(2), data, reuse_warmup=True)
+    mcmc.run(random.PRNGKey(2), data, reuse_warmup_state=True)
     samples = mcmc.get_samples()
     assert_allclose(np.mean(samples['mean']), true_mean, rtol=0.05)
     assert_allclose(np.mean(samples['std']), true_std, rtol=0.05)
@@ -398,6 +398,7 @@ def test_chain_smoke(chain_method, compile_args):
     kernel = NUTS(model)
     mcmc = MCMC(kernel, 2, 5, num_chains=2, chain_method=chain_method, jit_model_args=compile_args)
     mcmc.run(random.PRNGKey(0), data)
+    mcmc.run(random.PRNGKey(1), data, reuse_warmup_state=True)
 
 
 def test_extra_fields():


### PR DESCRIPTION
Addresses #467. 

This introduces a `return_init_state` argument to `fori_collect`, which if `True` returns the `lower-1` state. This is used by the `reuse_warmup` argument to `MCMC.run` as follows:

```python
# run for 1 sample; num_samples=0 will throw an error
mcmc = MCMC(num_warmup, num_samples=1)
mcmc.run(rng=.., *args, **kwargs)
# change number of samples
mcmc.num_samples = 1000
# runs from the last warmup state avoiding compilation
mcmc.run(rng=..., *args, reuse_warmup=True, **kwargs)
```

This pattern can probably be improved - in particular `num_samples=1` seems a bit odd. Ideally, we should make `num_samples=0` by default in which case running mcmc without num_samples argument will simply compile the model and store the initial state from warmup. This however requires much more refactoring, whose value is questionable at the moment. If this turns out to be a useful pattern, we can make this prettier.