### PR TITLE
Add reparam handler

### DIFF
--- a/docs/source/primitives.rst
+++ b/docs/source/primitives.rst
@@ -15,6 +15,10 @@ plate
 -----
 .. autoclass:: numpyro.primitives.plate
 
+plate_stack
+-----------
+.. autoclass:: numpyro.primitives.plate_stack
+
 deterministic
 -------------
 .. autofunction:: numpyro.primitives.deterministic

--- a/examples/funnel.py
+++ b/examples/funnel.py
@@ -35,9 +35,10 @@ from jax import random
 import jax.numpy as np
 
 import numpyro
+from numpyro.contrib.reparam import reparam, TransformReparam
 import numpyro.distributions as dist
 from numpyro.distributions.transforms import AffineTransform
-from numpyro.infer import MCMC, NUTS
+from numpyro.infer import MCMC, NUTS, Predictive
 
 
 def model(dim=10):
@@ -47,8 +48,9 @@ def model(dim=10):
 
 def reparam_model(dim=10):
     y = numpyro.sample('y', dist.Normal(0, 3))
-    numpyro.sample('x', dist.TransformedDistribution(
-        dist.Normal(np.zeros(dim - 1), 1), AffineTransform(0, np.exp(y / 2))))
+    with reparam(config={'x': TransformReparam()}):
+        numpyro.sample('x', dist.TransformedDistribution(
+            dist.Normal(np.zeros(dim - 1), 1), AffineTransform(0, np.exp(y / 2))))
 
 
 def run_inference(model, args, rng_key):
@@ -70,6 +72,9 @@ def main(args):
     # do inference with non-centered parameterization
     print("\n=========================== Non-centered Parameterization ============================")
     reparam_samples = run_inference(reparam_model, args, rng_key)
+    # collect deterministic sites
+    reparam_samples = Predictive(reparam_model, reparam_samples, return_sites=['x', 'y'])(
+        random.PRNGKey(1))
 
     # make plots
     fig, (ax1, ax2) = plt.subplots(2, 1, sharex=True, figsize=(8, 8))

