### PR TITLE
Update for jax >= 0.1.55

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,3 @@
-jax==0.1.53
-jaxlib==0.1.36
-# TODO: remove when https://github.com/google/jax/issues/1912 is fixed.
-numpy<1.18
+jax>=0.1.57
+jaxlib>=0.1.37
 tqdm

--- a/numpyro/contrib/autoguide/__init__.py
+++ b/numpyro/contrib/autoguide/__init__.py
@@ -27,7 +27,7 @@ from numpyro.distributions.transforms import (
     UnpackTransform,
     biject_to
 )
-from numpyro.distributions.util import cholesky_inverse, sum_rightmost
+from numpyro.distributions.util import cholesky_of_inverse, sum_rightmost
 from numpyro.handlers import seed, substitute
 from numpyro.infer.elbo import ELBO
 from numpyro.infer.util import constrain_fn, find_valid_initial_params, init_to_uniform, log_density, transform_fn
@@ -378,7 +378,7 @@ class AutoLaplaceApproximation(AutoContinuous):
 
         loc = params['{}_loc'.format(self.prefix)]
         precision = hessian(loss_fn)(loc)
-        scale_tril = cholesky_inverse(precision)
+        scale_tril = cholesky_of_inverse(precision)
         if not_jax_tracer(scale_tril):
             if np.any(np.isnan(scale_tril)):
                 warnings.warn("Hessian of log posterior at the MAP point is singular. Posterior"

--- a/numpyro/contrib/distributions/discrete.py
+++ b/numpyro/contrib/distributions/discrete.py
@@ -11,11 +11,11 @@ import numpy as onp
 from jax import device_put, random
 import jax.numpy as np
 from jax.numpy.lax_numpy import _promote_dtypes
-from jax.scipy.special import entr, expit, gammaln
+from jax.scipy.special import entr, expit, gammaln, xlog1py, xlogy
 
 from numpyro.contrib.distributions.distribution import jax_discrete
 from numpyro.distributions import constraints
-from numpyro.distributions.util import binary_cross_entropy_with_logits, xlog1py, xlogy
+from numpyro.distributions.util import binary_cross_entropy_with_logits
 
 
 class bernoulli_gen(jax_discrete):

--- a/numpyro/contrib/distributions/multivariate.py
+++ b/numpyro/contrib/distributions/multivariate.py
@@ -10,14 +10,13 @@ from jax import lax, random
 from jax.nn import softmax
 import jax.numpy as np
 from jax.numpy.lax_numpy import _promote_dtypes
-from jax.scipy.special import digamma, entr, gammaln, logsumexp
+from jax.scipy.special import digamma, entr, gammaln, logsumexp, xlogy
 
 from numpyro.contrib.distributions.discrete import binom
 from numpyro.contrib.distributions.distribution import jax_continuous, jax_discrete, jax_multivariate
 from numpyro.distributions import constraints
 from numpyro.distributions.util import categorical as categorical_rvs
 from numpyro.distributions.util import multinomial as multinomial_rvs
-from numpyro.distributions.util import xlogy
 
 
 def _lnB(alpha):

--- a/numpyro/distributions/continuous.py
+++ b/numpyro/distributions/continuous.py
@@ -33,7 +33,7 @@ from numpyro.distributions import constraints
 from numpyro.distributions.distribution import Distribution, TransformedDistribution
 from numpyro.distributions.transforms import AffineTransform, ExpTransform, InvCholeskyTransform, PowerTransform
 from numpyro.distributions.util import (
-    cholesky_inverse,
+    cholesky_of_inverse,
     cumsum,
     lazy_property,
     matrix_to_tril_vec,
@@ -608,7 +608,7 @@ class MultivariateNormal(Distribution):
             self.scale_tril = np.linalg.cholesky(self.covariance_matrix)
         elif precision_matrix is not None:
             loc, self.precision_matrix = promote_shapes(loc, precision_matrix)
-            self.scale_tril = cholesky_inverse(self.precision_matrix)
+            self.scale_tril = cholesky_of_inverse(self.precision_matrix)
         elif scale_tril is not None:
             loc, self.scale_tril = promote_shapes(loc, scale_tril)
         else:
@@ -638,6 +638,7 @@ class MultivariateNormal(Distribution):
 
     @lazy_property
     def precision_matrix(self):
+        # TODO: use solve_triangular for faster
         scale_tril_inv = np.linalg.inv(self.scale_tril)
         return np.dot(scale_tril_inv.T, scale_tril_inv)
 

--- a/numpyro/distributions/discrete.py
+++ b/numpyro/distributions/discrete.py
@@ -27,7 +27,7 @@ from jax.dtypes import canonicalize_dtype
 from jax.nn import softmax
 import jax.numpy as np
 import jax.random as random
-from jax.scipy.special import expit, gammaln, logsumexp
+from jax.scipy.special import expit, gammaln, logsumexp, xlog1py, xlogy
 
 from numpyro.distributions import constraints
 from numpyro.distributions.distribution import Distribution
@@ -43,8 +43,6 @@ from numpyro.distributions.util import (
     promote_shapes,
     sum_rightmost,
     validate_sample,
-    xlog1py,
-    xlogy
 )
 from numpyro.util import copy_docs_from
 

--- a/numpyro/distributions/discrete.py
+++ b/numpyro/distributions/discrete.py
@@ -22,7 +22,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from jax import lax
+from jax import device_put, lax
 from jax.dtypes import canonicalize_dtype
 from jax.nn import softmax
 import jax.numpy as np
@@ -315,7 +315,7 @@ class Delta(Distribution):
 
     def sample(self, key, sample_shape=()):
         shape = sample_shape + self.batch_shape + self.event_shape
-        return np.broadcast_to(self.value, shape)
+        return np.broadcast_to(device_put(self.value), shape)
 
     @validate_sample
     def log_prob(self, value):

--- a/numpyro/distributions/util.py
+++ b/numpyro/distributions/util.py
@@ -1,12 +1,9 @@
 from functools import update_wrapper
 import math
 
-import scipy.special as osp_special
-
 from jax import custom_transforms, defjvp, jit, lax, random, vmap
 from jax.dtypes import canonicalize_dtype
 import jax.numpy as np
-from jax.numpy.lax_numpy import _promote_args_inexact
 from jax.scipy.linalg import solve_triangular
 from jax.util import partial
 
@@ -105,56 +102,6 @@ def _multinomial(key, p, n, n_max, shape=()):
 def multinomial(key, p, n, shape=()):
     n_max = int(np.max(n))
     return _multinomial(key, p, n, n_max, shape)
-
-
-def _xlogy_jvp_lhs(g, ans, x, y):
-    shape = lax.broadcast_shapes(np.shape(g), np.shape(y))
-    g = np.broadcast_to(g, shape)
-    y = np.broadcast_to(y, shape)
-    g, y = _promote_args_inexact(osp_special.xlogy, g, y)
-    return lax._safe_mul(g, np.log(y))
-
-
-def _xlogy_jvp_rhs(g, ans, x, y):
-    shape = lax.broadcast_shapes(np.shape(g), np.shape(x))
-    g = np.broadcast_to(g, shape)
-    x = np.broadcast_to(x, shape)
-    x, y = _promote_args_inexact(osp_special.xlogy, x, y)
-    return g * lax._safe_mul(x, np.reciprocal(y))
-
-
-@custom_transforms
-def xlogy(x, y):
-    x, y = _promote_args_inexact(osp_special.xlogy, x, y)
-    return lax._safe_mul(x, np.log(y))
-
-
-defjvp(xlogy, _xlogy_jvp_lhs, _xlogy_jvp_rhs)
-
-
-def _xlog1py_jvp_lhs(g, ans, x, y):
-    shape = lax.broadcast_shapes(np.shape(g), np.shape(y))
-    g = np.broadcast_to(g, shape)
-    y = np.broadcast_to(y, shape)
-    g, y = _promote_args_inexact(osp_special.xlog1py, g, y)
-    return lax._safe_mul(g, np.log1p(y))
-
-
-def _xlog1py_jvp_rhs(g, ans, x, y):
-    shape = lax.broadcast_shapes(np.shape(g), np.shape(x))
-    g = np.broadcast_to(g, shape)
-    x = np.broadcast_to(x, shape)
-    x, y = _promote_args_inexact(osp_special.xlog1py, x, y)
-    return g * lax._safe_mul(x, np.reciprocal(1 + y))
-
-
-@custom_transforms
-def xlog1py(x, y):
-    x, y = _promote_args_inexact(osp_special.xlog1py, x, y)
-    return lax._safe_mul(x, np.log1p(y))
-
-
-defjvp(xlog1py, _xlog1py_jvp_lhs, _xlog1py_jvp_rhs)
 
 
 def cholesky_inverse(matrix):

--- a/numpyro/distributions/util.py
+++ b/numpyro/distributions/util.py
@@ -153,10 +153,7 @@ def multinomial(key, p, n, shape=()):
     return _multinomial(key, p, n, n_max, shape)
 
 
-# TODO: rename this function, in PyTorch cholesky_inverse computes the inverse using a cholesky
-# input; here we want to take cholesky of the inverse... (the name here is better but
-# we need to change to avoid confusion)
-def cholesky_inverse(matrix):
+def cholesky_of_inverse(matrix):
     # This formulation only takes the inverse of a triangular matrix
     # which is more numerically stable.
     # Refer to:

--- a/numpyro/distributions/util.py
+++ b/numpyro/distributions/util.py
@@ -6,7 +6,7 @@ import scipy.special as osp_special
 from jax import custom_transforms, defjvp, jit, lax, random, vmap
 from jax.dtypes import canonicalize_dtype
 import jax.numpy as np
-from jax.numpy.lax_numpy import _promote_args_like
+from jax.numpy.lax_numpy import _promote_args_inexact
 from jax.scipy.linalg import solve_triangular
 from jax.util import partial
 
@@ -111,7 +111,7 @@ def _xlogy_jvp_lhs(g, ans, x, y):
     shape = lax.broadcast_shapes(np.shape(g), np.shape(y))
     g = np.broadcast_to(g, shape)
     y = np.broadcast_to(y, shape)
-    g, y = _promote_args_like(osp_special.xlogy, g, y)
+    g, y = _promote_args_inexact(osp_special.xlogy, g, y)
     return lax._safe_mul(g, np.log(y))
 
 
@@ -119,13 +119,13 @@ def _xlogy_jvp_rhs(g, ans, x, y):
     shape = lax.broadcast_shapes(np.shape(g), np.shape(x))
     g = np.broadcast_to(g, shape)
     x = np.broadcast_to(x, shape)
-    x, y = _promote_args_like(osp_special.xlogy, x, y)
+    x, y = _promote_args_inexact(osp_special.xlogy, x, y)
     return g * lax._safe_mul(x, np.reciprocal(y))
 
 
 @custom_transforms
 def xlogy(x, y):
-    x, y = _promote_args_like(osp_special.xlogy, x, y)
+    x, y = _promote_args_inexact(osp_special.xlogy, x, y)
     return lax._safe_mul(x, np.log(y))
 
 
@@ -136,7 +136,7 @@ def _xlog1py_jvp_lhs(g, ans, x, y):
     shape = lax.broadcast_shapes(np.shape(g), np.shape(y))
     g = np.broadcast_to(g, shape)
     y = np.broadcast_to(y, shape)
-    g, y = _promote_args_like(osp_special.xlog1py, g, y)
+    g, y = _promote_args_inexact(osp_special.xlog1py, g, y)
     return lax._safe_mul(g, np.log1p(y))
 
 
@@ -144,13 +144,13 @@ def _xlog1py_jvp_rhs(g, ans, x, y):
     shape = lax.broadcast_shapes(np.shape(g), np.shape(x))
     g = np.broadcast_to(g, shape)
     x = np.broadcast_to(x, shape)
-    x, y = _promote_args_like(osp_special.xlog1py, x, y)
+    x, y = _promote_args_inexact(osp_special.xlog1py, x, y)
     return g * lax._safe_mul(x, np.reciprocal(1 + y))
 
 
 @custom_transforms
 def xlog1py(x, y):
-    x, y = _promote_args_like(osp_special.xlog1py, x, y)
+    x, y = _promote_args_inexact(osp_special.xlog1py, x, y)
     return lax._safe_mul(x, np.log1p(y))
 
 

--- a/numpyro/infer/hmc_util.py
+++ b/numpyro/infer/hmc_util.py
@@ -8,7 +8,7 @@ from jax.scipy.special import expit
 from jax.tree_util import tree_flatten, tree_map, tree_multimap
 
 import numpyro.distributions as dist
-from numpyro.distributions.util import cholesky_inverse, get_dtype
+from numpyro.distributions.util import cholesky_of_inverse, get_dtype
 from numpyro.util import cond, while_loop
 
 AdaptWindow = namedtuple('AdaptWindow', ['start', 'end'])
@@ -158,7 +158,7 @@ def welford_covariance(diagonal=True):
             else:
                 cov = scaled_cov + shrinkage * np.identity(mean.shape[0])
         if np.ndim(cov) == 2:
-            cov_inv_sqrt = cholesky_inverse(cov)
+            cov_inv_sqrt = cholesky_of_inverse(cov)
         else:
             cov_inv_sqrt = np.sqrt(np.reciprocal(cov))
         return cov, cov_inv_sqrt
@@ -372,7 +372,7 @@ def warmup_adapter(num_adapt_steps, find_reasonable_step_size=_identity_step_siz
             mass_matrix_sqrt = inverse_mass_matrix
         else:
             if dense_mass:
-                mass_matrix_sqrt = cholesky_inverse(inverse_mass_matrix)
+                mass_matrix_sqrt = cholesky_of_inverse(inverse_mass_matrix)
             else:
                 mass_matrix_sqrt = np.sqrt(np.reciprocal(inverse_mass_matrix))
 

--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,8 @@ setup(
     author_email='npradhan@uber.com',
     install_requires=[
         # TODO: pin to a specific version for the release (unless JAX's API becomes stable)
-        'jax==0.1.53',
-        'jaxlib==0.1.36',
+        'jax>=0.1.55',
+        'jaxlib>=0.1.36',
         'tqdm',
     ],
     extras_require={

--- a/test/test_distributions_util.py
+++ b/test/test_distributions_util.py
@@ -3,12 +3,10 @@ from numbers import Number
 import numpy as onp
 from numpy.testing import assert_allclose
 import pytest
-import scipy.special as osp_special
 
-from jax import grad, jacobian, jit, lax, random, vmap
+from jax import jacobian, lax, random, vmap
 import jax.numpy as np
-from jax.scipy.special import expit
-from jax.util import partial
+from jax.scipy.special import expit, xlog1py, xlogy
 
 from numpyro.distributions.util import (
     binary_cross_entropy_with_logits,
@@ -17,69 +15,7 @@ from numpyro.distributions.util import (
     cumsum,
     multinomial,
     vec_to_tril_matrix,
-    xlog1py,
-    xlogy
 )
-
-_zeros = partial(lax.full_like, fill_value=0)
-
-
-@pytest.mark.parametrize('x, y', [
-    (np.array([1]), np.array([1, 2, 3])),
-    (np.array([0]), np.array([0, 0])),
-    (np.array([[0.], [0.]]), np.array([1., 2.])),
-])
-@pytest.mark.parametrize('jit_fn', [False, True])
-def test_xlogy(x, y, jit_fn):
-    fn = xlogy if not jit_fn else jit(xlogy)
-    assert_allclose(fn(x, y), osp_special.xlogy(x, y))
-
-
-@pytest.mark.parametrize('x, y, grad1, grad2', [
-    (np.array([1., 1., 1.]), np.array([1., 2., 3.]),
-     np.log(np.array([1, 2, 3])), np.array([1., 0.5, 1./3])),
-    (np.array([1.]), np.array([1., 2., 3.]),
-     np.sum(np.log(np.array([1, 2, 3]))), np.array([1., 0.5, 1./3])),
-    (np.array([1., 2., 3.]), np.array([2.]),
-     np.log(np.array([2., 2., 2.])), np.array([3.])),
-    (np.array([0.]), np.array([0., 0.]),
-     np.array([-float('inf')]), np.array([0., 0.])),
-    (np.array([[0.], [0.]]), np.array([1., 2.]),
-     np.array([[np.log(2.)], [np.log(2.)]]), np.array([0, 0])),
-])
-def test_xlogy_jac(x, y, grad1, grad2):
-    assert_allclose(grad(lambda x, y: np.sum(xlogy(x, y)))(x, y), grad1)
-    assert_allclose(grad(lambda x, y: np.sum(xlogy(x, y)), 1)(x, y), grad2)
-
-
-@pytest.mark.parametrize('x, y', [
-    (np.array([1]), np.array([0, 1, 2])),
-    (np.array([0]), np.array([-1, -1])),
-    (np.array([[0.], [0.]]), np.array([1., 2.])),
-])
-@pytest.mark.parametrize('jit_fn', [False, True])
-def test_xlog1py(x, y, jit_fn):
-    fn = xlog1py if not jit_fn else jit(xlog1py)
-    assert_allclose(fn(x, y), osp_special.xlog1py(x, y))
-
-
-@pytest.mark.parametrize('x, y, grad1, grad2', [
-    (np.array([1., 1., 1.]), np.array([0., 1., 2.]),
-     np.log(np.array([1, 2, 3])), np.array([1., 0.5, 1./3])),
-    (np.array([1., 1., 1.]), np.array([-1., 0., 1.]),
-     np.log(np.array([0, 1, 2])), np.array([float('inf'), 1., 0.5])),
-    (np.array([1.]), np.array([0., 1., 2.]),
-     np.sum(np.log(np.array([1, 2, 3]))), np.array([1., 0.5, 1./3])),
-    (np.array([1., 2., 3.]), np.array([1.]),
-     np.log(np.array([2., 2., 2.])), np.array([3.])),
-    (np.array([0.]), np.array([-1., -1.]),
-     np.array([-float('inf')]), np.array([0., 0.])),
-    (np.array([[0.], [0.]]), np.array([1., 2.]),
-     np.array([[np.log(6.)], [np.log(6.)]]), np.array([0, 0])),
-])
-def test_xlog1py_jac(x, y, grad1, grad2):
-    assert_allclose(grad(lambda x, y: np.sum(xlog1py(x, y)))(x, y), grad1)
-    assert_allclose(grad(lambda x, y: np.sum(xlog1py(x, y)), 1)(x, y), grad2)
 
 
 @pytest.mark.parametrize('x, y', [

--- a/test/test_svi.py
+++ b/test/test_svi.py
@@ -37,8 +37,7 @@ def test_renyi_elbo(alpha):
 
 @pytest.mark.parametrize('elbo', [
     ELBO(),
-    pytest.param(RenyiELBO(num_particles=10),
-                 marks=pytest.mark.xfail(reason="https://github.com/pyro-ppl/numpyro/issues/414"))
+    RenyiELBO(num_particles=10),
 ])
 def test_beta_bernoulli(elbo):
     data = np.array([1.0] * 8 + [0.0] * 2)
@@ -63,7 +62,7 @@ def test_beta_bernoulli(elbo):
         svi_state, _ = svi.update(val, data)
         return svi_state
 
-    svi_state = fori_loop(0, 300, body_fn, svi_state)
+    svi_state = fori_loop(0, 1000, body_fn, svi_state)
     params = svi.get_params(svi_state)
     assert_allclose(params['alpha_q'] / (params['alpha_q'] + params['beta_q']), 0.8, atol=0.05, rtol=0.05)
 


### PR DESCRIPTION
The new version of jax renames `_promote_args_like` to `_promote_args_inexact`, so we need to rename and pump the requirement for master branch.