### PR TITLE
BTRS algorithm for sampling from binomial distribution

### DIFF
--- a/numpyro/distributions/util.py
+++ b/numpyro/distributions/util.py
@@ -76,7 +76,7 @@ def _binomial_btrs(key, p, n):
     def _btrs_cond_fn(val):
         def accept_fn(k, u, v):
             # See acceptance condition in Step 3. (Page 3) of TRS algorithm
-            # log(v) <= log(f(k)) + log(g_grad(u)) - log(alpha)
+            # v <= f(k) * g_grad(u) / alpha
 
             m = tr_params.m
             log_p = tr_params.log_p
@@ -85,8 +85,8 @@ def _binomial_btrs(key, p, n):
             log_f = (n + 1.) * np.log((n - m + 1.) / (n - k + 1.)) + \
                     (k + 0.5) * (np.log((n - k + 1.) / (k + 1.)) + log_p - log1_p) + \
                     (stirling_approx_tail(k) - stirling_approx_tail(n - k)) + tr_params.log_h
-            log_g = np.log((tr_params.a / (0.5 - np.abs(u)) ** 2) + tr_params.b)
-            return np.log(v) <= log_f + log_g - np.log(tr_params.alpha)
+            g = (tr_params.a / (0.5 - np.abs(u)) ** 2) + tr_params.b
+            return np.log((v * tr_params.alpha) / g) <= log_f
 
         k, key, u, v = val
         early_accept = (np.abs(u) <= tr_params.u_r) & (v <= tr_params.v_r)

--- a/numpyro/distributions/util.py
+++ b/numpyro/distributions/util.py
@@ -124,8 +124,6 @@ def _binomial_inversion(key, p, n):
 
 def _binomial_dispatch(key, p, n):
     def dispatch(key, p, n):
-        eps = 1e-6
-        p = np.clip(p, a_min=eps, a_max=1 - eps)
         is_le_mid = p <= 0.5
         pq = np.where(is_le_mid, p, 1 - p)
         mu = n * pq

--- a/numpyro/distributions/util.py
+++ b/numpyro/distributions/util.py
@@ -92,7 +92,7 @@ def _binomial_btrs(key, p, n):
 
     tr_params = _get_tr_params(n, p)
     ret = lax.while_loop(_btrs_cond_fn, _btrs_body_fn,
-                         (-1, key, 1., 1.))  # use k=-1 so that cond_fn returns False
+                         (-1, key, 1., 1.))  # use k=-1 initially so that cond_fn returns True
     return ret[0]
 
 

--- a/numpyro/distributions/util.py
+++ b/numpyro/distributions/util.py
@@ -4,7 +4,7 @@ from collections import namedtuple
 from functools import update_wrapper
 import math
 
-from jax import custom_transforms, defjvp, jit, lax, random, vmap, tree_map
+from jax import custom_transforms, defjvp, jit, lax, random, vmap
 from jax.dtypes import canonicalize_dtype
 from jax.lib import xla_bridge
 import jax.numpy as np

--- a/numpyro/distributions/util.py
+++ b/numpyro/distributions/util.py
@@ -107,7 +107,7 @@ def _binomial_inversion(key, p, n):
 
     def _binom_inv_cond_fn(val):
         i, _, geom_acc = val
-        return geom_acc < n
+        return geom_acc <= n
 
     log1_p = np.log1p(-p)
     ret = lax.while_loop(_binom_inv_cond_fn, _binom_inv_body_fn,

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -567,7 +567,7 @@ def test_log_prob_gradient(jax_dist, sp_dist, params):
             # grad w.r.t. `value` of Delta distribution will be 0
             # but numerical value will give nan (= inf - inf)
             expected_grad = 0.
-        assert_allclose(np.sum(actual_grad), expected_grad, rtol=0.01, atol=1e-3)
+        assert_allclose(np.sum(actual_grad), expected_grad, rtol=0.01, atol=0.01)
 
 
 @pytest.mark.parametrize('jax_dist, sp_dist, params', CONTINUOUS + DISCRETE)

--- a/test/test_distributions_util.py
+++ b/test/test_distributions_util.py
@@ -196,8 +196,8 @@ def test_cholesky_update(chol_batch_shape, vec_batch_shape, dim, coef):
 
 
 @pytest.mark.parametrize("n", [10, 100, 1000])
-@pytest.mark.parametrize("p", [0., 0.01, 0.05, 0.3, 0.7, 0.95, 1.])
+@pytest.mark.parametrize("p", [0., 0.01, 0.05, 0.3, 0.5, 0.7, 0.95, 1.])
 def test_binomial_mean(n, p):
-    samples = binomial(random.PRNGKey(1), p, n, shape=(100, 1000))
+    samples = binomial(random.PRNGKey(1), p, n, shape=(100, 100))
     expected_mean = n * p
     assert_allclose(np.mean(samples), expected_mean, rtol=0.05)

--- a/test/test_distributions_util.py
+++ b/test/test_distributions_util.py
@@ -20,7 +20,7 @@ from numpyro.distributions.util import (
     multinomial,
     poisson,
     vec_to_tril_matrix,
-)
+    binomial)
 
 
 @pytest.mark.parametrize('x, y', [
@@ -193,3 +193,11 @@ def test_cholesky_update(chol_batch_shape, vec_batch_shape, dim, coef):
     expected = np.linalg.cholesky(A + coef * xxt)
     actual = cholesky_update(np.linalg.cholesky(A), x, coef)
     assert_allclose(actual, expected, atol=1e-4, rtol=1e-4)
+
+
+@pytest.mark.parametrize("n", [10, 100, 1000])
+@pytest.mark.parametrize("p", [0., 0.01, 0.05, 0.3, 0.7, 0.95, 1.])
+def test_binomial_mean(n, p):
+    samples = binomial(random.PRNGKey(1), p, n, shape=(100, 1000))
+    expected_mean = n * p
+    assert_allclose(np.mean(samples), expected_mean, rtol=0.05)


### PR DESCRIPTION
This adds a BTRS sampler for the binomial distribution which is much faster for large `n` and orders of magnitude more memory efficient than our naive sampler. This should be pretty close to the implementation in https://github.com/pytorch/pytorch/pull/31278, and the reference [paper](https://core.ac.uk/download/pdf/11007254.pdf).

`binomial(random.PRNGKey(0), 0.5, 1000, (1000, 1000))` takes 250 ms as compares to over 8 seconds earlier and consumes far less memory. Additionally, the inversion algorithm (used when `np <= 10.`) is also quite fast and comparable to our existing implementation.