--- a/examples/neutra.py
+++ b/examples/neutra.py
@@ -15,26 +15,24 @@ Gaussian-like one. The transform will be used to get better mixing rate for NUTS
 """
 
 import argparse
-from functools import partial
 import os
 
 from matplotlib.gridspec import GridSpec
 import matplotlib.pyplot as plt
 import seaborn as sns
 
-from jax import lax, random, vmap
+from jax import lax, random
 import jax.numpy as np
-from jax.tree_util import tree_map
 
 import numpyro
 from numpyro import optim
 from numpyro.contrib.autoguide import AutoContinuousELBO, AutoBNAFNormal
+from numpyro.contrib.reparam import NeuTraReparam
 from numpyro.diagnostics import print_summary
 import numpyro.distributions as dist
 from numpyro.distributions import constraints
 from numpyro.distributions.util import logsumexp
 from numpyro.infer import MCMC, NUTS, SVI
-from numpyro.infer.util import initialize_model, transformed_potential_energy
 
 
 class DualMoonDistribution(dist.Distribution):
@@ -61,7 +59,7 @@ def dual_moon_model():
 def main(args):
     print("Start vanilla HMC...")
     nuts_kernel = NUTS(dual_moon_model)
-    mcmc = MCMC(nuts_kernel, args.num_warmup, args.num_samples,
+    mcmc = MCMC(nuts_kernel, args.num_warmup, args.num_samples, num_chains=args.num_chains,
                 progress_bar=False if "NUMPYRO_SPHINXBUILD" in os.environ else True)
     mcmc.run(random.PRNGKey(0))
     mcmc.print_summary()
@@ -78,29 +76,26 @@ def main(args):
     guide_samples = guide.sample_posterior(random.PRNGKey(0), params,
                                            sample_shape=(args.num_samples,))['x'].copy()
 
-    transform = guide.get_transform(params)
-    _, potential_fn, constrain_fn = initialize_model(random.PRNGKey(2), dual_moon_model)
-    transformed_potential_fn = partial(transformed_potential_energy, potential_fn, transform)
-    transformed_constrain_fn = lambda x: constrain_fn(transform(x))  # noqa: E731
-
     print("\nStart NeuTra HMC...")
-    nuts_kernel = NUTS(potential_fn=transformed_potential_fn)
-    mcmc = MCMC(nuts_kernel, args.num_warmup, args.num_samples,
+    neutra = NeuTraReparam(guide, params)
+    neutra_model = neutra.reparam(dual_moon_model)
+    nuts_kernel = NUTS(neutra_model)
+    mcmc = MCMC(nuts_kernel, args.num_warmup, args.num_samples, num_chains=args.num_chains,
                 progress_bar=False if "NUMPYRO_SPHINXBUILD" in os.environ else True)
-    init_params = np.zeros(guide.latent_size)
-    mcmc.run(random.PRNGKey(3), init_params=init_params)
+    mcmc.run(random.PRNGKey(3))
     mcmc.print_summary()
-    zs = mcmc.get_samples()
+    zs = mcmc.get_samples(group_by_chain=True)["auto_shared_latent"]
     print("Transform samples into unwarped space...")
-    samples = vmap(transformed_constrain_fn)(zs)
-    print_summary(tree_map(lambda x: x[None, ...], samples))
-    samples = samples['x'].copy()
+    samples = neutra.transform_sample(zs)
+    print_summary(samples)
+    zs = zs.reshape(-1, 2)
+    samples = samples['x'].reshape(-1, 2).copy()
 
     # make plots
 
     # guide samples (for plotting)
     guide_base_samples = dist.Normal(np.zeros(2), 1.).sample(random.PRNGKey(4), (1000,))
-    guide_trans_samples = vmap(transformed_constrain_fn)(guide_base_samples)['x']
+    guide_trans_samples = neutra.transform_sample(guide_base_samples)['x']
 
     x1 = np.linspace(-3, 3, 100)
     x2 = np.linspace(-3, 3, 100)
@@ -154,11 +149,13 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="NeuTra HMC")
     parser.add_argument('-n', '--num-samples', nargs='?', default=4000, type=int)
     parser.add_argument('--num-warmup', nargs='?', default=1000, type=int)
+    parser.add_argument("--num-chains", nargs='?', default=1, type=int)
     parser.add_argument('--hidden-factor', nargs='?', default=8, type=int)
     parser.add_argument('--num-iters', nargs='?', default=10000, type=int)
     parser.add_argument('--device', default='cpu', type=str, help='use "cpu" or "gpu".')
     args = parser.parse_args()
 
     numpyro.set_platform(args.device)
+    numpyro.set_host_device_count(args.num_chains)
 
     main(args)

--- a/numpyro/__init__.py
+++ b/numpyro/__init__.py
@@ -4,7 +4,7 @@
 from numpyro import compat, diagnostics, distributions, handlers, infer, optim
 from numpyro.distributions.distribution import enable_validation, validation_enabled
 import numpyro.patch  # noqa: F401
-from numpyro.primitives import deterministic, factor, module, param, plate, sample
+from numpyro.primitives import deterministic, factor, module, param, plate, plate_stack, sample
 from numpyro.util import enable_x64, set_host_device_count, set_platform
 from numpyro.version import __version__
 
@@ -26,6 +26,7 @@ __all__ = [
     'optim',
     'param',
     'plate',
+    'plate_stack',
     'sample',
     'set_host_device_count',
     'set_platform',

--- a/numpyro/contrib/autoguide/__init__.py
+++ b/numpyro/contrib/autoguide/__init__.py
@@ -211,7 +211,6 @@ class AutoContinuous(AutoGuide):
 
     def _unpack_and_constrain(self, latent_sample, params):
         sample_shape = np.shape(latent_sample)[:-1]
-        latent_sample = np.reshape(latent_sample, (-1, np.shape(latent_sample)[-1]))
         # XXX: we do not support priors with supports depending on dynamic data
         # because it adds complexity to the interface.
         # Users can achieve that behaviour by changing the default `self._args`
@@ -229,9 +228,13 @@ class AutoContinuous(AutoGuide):
             else:
                 return transform_fn(self._inv_transforms, unpacked_samples)
 
-        unpacked_samples = vmap(unpack_single_latent)(latent_sample)
-        unpacked_samples = tree_map(lambda x: np.reshape(x, sample_shape + np.shape(x)[1:]),
-                                    unpacked_samples)
+        if sample_shape:
+            latent_sample = np.reshape(latent_sample, (-1, np.shape(latent_sample)[-1]))
+            unpacked_samples = vmap(unpack_single_latent)(latent_sample)
+            unpacked_samples = tree_map(lambda x: np.reshape(x, sample_shape + np.shape(x)[1:]),
+                                        unpacked_samples)
+        else:
+            unpacked_samples = unpack_single_latent(latent_sample)
         return unpacked_samples
 
     @property

--- a/numpyro/contrib/reparam.py
+++ b/numpyro/contrib/reparam.py
@@ -1,0 +1,192 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+from abc import ABC, abstractmethod
+
+import jax.numpy as jnp
+
+import numpyro
+from numpyro.contrib.autoguide import AutoContinuous
+import numpyro.distributions as dist
+from numpyro.distributions import biject_to
+from numpyro.distributions.util import sum_rightmost
+from numpyro.handlers import Messenger
+
+
+class reparam(Messenger):
+    """
+    Reparametrizes each affected sample site into one or more auxiliary sample
+    sites followed by a deterministic transformation [1].
+
+    To specify reparameterizers, pass a ``config`` dict or callable to the
+    constructor.  See the :mod:`numpyro.contrib.reparam` module for available
+    reparameterizers.
+
+    Note some reparameterizers can examine the ``*args,**kwargs`` inputs of
+    functions they affect; these reparameterizers require using
+    ``poutine.reparam`` as a decorator rather than as a context manager.
+
+    [1] Maria I. Gorinova, Dave Moore, Matthew D. Hoffman (2019)
+        "Automatic Reparameterisation of Probabilistic Programs"
+        https://arxiv.org/pdf/1906.03028.pdf
+
+    :param config: Configuration, either a dict mapping site name to
+        :class:`~numpyro.contrib.reparam.Reparam` ,
+        or a function mapping site to
+        :class:`~numpyro.contrib.reparam.Reparam` or None.
+    :type config: dict or callable
+    """
+    def __init__(self, fn=None, config=None):
+        assert isinstance(config, dict) or callable(config)
+        self.config = config
+        super().__init__(fn)
+
+    def process_message(self, msg):
+        if msg["type"] != "sample":
+            return
+
+        if isinstance(self.config, dict):
+            reparam = self.config.get(msg["name"])
+        else:
+            reparam = self.config(msg)
+        if reparam is None:
+            return
+
+        new_fn, value = reparam(msg["name"], msg["fn"], msg["value"])
+
+        if value is not None:
+            if msg["value"] is None:
+                msg["is_observed"] = True
+            msg["value"] = value
+        msg["fn"] = new_fn
+
+
+class Reparam(ABC):
+    """
+    Base class for reparameterizers.
+    """
+    @abstractmethod
+    def __call__(self, name, fn, obs):
+        """
+        :param str name: A sample site name.
+        :param ~numpyro.distributions.Distribution fn: A distribution.
+        :param numpy.ndarray obs: Observed value or None.
+        :return: A pair (``new_fn``, ``value``).
+        """
+        return fn, obs
+
+
+class TransformReparam(Reparam):
+    """
+    Reparameterizer for
+    :class:`~numpyro.distributions.TransformedDistribution` latent variables.
+
+    This is useful for transformed distributions with complex,
+    geometry-changing transforms, where the posterior has simple shape in
+    the space of ``base_dist``.
+
+    This reparameterization works only for latent variables, not likelihoods.
+    """
+    def __call__(self, name, fn, obs):
+        assert obs is None, "TransformReparam does not support observe statements"
+        assert isinstance(fn, dist.TransformedDistribution)
+
+        # Draw noise from the base distribution.
+        x = numpyro.sample("{}_base".format(name), fn.base_dist)
+
+        # Differentiably transform.
+        for t in fn.transforms:
+            x = t(x)
+
+        # Simulate a pyro.deterministic() site.
+        new_fn = dist.Delta(x, event_ndim=len(fn.event_shape))
+        return new_fn, x
+
+
+class NeuTraReparam(Reparam):
+    """
+    Neural Transport reparameterizer [1] of multiple latent variables.
+
+    This uses a trained :class:`~pyro.contrib.autoguide.AutoContinuous`
+    guide to alter the geometry of a model, typically for use e.g. in MCMC.
+    Example usage::
+
+        # Step 1. Train a guide
+        guide = AutoIAFNormal(model)
+        svi = SVI(model, guide, ...)
+        # ...train the guide...
+
+        # Step 2. Use trained guide in NeuTra MCMC
+        neutra = NeuTraReparam(guide)
+        model = reparam(model, config=lambda _: neutra)
+        nuts = NUTS(model)
+        # ...now use the model in HMC or NUTS...
+
+    This reparameterization works only for latent variables, not likelihoods.
+    Note that all sites must share a single common :class:`NeuTraReparam`
+    instance, and that the model must have static structure.
+
+    [1] Hoffman, M. et al. (2019)
+        "NeuTra-lizing Bad Geometry in Hamiltonian Monte Carlo Using Neural Transport"
+        https://arxiv.org/abs/1903.03704
+
+    :param ~numpyro.contrib.autoguide.AutoContinuous guide: A guide.
+    :param params: trained parameters of the guide.
+    """
+    def __init__(self, guide, params):
+        if not isinstance(guide, AutoContinuous):
+            raise TypeError("NeuTraReparam expected an AutoContinuous guide, but got {}"
+                            .format(type(guide)))
+        self.guide = guide
+        self._x_unconstrained = {}
+        try:
+            self.transform = self.guide.get_transform(params)
+        except (NotImplementedError, TypeError):
+            raise ValueError("NeuTraReparam only supports guides that implement "
+                             "`get_transform` method that does not depend on the "
+                             "model's `*args, **kwargs`")
+
+    def __call__(self, name, fn, obs):
+        if name not in self.guide.prototype_trace.nodes:
+            return fn, obs
+        assert obs is None, "NeuTraReparam does not support observe statements"
+
+        log_density = 0.
+        if not self._x_unconstrained:  # On first sample site.
+            # Sample a shared latent.
+            z_unconstrained = numpyro.sample("{}_shared_latent".format(name),
+                                             self.guide.get_base_dist().mask(False))
+
+            # Differentiably transform.
+            x_unconstrained = self.transform(z_unconstrained)
+            log_density = self.transform.log_abs_det_jacobian(z_unconstrained, x_unconstrained)
+            self._x_unconstrained = self.guide._unpack_latent(x_unconstrained)
+
+        # Extract a single site's value from the shared latent.
+        unconstrained_value = self._x_unconstrained.pop(name)
+        transform = biject_to(fn.support)
+        value = transform(unconstrained_value)
+        logdet = transform.log_abs_det_jacobian(unconstrained_value, value)
+        logdet = sum_rightmost(logdet, jnp.ndim(logdet) - jnp.ndim(value) + len(fn.event_shape))
+        log_density = log_density + fn.log_prob(value) + logdet
+        new_fn = dist.Delta(value, log_density, event_ndim=len(fn.event_shape))
+        return new_fn, value
+
+    def transform_sample(self, latent):
+        """
+        Given latent samples from the warped posterior (with a possible batch dimension),
+        return a `dict` of samples from the latent sites in the model.
+
+        :param latent: sample from the warped posterior (possibly batched). Note that the
+            batch dimension must not collide with plate dimensions in the model, i.e.
+            any batch dims `d < - max_plate_nesting`.
+        :return: a `dict` of samples keyed by latent sites in the model.
+        :rtype: dict
+        """
+        x_unconstrained = self.transform(latent)
+        transformed_samples = {}
+        for site, value in self.guide._unpack_latent(x_unconstrained):
+            transform = biject_to(site["fn"].support)
+            x_constrained = transform(value)
+            transformed_samples[site["name"]] = x_constrained
+        return transformed_samples

--- a/numpyro/distributions/transforms.py
+++ b/numpyro/distributions/transforms.py
@@ -498,7 +498,7 @@ class UnpackTransform(Transform):
         batch_shape = x.shape[:-1]
         if batch_shape:
             unpacked = vmap(self.unpack_fn)(x.reshape((-1,) + x.shape[-1:]))
-            return tree_map(lambda x: np.reshape(x, batch_shape + x.shape[1:]), unpacked)
+            return tree_map(lambda x: np.reshape(x, batch_shape + x.shape[-1:]), unpacked)
         else:
             return self.unpack_fn(x)
 

--- a/numpyro/distributions/transforms.py
+++ b/numpyro/distributions/transforms.py
@@ -503,9 +503,11 @@ class UnpackTransform(Transform):
             return self.unpack_fn(x)
 
     def inv(self, y):
-        leading_dims = [v.shape[:1] if np.ndim(v) > 0 else 0
+        leading_dims = [v.shape[0] if np.ndim(v) > 0 else 0
                         for v in tree_flatten(y)[0]]
-        if all(d == leading_dims[0] for d in leading_dims[1:]):
+        d0 = leading_dims[0]
+        not_scalar = d0 > 0 or len(leading_dims) > 1
+        if not_scalar and all(d == d0 for d in leading_dims[1:]):
             warnings.warn("UnpackTransform.inv might lead to an unexpected behavior because it"
                           " cannot transform a batch of unpacked arrays.")
         return ravel_pytree(y)[0]

--- a/numpyro/primitives.py
+++ b/numpyro/primitives.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from collections import namedtuple
+from contextlib import contextmanager, ExitStack
 import functools
 
 from jax import lax
@@ -282,6 +283,24 @@ class plate(Messenger):
         if self.size != self.subsample_size:
             scale = 1. if msg['scale'] is None else msg['scale']
             msg['scale'] = scale * self.size / self.subsample_size
+
+
+@contextmanager
+def plate_stack(prefix, sizes, rightmost_dim=-1):
+    """
+    Create a contiguous stack of :class:`plate` s with dimensions::
+        rightmost_dim - len(sizes), ..., rightmost_dim
+
+    :param str prefix: Name prefix for plates.
+    :param iterable sizes: An iterable of plate sizes.
+    :param int rightmost_dim: The rightmost dim, counting from the right.
+    """
+    assert rightmost_dim < 0
+    with ExitStack() as stack:
+        for i, size in enumerate(reversed(sizes)):
+            plate_i = plate("{}_{}".format(prefix, i), size, dim=rightmost_dim - i)
+            stack.enter_context(plate_i)
+        yield
 
 
 def factor(name, log_factor):

--- a/test/contrib/test_autoguide.py
+++ b/test/contrib/test_autoguide.py
@@ -268,7 +268,7 @@ def test_dynamic_supports():
 
 def test_elbo_dynamic_support():
     x_prior = dist.Uniform(0, 5)
-    x_unconstrained = 2.
+    x_unconstrained = np.array([2.])
 
     def model():
         numpyro.sample('x', x_prior)

--- a/test/contrib/test_reparam.py
+++ b/test/contrib/test_reparam.py
@@ -94,7 +94,7 @@ def test_neals_funnel_smoke():
     mcmc = MCMC(nuts, num_warmup=50, num_samples=50)
     mcmc.run(random.PRNGKey(1), dim)
     samples = mcmc.get_samples()
-    transformed_samples = neutra.transform(samples['auto_shared_latent'])
+    transformed_samples = neutra.transform_sample(samples['auto_shared_latent'])
     assert 'x' in transformed_samples
     assert 'y' in transformed_samples
 
@@ -116,5 +116,5 @@ def test_reparam_log_joint(model, kwargs):
     pe_transformed = pe_fn_neutra(init_params)
     latent_y = neutra.transform(latent_x)
     log_det_jacobian = neutra.transform.log_abs_det_jacobian(latent_x, latent_y)
-    pe = pe_fn(latent_y)
+    pe = pe_fn(guide._unpack_latent(latent_y))
     assert_allclose(pe_transformed, pe - log_det_jacobian)

--- a/test/contrib/test_reparam.py
+++ b/test/contrib/test_reparam.py
@@ -1,0 +1,120 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+from jax import lax, numpy as np, random
+import numpy as onp
+import pytest
+
+import numpyro
+import numpyro.distributions as dist
+from numpyro.distributions.transforms import AffineTransform, ExpTransform
+import numpyro.handlers as handlers
+from numpyro.contrib.autoguide import AutoIAFNormal
+from numpyro.contrib.reparam import NeuTraReparam, TransformReparam, reparam
+from numpyro.infer.util import initialize_model
+from numpyro.infer import MCMC, NUTS, SVI, ELBO
+from numpyro.optim import Adam
+from tests.common import assert_close
+
+
+# Test helper to extract a few log central moments from samples.
+def get_moments(x):
+    assert (x > 0).all()
+    x = np.log(x)
+    m1 = np.mean(x, axis=0)
+    x = x - m1
+    xx = x * x
+    xxx = x * xx
+    xxxx = xx * xx
+    m2 = np.mean(xx, axis=0)
+    m3 = np.mean(xxx, axis=0) / m2 ** 1.5
+    m4 = np.mean(xxxx, axis=0) / m2 ** 2
+    return np.stack([m1, m2, m3, m4])
+
+
+@pytest.mark.parametrize("shape", [(), (4,), (2, 3)], ids=str)
+def test_log_normal(shape):
+    loc = onp.random.rand(*shape) * 2 - 1
+    scale = onp.random.rand(*shape) + 0.5
+
+    def model():
+        with numpyro.plate_stack("plates", shape):
+            with numpyro.plate("particles", 100000):
+                return numpyro.sample("x",
+                                      dist.TransformedDistribution(
+                                          dist.Normal(np.zeros_like(loc),
+                                                      np.ones_like(scale)),
+                                          [AffineTransform(loc, scale),
+                                           ExpTransform()]))
+
+    with handlers.trace() as tr:
+        value = handlers.seed(model, 0)()
+    assert isinstance(tr["x"]["fn"], dist.TransformedDistribution)
+    expected_moments = get_moments(value)
+
+    with reparam(config={"x": TransformReparam()}):
+        with handlers.trace() as tr:
+            value = handlers.seed(model, 0)()
+    assert isinstance(tr["x"]["fn"], dist.Delta)
+    actual_moments = get_moments(value)
+    assert_close(actual_moments, expected_moments, atol=0.05)
+
+
+def neals_funnel(dim):
+    y = numpyro.sample('y', dist.Normal(0, 3))
+    with numpyro.plate('D', dim):
+        numpyro.sample('x', dist.Normal(0, np.exp(y / 2)))
+
+
+def dirichlet_categorical(data):
+    concentration = np.array([1.0, 1.0, 1.0])
+    p_latent = numpyro.sample('p', dist.Dirichlet(concentration))
+    with numpyro.plate('N', data.shape[0]):
+        numpyro.sample('obs', dist.Categorical(p_latent), obs=data)
+    return p_latent
+
+
+def test_neals_funnel_smoke():
+    dim = 10
+
+    guide = AutoIAFNormal(neals_funnel)
+    svi = SVI(neals_funnel, guide, Adam(1e-10), ELBO())
+    svi_state = svi.init(random.PRNGKey(0), dim)
+
+    def body_fn(i, val):
+        svi_state, loss = svi.update(val, dim)
+        return svi_state
+
+    svi_state = lax.fori_loop(0, 1000, body_fn, svi_state)
+    params = svi.get_params(svi_state)
+
+    neutra = NeuTraReparam(guide, params)
+    model = neutra.reparam(neals_funnel)
+    nuts = NUTS(model)
+    mcmc = MCMC(nuts, num_warmup=50, num_samples=50)
+    mcmc.run(random.PRNGKey(1), dim)
+    samples = mcmc.get_samples()
+    transformed_samples = neutra.transform(samples['auto_shared_latent'])
+    assert 'x' in transformed_samples
+    assert 'y' in transformed_samples
+
+
+@pytest.mark.parametrize('model, kwargs', [
+    (neals_funnel, {'dim': 10}),
+    (dirichlet_categorical, {'data': np.ones(10, dtype=np.int32)})
+])
+def test_reparam_log_joint(model, kwargs):
+    guide = AutoIAFNormal(model)
+    svi = SVI(model, guide, Adam(1e-10), ELBO(), **kwargs)
+    svi_state = svi.init(random.PRNGKey(0))
+    params = svi.get_params(svi_state)
+    neutra = NeuTraReparam(guide, params)
+    reparam_model = neutra.reparam(model)
+    _, pe_fn, _ = initialize_model(random.PRNGKey(1), model, model_kwargs=kwargs)
+    init_params, pe_fn_neutra, _ = initialize_model(random.PRNGKey(2), reparam_model, model_kwargs=kwargs)
+    latent_x = list(init_params.values())[0]
+    pe_transformed = pe_fn_neutra(init_params)
+    latent_y = neutra.transform(latent_x)
+    log_det_jacobian = neutra.transform.log_abs_det_jacobian(latent_x, latent_y)
+    pe = pe_fn(latent_y)
+    assert_close(pe_transformed, pe - log_det_jacobian)

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -937,6 +937,7 @@ def test_compose_transform_with_intermediates(ts):
     assert_allclose(logdet, transform.log_abs_det_jacobian(x, y))
 
 
+@pytest.mark.filterwarnings("ignore:UnpackTransform.inv")
 def test_unpack_transform():
     x = np.ones(3)
     unpack_fn = lambda x: {'key': x}  # noqa: E731

--- a/test/test_handlers.py
+++ b/test/test_handlers.py
@@ -231,3 +231,13 @@ def test_messenger_fn_invalid():
     with pytest.raises(ValueError, match="to be a Python callable object"):
         with numpyro.handlers.mask(False):
             pass
+
+
+@pytest.mark.parametrize('shape', [(), (5,), (2, 3)])
+def test_plate_stack(shape):
+    def guide():
+        with numpyro.plate_stack("plates", shape):
+            return numpyro.sample("x", dist.Normal(0, 1))
+
+    x = handlers.seed(guide, 0)()
+    assert x.shape == shape


### PR DESCRIPTION
Address #511.

The port is almost identical to Pyro implementation, except for conjugate reparam logic (e.g. passing args, kwargs to the handler).

### TODO

- [x] add tests for transform reparam
- [x] add tests for neutra reparam

~I'll update current examples after a PR for removing base_param_map~