### PR TITLE
Replace instances of jax.partial with functools.partial.

### DIFF
--- a/numpyro/infer/svi.py
+++ b/numpyro/infer/svi.py
@@ -1,7 +1,7 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
-from functools import namedtuple
+from functools import namedtuple, partial
 
 import jax
 from jax import random, value_and_grad
@@ -67,7 +67,7 @@ class SVI(object):
                 inv_transforms[site['name']] = transform
                 params[site['name']] = transform.inv(site['value'])
 
-        self.constrain_fn = jax.partial(transform_fn, inv_transforms)
+        self.constrain_fn = partial(transform_fn, inv_transforms)
         return SVIState(self.optim.init(params), rng_key)
 
     def get_params(self, svi_state):

--- a/numpyro/infer/svi.py
+++ b/numpyro/infer/svi.py
@@ -3,7 +3,6 @@
 
 from functools import namedtuple, partial
 
-import jax
 from jax import random, value_and_grad
 
 from numpyro.distributions import constraints

--- a/numpyro/infer/util.py
+++ b/numpyro/infer/util.py
@@ -315,7 +315,7 @@ def find_valid_initial_params(rng_key, model,
     :param dict model_kwargs: kwargs provided to the model.
     :return: tuple of (`init_params`, `is_valid`).
     """
-    init_strategy = jax.partial(init_strategy, skip_param=not param_as_improper)
+    init_strategy = partial(init_strategy, skip_param=not param_as_improper)
 
     def cond_fn(state):
         i, _, _, is_valid = state
@@ -351,7 +351,7 @@ def find_valid_initial_params(rng_key, model,
         params = transform_fn(inv_transforms,
                               {k: v for k, v in constrained_values.items()},
                               invert=True)
-        potential_fn = jax.partial(potential_energy, model, inv_transforms, model_args, model_kwargs)
+        potential_fn = partial(potential_energy, model, inv_transforms, model_args, model_kwargs)
         pe, param_grads = value_and_grad(potential_fn)(params)
         z_grad = ravel_pytree(param_grads)[0]
         is_valid = np.isfinite(pe) & np.all(np.isfinite(z_grad))
@@ -429,23 +429,23 @@ def get_potential_fn(rng_key, model, dynamic_args=False, model_args=(), model_kw
     if dynamic_args:
         def potential_fn(*args, **kwargs):
             inv_transforms, replay_model = get_model_transforms(rng_key, model, args, kwargs)
-            return jax.partial(potential_energy, model, inv_transforms, args, kwargs)
+            return partial(potential_energy, model, inv_transforms, args, kwargs)
 
         def postprocess_fn(*args, **kwargs):
             inv_transforms, replay_model = get_model_transforms(rng_key, model, args, kwargs)
             if replay_model:
-                return jax.partial(constrain_fn, model, inv_transforms, args, kwargs,
-                                   return_deterministic=True)
+                return partial(constrain_fn, model, inv_transforms, args, kwargs,
+                               return_deterministic=True)
             else:
-                return jax.partial(transform_fn, inv_transforms)
+                return partial(transform_fn, inv_transforms)
     else:
         inv_transforms, replay_model = get_model_transforms(rng_key, model, model_args, model_kwargs)
-        potential_fn = jax.partial(potential_energy, model, inv_transforms, model_args, model_kwargs)
+        potential_fn = partial(potential_energy, model, inv_transforms, model_args, model_kwargs)
         if replay_model:
-            postprocess_fn = jax.partial(constrain_fn, model, inv_transforms, model_args, model_kwargs,
-                                         return_deterministic=True)
+            postprocess_fn = partial(constrain_fn, model, inv_transforms, model_args, model_kwargs,
+                                     return_deterministic=True)
         else:
-            postprocess_fn = jax.partial(transform_fn, inv_transforms)
+            postprocess_fn = partial(transform_fn, inv_transforms)
 
     return potential_fn, postprocess_fn
 

--- a/numpyro/primitives.py
+++ b/numpyro/primitives.py
@@ -4,7 +4,6 @@
 from collections import namedtuple
 import functools
 
-import jax
 from jax import lax
 
 import numpyro

--- a/numpyro/primitives.py
+++ b/numpyro/primitives.py
@@ -199,7 +199,7 @@ def module(name, nn, input_shape=None):
         rng_key = numpyro.sample(name + '$rng_key', PRNGIdentity())
         _, nn_params = nn_init(rng_key, input_shape)
         param(module_key, nn_params)
-    return jax.partial(nn_apply, nn_params)
+    return functools.partial(nn_apply, nn_params)
 
 
 class plate(Messenger):


### PR DESCRIPTION
`jax.partial` doesn't add anything useful over `functools.partial`, so there's no value to JAX exporting it from its API. It's better to use the standard Python library function instead.