### PR TITLE
Avoid finding inv_transform in potential_fn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
     # Keep track of pyro-api master branch
     - pip install https://github.com/pyro-ppl/pyro-api/archive/master.zip
     - pip install jaxlib
-    - pip install -e git+https://github.com/google/jax.git@2512ec6ebebf1b26d2aefbe618b4c147c251d194#egg=jax
+    - pip install jax
     - pip install .[examples,test]
     - pip freeze
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-jax>=0.1.63
-jaxlib>=0.1.43
+jax>=0.1.65
+jaxlib>=0.1.45
 tqdm

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-jax>=0.1.57
-jaxlib>=0.1.37
+jax>=0.1.63
+jaxlib>=0.1.43
 tqdm

--- a/numpyro/infer/util.py
+++ b/numpyro/infer/util.py
@@ -426,20 +426,19 @@ def get_potential_fn(rng_key, model, dynamic_args=False, model_args=(), model_kw
         to values that lie within the site's support, and return values at
         `deterministic` sites in the model.
     """
+    inv_transforms, replay_model = get_model_transforms(rng_key, model, model_args, model_kwargs)
+
     if dynamic_args:
         def potential_fn(*args, **kwargs):
-            inv_transforms, replay_model = get_model_transforms(rng_key, model, args, kwargs)
             return jax.partial(potential_energy, model, inv_transforms, args, kwargs)
 
         def postprocess_fn(*args, **kwargs):
-            inv_transforms, replay_model = get_model_transforms(rng_key, model, args, kwargs)
             if replay_model:
                 return jax.partial(constrain_fn, model, inv_transforms, args, kwargs,
                                    return_deterministic=True)
             else:
                 return jax.partial(transform_fn, inv_transforms)
     else:
-        inv_transforms, replay_model = get_model_transforms(rng_key, model, model_args, model_kwargs)
         potential_fn = jax.partial(potential_energy, model, inv_transforms, model_args, model_kwargs)
         if replay_model:
             postprocess_fn = jax.partial(constrain_fn, model, inv_transforms, model_args, model_kwargs,

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     author_email='npradhan@uber.com',
     install_requires=[
         # TODO: pin to a specific version for the release (until JAX's API becomes stable)
-        'jax @ git+https://github.com/google/jax.git@2512ec6ebebf1b26d2aefbe618b4c147c251d194#egg=jax',
+        'jax>=0.1.63',
         'jaxlib>=0.1.43',
         'tqdm',
     ],

--- a/setup.py
+++ b/setup.py
@@ -34,8 +34,8 @@ setup(
     author_email='npradhan@uber.com',
     install_requires=[
         # TODO: pin to a specific version for the release (until JAX's API becomes stable)
-        'jax>=0.1.63',
-        'jaxlib>=0.1.43',
+        'jax>=0.1.65',
+        'jaxlib>=0.1.45',
         'tqdm',
     ],
     extras_require={

--- a/test/test_flows.py
+++ b/test/test_flows.py
@@ -17,7 +17,7 @@ from numpyro.distributions.util import matrix_to_tril_vec
 
 def _make_iaf_args(input_dim, hidden_dims):
     _, rng_perm = random.split(random.PRNGKey(0))
-    perm = random.shuffle(rng_perm, onp.arange(input_dim))
+    perm = random.permutation(rng_perm, onp.arange(input_dim))
     # we use Elu nonlinearity because the default one, Relu, masks out negative hidden values,
     # which in turn create some zero entries in the lower triangular part of Jacobian.
     arn_init, arn = AutoregressiveNN(input_dim, hidden_dims, param_dims=[1, 1],


### PR DESCRIPTION
Addresses the second point of #585.

### Context

Currently, while computing potential_energy, we also get the model's transforms. This is not necessary and can affect the compiling/execution speed if sampling latent sites are slow.

However, in the past, we allow users to provide different args during different `.run(...)`. I guess we need to keep that behavior, so we need to invoke some caching mechanism here.

### Solutions

I guess a good solution is to add a caching mechanism here so that depending `args`, `kwargs`, we decide to update `inv_transforms` or not. However, I am not sure if it will work under `pmap`. Need to investigate though...

A simpler solution is to remove the above behavior ([bayesian regression](http://pyro.ai/numpyro/bayesian_regression.html#Model-3:-Predictor---Marriage-Rate-and-Median-Age-of-Marriage) is a showcase for it). There is no gain in performance to keep that behavior. So I suggest that in MCMCKernel, if `jit_model_args` is True, we use `potential_fn_gen`; otherwise, we use `potential_fn`. WDYT @neerajprad ? I like this solution more than the above caching solution. Although this solution does not address the compiling issue with `jit_model_args` is True, it solves the issue for the most usage case: `jit_model_args=False`.