### PR TITLE
Separating compiling, warmup phases

### DIFF
--- a/numpyro/infer/mcmc.py
+++ b/numpyro/infer/mcmc.py
@@ -796,7 +796,7 @@ class MCMC(object):
         self._collection_params["collection_size"] = collection_size
 
     def _compile(self, rng_key, *args, extra_fields=(), init_params=None, **kwargs):
-        self._set_fori_collect_infos(0, 0, self.num_samples)
+        self._set_collection_params(0, 0, self.num_samples)
         self.run(rng_key, *args, extra_fields=extra_fields, init_params=init_params, **kwargs)
         rng_key = (_hashable(rng_key),)
         args = tree_map(lambda x: _hashable(x), args)
@@ -827,11 +827,11 @@ class MCMC(object):
         :param kwargs: Keyword arguments to be provided to the :meth:`numpyro.infer.mcmc.MCMCKernel.init`
             method. These are typically the keyword arguments needed by the `model`.
         """
-        self._warmup_state = False
+        self._warmup_state = None
         if collect_warmup:
-            self._set_fori_collect_infos(0, self.num_warmup, self.num_warmup)
+            self._set_collection_params(0, self.num_warmup, self.num_warmup)
         else:
-            self._set_fori_collect_infos(self.num_warmup, self.num_warmup, self.num_samples)
+            self._set_collection_params(self.num_warmup, self.num_warmup, self.num_samples)
         self.run(rng_key, *args, extra_fields=extra_fields, init_params=init_params, **kwargs)
         self._warmup_state = self._last_state
 
@@ -859,7 +859,7 @@ class MCMC(object):
             rng_key = random.split(rng_key, self.num_chains)
 
         if self._warmup_state is not None:
-            self._set_fori_collect_infos(0, self.num_samples, self.num_samples)
+            self._set_collection_params(0, self.num_samples, self.num_samples)
             init_state = self._warmup_state._replace(rng_key=rng_key)
 
         chain_method = self.chain_method
@@ -914,7 +914,7 @@ class MCMC(object):
         self._last_state = last_state
         self._states = states
         self._states_flat = states_flat
-        self._set_fori_collect_infos()
+        self._set_collection_params()
 
     def get_samples(self, group_by_chain=False):
         """

--- a/numpyro/infer/mcmc.py
+++ b/numpyro/infer/mcmc.py
@@ -780,7 +780,9 @@ class MCMC(object):
         self._fori_collect_infos["collect_size"] = collect_size
 
     def _compile(self, *args, extra_fields=(), init_params=None, **kwargs):
-        self._set_fori_collect_infos(0, 0, self.num_samples)
+        # run 1 step if progress_bar is True
+        upper = 1 if self.progress_bar else 0
+        self._set_fori_collect_infos(upper, upper, self.num_samples)
         self.run(random.PRNGKey(0), *args, extra_fields=extra_fields, init_params=init_params, **kwargs)
 
     def warmup(self, rng_key, *args, extra_fields=(), collect_warmup=False, init_params=None, **kwargs):
@@ -822,7 +824,7 @@ class MCMC(object):
         :param init_params: Initial parameters to begin sampling. The type must be consistent
             with the input type to `potential_fn`.
         :param bool reuse_warmup_state: If `True`, sampling would make use of the last state and
