### PR TITLE
Update jax version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
     # Keep track of pyro-api master branch
     - pip install https://github.com/pyro-ppl/pyro-api/archive/master.zip
     - pip install jaxlib
-    - pip install -e git+https://github.com/google/jax.git@2512ec6ebebf1b26d2aefbe618b4c147c251d194#egg=jax
+    - pip install jax
     - pip install .[examples,test]
     - pip freeze
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-jax>=0.1.63
-jaxlib>=0.1.43
+jax>=0.1.65
+jaxlib>=0.1.45
 tqdm

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-jax>=0.1.57
-jaxlib>=0.1.37
+jax>=0.1.63
+jaxlib>=0.1.43
 tqdm

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     author_email='npradhan@uber.com',
     install_requires=[
         # TODO: pin to a specific version for the release (until JAX's API becomes stable)
-        'jax @ git+https://github.com/google/jax.git@2512ec6ebebf1b26d2aefbe618b4c147c251d194#egg=jax',
+        'jax>=0.1.63',
         'jaxlib>=0.1.43',
         'tqdm',
     ],

--- a/setup.py
+++ b/setup.py
@@ -34,8 +34,8 @@ setup(
     author_email='npradhan@uber.com',
     install_requires=[
         # TODO: pin to a specific version for the release (until JAX's API becomes stable)
-        'jax>=0.1.63',
-        'jaxlib>=0.1.43',
+        'jax>=0.1.65',
+        'jaxlib>=0.1.45',
         'tqdm',
     ],
     extras_require={

--- a/test/contrib/test_nn.py
+++ b/test/contrib/test_nn.py
@@ -23,7 +23,7 @@ from numpyro.distributions.util import matrix_to_tril_vec
 @pytest.mark.parametrize('skip_connections', [True, False])
 def test_auto_reg_nn(input_dim, hidden_dims, param_dims, skip_connections):
     rng_key, rng_key_perm = random.split(random.PRNGKey(0))
-    perm = random.shuffle(rng_key_perm, onp.arange(input_dim))
+    perm = random.permutation(rng_key_perm, onp.arange(input_dim))
     arn_init, arn = AutoregressiveNN(input_dim, hidden_dims, param_dims=param_dims,
                                      skip_connections=skip_connections, permutation=perm)
 

--- a/test/test_flows.py
+++ b/test/test_flows.py
@@ -17,7 +17,7 @@ from numpyro.distributions.util import matrix_to_tril_vec
 
 def _make_iaf_args(input_dim, hidden_dims):
     _, rng_perm = random.split(random.PRNGKey(0))
-    perm = random.shuffle(rng_perm, onp.arange(input_dim))
+    perm = random.permutation(rng_perm, onp.arange(input_dim))
     # we use Elu nonlinearity because the default one, Relu, masks out negative hidden values,
     # which in turn create some zero entries in the lower triangular part of Jacobian.
     arn_init, arn = AutoregressiveNN(input_dim, hidden_dims, param_dims=[1, 1],

--- a/test/test_flows.py
+++ b/test/test_flows.py
@@ -66,7 +66,7 @@ def test_flows(flow_class, flow_args, input_dim, batch_shape):
         if isinstance(transform, InverseAutoregressiveTransform):
             permuted_jac = onp.zeros(jac.shape)
             _, rng_key_perm = random.split(random.PRNGKey(0))
-            perm = random.shuffle(rng_key_perm, onp.arange(input_dim))
+            perm = random.permutation(rng_key_perm, onp.arange(input_dim))
 
             for j in range(input_dim):
                 for k in range(input_dim):


### PR DESCRIPTION
This is also to diagnose the Travis issue at #588.

Currently, min jaxlib version is [0.1.45](https://github.com/google/jax/blob/master/jax/lib/__init__.py#L20).