### PR TITLE
resolve overflow issue of poisson sampler

### DIFF
--- a/numpyro/distributions/util.py
+++ b/numpyro/distributions/util.py
@@ -46,6 +46,8 @@ def categorical(key, p, shape=()):
     return _categorical(key, p, shape)
 
 
+# Ref https://github.com/numpy/numpy/blob/8a0858f3903e488495a56b4a6d19bbefabc97dca/
+# numpy/random/src/distributions/distributions.c#L574
 def _poisson_large(val):
     rng_key, lam = val
     slam = np.sqrt(lam)

--- a/numpyro/distributions/util.py
+++ b/numpyro/distributions/util.py
@@ -89,7 +89,8 @@ def _poisson_small(val):
         prod = prod * U
         return rng_key, prod, k + 1
 
-    *_, k = lax.while_loop(lambda val: val[1] > enlam, body_fn, (rng_key, 1., 0.))
+    init = np.where(lam == 0., 0., -1.)
+    *_, k = lax.while_loop(lambda val: val[1] > enlam, body_fn, (rng_key, 1., init))
     return k
 
 

--- a/numpyro/distributions/util.py
+++ b/numpyro/distributions/util.py
@@ -5,9 +5,11 @@ import scipy.special as osp_special
 
 from jax import custom_transforms, defjvp, jit, lax, random, vmap
 from jax.dtypes import canonicalize_dtype
+from jax.lib import xla_bridge
 import jax.numpy as np
 from jax.numpy.lax_numpy import _promote_args_like
 from jax.scipy.linalg import solve_triangular
+from jax.scipy.special import gammaln
 from jax.util import partial
 
 
@@ -44,27 +46,71 @@ def categorical(key, p, shape=()):
     return _categorical(key, p, shape)
 
 
+def _poisson_large(val):
+    rng_key, lam = val
+    slam = np.sqrt(lam)
+    loglam = np.log(lam)
+    b = 0.931 + 2.53 * slam
+    a = -0.059 + 0.02483 * b
+    invalpha = 1.1239 + 1.1328 / (b - 3.4)
+    vr = 0.9277 - 3.6224 / (b - 2)
+
+    def cond_fn(val):
+        _, V, us, k = val
+        cond1 = (us >= 0.07) & (V <= vr)
+        cond2 = (k < 0) | ((us < 0.013) & (V > us))
+        cond3 = ((np.log(V) + np.log(invalpha) - np.log(a / (us * us) + b))
+                 <= (-lam + k * loglam - gammaln(k + 1)))
+        return (~cond1) & (cond2 | (~cond3))
+
+    def body_fn(val):
+        rng_key, *_ = val
+        rng_key, key_U, key_V = random.split(rng_key, 3)
+        U = random.uniform(key_U) - 0.5
+        V = random.uniform(key_V)
+        us = 0.5 - np.abs(U)
+        k = np.floor((2 * a / us + b) * U + lam + 0.43)
+        return rng_key, V, us, k
+
+    *_, k = lax.while_loop(cond_fn, body_fn, (rng_key, 0., 0., -1.))
+    return k
+
+
+def _poisson_small(val):
+    rng_key, lam = val
+    enlam = np.exp(-lam)
+
+    def body_fn(val):
+        rng_key, prod, k = val
+        rng_key, key_U = random.split(rng_key)
+        U = random.uniform(key_U)
+        prod = prod * U
+        return rng_key, prod, k + 1
+
+    *_, k = lax.while_loop(lambda val: val[1] > enlam, body_fn, (rng_key, 1., 0.))
+    return k
+
+
+def _poisson_one(val):
+    return lax.cond(val[1] >= 10, val, _poisson_large, val, _poisson_small)
+
+
 @partial(jit, static_argnums=(2, 3))
 def _poisson(key, rate, shape, dtype):
     # Ref: https://en.wikipedia.org/wiki/Poisson_distribution#Generating_Poisson-distributed_random_variables
     shape = shape or np.shape(rate)
