### PR TITLE
Add forecast module

### DIFF
--- a/docs/source/forecast.rst
+++ b/docs/source/forecast.rst
@@ -1,0 +1,23 @@
+Forecasting
+===========
+
+.. automodule:: numpyro.contrib.forecast
+
+Forecaster Interface
+---------------------
+.. automodule:: numpyro.contrib.forecast.forecaster
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :member-order: bysource
+
+Models
+------
+
+Evaluation
+----------
+.. automodule:: numpyro.contrib.forecast.evaluate
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :member-order: bysource

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -32,6 +32,7 @@ NumPyro documentation
    optimizers
    diagnostics
    utilities
+   forecast
 
 
 Indices and tables

--- a/numpyro/contrib/forecast/__init__.py
+++ b/numpyro/contrib/forecast/__init__.py
@@ -1,0 +1,12 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+from .evaluate import eval_crps, eval_mae, eval_rmse
+from .forecaster import Forecaster
+
+__all__ = [
+    "Forecaster",
+    "eval_crps",
+    "eval_mae",
+    "eval_rmse",
+]

--- a/numpyro/contrib/forecast/evaluate.py
+++ b/numpyro/contrib/forecast/evaluate.py
@@ -1,0 +1,48 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+
+
+def eval_mae(pred, truth):
+    """
+    Evaluate mean absolute error, using sample median as point estimate.
+
+    :param np.ndarray pred: Forecasted samples.
+    :param np.ndarray truth: Ground truth.
+    :rtype: float
+    """
+    pred = np.median(pred, 0)
+    return np.mean(np.abs(pred - truth)).item()
+
+
+def eval_rmse(pred, truth):
+    """
+    Evaluate root mean squared error, using sample mean as point estimate.
+
+    :param np.ndarray pred: Forecasted samples.
+    :param np.ndarray truth: Ground truth.
+    :rtype: float
+    """
+    pred = np.mean(pred, 0)
+    return np.sqrt(np.mean(np.square(pred - truth))).item()
+
+
+def eval_crps(pred, truth):
+    """
+    Evaluate continuous ranked probability score, averaged over all data
+    elements.
+
+    :param np.ndarray pred: Forecasted samples.
+    :param np.ndarray truth: Ground truth.
+    :rtype: float
+    """
+    # ref: https://github.com/pyro-ppl/pyro/pull/2045
+    num_samples = pred.shape[0]
+    pred = np.sort(pred, axis=0)
+    diff = pred[1:] - pred[:-1]
+    weight = np.arange(1, num_samples) * np.arange(num_samples - 1, 0, -1)
+    weight = weight.reshape(weight.shape + (1,) * truth.ndim)
+    crps_empirical = np.mean(np.abs(pred - truth), 0) \
+        - (diff * weight).sum(axis=0) / num_samples ** 2
+    return np.mean(crps_empirical).item()

--- a/numpyro/contrib/forecast/forecaster.py
+++ b/numpyro/contrib/forecast/forecaster.py
@@ -1,0 +1,46 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+
+from jax import random
+
+import numpyro
+from numpyro.infer import MCMC, NUTS, Predictive
+
+
+class Forecaster:
+    """
+    Forecaster for univariate time series models. These models should take
+    two arguments: `data` and `covariates`.
+
+    On initialization, this will run MCMC to get posterior samples of the model.
+
+    After construction, this can be called to generate sample forecasts.
+
+    :param callable model: A forecasting model.
+    :param data: A 1D time series data.
+    :param covariates: An array of covariates with time dimension -2. For models not
+        using covariates, pass a shaped empty array ``np.empty((duration, 0))``.
+    :param int num_warmup: number of MCMC warmup steps.
+    :param int num_samples: number of MCMC samples.
+    :param int num_chains: number of parallel MCMC chains.
+    :param int seed: initial random seed.
+    """
+    def __init__(self, model, data, covariates=None, *,
+                 num_warmup=2500, num_samples=2500, num_chains=1, seed=0):
+        self.model = model
+        covariates = np.empty((data.shape[0], 0)) if covariates is None else covariates
+        key_mcmc, self.rng_key = random.split(random.PRNGKey(seed))
+        if num_chains > 1:
+            numpyro.set_host_device_count(num_chains)
+        mcmc = MCMC(NUTS(model), num_warmup, num_samples, num_chains)
+        mcmc.run(key_mcmc, data, covariates)
+        mcmc.print_summary()
+        self._samples = mcmc.get_samples()
+
+    def __call__(self, data, covariates):
+        key_forecast, self.rng_key = random.split(self.rng_key)
+        samples = self._samples  # XXX: should we resample?
+        forecast = Predictive(self.model, samples)(key_forecast, data, covariates)["y"]
+        return forecast.copy()

--- a/numpyro/infer/mcmc.py
+++ b/numpyro/infer/mcmc.py
@@ -250,8 +250,8 @@ def hmc(potential_fn=None, potential_fn_gen=None, kinetic_fn=None, algo='NUTS'):
                                             adapt_step_size=adapt_step_size,
                                             adapt_mass_matrix=adapt_mass_matrix,
                                             dense_mass=dense_mass,
-                                            target_accept_prob=target_accept_prob,
-                                            find_reasonable_step_size=find_reasonable_ss)
+                                            target_accept_prob=target_accept_prob)
+                                            # find_reasonable_step_size=find_reasonable_ss)
 
         rng_key_hmc, rng_key_wa, rng_key_momentum = random.split(rng_key, 3)
         wa_state = wa_init(z, rng_key_wa, step_size,


### PR DESCRIPTION
Follow up #544. But instead of using [global trend models](https://cran.r-project.org/web/packages/Rlgt/vignettes/GT_models.html) (we have a license issue with those models), this implements the more basic (and popular) [ets](https://otexts.com/fpp3/taxonomy.html) models, where the predictions are composed of 4 terms:
+ error: either additive (y = y_hat + eps) or multiplicative (y = y_hat + eps * y_hat)). To simplify the notions, we will incorporate an idea from global trend models: use the error term `eps * y_hat^alpha` with `alpha \in [0, 1]`. Probably we will put some informative priors at two endpoints 0 and 1.
+ trend: either none, additive, or damped additive. We'll only use damped additive here because both `none` and `additive` are special cases of it (i.e. damp_coef = 0 or 1 respectively).
+ season: either none, multiplicative or additive. I can't find a good way to merge these cases together so it is better to have an arg to distinguish them.
+ a regressor term: either multiplicative or additive. This is useful to incorporate some covariates such as holiday events (which can be encoded using one-hot encoding). We will use a linear regression here for simplicity, but it can be more complicated (e.g. the winning solution ES-RNN of M4 competition uses an RNN - stead of a regressor - multiplicative term here).

### Tasks
- [ ] add exponential smoothing models
- [ ] the multiplicative error is not useful for non-strictly positive time series (eps * y_hat ^ alpha will be 0). Find a workaround here...
- [ ] add backtest function
- [ ] add smoke tests to make sure that we can run mcmc with all options and with time series having `0` entries.