### PR TITLE
Reduce compiling time in iterative_build_tree

### DIFF
--- a/examples/hmm.py
+++ b/examples/hmm.py
@@ -36,10 +36,10 @@ from scipy.stats import gaussian_kde
 
 from jax import lax, random
 import jax.numpy as np
-from jax.scipy.special import logsumexp
 
 import numpyro
 import numpyro.distributions as dist
+from numpyro.distributions.util import logsumexp
 from numpyro.infer import MCMC, NUTS
 
 

--- a/examples/neutra.py
+++ b/examples/neutra.py
@@ -32,14 +32,9 @@ from numpyro.contrib.autoguide import AutoContinuousELBO, AutoBNAFNormal
 from numpyro.diagnostics import print_summary
 import numpyro.distributions as dist
 from numpyro.distributions import constraints
+from numpyro.distributions.util import logsumexp
 from numpyro.infer import MCMC, NUTS, SVI
 from numpyro.infer.util import initialize_model, transformed_potential_energy
-
-
-def logsumexp(x, axis=0):
-    # TODO: remove when https://github.com/google/jax/pull/2260 merged upstream
-    x_max = lax.stop_gradient(np.max(x, axis=axis, keepdims=True))
-    return np.log(np.sum(np.exp(x - x_max), axis=axis)) + x_max.squeeze(axis=axis)
 
 
 class DualMoonDistribution(dist.Distribution):

--- a/numpyro/distributions/util.py
+++ b/numpyro/distributions/util.py
@@ -415,10 +415,17 @@ def logmatmulexp(x, y):
     """
     Numerically stable version of ``(x.log() @ y.log()).exp()``.
     """
-    x_shift = np.amax(x, -1, keepdims=True)
-    y_shift = np.amax(y, -2, keepdims=True)
+    x_shift = lax.stop_gradient(np.amax(x, -1, keepdims=True))
+    y_shift = lax.stop_gradient(np.amax(y, -2, keepdims=True))
     xy = np.log(np.matmul(np.exp(x - x_shift), np.exp(y - y_shift)))
     return xy + x_shift + y_shift
+
+
+def logsumexp(x, axis=0, keepdims=False):
+    # TODO: remove when https://github.com/google/jax/pull/2260 merged upstream
+    x_max = lax.stop_gradient(np.amax(x, axis=axis, keepdims=True))
+    y = np.log(np.sum(np.exp(x - x_max), axis=axis, keepdims=True)) + x_max
+    return y if keepdims else y.squeeze(axis=axis)
 
 
 def clamp_probs(probs):

--- a/numpyro/infer/hmc_util.py
+++ b/numpyro/infer/hmc_util.py
@@ -630,7 +630,7 @@ def _iterative_build_subtree(prototype_tree, vv_update, kinetic_fn,
                         lambda x: _combine_tree(*x, False))
 
         leaf_idx = current_tree.num_proposals
-        # NB: in the special case leaf_idx=0, ckpt_idx_min=1 and ckpt_idx_max=1,
+        # NB: in the special case leaf_idx=0, ckpt_idx_min=1 and ckpt_idx_max=0,
         # the following logic is still valid for that case
         ckpt_idx_min, ckpt_idx_max = _leaf_idx_to_ckpt_idxs(leaf_idx)
         r, _ = ravel_pytree(new_leaf.r_right)

--- a/numpyro/infer/hmc_util.py
+++ b/numpyro/infer/hmc_util.py
@@ -561,11 +561,9 @@ def _get_leaf(tree, going_right):
 def _double_tree(current_tree, vv_update, kinetic_fn, inverse_mass_matrix, step_size,
                  going_right, rng_key, energy_current, max_delta_energy, r_ckpts, r_sum_ckpts):
     key, transition_key = random.split(rng_key)
-    # If we are going to the right, start from the right leaf of the current tree.
-    z, r, z_grad = _get_leaf(current_tree, going_right)
 