-            adaptation parameters from the previous warmup run.
+            adaptation parameters from the previous :meth:`warmup` run.
         :param kwargs: Keyword arguments to be provided to the :meth:`numpyro.infer.mcmc.MCMCKernel.init`
             method. These are typically the keyword arguments needed by the `model`.
         """

--- a/numpyro/infer/mcmc.py
+++ b/numpyro/infer/mcmc.py
@@ -769,7 +769,7 @@ class MCMC(object):
                                     transform=_collect_fn(collect_fields),
                                     progbar=self.progress_bar,
                                     return_last_val=True,
-                                    collect_size=self._collection_params["collect_size"],
+                                    collection_size=self._collection_params["collection_size"],
                                     progbar_desc=functools.partial(get_progbar_desc_str, num_warmup),
                                     diagnostics_fn=diagnostics)
         states, last_val = collect_vals
@@ -790,10 +790,10 @@ class MCMC(object):
     def _single_chain_nojit_args(self, init, model_args, model_kwargs, collect_fields=('z',)):
         return self._single_chain_mcmc(*init, model_args, model_kwargs, collect_fields=collect_fields)
 
-    def _set_collection_params(self, lower=None, upper=None, collect_size=None):
+    def _set_collection_params(self, lower=None, upper=None, collection_size=None):
         self._collection_params["lower"] = self.num_warmup if lower is None else lower
         self._collection_params["upper"] = self.num_warmup + self.num_samples if upper is None else upper
-        self._collection_params["collect_size"] = collect_size
+        self._collection_params["collection_size"] = collection_size
 
     def _compile(self, rng_key, *args, extra_fields=(), init_params=None, **kwargs):
         self._set_fori_collect_infos(0, 0, self.num_samples)

--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -8,7 +8,7 @@ import numpy as onp
 import tqdm
 
 import jax
-from jax import jit, lax, ops, vmap
+from jax import device_put, jit, lax, ops, vmap
 from jax.interpreters.batching import BatchTracer
 from jax.interpreters.partial_eval import JaxprTracer
 from jax.dtypes import canonicalize_dtype
@@ -156,7 +156,7 @@ def cached_by(outer_fn, *keys):
 
 
 def fori_collect(lower, upper, body_fun, init_val, transform=identity,
-                 progbar=True, return_init_state=False, **progbar_opts):
+                 progbar=True, return_last_val=False, collect_size=None, **progbar_opts):
     """
     This looping construct works like :func:`~jax.lax.fori_loop` but with the additional
     effect of collecting values from the loop body. In addition, this allows for
