### PR TITLE
Fix bug in fori_collect for init val collection

### DIFF
--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -181,11 +181,11 @@ def fori_collect(lower, upper, body_fun, init_val, transform=identity,
 
         def _body_fn(i, vals):
             val, collection, start_state = vals
-            val = body_fun(val)
-            i = np.where(i >= lower, i - lower, 0)
-            start_state = lax.cond(i == lower-1,
-                                   start_state, lambda _: val,
+            val = jit(body_fun)(val)
+            start_state = lax.cond(i < lower,
+                                   val, lambda x: x,
                                    start_state, lambda x: x)
+            i = np.where(i >= lower, i - lower, 0)
             collection = ops.index_update(collection, i, ravel_fn(val))
             return val, collection, start_state
 

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -20,6 +20,22 @@ def test_fori_collect():
     check_eq(actual_tree, expected_tree)
 
 
+@pytest.mark.parametrize('progbar', [False, True])
+def test_fori_collect_return_init(progbar):
+    def f(x):
+        x['i'] = x['i'] + 1
+        return x
+
+    tree, init_state = fori_collect(2, 4, f, {'i': 0},
+                                    transform=lambda a: {'i': a['i']},
+                                    return_init_state=True,
+                                    progbar=progbar)
+    expected_tree = {'i': np.array([3, 4])}
+    expected_init_state = {'i': np.array(2)}
+    check_eq(init_state, expected_init_state)
+    check_eq(tree, expected_tree)
+
+
 @pytest.mark.parametrize('pytree', [
     {'a': np.array(0.), 'b': np.array([[1., 2.], [3., 4.]])},
     {'a': np.array(0), 'b': np.array([[1, 2], [3, 4]])},


### PR DESCRIPTION
Partly fixes #475 - this is only a fix for the first part, namely collecting the wrong `init_state`. I'm still investigating the perf regression.