### PR TITLE
some fixes for mvn

### DIFF
--- a/numpyro/distributions/continuous.py
+++ b/numpyro/distributions/continuous.py
@@ -553,6 +553,11 @@ class LogNormal(TransformedDistribution):
 
 
 def _batch_mahalanobis(bL, bx):
+    if bL.shape[:-1] == bx.shape:
+        # no need to use the below optimization procedure
+        solve_bL_bx = solve_triangular(bL, bx[..., None], lower=True).squeeze(-1)
+        return np.sum(np.square(solve_bL_bx), -1)
+
     # NB: The following procedure handles the case: bL.shape = (i, 1, n, n), bx.shape = (i, j, n)
     # because we don't want to broadcast bL to the shape (i, j, n, n).
 

--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -12,8 +12,7 @@ import tqdm
 
 import jax
 from jax import device_put, jit, lax, ops, vmap
-from jax.interpreters.batching import BatchTracer
-from jax.interpreters.partial_eval import JaxprTracer
+from jax.core import Tracer
 from jax.dtypes import canonicalize_dtype
 import jax.numpy as np
 from jax.tree_util import tree_flatten, tree_map, tree_unflatten
@@ -138,7 +137,7 @@ def not_jax_tracer(x):
     """
     Checks if `x` is not an array generated inside `jit`, `pmap`, `vmap`, or `lax_control_flow`.
     """
-    return not isinstance(x, (JaxprTracer, BatchTracer))
+    return not isinstance(x, Tracer)
 
 
 def identity(x):

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -124,6 +124,7 @@ CONTINUOUS = [
     T(dist.LogNormal, np.array([0.5, -0.7]), np.array([[0.1, 0.4], [0.5, 0.1]])),
     T(dist.MultivariateNormal, 0., np.array([[1., 0.5], [0.5, 1.]]), None, None),
     T(dist.MultivariateNormal, np.array([1., 3.]), None, np.array([[1., 0.5], [0.5, 1.]]), None),
+    T(dist.MultivariateNormal, np.array([1., 3.]), None, np.array([[[1., 0.5], [0.5, 1.]]]), None),
     T(dist.MultivariateNormal, np.array([2.]), None, None, np.array([[1., 0.], [0.5, 1.]])),
     T(dist.MultivariateNormal, np.arange(6, dtype=np.float32).reshape((3, 2)), None, None,
       np.array([[1., 0.], [0., 1.]])),
@@ -287,6 +288,9 @@ def test_dist_shape(jax_dist, sp_dist, params, prepend_shape):
         sp_dist = sp_dist(*params)
         sp_samples = sp_dist.rvs(size=prepend_shape + jax_dist.batch_shape)
         assert np.shape(sp_samples) == expected_shape
+    if isinstance(jax_dist, dist.MultivariateNormal):
+        assert jax_dist.covariance_matrix.ndim == len(jax_dist.batch_shape) + 2
+        assert_allclose(jax_dist.precision_matrix, np.linalg.inv(jax_dist.covariance_matrix), rtol=1e-6)
 
 
 @pytest.mark.parametrize('batch_shape', [(), (4,), (3, 2)])


### PR DESCRIPTION
Those bugs are exercised in funsor GaussianHMM:
+ `foo.T` is a permutation of `foo` over all axes.
+ `np.dot(x, y)` appends dimensions of x and y, not broadcasting.

I also add enhancement for `not_jax_tracer` utility. Both JaxprTracer, BatchTracer are subclasses of [jax.core.Tracer](https://github.com/google/jax/blob/master/jax/core.py#L325).