### PR TITLE
add enumerate_support method for discrete distributions

### DIFF
--- a/numpyro/distributions/conjugate.py
+++ b/numpyro/distributions/conjugate.py
@@ -10,6 +10,7 @@ from numpyro.distributions.continuous import Beta, Gamma
 from numpyro.distributions.discrete import Binomial, Poisson
 from numpyro.distributions.distribution import Distribution
 from numpyro.distributions.util import promote_shapes, validate_sample
+from numpyro.util import not_jax_tracer
 
 
 class BetaBinomial(Distribution):
@@ -62,6 +63,15 @@ class BetaBinomial(Distribution):
     @property
     def support(self):
         return constraints.integer_interval(0, self.total_count)
+
+    def enumerate_support(self):
+        total_count = np.amax(self.total_count)
+        if not_jax_tracer(total_count):
+            # NB: the error can't be raised if inhomogeneous issue happens when tracing
+            if np.amin(self.total_count) != total_count:
+                raise NotImplementedError("Inhomogeneous total count not supported"
+                                          " by `enumerate_support`.")
+        return np.arange(total_count + 1)
 
 
 class GammaPoisson(Distribution):

--- a/numpyro/distributions/conjugate.py
+++ b/numpyro/distributions/conjugate.py
@@ -66,14 +66,17 @@ class BetaBinomial(Distribution):
     def support(self):
         return constraints.integer_interval(0, self.total_count)
 
-    def enumerate_support(self):
+    def enumerate_support(self, expand=False):
         total_count = np.amax(self.total_count)
         if not_jax_tracer(total_count):
             # NB: the error can't be raised if inhomogeneous issue happens when tracing
             if np.amin(self.total_count) != total_count:
                 raise NotImplementedError("Inhomogeneous total count not supported"
                                           " by `enumerate_support`.")
-        return np.arange(total_count + 1)
+        values = np.arange(total_count + 1).reshape((-1,) + (1,) * len(self.batch_shape))
+        if expand:
+            values = np.broadcast_to(values, values.shape[:1] + self.batch_shape)
+        return values
 
 
 class GammaPoisson(Distribution):

--- a/numpyro/distributions/conjugate.py
+++ b/numpyro/distributions/conjugate.py
@@ -28,6 +28,8 @@ class BetaBinomial(Distribution):
     """
     arg_constraints = {'concentration1': constraints.positive, 'concentration0': constraints.positive,
                        'total_count': constraints.nonnegative_integer}
+    has_enumerate_support = True
+    is_discrete = True
 
     def __init__(self, concentration1, concentration0, total_count=1, validate_args=None):
         batch_shape = lax.broadcast_shapes(np.shape(concentration1), np.shape(concentration0),
@@ -86,6 +88,7 @@ class GammaPoisson(Distribution):
     """
     arg_constraints = {'concentration': constraints.positive, 'rate': constraints.positive}
     support = constraints.nonnegative_integer
+    is_discrete = True
 
     def __init__(self, concentration, rate=1., validate_args=None):
         self._gamma = Gamma(concentration, rate)

--- a/numpyro/distributions/discrete.py
+++ b/numpyro/distributions/discrete.py
@@ -95,8 +95,11 @@ class BernoulliProbs(Distribution):
     def variance(self):
         return self.probs * (1 - self.probs)
 
-    def enumerate_support(self):
-        return np.arange(2)
+    def enumerate_support(self, expand=False):
+        values = np.arange(2).reshape((-1,) + (1,) * len(self.batch_shape))
+        if expand:
+            values = np.broadcast_to(values, values.shape[:1] + self.batch_shape)
+        return values
 
 
 @copy_docs_from(Distribution)
@@ -129,8 +132,11 @@ class BernoulliLogits(Distribution):
     def variance(self):
         return self.probs * (1 - self.probs)
 
-    def enumerate_support(self):
-        return np.arange(2)
+    def enumerate_support(self, expand=False):
+        values = np.arange(2).reshape((-1,) + (1,) * len(self.batch_shape))
+        if expand:
+            values = np.broadcast_to(values, values.shape[:1] + self.batch_shape)
+        return values
 
 
 def Bernoulli(probs=None, logits=None, validate_args=None):
@@ -177,14 +183,17 @@ class BinomialProbs(Distribution):
     def support(self):
         return constraints.integer_interval(0, self.total_count)
 
-    def enumerate_support(self):
+    def enumerate_support(self, expand=False):
         total_count = np.amax(self.total_count)
         if not_jax_tracer(total_count):
             # NB: the error can't be raised if inhomogeneous issue happens when tracing
             if np.amin(self.total_count) != total_count:
                 raise NotImplementedError("Inhomogeneous total count not supported"
                                           " by `enumerate_support`.")
-        return np.arange(total_count + 1)
+        values = np.arange(total_count + 1).reshape((-1,) + (1,) * len(self.batch_shape))
+        if expand:
+            values = np.broadcast_to(values, values.shape[:1] + self.batch_shape)
+        return values
 
 
 @copy_docs_from(Distribution)