-    new_tree = _iterative_build_subtree(current_tree.depth, vv_update, kinetic_fn,
-                                        z, r, z_grad, inverse_mass_matrix, step_size,
+    new_tree = _iterative_build_subtree(current_tree, vv_update, kinetic_fn,
+                                        inverse_mass_matrix, step_size,
                                         going_right, key, energy_current, max_delta_energy,
                                         r_ckpts, r_sum_ckpts)
 
@@ -609,10 +607,10 @@ def _is_iterative_turning(inverse_mass_matrix, r, r_sum, r_ckpts, r_sum_ckpts, i
     return turning
 
 
-def _iterative_build_subtree(depth, vv_update, kinetic_fn, z, r, z_grad,
+def _iterative_build_subtree(prototype_tree, vv_update, kinetic_fn,
                              inverse_mass_matrix, step_size, going_right, rng_key,
                              energy_current, max_delta_energy, r_ckpts, r_sum_ckpts):
-    max_num_proposals = 2 ** depth
+    max_num_proposals = 2 ** prototype_tree.depth
 
     def _cond_fn(state):
         tree, turning, _, _, _ = state
@@ -621,13 +619,19 @@ def _iterative_build_subtree(depth, vv_update, kinetic_fn, z, r, z_grad,
     def _body_fn(state):
         current_tree, _, r_ckpts, r_sum_ckpts, rng_key = state
         rng_key, transition_rng_key = random.split(rng_key)
+        # If we are going to the right, start from the right leaf of the current tree.
         z, r, z_grad = _get_leaf(current_tree, going_right)
         new_leaf = _build_basetree(vv_update, kinetic_fn, z, r, z_grad, inverse_mass_matrix, step_size,
                                    going_right, energy_current, max_delta_energy)
-        new_tree = _combine_tree(current_tree, new_leaf, inverse_mass_matrix, going_right,
-                                 transition_rng_key, False)
+        new_tree = cond(current_tree.num_proposals == 0,
+                        new_leaf,
+                        lambda x: x,
+                        (current_tree, new_leaf, inverse_mass_matrix, going_right, transition_rng_key),
+                        lambda x: _combine_tree(*x, False))
 
         leaf_idx = current_tree.num_proposals
+        # NB: in the special case leaf_idx=0, ckpt_idx_min=1 and ckpt_idx_max=1,
+        # the following logic is still valid for that case
         ckpt_idx_min, ckpt_idx_max = _leaf_idx_to_ckpt_idxs(leaf_idx)
         r, _ = ravel_pytree(new_leaf.r_right)
         r_sum, _ = ravel_pytree(new_tree.r_sum)
@@ -643,11 +647,7 @@ def _iterative_build_subtree(depth, vv_update, kinetic_fn, z, r, z_grad,
                                         ckpt_idx_min, ckpt_idx_max)
         return new_tree, turning, r_ckpts, r_sum_ckpts, rng_key
 
-    basetree = _build_basetree(vv_update, kinetic_fn, z, r, z_grad, inverse_mass_matrix, step_size,
-                               going_right, energy_current, max_delta_energy)
-    r_init, _ = ravel_pytree(basetree.r_left)
-    r_ckpts = index_update(r_ckpts, 0, r_init)
-    r_sum_ckpts = index_update(r_sum_ckpts, 0, r_init)
+    basetree = prototype_tree._replace(num_proposals=0)
 
     tree, turning, _, _, _ = while_loop(
         _cond_fn,
@@ -658,7 +658,7 @@ def _iterative_build_subtree(depth, vv_update, kinetic_fn, z, r, z_grad,
     return TreeInfo(tree.z_left, tree.r_left, tree.z_left_grad,
                     tree.z_right, tree.r_right, tree.z_right_grad,
                     tree.z_proposal, tree.z_proposal_pe, tree.z_proposal_grad, tree.z_proposal_energy,
-                    depth, tree.weight, tree.r_sum, turning, tree.diverging,
+                    prototype_tree.depth, tree.weight, tree.r_sum, turning, tree.diverging,
                     tree.sum_accept_probs, tree.num_proposals)
 
 

--- a/test/test_hmc_util.py
+++ b/test/test_hmc_util.py
@@ -328,6 +328,7 @@ def test_warmup_adapter(jitted):
 
 
 @pytest.mark.parametrize('leaf_idx, ckpt_idxs', [
+    (0, (1, 0)),
     (6, (3, 2)),
     (7, (0, 2)),
     (13, (2, 2)),


### PR DESCRIPTION
Currently, in `iterative_build_tree`, we compile potential_energy 2 times: one for the first leaf and the other one for the loop. With this PR, we will only compile 1 time.

### Benchmark:

+ time to compile `hmm` example is reduced from 28s to 14s.

### TODO

- [x] There is something wrong for `cond` with `jaxlib >= 0.1.40`. The HMM result is weird.