### PR TITLE
relax jax and jaxlib version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,8 +34,8 @@ setup(
     author_email='npradhan@uber.com',
     install_requires=[
         # TODO: pin to a specific version for the release (until JAX's API becomes stable)
-        'jax==0.1.57',
-        'jaxlib==0.1.37',
+        'jax>=0.1.57',
+        'jaxlib>=0.1.37',
         'tqdm',
     ],
     extras_require={


### PR DESCRIPTION
I am going to wrap NumPyro distribution in Funsor, which requires the master version of JAX (particularly [this PR](https://github.com/google/jax/pull/2039)) to fix some shape issues. This PR relaxes the version restriction for development.