@@ -228,13 +237,17 @@ class BinomialLogits(Distribution):
     def support(self):
         return constraints.integer_interval(0, self.total_count)
 
-    def enumerate_support(self):
+    def enumerate_support(self, expand=False):
         total_count = np.amax(self.total_count)
         if not_jax_tracer(total_count):
+            # NB: the error can't be raised if inhomogeneous issue happens when tracing
             if np.amin(self.total_count) != total_count:
                 raise NotImplementedError("Inhomogeneous total count not supported"
                                           " by `enumerate_support`.")
-        return np.arange(total_count + 1)
+        values = np.arange(total_count + 1).reshape((-1,) + (1,) * len(self.batch_shape))
+        if expand:
+            values = np.broadcast_to(values, values.shape[:1] + self.batch_shape)
+        return values
 
 
 def Binomial(total_count=1, probs=None, logits=None, validate_args=None):
@@ -283,8 +296,11 @@ class CategoricalProbs(Distribution):
     def support(self):
         return constraints.integer_interval(0, np.shape(self.probs)[-1])
 
-    def enumerate_support(self):
-        return np.arange(self.probs.shape[-1])
+    def enumerate_support(self, expand=False):
+        values = np.arange(self.probs.shape[-1]).reshape((-1,) + (1,) * len(self.batch_shape))
+        if expand:
+            values = np.broadcast_to(values, values.shape[:1] + self.batch_shape)
+        return values
 
 
 @copy_docs_from(Distribution)
@@ -328,8 +344,11 @@ class CategoricalLogits(Distribution):
     def support(self):
         return constraints.integer_interval(0, np.shape(self.logits)[-1])
 
-    def enumerate_support(self):
-        return np.arange(self.logits.shape[-1])
+    def enumerate_support(self, expand=False):
+        values = np.arange(self.probs.shape[-1]).reshape((-1,) + (1,) * len(self.batch_shape))
+        if expand:
+            values = np.broadcast_to(values, values.shape[:1] + self.batch_shape)
+        return values
 
 
 def Categorical(probs=None, logits=None, validate_args=None):

--- a/numpyro/distributions/discrete.py
+++ b/numpyro/distributions/discrete.py
@@ -73,6 +73,8 @@ def _to_logits_multinom(probs):
 class BernoulliProbs(Distribution):
     arg_constraints = {'probs': constraints.unit_interval}
     support = constraints.boolean
+    has_enumerate_support = True
+    is_discrete = True
 
     def __init__(self, probs, validate_args=None):
         self.probs = probs
@@ -101,6 +103,8 @@ class BernoulliProbs(Distribution):
 class BernoulliLogits(Distribution):
     arg_constraints = {'logits': constraints.real}
     support = constraints.boolean
+    has_enumerate_support = True
+    is_discrete = True
 
     def __init__(self, logits=None, validate_args=None):
         self.logits = logits
@@ -142,6 +146,8 @@ def Bernoulli(probs=None, logits=None, validate_args=None):
 class BinomialProbs(Distribution):
     arg_constraints = {'total_count': constraints.nonnegative_integer,
                        'probs': constraints.unit_interval}
+    has_enumerate_support = True
+    is_discrete = True
 
     def __init__(self, probs, total_count=1, validate_args=None):
         self.probs, self.total_count = promote_shapes(probs, total_count)
@@ -185,6 +191,8 @@ class BinomialProbs(Distribution):
 class BinomialLogits(Distribution):
     arg_constraints = {'total_count': constraints.nonnegative_integer,
                        'logits': constraints.real}
+    has_enumerate_support = True
+    is_discrete = True
 
     def __init__(self, logits, total_count=1, validate_args=None):
         self.logits, self.total_count = promote_shapes(logits, total_count)
@@ -242,6 +250,7 @@ def Binomial(total_count=1, probs=None, logits=None, validate_args=None):
 class CategoricalProbs(Distribution):
     arg_constraints = {'probs': constraints.simplex}
     has_enumerate_support = True
+    is_discrete = True
 
     def __init__(self, probs, validate_args=None):
         if np.ndim(probs) < 1:
@@ -281,6 +290,8 @@ class CategoricalProbs(Distribution):
 @copy_docs_from(Distribution)
 class CategoricalLogits(Distribution):
     arg_constraints = {'logits': constraints.real}
+    has_enumerate_support = True
+    is_discrete = True
 
     def __init__(self, logits, validate_args=None):
         if np.ndim(logits) < 1:
@@ -334,6 +345,7 @@ def Categorical(probs=None, logits=None, validate_args=None):
 class Delta(Distribution):
     arg_constraints = {'value': constraints.real, 'log_density': constraints.real}
     support = constraints.real
+    is_discrete = True
 
     def __init__(self, value=0., log_density=0., event_ndim=0, validate_args=None):
         if event_ndim > np.ndim(value):
