### PR TITLE
Port pyro.ops.indexing to a new numpyro.contrib.indexing

### DIFF
--- a/docs/source/utilities.rst
+++ b/docs/source/utilities.rst
@@ -84,3 +84,12 @@ init_to_feasible
 init_to_value
 ^^^^^^^^^^^^^
 .. autofunction:: numpyro.infer.util.init_to_value
+
+Tensor Indexing
+---------------
+
+.. automodule:: numpyro.contrib.indexing
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :member-order: bysource

--- a/numpyro/contrib/indexing.py
+++ b/numpyro/contrib/indexing.py
@@ -5,7 +5,7 @@ import jax.numpy as np
 
 
 def _is_batched(arg):
-    return isinstance(arg, np.ndarray) and len(arg.shape) > 0
+    return np.ndim(arg) > 0
 
 
 def vindex(tensor, args):
@@ -82,23 +82,24 @@ def vindex(tensor, args):
     if not args:
         return tensor
 
+    assert np.ndim(tensor) > 0
     # Compute event dim before and after indexing.
     if args[0] is Ellipsis:
         args = args[1:]
         if not args:
             return tensor
         old_event_dim = len(args)
-        args = (slice(None),) * (len(tensor.shape) - len(args)) + args
+        args = (slice(None),) * (np.ndim(tensor) - len(args)) + args
     else:
-        args = args + (slice(None),) * (len(tensor.shape) - len(args))
+        args = args + (slice(None),) * (np.ndim(tensor) - len(args))
         old_event_dim = len(args)
-    assert len(args) == len(tensor.shape)
+    assert len(args) == np.ndim(tensor)
     if any(a is Ellipsis for a in args):
         raise NotImplementedError("Non-leading Ellipsis is not supported")
 
     # In simple cases, standard advanced indexing broadcasts correctly.
     is_standard = True
-    if len(tensor.shape) > old_event_dim and _is_batched(args[0]):
+    if np.ndim(tensor) > old_event_dim and _is_batched(args[0]):
         is_standard = False
     elif any(_is_batched(a) for a in args[1:]):
         is_standard = False

