### PR TITLE
Remove find_reasonable_step_size

### DIFF
--- a/numpyro/infer/hmc_util.py
+++ b/numpyro/infer/hmc_util.py
@@ -328,7 +328,7 @@ def _identity_step_size(inverse_mass_matrix, z, rng_key, step_size):
     return step_size
 
 
-def warmup_adapter(num_adapt_steps, find_reasonable_step_size=_identity_step_size,
+def warmup_adapter(num_adapt_steps, find_reasonable_step_size=None,
                    adapt_step_size=True, adapt_mass_matrix=True,
                    dense_mass=False, target_accept_prob=0.8):
     """
@@ -349,6 +349,8 @@ def warmup_adapter(num_adapt_steps, find_reasonable_step_size=_identity_step_siz
         step size, hence the sampling will be slower but more robust. Default to 0.8.
     :return: a pair of (`init_fn`, `update_fn`).
     """
+    if find_reasonable_step_size is None:
+        find_reasonable_step_size = _identity_step_size
     ss_init, ss_update = dual_averaging()
     mm_init, mm_update, mm_final = welford_covariance(diagonal=not dense_mass)
     adaptation_schedule = np.array(build_adaptation_schedule(num_adapt_steps))

--- a/numpyro/infer/mcmc.py
+++ b/numpyro/infer/mcmc.py
@@ -27,7 +27,6 @@ from numpyro.infer.hmc_util import (
     IntegratorState,
     build_tree,
     euclidean_kinetic_energy,
-    find_reasonable_step_size,
     velocity_verlet,
     warmup_adapter
 )
@@ -243,15 +242,11 @@ def hmc(potential_fn=None, potential_fn_gen=None, kinetic_fn=None, algo='NUTS'):
                 kwargs = {} if model_kwargs is None else model_kwargs
                 pe_fn = potential_fn_gen(*model_args, **kwargs)
 
-        find_reasonable_ss = partial(find_reasonable_step_size,
-                                     pe_fn, kinetic_fn, momentum_generator)
-
         wa_init, wa_update = warmup_adapter(num_warmup,
                                             adapt_step_size=adapt_step_size,
                                             adapt_mass_matrix=adapt_mass_matrix,
                                             dense_mass=dense_mass,
-                                            target_accept_prob=target_accept_prob,
-                                            find_reasonable_step_size=find_reasonable_ss)
+                                            target_accept_prob=target_accept_prob)
 
         rng_key_hmc, rng_key_wa, rng_key_momentum = random.split(rng_key, 3)
         wa_state = wa_init(z, rng_key_wa, step_size,

--- a/numpyro/infer/mcmc.py
+++ b/numpyro/infer/mcmc.py
@@ -222,8 +222,8 @@ def hmc(potential_fn=None, potential_fn_gen=None, kinetic_fn=None, algo='NUTS'):
             value is :math:`2\\pi`.
         :param int max_tree_depth: Max depth of the binary tree created during the doubling
             scheme of NUTS sampler. Defaults to 10.
-        :param bool find_heuristic_step_size: whether to use an extra heuristic
-            mechanism to adapt step size. Defaults to False.
+        :param bool find_heuristic_step_size: whether to a heuristic function to adjust the
+            step size at the beginning of each adaptation window. Defaults to False.
         :param tuple model_args: Model arguments if `potential_fn_gen` is specified.
         :param dict model_kwargs: Model keyword arguments if `potential_fn_gen` is specified.
         :param jax.random.PRNGKey rng_key: random key to be used as the source of
@@ -444,8 +444,8 @@ class HMC(MCMCKernel):
         value is :math:`2\\pi`.
     :param callable init_strategy: a per-site initialization function.
         See :ref:`init_strategy` section for available functions.
-    :param bool find_heuristic_step_size: whether to use an extra heuristic
-        mechanism to adapt step size. Defaults to False.
+    :param bool find_heuristic_step_size: whether to a heuristic function to adjust the
+        step size at the beginning of each adaptation window. Defaults to False.
     """
     def __init__(self,
                  model=None,
@@ -612,8 +612,8 @@ class NUTS(HMC):
         scheme of NUTS sampler. Defaults to 10.
     :param callable init_strategy: a per-site initialization function.
         See :ref:`init_strategy` section for available functions.
-    :param bool find_heuristic_step_size: whether to use an extra heuristic
-        mechanism to adapt step size. Defaults to False.
+    :param bool find_heuristic_step_size: whether to a heuristic function to adjust the
+        step size at the beginning of each adaptation window. Defaults to False.
     """
     def __init__(self,
                  model=None,

--- a/test/test_mcmc.py
+++ b/test/test_mcmc.py
@@ -87,7 +87,7 @@ def test_logistic_regression_x64(kernel_cls):
     if kernel_cls is SA:
         kernel = SA(model=model, adapt_state_size=9)
     else:
-        kernel = kernel_cls(model=model, trajectory_length=8)
+        kernel = kernel_cls(model=model, trajectory_length=8, find_heuristic_step_size=True)
     mcmc = MCMC(kernel, warmup_steps, num_samples, progress_bar=False)
     mcmc.run(random.PRNGKey(2), labels)
     mcmc.print_summary()


### PR DESCRIPTION
Addresses #543. This PR drops the usage of `find_reasonable_step_size` in `hmc`.

### Reason

In HMC/NUTS, we only compile potential_fn and its grad 1 time: at leap_frog step. However, in find_reasonable_step_size, we compile potential_fn 2 times (to get initial potential energy and in the while-loop to find reasonable step_size) and its grad 1 time (in the while-loop to find reasonable step_size). Those together require JAX to compile a computational graph which is 2.5x larger than if we drop `find_reasonable_step_size`. It is known that JAX compiling time is superlinear w.r.t. its computational graph, so if the model is slow to compile, our MCMC will take a very long time for its initial step. Some evidence:
+ As @jhmenke observed in #543, removing this functionality reduces compiling time from 3m to 11s.
+ In our early development, we observed the slowness and introduced `heuristic_step_size` flag at hmc_init (see https://github.com/pyro-ppl/numpyro/pull/127). But we removed it at 0.2 release to clean up the interface, and the compiling time is acceptable for models we tested.
+ `hmm` example: 39s -> 28s elapsed time
+ `ode` example: 20s compiling -> 10s compiling

With this change, the compiling time of `sample_kernel` will be aligned with the compiling time of `value_and_grad(potential_fn)`.

### Effect

I used the following code to test the effect of removing this feature. Surprisingly, it seems that dual_averaging can do a pretty good job to remedy it
```python
from numpyro.infer.hmc_util import dual_averaging
import jax.numpy as np

ss_init, ss_update = dual_averaging()

ss_state = ss_init()
for i in range(10):
    accept_prob = 0.4  # 0.4, 0.6, 0.9
    ss_state = ss_update(0.8 - accept_prob, ss_state)
    print("current ss", np.exp(ss_state[0]), "    \taverage ss", np.exp(ss_state[1]))
```
With `accept_prob = 0.4`, we get
```
current ss 0.48322508     	average ss 0.48322508
current ss 0.15173525     	average ss 0.24267578
current ss 0.04085883     	average ss 0.111069076
current ss 0.010343172     	average ss 0.047984514
current ss 0.0025725756     	average ss 0.020001529
current ss 0.0006435767     	average ss 0.008161279
current ss 0.00016403742     	average ss 0.0032920958
current ss 4.290037e-05     	average ss 0.0013218971
current ss 1.1554674e-05     	average ss 0.0005309463
current ss 3.2104135e-06     	average ss 0.0002140629
```
we can see that if things are bad, step_size will drop pretty fast. On the other hand `accept_prob = 1`, we get
```
current ss 1.438551     	average ss 1.438551
current ss 2.5671825     	average ss 2.0299568
current ss 4.947172     	average ss 3.0005677
current ss 9.832708     	average ss 4.565091
current ss 19.71587     	average ss 7.0707974
current ss 39.418476     	average ss 11.069319
current ss 78.07797     	average ss 17.42865
current ss 152.67555     	average ss 27.504337
current ss 294.18542     	average ss 43.3985
current ss 558.1096     	average ss 68.34855
```
which shows that step_size (and its average) will be increased quickly if things look good. The length of the last window in warmup_adapter is 50, so `step_size` has the whole room to adjust in this interval. So I believe that inference results won't change if we remove this functionality.

As an example, running `hmm`, I don't observe differences in the inference result.