### PR TITLE
fix a bug of block_masked_dense

### DIFF
--- a/numpyro/contrib/nn/block_neural_arn.py
+++ b/numpyro/contrib/nn/block_neural_arn.py
@@ -61,7 +61,7 @@ def BlockMaskedDense(num_blocks, in_factor, out_factor, bias=True, W_init=glorot
         w = np.exp(W) * mask_d + W * mask_o
 
         # Compute norm of each column (i.e. each output features)
-        w_norm = np.linalg.norm(w ** 2, axis=-2, keepdims=True)
+        w_norm = np.linalg.norm(w, axis=-2, keepdims=True)
 
         # Normalize weight and rescale
         w = np.exp(ws) * w / w_norm


### PR DESCRIPTION
This issue is detected while I try to debug why posterior in unwrapped space is not normal in https://github.com/pyro-ppl/pyro/pull/2294.