--- a/numpyro/contrib/indexing.py
+++ b/numpyro/contrib/indexing.py
@@ -1,0 +1,145 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+import jax.numpy as np
+
+
+def _is_batched(arg):
+    return isinstance(arg, np.ndarray) and len(arg.shape) > 0
+
+
+def vindex(tensor, args):
+    """
+    Vectorized advanced indexing with broadcasting semantics.
+
+    See also the convenience wrapper :class:`Vindex`.
+
+    This is useful for writing indexing code that is compatible with batching
+    and enumeration, especially for selecting mixture components with discrete
+    random variables.
+
+    For example suppose ``x`` is a parameter with ``len(x.shape) == 3`` and we wish
+    to generalize the expression ``x[i, :, j]`` from integer ``i,j`` to tensors
+    ``i,j`` with batch dims and enum dims (but no event dims). Then we can
+    write the generalize version using :class:`Vindex` ::
+
+        xij = Vindex(x)[i, :, j]
+
+        batch_shape = broadcast_shape(i.shape, j.shape)
+        event_shape = (x.size(1),)
+        assert xij.shape == batch_shape + event_shape
+
+    To handle the case when ``x`` may also contain batch dimensions (e.g. if
+    ``x`` was sampled in a plated context as when using vectorized particles),
+    :func:`vindex` uses the special convention that ``Ellipsis`` denotes batch
+    dimensions (hence ``...`` can appear only on the left, never in the middle
+    or in the right). Suppose ``x`` has event dim 3. Then we can write::
+
+        old_batch_shape = x.shape[:-3]
+        old_event_shape = x.shape[-3:]
+
+        xij = Vindex(x)[..., i, :, j]   # The ... denotes unknown batch shape.
+
+        new_batch_shape = broadcast_shape(old_batch_shape, i.shape, j.shape)
+        new_event_shape = (x.size(1),)
+        assert xij.shape = new_batch_shape + new_event_shape
+
+    Note that this special handling of ``Ellipsis`` differs from the NEP [1].
+
+    Formally, this function assumes:
+
+    1.  Each arg is either ``Ellipsis``, ``slice(None)``, an integer, or a
+        batched integer tensor (i.e. with empty event shape). This
+        function does not support Nontrivial slices or boolean tensor
+        masks. ``Ellipsis`` can only appear on the left as ``args[0]``.
+    2.  If ``args[0] is not Ellipsis`` then ``tensor`` is not
+        batched, and its event dim is equal to ``len(args)``.
+    3.  If ``args[0] is Ellipsis`` then ``tensor`` is batched and
+        its event dim is equal to ``len(args[1:])``. Dims of ``tensor``
+        to the left of the event dims are considered batch dims and will be
+        broadcasted with dims of tensor args.
+
+    Note that if none of the args is a tensor with ``len(shape) > 0``, then this
+    function behaves like standard indexing::
+
+        if not any(isinstance(a, np.ndarray) and len(a.shape) > 0 for a in args):
+            assert Vindex(x)[args] == x[args]
+
+    **References**
+
+    [1] https://www.numpy.org/neps/nep-0021-advanced-indexing.html
+        introduces ``vindex`` as a helper for vectorized indexing.
+        This implementation is similar to the proposed notation
+        ``x.vindex[]`` except for slightly different handling of ``Ellipsis``.
+
+    :param np.ndarray tensor: A tensor to be indexed.
+    :param tuple args: An index, as args to ``__getitem__``.
+    :returns: A nonstandard interpetation of ``tensor[args]``.
+    :rtype: np.ndarray
+    """
+    if not isinstance(args, tuple):
+        return tensor[args]
+    if not args:
+        return tensor
+
+    # Compute event dim before and after indexing.
+    if args[0] is Ellipsis:
+        args = args[1:]
+        if not args:
+            return tensor
+        old_event_dim = len(args)
+        args = (slice(None),) * (len(tensor.shape) - len(args)) + args
+    else:
+        args = args + (slice(None),) * (len(tensor.shape) - len(args))
+        old_event_dim = len(args)
+    assert len(args) == len(tensor.shape)
+    if any(a is Ellipsis for a in args):
+        raise NotImplementedError("Non-leading Ellipsis is not supported")
+
+    # In simple cases, standard advanced indexing broadcasts correctly.
+    is_standard = True
+    if len(tensor.shape) > old_event_dim and _is_batched(args[0]):
+        is_standard = False
+    elif any(_is_batched(a) for a in args[1:]):
+        is_standard = False
+    if is_standard:
+        return tensor[args]
+
+    # Convert args to use broadcasting semantics.
+    new_event_dim = sum(isinstance(a, slice) for a in args[-old_event_dim:])
+    new_dim = 0
+    args = list(args)
+    for i, arg in reversed(list(enumerate(args))):
+        if isinstance(arg, slice):
+            # Convert slices to arange()s.
+            if arg != slice(None):
+                raise NotImplementedError("Nontrivial slices are not supported")
+            arg = np.arange(tensor.shape[i], dtype=np.int32)
+            arg = arg.reshape((-1,) + (1,) * new_dim)
+            new_dim += 1
+        elif _is_batched(arg):
+            # Reshape nontrivial tensors.
+            arg = arg.reshape(arg.shape + (1,) * new_event_dim)
+        args[i] = arg
+    args = tuple(args)
+
+    return tensor[args]
+
+
+class Vindex:
+    """
+    Convenience wrapper around :func:`vindex`.
+
+    The following are equivalent::
+
+        Vindex(x)[..., i, j, :]
+        vindex(x, (Ellipsis, i, j, slice(None)))
+
+    :param np.ndarray tensor: A tensor to be indexed.
+    :return: An object with a special :meth:`__getitem__` method.
+    """
+    def __init__(self, tensor):
+        self._tensor = tensor
+
+    def __getitem__(self, args):
+        return vindex(self._tensor, args)

