### PR TITLE
Enable x64 tests in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ jobs:
           python: 3.6
           script:
               - pytest -vs -k "not test_example" --deselect test/contrib/test_distributions_contrib.py --durations=100
-              - JAX_ENABLE_x64=1 pytest -vs test/test_mcmc.py -k x64
+              - JAX_ENABLE_X64=1 pytest -vs test/test_mcmc.py -k x64
               - XLA_FLAGS="--xla_force_host_platform_device_count=2" pytest -vs test/test_mcmc.py -k \
                   "chain or pmap or vmap"
         - name: "examples"

--- a/docs/source/utilities.rst
+++ b/docs/source/utilities.rst
@@ -11,6 +11,10 @@ validation_enabled
 
 .. automodule:: numpyro.util
 
+enable_x64
+----------
+.. autofunction:: numpyro.util.enable_x64
+
 set_platform
 ------------
 .. autofunction:: numpyro.util.set_platform

--- a/numpyro/__init__.py
+++ b/numpyro/__init__.py
@@ -2,7 +2,7 @@ from numpyro import compat, diagnostics, distributions, handlers, infer, optim
 from numpyro.distributions.distribution import enable_validation, validation_enabled
 import numpyro.patch  # noqa: F401
 from numpyro.primitives import factor, module, param, plate, sample
-from numpyro.util import set_host_device_count, set_platform
+from numpyro.util import enable_x64, set_host_device_count, set_platform
 from numpyro.version import __version__
 
 set_platform('cpu')
@@ -13,6 +13,7 @@ __all__ = [
     'compat',
     'diagnostics',
     'distributions',
+    'enable_x64',
     'enable_validation',
     'factor',
     'handlers',

--- a/numpyro/infer/mcmc.py
+++ b/numpyro/infer/mcmc.py
@@ -752,10 +752,7 @@ class MCMC(object):
                                     diagnostics_fn=diagnostics)
         states, warmup_state = collect_vals
         # Get first argument of type `HMCState`
-        warmup_state = warmup_state[0]
-        # Note that setting i = 0 may result in recompilation due to python integers having
-        # weak type
-        self._warmup_state = warmup_state._replace(i=np.zeros_like(warmup_state.i))
+        self._warmup_state = warmup_state[0]
         if len(collect_fields) == 1:
             states = (states,)
         states = dict(zip(collect_fields, states))

--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -29,6 +29,18 @@ def set_rng_seed(rng_seed):
     onp.random.seed(rng_seed)
 
 
+def enable_x64(use_x64=True):
+    """
+    Changes the default array type to use 64 bit precision as in NumPy.
+
+    :param bool use_x64: when `True`, JAX arrays will use 64 bits by default;
+        else 32 bits.
+    """
+    if not use_x64:
+        use_x64 = os.getenv('JAX_ENABLE_X64', 0)
+    jax.config.update('jax_enable_x64', use_x64)
+
+
 def set_platform(platform=None):
     """
     Changes platform to CPU, GPU, or TPU. This utility only takes

--- a/test/test_mcmc.py
+++ b/test/test_mcmc.py
@@ -36,7 +36,7 @@ def test_unnormalized_normal_x64(kernel_cls, dense_mass):
     assert_allclose(np.mean(hmc_states), true_mean, rtol=0.05)
     assert_allclose(np.std(hmc_states), true_std, rtol=0.05)
 
-    if 'JAX_ENABLE_x64' in os.environ:
+    if 'JAX_ENABLE_X64' in os.environ:
         assert hmc_states.dtype == np.float64
 
 
@@ -83,7 +83,7 @@ def test_logistic_regression_x64(kernel_cls):
     samples = mcmc.get_samples()
     assert_allclose(np.mean(samples['coefs'], 0), true_coefs, atol=0.22)
 
-    if 'JAX_ENABLE_x64' in os.environ:
+    if 'JAX_ENABLE_X64' in os.environ:
         assert samples['coefs'].dtype == np.float64
 
 
@@ -140,7 +140,7 @@ def test_beta_bernoulli_x64(kernel_cls):
     samples = mcmc.get_samples()
     assert_allclose(np.mean(samples['p_latent'], 0), true_probs, atol=0.05)
 
-    if 'JAX_ENABLE_x64' in os.environ:
+    if 'JAX_ENABLE_X64' in os.environ:
         assert samples['p_latent'].dtype == np.float64
 
 
@@ -163,7 +163,7 @@ def test_dirichlet_categorical_x64(kernel_cls, dense_mass):
     samples = mcmc.get_samples()
     assert_allclose(np.mean(samples['p_latent'], 0), true_probs, atol=0.02)
 
-    if 'JAX_ENABLE_x64' in os.environ:
+    if 'JAX_ENABLE_X64' in os.environ:
         assert samples['p_latent'].dtype == np.float64
 
 
@@ -197,7 +197,7 @@ def test_change_point_x64():
     mode = tau_values[mode_ind]
     assert mode == 44
 
-    if 'JAX_ENABLE_x64' in os.environ:
+    if 'JAX_ENABLE_X64' in os.environ:
         assert samples['lambda1'].dtype == np.float64
         assert samples['lambda2'].dtype == np.float64
         assert samples['tau'].dtype == np.float64
@@ -223,7 +223,7 @@ def test_binomial_stable_x64(with_logits):
     samples = mcmc.get_samples()
     assert_allclose(np.mean(samples['p'], 0), data['x'] / data['n'], rtol=0.05)
 
-    if 'JAX_ENABLE_x64' in os.environ:
+    if 'JAX_ENABLE_X64' in os.environ:
         assert samples['p'].dtype == np.float64
 
 
@@ -439,7 +439,7 @@ def test_functional_beta_bernoulli_x64(algo):
                            transform=lambda x: constrain_fn(x.z))
     assert_allclose(np.mean(samples['p_latent'], 0), true_probs, atol=0.05)
 
-    if 'JAX_ENABLE_x64' in os.environ:
+    if 'JAX_ENABLE_X64' in os.environ:
         assert samples['p_latent'].dtype == np.float64
 
 


### PR DESCRIPTION
Some minor changes to help with #470:
 - [x] Enable x64 tests; they were not being tested due to a typo.
 - [x] Add an `enable_x64` option to numpyro for convenience.
 - [x] Fix issue with #469 where we were running warmup adaptation during sampling - we shouldn't reset `HMCState.i` to 0 since that will be used by the `hmc` function when deciding whether to run the adaptation. 