-    L = np.exp(-rate)
-    k = np.zeros(shape, dtype=dtype)
-    p = np.ones(shape)
-
-    def body_fn(val):
-        k, p, rng_key = val
-        k = np.where(p > L, k + 1, k)
-        rng_key, rng_key_u = random.split(rng_key)
-        u = random.uniform(rng_key_u, shape)
-        p = p * u
-        return k, p, rng_key
-
-    k, _, _ = lax.while_loop(lambda val: np.any(val[1] > L), body_fn, (k, p, key))
-    return k - 1
+    rate = lax.convert_element_type(rate, canonicalize_dtype(np.float64))
+    rate = np.broadcast_to(rate, shape)
+    rng_keys = random.split(key, np.size(rate))
+    if xla_bridge.get_backend().platform == 'cpu':
+        k = lax.map(_poisson_one, (rng_keys, np.reshape(rate, -1)))
+    else:
+        k = vmap(_poisson_one)((rng_keys, np.reshape(rate, -1)))
+    k = lax.convert_element_type(k, dtype)
+    return np.reshape(k, shape)
 
 
-def poisson(key, rate, shape, dtype=np.int64):
+def poisson(key, rate, shape=(), dtype=np.int64):
     dtype = canonicalize_dtype(dtype)
     return _poisson(key, rate, shape, dtype)
 

--- a/test/test_distributions_util.py
+++ b/test/test_distributions_util.py
@@ -16,6 +16,7 @@ from numpyro.distributions.util import (
     cumprod,
     cumsum,
     multinomial,
+    poisson,
     vec_to_tril_matrix,
     xlog1py,
     xlogy
@@ -209,6 +210,15 @@ def test_multinomial_stats(p, n):
     n = float(n) if isinstance(n, Number) else np.expand_dims(n.astype(p.dtype), -1)
     p = np.broadcast_to(p, z.shape)
     assert_allclose(z / n, p, atol=0.01)
+
+
+def test_poisson():
+    mu = rate = 1000
+    N = 2 ** 18
+
+    key = random.PRNGKey(64)
+    B = poisson(key, rate=rate, shape=(N,))
+    assert_allclose(B.mean(), mu, rtol=0.001)
 
 
 @pytest.mark.parametrize("shape", [

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -25,6 +25,8 @@ EXAMPLES = [
 @pytest.mark.parametrize('example', EXAMPLES)
 @pytest.mark.filterwarnings("ignore:There are not enough devices:UserWarning")
 def test_cpu(example):
+    if 'hmm' in example and 'XLA_FLAGS' in os.environ:
+        pytest.skip("Issue https://github.com/pyro-ppl/numpyro/issues/498")
     print('Running:\npython examples/{}'.format(example))
     example = example.split()
     filename, args = example[0], example[1:]

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -25,7 +25,7 @@ EXAMPLES = [
 @pytest.mark.parametrize('example', EXAMPLES)
 @pytest.mark.filterwarnings("ignore:There are not enough devices:UserWarning")
 def test_cpu(example):
-    if 'hmm' in example and 'XLA_FLAGS' in os.environ:
+    if 'hmm' in example and 'XLA_FLAGS' not in os.environ:
         pytest.skip("Issue https://github.com/pyro-ppl/numpyro/issues/498")
     print('Running:\npython examples/{}'.format(example))
     example = example.split()

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -25,8 +25,6 @@ EXAMPLES = [
 @pytest.mark.parametrize('example', EXAMPLES)
 @pytest.mark.filterwarnings("ignore:There are not enough devices:UserWarning")
 def test_cpu(example):
-    if 'hmm' in example:
-        pytest.skip("Issue https://github.com/pyro-ppl/numpyro/issues/498")
     print('Running:\npython examples/{}'.format(example))
     example = example.split()
     filename, args = example[0], example[1:]

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -25,7 +25,7 @@ EXAMPLES = [
 @pytest.mark.parametrize('example', EXAMPLES)
 @pytest.mark.filterwarnings("ignore:There are not enough devices:UserWarning")
 def test_cpu(example):
-    if 'hmm' in example and 'XLA_FLAGS' not in os.environ:
+    if 'hmm' in example:
         pytest.skip("Issue https://github.com/pyro-ppl/numpyro/issues/498")
     print('Running:\npython examples/{}'.format(example))
     example = example.split()


### PR DESCRIPTION
Addresses #491. The implementation is based on [numpy](https://github.com/numpy/numpy/blob/master/numpy/random/src/distributions/distributions.c#L574), which is also used in PyTorch. The version in [wikipedia](https://en.wikipedia.org/wiki/Poisson_distribution#Generating_Poisson-distributed_random_variables) works but is slow.

I have tested the performance of using `lax.map` in CPU and `lax.vmap` in GPU. The current setting gives the best performance overall.