### PR TITLE
Minor follow up issues with numpyro.deterministic

### DIFF
--- a/numpyro/infer/mcmc.py
+++ b/numpyro/infer/mcmc.py
@@ -1255,7 +1255,7 @@ class MCMC(object):
     def print_summary(self, prob=0.9, exclude_deterministic=True):
         # Exclude deterministic sites by default
         sites = self._states['z']
-        if exclude_deterministic:
+        if isinstance(sites, dict) and exclude_deterministic:
             sites = {k: v for k, v in self._states['z'].items() if k in self._last_state.z}
         print_summary(sites, prob=prob)
         extra_fields = self.get_extra_fields()

--- a/test/test_mcmc.py
+++ b/test/test_mcmc.py
@@ -90,8 +90,7 @@ def test_logistic_regression_x64(kernel_cls):
         kernel = kernel_cls(model=model, trajectory_length=8)
     mcmc = MCMC(kernel, warmup_steps, num_samples, progress_bar=False)
     mcmc.run(random.PRNGKey(2), labels)
-    # Commenting since this is slow with deterministic sites present
-    # mcmc.print_summary()
+    mcmc.print_summary()
     samples = mcmc.get_samples()
     assert samples['logits'].shape == (num_samples, N)
     assert_allclose(np.mean(samples['coefs'], 0), true_coefs, atol=0.22)


### PR DESCRIPTION
 - exclude `deterministic` sites from `print_summary`.
 - change `constrain_fn` to `postprocess_fn` in `mcmc` since the function is effectively postprocessing unconstrained samples and returning deterministic sites.
 - change `infer.util.constrain_fn` to not return deterministic sites by default so that we can avoid checks / bugs in other parts of the codebase that uses this.