### PR TITLE
Add deterministic primitive

### DIFF
--- a/numpyro/__init__.py
+++ b/numpyro/__init__.py
@@ -4,7 +4,7 @@
 from numpyro import compat, diagnostics, distributions, handlers, infer, optim
 from numpyro.distributions.distribution import enable_validation, validation_enabled
 import numpyro.patch  # noqa: F401
-from numpyro.primitives import factor, module, param, plate, sample
+from numpyro.primitives import deterministic, factor, module, param, plate, sample
 from numpyro.util import enable_x64, set_host_device_count, set_platform
 from numpyro.version import __version__
 
@@ -14,6 +14,7 @@ set_platform('cpu')
 __all__ = [
     '__version__',
     'compat',
+    'deterministic',
     'diagnostics',
     'distributions',
     'enable_x64',

--- a/numpyro/handlers.py
+++ b/numpyro/handlers.py
@@ -184,7 +184,7 @@ class replay(Messenger):
         super(replay, self).__init__(fn)
 
     def process_message(self, msg):
-        if msg['name'] in self.guide_trace:
+        if msg['name'] in self.guide_trace and msg['type'] in ('sample', 'plate'):
             msg['value'] = self.guide_trace[msg['name']]['value']
 
 
@@ -423,6 +423,8 @@ class substitute(Messenger):
         super(substitute, self).__init__(fn)
 
     def process_message(self, msg):
+        if msg['type'] not in ('sample', 'param'):
+            return
         if self.param_map is not None:
             if msg['name'] in self.param_map:
                 msg['value'] = self.param_map[msg['name']]

--- a/numpyro/infer/elbo.py
+++ b/numpyro/infer/elbo.py
@@ -57,10 +57,8 @@ class ELBO(object):
             seeded_model = seed(model, model_seed)
             seeded_guide = seed(guide, guide_seed)
             guide_log_density, guide_trace = log_density(seeded_guide, args, kwargs, param_map)
-            # NB: we only want to substitute params not available in guide_trace
-            model_param_map = {k: v for k, v in param_map.items() if k not in guide_trace}
             seeded_model = replay(seeded_model, guide_trace)
-            model_log_density, _ = log_density(seeded_model, args, kwargs, model_param_map)
+            model_log_density, _ = log_density(seeded_model, args, kwargs, param_map)
 
             # log p(z) - log q(z)
             elbo = model_log_density - guide_log_density

--- a/numpyro/infer/util.py
+++ b/numpyro/infer/util.py
@@ -345,8 +345,6 @@ def find_valid_initial_params(rng_key, model,
                 else:
                     inv_transforms[k] = transform
                     constrained_values[k] = v['value']
-            elif v['type'] == 'deterministic':
-                constrained_values[k] = v['value']
         params = transform_fn(inv_transforms,
                               {k: v for k, v in constrained_values.items()},
                               invert=True)

--- a/numpyro/infer/util.py
+++ b/numpyro/infer/util.py
@@ -345,6 +345,8 @@ def find_valid_initial_params(rng_key, model,
                 else:
                     inv_transforms[k] = transform
                     constrained_values[k] = v['value']
+            elif v['type'] == 'deterministic':
+                constrained_values[k] = v['value']
         params = transform_fn(inv_transforms,
                               {k: v for k, v in constrained_values.items()},
                               invert=True)

--- a/numpyro/primitives.py
+++ b/numpyro/primitives.py
@@ -75,8 +75,8 @@ def sample(name, fn, obs=None, rng_key=None, sample_shape=()):
         state to `fn`. In those situations, `rng_key` keyword will take no
         effect.
 
-    :param str name: name of the sample site
-    :param fn: Python callable
+    :param str name: name of the sample site.
+    :param fn: a stochastic function that returns a sample.
     :param numpy.ndarray obs: observed value
     :param jax.random.PRNGKey rng_key: an optional random key for `fn`.
     :param sample_shape: Shape of samples to be drawn.
@@ -140,6 +140,31 @@ def param(name, init_value=None, **kwargs):
         'mask': None,
         'scale': None,
         'cond_indep_stack': [],
+    }
+
+    # ...and use apply_stack to send it to the Messengers
+    msg = apply_stack(initial_msg)
+    return msg['value']
+
+
+def deterministic(name, value):
+    """
+    Used to designate deterministic sites in the model. Note that most effect
+    handlers will not operate on deterministic sites (except
+    :function:`~numpyro.handlers.trace`), so deterministic sites should be
+    side-effect free. The use case for deterministic nodes is to record any
+    values in the model execution trace.
+
+    :param str name: name of the deterministic site.
+    :param numpy.ndarray value: deterministic value to record in the trace.
+    """
+    if not _PYRO_STACK:
+        return value
+
+    initial_msg = {
+        'type': 'deterministic',
+        'name': name,
+        'value': value,
     }
 
     # ...and use apply_stack to send it to the Messengers
@@ -233,6 +258,8 @@ class plate(Messenger):
         return tuple(batch_shape)
 
     def process_message(self, msg):
+        if msg['type'] not in ('sample', 'plate'):
+            return
         cond_indep_stack = msg['cond_indep_stack']
         frame = CondIndepStackFrame(self.name, self.dim, self.subsample_size)
         cond_indep_stack.append(frame)

--- a/test/test_handlers.py
+++ b/test/test_handlers.py
@@ -134,6 +134,8 @@ def model_nested_plates_0():
         with numpyro.plate('inner', 5):
             y = numpyro.sample('x', dist.Normal(0., 1.))
             assert y.shape == (5, 10)
+            z = numpyro.deterministic('z', x ** 2)
+            assert z.shape == (10,)
 
 
 def model_nested_plates_1():
@@ -143,6 +145,8 @@ def model_nested_plates_1():
         with numpyro.plate('inner', 5):
             y = numpyro.sample('x', dist.Normal(0., 1.))
             assert y.shape == (10, 5)
+            z = numpyro.deterministic('z', x ** 2)
+            assert z.shape == (10, 1)
 
 
 def model_nested_plates_2():
@@ -154,6 +158,8 @@ def model_nested_plates_2():
     with inner:
         y = numpyro.sample('y', dist.Normal(0., 1.))
         assert y.shape == (5, 1, 1)
+        z = numpyro.deterministic('z', x ** 2)
+        assert z.shape == (10,)
 
     with outer, inner:
         xy = numpyro.sample('xy', dist.Normal(0., 1.), sample_shape=(10,))
@@ -169,6 +175,8 @@ def model_dist_batch_shape():
     with inner:
         y = numpyro.sample('y', dist.Normal(0., np.ones(10)))
         assert y.shape == (5, 1, 10)
+        z = numpyro.deterministic('z', x ** 2)
+        assert z.shape == (10,)
 
     with outer, inner:
         xy = numpyro.sample('xy', dist.Normal(0., np.ones(10)), sample_shape=(10,))
@@ -184,6 +192,8 @@ def model_subsample_1():
     with inner:
         y = numpyro.sample('y', dist.Normal(0., 1.))
         assert y.shape == (5, 1, 1)
+        z = numpyro.deterministic('z', x ** 2)
+        assert z.shape == (10,)
 
     with outer, inner:
         xy = numpyro.sample('xy', dist.Normal(0., 1.))
@@ -200,6 +210,7 @@ def model_subsample_1():
 def test_plate(model):
     trace = handlers.trace(handlers.seed(model, random.PRNGKey(1))).get_trace()
     jit_trace = handlers.trace(jit(handlers.seed(model, random.PRNGKey(1)))).get_trace()
+    assert 'z' in trace
     for name, site in trace.items():
         if site['type'] == 'sample':
             assert_allclose(jit_trace[name]['value'], site['value'])

--- a/test/test_infer_util.py
+++ b/test/test_infer_util.py
@@ -37,8 +37,10 @@ def beta_bernoulli():
     data = dist.Bernoulli(true_probs).sample(random.PRNGKey(0), (N,))
 
     def model(data=None):
-        beta = numpyro.sample("beta", dist.Beta(np.ones(2), np.ones(2)))
+        with numpyro.plate("dim", 2):
+            beta = numpyro.sample("beta", dist.Beta(1., 1.))
         with numpyro.plate("plate", N, dim=-2):
+            numpyro.deterministic("beta_sq", beta ** 2)
             numpyro.sample("obs", dist.Bernoulli(beta), obs=data)
 
     return model, data, true_probs
@@ -52,12 +54,13 @@ def test_predictive(parallel):
     samples = mcmc.get_samples()
     predictive = Predictive(model, samples, parallel=parallel)
     predictive_samples = predictive(random.PRNGKey(1))
-    assert predictive_samples.keys() == {"obs"}
+    assert predictive_samples.keys() == {"beta_sq", "obs"}
 
-    predictive.return_sites = ["beta", "obs"]
+    predictive.return_sites = ["beta", "beta_sq", "obs"]
     predictive_samples = predictive(random.PRNGKey(1))
     # check shapes
     assert predictive_samples["beta"].shape == (100,) + true_probs.shape
+    assert predictive_samples["beta_sq"].shape == (100,) + true_probs.shape
     assert predictive_samples["obs"].shape == (100,) + data.shape
     # check sample mean
     assert_allclose(predictive_samples["obs"].reshape((-1,) + true_probs.shape).mean(0), true_probs, rtol=0.1)
@@ -69,6 +72,7 @@ def test_predictive_with_guide():
     def model(data):
         f = numpyro.sample("beta", dist.Beta(1., 1.))
         with numpyro.plate("plate", 10):
+            numpyro.deterministic("beta_sq", f ** 2)
             numpyro.sample("obs", dist.Bernoulli(f), obs=data)
 
     def guide(data):
@@ -87,8 +91,9 @@ def test_predictive_with_guide():
 
     svi_state = lax.fori_loop(0, 1000, body_fn, svi_state)
     params = svi.get_params(svi_state)
-    predictive = Predictive(model, guide=guide, params=params, num_samples=1000)
-    obs_pred = predictive(random.PRNGKey(2), data=None)["obs"]
+    predictive = Predictive(model, guide=guide, params=params, num_samples=1000)(random.PRNGKey(2), data=None)
+    assert predictive["beta_sq"].shape == (1000,)
+    obs_pred = predictive["obs"]
     assert_allclose(np.mean(obs_pred), 0.8, atol=0.05)
 
 

--- a/test/test_infer_util.py
+++ b/test/test_infer_util.py
@@ -117,7 +117,7 @@ def test_predictive_with_improper():
 def test_prior_predictive():
     model, data, true_probs = beta_bernoulli()
     predictive_samples = Predictive(model, num_samples=100)(random.PRNGKey(1))
-    assert predictive_samples.keys() == {"beta", "obs"}
+    assert predictive_samples.keys() == {"beta", "beta_sq", "obs"}
 
     # check shapes
     assert predictive_samples["beta"].shape == (100,) + true_probs.shape

--- a/test/test_mcmc.py
+++ b/test/test_mcmc.py
@@ -90,8 +90,9 @@ def test_logistic_regression_x64(kernel_cls):
         kernel = kernel_cls(model=model, trajectory_length=8)
     mcmc = MCMC(kernel, warmup_steps, num_samples, progress_bar=False)
     mcmc.run(random.PRNGKey(2), labels)
-    mcmc.print_summary()
-    samples = Predictive(model, mcmc.get_samples(), return_sites=['coefs', 'logits'])(random.PRNGKey(1), labels)
+    # Commenting since this is slow with deterministic sites present
+    # mcmc.print_summary()
+    samples = mcmc.get_samples()
     assert samples['logits'].shape == (num_samples, N)
     assert_allclose(np.mean(samples['coefs'], 0), true_coefs, atol=0.22)
 

--- a/test/test_mcmc.py
+++ b/test/test_mcmc.py
@@ -18,7 +18,7 @@ import numpyro.distributions as dist
 from numpyro.distributions import constraints
 from numpyro.infer import HMC, MCMC, NUTS, SA
 from numpyro.infer.mcmc import hmc, _get_proposal_loc_and_scale, _numpy_delete
-from numpyro.infer.util import initialize_model, Predictive
+from numpyro.infer.util import initialize_model
 from numpyro.util import fori_collect
 
 


### PR DESCRIPTION
Fixes #462. 

This adds a new primitive site type called `deterministic` which has the benefit that it will be neglected by most effect handlers except `trace`, so deterministic sites won't broadcast under `plate` and it will be cheaper to include these in the model.

Note that this makes a design decision so that the values for deterministic sites are only accessible via `Predictive`. An alternative (and what I had in an earlier commit) would store deterministic nodes as HMC is run and was directly available via `mcmc.get_samples`. However, for some reason there were some serious perf issues with NUTS and SA (I think compilation takes a really long time even though these nodes are shouldn't have any operation recorded by the tracer, but I didn't investigate in detail). The current version has no performance issue, but has a downside that users need to call `Predictive` to access deterministic nodes in the model and these sites are not printed in model summary. If these seem like big cons, we can modify `get_samples` to use `Predictive` if a model has deterministic nodes, but I would like to go with this simpler solution first.