--- a/test/contrib/test_indexing.py
+++ b/test/contrib/test_indexing.py
@@ -1,0 +1,138 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+import itertools
+
+import jax.lax as lax
+import jax.numpy as np
+import jax.random as random
+import numpy as onp
+import pytest
+
+import numpyro.distributions as dist
+from numpyro.contrib.indexing import Vindex
+
+
+def z(*shape):
+    return np.zeros(shape, dtype=np.int32)
+
+
+SHAPE_EXAMPLES = [
+    ('Vindex(z())[...]', ()),
+    ('Vindex(z(2))[...]', (2,)),
+    ('Vindex(z(2))[...,0]', ()),
+    ('Vindex(z(2))[...,:]', (2,)),
+    ('Vindex(z(2))[...,z(3)]', (3,)),
+    ('Vindex(z(2))[0]', ()),
+    ('Vindex(z(2))[:]', (2,)),
+    ('Vindex(z(2))[z(3)]', (3,)),
+    ('Vindex(z(2,3))[...]', (2, 3)),
+    ('Vindex(z(2,3))[...,0]', (2,)),
+    ('Vindex(z(2,3))[...,:]', (2, 3)),
+    ('Vindex(z(2,3))[...,z(2)]', (2,)),
+    ('Vindex(z(2,3))[...,z(4,1)]', (4, 2)),
+    ('Vindex(z(2,3))[...,0,0]', ()),
+    ('Vindex(z(2,3))[...,0,:]', (3,)),
+    ('Vindex(z(2,3))[...,0,z(4)]', (4,)),
+    ('Vindex(z(2,3))[...,:,0]', (2,)),
+    ('Vindex(z(2,3))[...,:,:]', (2, 3)),
+    ('Vindex(z(2,3))[...,:,z(4)]', (4, 2)),
+    ('Vindex(z(2,3))[...,z(4),0]', (4,)),
+    ('Vindex(z(2,3))[...,z(4),:]', (4, 3)),
+    ('Vindex(z(2,3))[...,z(4),z(4)]', (4,)),
+    ('Vindex(z(2,3))[...,z(5,1),z(4)]', (5, 4)),
+    ('Vindex(z(2,3))[...,z(4),z(5,1)]', (5, 4)),
+    ('Vindex(z(2,3))[0,0]', ()),
+    ('Vindex(z(2,3))[0,:]', (3,)),
+    ('Vindex(z(2,3))[0,z(4)]', (4,)),
+    ('Vindex(z(2,3))[:,0]', (2,)),
+    ('Vindex(z(2,3))[:,:]', (2, 3)),
+    ('Vindex(z(2,3))[:,z(4)]', (4, 2)),
+    ('Vindex(z(2,3))[z(4),0]', (4,)),
+    ('Vindex(z(2,3))[z(4),:]', (4, 3)),
+    ('Vindex(z(2,3))[z(4)]', (4, 3)),
+    ('Vindex(z(2,3))[z(4),z(4)]', (4,)),
+    ('Vindex(z(2,3))[z(5,1),z(4)]', (5, 4)),
+    ('Vindex(z(2,3))[z(4),z(5,1)]', (5, 4)),
+    ('Vindex(z(2,3,4))[...]', (2, 3, 4)),
+    ('Vindex(z(2,3,4))[...,z(3)]', (2, 3)),
+    ('Vindex(z(2,3,4))[...,z(2,1)]', (2, 3)),
+    ('Vindex(z(2,3,4))[...,z(2,3)]', (2, 3)),
+    ('Vindex(z(2,3,4))[...,z(5,1,1)]', (5, 2, 3)),
+    ('Vindex(z(2,3,4))[...,z(2),0]', (2,)),
+    ('Vindex(z(2,3,4))[...,z(5,1),0]', (5, 2)),
+    ('Vindex(z(2,3,4))[...,z(2),:]', (2, 4)),
+    ('Vindex(z(2,3,4))[...,z(5,1),:]', (5, 2, 4)),
+    ('Vindex(z(2,3,4))[...,z(5),0,0]', (5,)),
+    ('Vindex(z(2,3,4))[...,z(5),0,:]', (5, 4)),
+    ('Vindex(z(2,3,4))[...,z(5),:,0]', (5, 3)),
+    ('Vindex(z(2,3,4))[...,z(5),:,:]', (5, 3, 4)),
+    ('Vindex(z(2,3,4))[0,0,z(5)]', (5,)),
+    ('Vindex(z(2,3,4))[0,:,z(5)]', (5, 3)),
+    ('Vindex(z(2,3,4))[0,z(5),0]', (5,)),
+    ('Vindex(z(2,3,4))[0,z(5),:]', (5, 4)),
+    ('Vindex(z(2,3,4))[0,z(5),z(5)]', (5,)),
+    ('Vindex(z(2,3,4))[0,z(5,1),z(6)]', (5, 6)),
+    ('Vindex(z(2,3,4))[0,z(6),z(5,1)]', (5, 6)),
+    ('Vindex(z(2,3,4))[:,0,z(5)]', (5, 2)),
+    ('Vindex(z(2,3,4))[:,:,z(5)]', (5, 2, 3)),
+    ('Vindex(z(2,3,4))[:,z(5),0]', (5, 2)),
+    ('Vindex(z(2,3,4))[:,z(5),:]', (5, 2, 4)),
+    ('Vindex(z(2,3,4))[:,z(5),z(5)]', (5, 2)),
+    ('Vindex(z(2,3,4))[:,z(5,1),z(6)]', (5, 6, 2)),
+    ('Vindex(z(2,3,4))[:,z(6),z(5,1)]', (5, 6, 2)),
+    ('Vindex(z(2,3,4))[z(5),0,0]', (5,)),
+    ('Vindex(z(2,3,4))[z(5),0,:]', (5, 4)),
+    ('Vindex(z(2,3,4))[z(5),:,0]', (5, 3)),
+    ('Vindex(z(2,3,4))[z(5),:,:]', (5, 3, 4)),
+    ('Vindex(z(2,3,4))[z(5),0,z(5)]', (5,)),
+    ('Vindex(z(2,3,4))[z(5,1),0,z(6)]', (5, 6)),
+    ('Vindex(z(2,3,4))[z(6),0,z(5,1)]', (5, 6)),
+    ('Vindex(z(2,3,4))[z(5),:,z(5)]', (5, 3)),
+    ('Vindex(z(2,3,4))[z(5,1),:,z(6)]', (5, 6, 3)),
+    ('Vindex(z(2,3,4))[z(6),:,z(5,1)]', (5, 6, 3)),
+]
+
+
+@pytest.mark.parametrize('expression,expected_shape', SHAPE_EXAMPLES, ids=str)
+def test_shape(expression, expected_shape):
+    result = eval(expression)
+    assert result.shape == expected_shape
+
+
+@pytest.mark.parametrize('event_shape', [(), (7,)], ids=str)
+@pytest.mark.parametrize('j_shape', [(), (2,), (3, 1), (4, 1, 1), (4, 3, 2)], ids=str)
+@pytest.mark.parametrize('i_shape', [(), (2,), (3, 1), (4, 1, 1), (4, 3, 2)], ids=str)
+@pytest.mark.parametrize('x_shape', [(), (2,), (3, 1), (4, 1, 1), (4, 3, 2)], ids=str)
+def test_value(x_shape, i_shape, j_shape, event_shape):
+    x = np.array(onp.random.rand(*(x_shape + (5, 6) + event_shape)))
+    i = dist.Categorical(np.ones((5,))).sample(random.PRNGKey(1), i_shape)
+    j = dist.Categorical(np.ones((6,))).sample(random.PRNGKey(2), j_shape)
+    if event_shape:
+        actual = Vindex(x)[..., i, j, :]
+    else:
+        actual = Vindex(x)[..., i, j]
+
+    shape = lax.broadcast_shapes(x_shape, i_shape, j_shape)
+    x = np.broadcast_to(x, shape + (5, 6) + event_shape)
+    i = np.broadcast_to(i, shape)
+    j = np.broadcast_to(j, shape)
+    expected = onp.empty(shape + event_shape, dtype=x.dtype)
+    for ind in (itertools.product(*map(range, shape)) if shape else [()]):
+        expected[ind] = x[ind + (i[ind].item(), j[ind].item())]
+    assert np.all(actual == np.array(expected, dtype=x.dtype))
+
+
+@pytest.mark.parametrize('prev_enum_dim,curr_enum_dim', [(-3, -4), (-4, -5), (-5, -3)])
+def test_hmm_example(prev_enum_dim, curr_enum_dim):
+    hidden_dim = 8
+    probs_x = np.array(onp.random.rand(hidden_dim, hidden_dim, hidden_dim))
+    x_prev = np.arange(hidden_dim).reshape((-1,) + (1,) * (-1 - prev_enum_dim))
+    x_curr = np.arange(hidden_dim).reshape((-1,) + (1,) * (-1 - curr_enum_dim))
+
+    expected = probs_x[x_prev.reshape(x_prev.shape + (1,)),
+                       x_curr.reshape(x_curr.shape + (1,)),
+                       np.arange(hidden_dim)]
+
+    actual = Vindex(probs_x)[x_prev, x_curr, :]
+    assert np.all(actual == expected)


### PR DESCRIPTION
This PR ports Pyro's `pyro.ops.indexing` module, an implementation of [NEP 21](https://numpy.org/neps/nep-0021-advanced-indexing.html), to NumPyro as a new `numpyro.contrib.indexing` module.  The `Vindex` utility is extremely useful for working with enumerated models like the ones in #572.

The code and tests from Pyro have been ported almost verbatim.