@@ -174,9 +174,9 @@ def fori_collect(lower, upper, body_fun, init_val, transform=identity,
         be any Python collection type containing `np.ndarray` objects.
     :param transform: a callable to post-process the values returned by `body_fn`.
     :param progbar: whether to post progress bar updates.
-    :param bool return_init_state: If `True`, the state at iteration `lower-1`,
-        where the collection begins, is also returned. This has the same type
-        as `init_val`.
+    :param bool return_last_val: If `True`, the last value is also returned.
+        This has the same type as `init_val`.
+    :param int collect_size: Size of the returned collection.
     :param `**progbar_opts`: optional additional progress bar arguments. A
         `diagnostics_fn` can be supplied which when passed the current value
         from `body_fun` returns a string that is used to update the progress
@@ -186,46 +186,36 @@ def fori_collect(lower, upper, body_fun, init_val, transform=identity,
         collected along the leading axis of `np.ndarray` objects.
     """
     assert lower <= upper
+    collect_size = upper - lower if collect_size is None else collect_size
+    assert collect_size >= upper - lower
     init_val_flat, unravel_fn = ravel_pytree(transform(init_val))
-    ravel_fn = lambda x: ravel_pytree(transform(x))[0]  # noqa: E731
 
+    @cached_by(fori_collect, body_fun, transform)
+    def _body_fn(i, vals):
+        val, collection, lower_idx = vals
+        val = body_fun(val)
+        i = np.where(i >= lower_idx, i - lower_idx, 0)
+        collection = ops.index_update(collection, i, ravel_pytree(transform(val))[0])
+        return val, collection, lower_idx
+
+    collection = np.zeros((collect_size,) + init_val_flat.shape)
     if not progbar:
-        collection = np.zeros((upper - lower,) + init_val_flat.shape)
-
-        @cached_by(fori_collect, body_fun, transform)
-        def _body_fn(i, vals):
-            val, collection, start_state, lower_idx = vals
-            val = body_fun(val)
-            start_state = lax.cond(i < lower_idx,
-                                   val, lambda x: x,
-                                   start_state, lambda x: x)
-            i = np.where(i >= lower_idx, i - lower_idx, 0)
-            collection = ops.index_update(collection, i, ravel_pytree(transform(val))[0])
-            return val, collection, start_state, lower_idx
-
-        _, collection, start_state, _ = fori_loop(0, upper, _body_fn, (init_val, collection, init_val, lower))
+        last_val, collection, _ = fori_loop(0, upper, _body_fn, (init_val, collection, lower))
     else:
         diagnostics_fn = progbar_opts.pop('diagnostics_fn', None)
         progbar_desc = progbar_opts.pop('progbar_desc', lambda x: '')
-        collection = []
 
-        val, start_state = init_val, init_val
         with tqdm.trange(upper) as t:
+            vals = (init_val, collection, device_put(lower))
             for i in t:
-                val = jit(body_fun)(val)
-                if i == lower - 1:
-                    start_state = val
-                elif i >= lower:
-                    collection.append(jit(ravel_fn)(val))
+                vals = jit(_body_fn)(i, vals)
                 t.set_description(progbar_desc(i), refresh=False)
                 if diagnostics_fn:
-                    t.set_postfix_str(diagnostics_fn(val), refresh=False)
-
-        collection = np.stack(collection) if len(collection) > 0 else \
-            np.zeros((upper - lower,) + init_val_flat.shape)
+                    t.set_postfix_str(diagnostics_fn(vals[0]), refresh=False)
+            last_val, collection, _ = vals
 
     unravel_collection = vmap(unravel_fn)(collection)
-    return (unravel_collection, start_state) if return_init_state else unravel_collection
+    return (unravel_collection, last_val) if return_last_val else unravel_collection
 
 
 def copy_docs_from(source_class, full_text=False):

--- a/test/test_mcmc.py
+++ b/test/test_mcmc.py
@@ -244,7 +244,7 @@ def test_improper_prior():
     kernel = NUTS(model=model)
     mcmc = MCMC(kernel, num_warmup, num_samples)
     mcmc.warmup(random.PRNGKey(2), data)
-    mcmc.run(random.PRNGKey(2), data, reuse_warmup_state=True)
+    mcmc.run(random.PRNGKey(2), data)
     samples = mcmc.get_samples()
     assert_allclose(np.mean(samples['mean']), true_mean, rtol=0.05)
     assert_allclose(np.mean(samples['std']), true_std, rtol=0.05)
@@ -263,14 +263,14 @@ def test_mcmc_progbar():
     kernel = NUTS(model=model)
     mcmc = MCMC(kernel, num_warmup, num_samples)
     mcmc.warmup(random.PRNGKey(2), data)
-    mcmc.run(random.PRNGKey(3), data, reuse_warmup_state=True)
+    mcmc.run(random.PRNGKey(3), data)
     mcmc1 = MCMC(kernel, num_warmup, num_samples, progress_bar=False)
     mcmc1.run(random.PRNGKey(2), data)
 
     with pytest.raises(AssertionError):
         check_close(mcmc1.get_samples(), mcmc.get_samples(), atol=1e-3, rtol=0.01)
     mcmc1.warmup(random.PRNGKey(2), data)
-    mcmc1.run(random.PRNGKey(3), data, reuse_warmup_state=True)
+    mcmc1.run(random.PRNGKey(3), data)
     check_close(mcmc1.get_samples(), mcmc.get_samples(), atol=1e-3, rtol=0.01)
     check_close(mcmc1._warmup_state, mcmc._warmup_state, atol=1e-3, rtol=0.01)
 
@@ -289,7 +289,7 @@ def test_diverging(kernel_cls, adapt_step_size):
     mcmc = MCMC(kernel, num_warmup, num_samples)
     mcmc.warmup(random.PRNGKey(1), data, extra_fields=['diverging'], collect_warmup=True)
     warmup_divergences = mcmc.get_extra_fields()['diverging'].sum()
-    mcmc.run(random.PRNGKey(2), data, extra_fields=['diverging'], reuse_warmup_state=True)
+    mcmc.run(random.PRNGKey(2), data, extra_fields=['diverging'])
     num_divergences = warmup_divergences + mcmc.get_extra_fields()['diverging'].sum()
     if adapt_step_size:
         assert num_divergences <= num_warmup
@@ -428,7 +428,7 @@ def test_chain_smoke(chain_method, compile_args):
     kernel = NUTS(model)
     mcmc = MCMC(kernel, 2, 5, num_chains=2, chain_method=chain_method, jit_model_args=compile_args)
     mcmc.warmup(random.PRNGKey(0), data)
-    mcmc.run(random.PRNGKey(1), data, reuse_warmup_state=True)
+    mcmc.run(random.PRNGKey(1), data)
 
 
 def test_extra_fields():
@@ -544,8 +544,7 @@ def test_model_with_multiple_exec_paths(jit_args):
     # Run MCMC on zero observations.
     kernel = NUTS(model)
     mcmc = MCMC(kernel, 20, 10, jit_model_args=jit_args)
-    mcmc.warmup(random.PRNGKey(0), a, b=None, z=z)
-    mcmc.run(random.PRNGKey(1), a, b=None, z=z, reuse_warmup_state=True)
+    mcmc.run(random.PRNGKey(1), a, b=None, z=z)
     mcmc.run(random.PRNGKey(2), a=None, b=b, z=z)
     mcmc.run(random.PRNGKey(3), a=a, b=b, z=z)
 
@@ -573,7 +572,7 @@ def test_compile_warmup_run(num_chains, chain_method, progress_bar):
     mcmc._compile(rng_key)
     # no delay after compiling
     mcmc.warmup(rng_key)
-    mcmc.run(mcmc._warmup_state.rng_key, reuse_warmup_state=True)
+    mcmc.run(mcmc._warmup_state.rng_key)
     actual_samples = mcmc.get_samples()["x"]
 
     assert_allclose(actual_samples, expected_samples)

--- a/test/test_mcmc.py
+++ b/test/test_mcmc.py
@@ -242,10 +242,8 @@ def test_improper_prior():
 
     data = dist.Normal(true_mean, true_std).sample(random.PRNGKey(1), (2000,))
     kernel = NUTS(model=model)
-    # num_samples must be >= 1; otherwise we'll get an error
-    mcmc = MCMC(kernel, num_warmup)
-    mcmc.run(random.PRNGKey(2), data)
-    mcmc.num_samples = num_samples
+    mcmc = MCMC(kernel, num_warmup, num_samples)
+    mcmc.warmup(random.PRNGKey(2), data)
     mcmc.run(random.PRNGKey(2), data, reuse_warmup_state=True)
     samples = mcmc.get_samples()
     assert_allclose(np.mean(samples['mean']), true_mean, rtol=0.05)
@@ -263,15 +261,15 @@ def test_mcmc_progbar():
 
     data = dist.Normal(true_mean, true_std).sample(random.PRNGKey(1), (2000,))
     kernel = NUTS(model=model)
-    mcmc = MCMC(kernel, num_warmup)
-    mcmc.run(random.PRNGKey(2), data)
-    mcmc.num_samples = num_samples
+    mcmc = MCMC(kernel, num_warmup, num_samples)
+    mcmc.warmup(random.PRNGKey(2), data)
     mcmc.run(random.PRNGKey(3), data, reuse_warmup_state=True)
     mcmc1 = MCMC(kernel, num_warmup, num_samples, progress_bar=False)
     mcmc1.run(random.PRNGKey(2), data)
 
     with pytest.raises(AssertionError):
         check_close(mcmc1.get_samples(), mcmc.get_samples(), atol=1e-3, rtol=0.01)
+    mcmc1.warmup(random.PRNGKey(2), data)
     mcmc1.run(random.PRNGKey(3), data, reuse_warmup_state=True)
     check_close(mcmc1.get_samples(), mcmc.get_samples(), atol=1e-3, rtol=0.01)
     check_close(mcmc1._warmup_state, mcmc._warmup_state, atol=1e-3, rtol=0.01)

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -21,18 +21,18 @@ def test_fori_collect():
 
 
 @pytest.mark.parametrize('progbar', [False, True])
-def test_fori_collect_return_init(progbar):
+def test_fori_collect_return_last(progbar):
     def f(x):
         x['i'] = x['i'] + 1
         return x
 
     tree, init_state = fori_collect(2, 4, f, {'i': 0},
                                     transform=lambda a: {'i': a['i']},
-                                    return_init_state=True,
+                                    return_last_val=True,
                                     progbar=progbar)
     expected_tree = {'i': np.array([3, 4])}
-    expected_init_state = {'i': np.array(2)}
-    check_eq(init_state, expected_init_state)
+    expected_last_state = {'i': np.array(4)}
+    check_eq(init_state, expected_last_state)
     check_eq(tree, expected_tree)
 
 


### PR DESCRIPTION
This PR
+ adds `_compile` method to separate out compiling time (only useful for benchmark purpose so I made it hidden) 
+ adds `warmup` method to separate out the warmup phase and run phase.
+ groups all logics of `collect_warmup`, `reuse_warmup_state` to set_fori_collect_infos method. This makes the code easier to follow.
+ allow `rng_key` have a batch size for reproducible purpose
+ add `compiling_size` to `fori_collect` for the caching purpose (we need `collection` to have the same size across runs)
+ change return_warmup_state to `return_last_val`, which is more suitable for the standalone `fori_collect`.
+ use the same `body_fn` for progbar=True/False in `fori_collect`. This saves a bit of time when we use the progbar, especially for small models.

### Fixes
+ warmup_state is updated after each run. This is unexpected behavior. Having a separated warmup method solves this.
+ warmup_state is the same across multi-chains. This is solved by moving init_state logic to `run` method.

### Side effect

I only discover that we can do this while writing this comment. :D Users can keep drawing `num_samples` samples from the last state by using the pattern
```python
mcmc._warmup_state = mcmc._last_state  # hack: set warmup_state to be last_state
mcmc.run(..., reuse_warmup_state=True)
```

### TODO:
Add tests to verify that
- [x] caching works for single/multi-chain.
- [x] the result is reproducible for single/multi-chain.