@@ -399,6 +411,8 @@ class PRNGIdentity(Distribution):
     draw a batch of :func:`~jax.random.PRNGKey` using the :class:`~numpyro.handlers.seed`
     handler. Only `sample` method is supported.
     """
+    is_discrete = True
+
     def __init__(self):
         super(PRNGIdentity, self).__init__(event_shape=(2,))
 
@@ -411,6 +425,7 @@ class PRNGIdentity(Distribution):
 class MultinomialProbs(Distribution):
     arg_constraints = {'total_count': constraints.nonnegative_integer,
                        'probs': constraints.simplex}
+    is_discrete = True
 
     def __init__(self, probs, total_count=1, validate_args=None):
         if np.ndim(probs) < 1:
@@ -449,6 +464,7 @@ class MultinomialProbs(Distribution):
 class MultinomialLogits(Distribution):
     arg_constraints = {'total_count': constraints.nonnegative_integer,
                        'logits': constraints.real}
+    is_discrete = True
 
     def __init__(self, logits, total_count=1, validate_args=None):
         if np.ndim(logits) < 1:
@@ -501,6 +517,7 @@ def Multinomial(total_count=1, probs=None, logits=None, validate_args=None):
 class Poisson(Distribution):
     arg_constraints = {'rate': constraints.positive}
     support = constraints.nonnegative_integer
+    is_discrete = True
 
     def __init__(self, rate, validate_args=None):
         self.rate = rate
@@ -533,6 +550,7 @@ class ZeroInflatedPoisson(Distribution):
     """
     arg_constraints = {'gate': constraints.unit_interval, 'rate': constraints.positive}
     support = constraints.nonnegative_integer
+    is_discrete = True
 
     def __init__(self, gate, rate=1., validate_args=None):
         batch_shape = lax.broadcast_shapes(np.shape(gate), np.shape(rate))

--- a/numpyro/distributions/distribution.py
+++ b/numpyro/distributions/distribution.py
@@ -231,9 +231,10 @@ class Distribution(object):
             reinterpreted_batch_ndims = len(self.batch_shape)
         return Independent(self, reinterpreted_batch_ndims)
 
-    def enumerate_support(self):
+    def enumerate_support(self, expand=False):
         """
-        Returns a 1D array containing all values in the support.
+        Returns an array with shape `len(support) x batch_shape`
+        containing all values in the support.
         """
         raise NotImplementedError
 

--- a/numpyro/distributions/distribution.py
+++ b/numpyro/distributions/distribution.py
@@ -233,7 +233,7 @@ class Distribution(object):
 
     def enumerate_support(self):
         """
-        Returns an array containing all values in the support.
+        Returns a 1D array containing all values in the support.
         """
         raise NotImplementedError
 

--- a/numpyro/distributions/distribution.py
+++ b/numpyro/distributions/distribution.py
@@ -100,6 +100,7 @@ class Distribution(object):
     """
     arg_constraints = {}
     support = None
+    has_enumerate_support = False
     reparametrized_params = []
     _validate_args = False
 
@@ -229,6 +230,12 @@ class Distribution(object):
         if reinterpreted_batch_ndims is None:
             reinterpreted_batch_ndims = len(self.batch_shape)
         return Independent(self, reinterpreted_batch_ndims)
+
+    def enumerate_support(self):
+        """
+        Returns an array containing all values in the support.
+        """
+        raise NotImplementedError
 
 
 class Independent(Distribution):

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -962,3 +962,16 @@ def test_generated_sample_distribution(jax_dist, sp_dist, params,
         our_samples = jax_dist.sample(key, (N_sample,))
         ks_result = osp.kstest(our_samples, sp_dist(*params).cdf)
         assert ks_result.pvalue > 0.05
+
+
+@pytest.mark.parametrize('jax_dist, params, support', [
+    (dist.BernoulliLogits, (5.,), np.arange(2)),
+    (dist.BernoulliProbs, (0.5,), np.arange(2)),
+    (dist.BinomialLogits, (4.5, 10), np.arange(11)),
+    (dist.BinomialProbs, (0.5, 11), np.arange(12)),
+    (dist.BetaBinomial, (2., 0.5, 12), np.arange(13)),
+    (dist.CategoricalLogits, (np.array([3., 4., 5.]),), np.arange(3)),
+    (dist.CategoricalProbs, (np.array([[0.1, 0.5, 0.4]]),), np.arange(3)),
+])
+def test_enumerate_support_smoke(jax_dist, params, support):
+    assert_allclose(jax_dist(*params).enumerate_support(), support)


### PR DESCRIPTION
This is required to support enumeration in #572.

There is an edge case in Binomial under tracing: when `total_count` is not constant, the error will not be raised. Actually, when `total_count` is not constant, we can still consider `arange(0, max(total_count) + 1)` as the support (in the ExtendedBinomial sense - with `validate_args` is True). It is not important though.