### PR TITLE
fix numerical issues of Dirichlet distribution

### DIFF
--- a/numpyro/distributions/continuous.py
+++ b/numpyro/distributions/continuous.py
@@ -126,7 +126,8 @@ class Dirichlet(Distribution):
     def sample(self, key, sample_shape=()):
         shape = sample_shape + self.batch_shape + self.event_shape
         gamma_samples = random.gamma(key, self.concentration, shape=shape)
-        return gamma_samples / np.sum(gamma_samples, axis=-1, keepdims=True)
+        samples = gamma_samples / np.sum(gamma_samples, axis=-1, keepdims=True)
+        return np.clip(samples, a_min=np.finfo(samples).tiny, a_max=1 - np.finfo(samples).eps)
 
     @validate_sample
     def log_prob(self, value):

--- a/numpyro/distributions/discrete.py
+++ b/numpyro/distributions/discrete.py
@@ -482,7 +482,7 @@ class MultinomialProbs(Distribution):
 @copy_docs_from(Distribution)
 class MultinomialLogits(Distribution):
     arg_constraints = {'total_count': constraints.nonnegative_integer,
-                       'logits': constraints.real}
+                       'logits': constraints.real_vector}
     is_discrete = True
 
     def __init__(self, logits, total_count=1, validate_args=None):


### PR DESCRIPTION
This PR clamps Dirichlet samples by `(tiny, 1-eps)`. In PyTorch, Dirichlet samples are strictly in (0, 1) but in NumPyro, there are some cases the values are in [0, 1] (when some gamma samples are very small). This causes some failing tests in funsor with JAX backend.

I also fix a small issue regarding the constraint of `Multinomial.logits`.