### PR TITLE
Remove base_param_map

### DIFF
--- a/docs/source/autoguide.rst
+++ b/docs/source/autoguide.rst
@@ -58,11 +58,3 @@ AutoLowRankMultivariateNormal
     :undoc-members:
     :show-inheritance:
     :member-order: bysource
-
-AutoContinuousELBO
-------------------
-.. autoclass:: numpyro.contrib.autoguide.AutoContinuousELBO
-    :members:
-    :undoc-members:
-    :show-inheritance:
-    :member-order: bysource

--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -102,7 +102,7 @@ Gamma
     :member-order: bysource
 
 Gumbel
------
+------
 .. autoclass:: numpyro.distributions.continuous.Gumbel
     :members:
     :undoc-members:

--- a/docs/source/utilities.rst
+++ b/docs/source/utilities.rst
@@ -67,23 +67,23 @@ Initialization Strategies
 
 init_to_median
 ^^^^^^^^^^^^^^
-.. autofunction:: numpyro.infer.util.init_to_median
+.. autofunction:: numpyro.infer.initialization.init_to_median
 
 init_to_prior
 ^^^^^^^^^^^^^
-.. autofunction:: numpyro.infer.util.init_to_prior
+.. autofunction:: numpyro.infer.initialization.init_to_prior
 
 init_to_uniform
 ^^^^^^^^^^^^^^^
-.. autofunction:: numpyro.infer.util.init_to_uniform
+.. autofunction:: numpyro.infer.initialization.init_to_uniform
 
 init_to_feasible
 ^^^^^^^^^^^^^^^^
-.. autofunction:: numpyro.infer.util.init_to_feasible
+.. autofunction:: numpyro.infer.initialization.init_to_feasible
 
 init_to_value
 ^^^^^^^^^^^^^
-.. autofunction:: numpyro.infer.util.init_to_value
+.. autofunction:: numpyro.infer.initialization.init_to_value
 
 Tensor Indexing
 ---------------

--- a/examples/hmm.py
+++ b/examples/hmm.py
@@ -158,7 +158,7 @@ def main(args):
     rng_key = random.PRNGKey(2)
     start = time.time()
     kernel = NUTS(semi_supervised_hmm)
-    mcmc = MCMC(kernel, args.num_warmup, args.num_samples,
+    mcmc = MCMC(kernel, args.num_warmup, args.num_samples, num_chains=args.num_chains,
                 progress_bar=False if "NUMPYRO_SPHINXBUILD" in os.environ else True)
     mcmc.run(rng_key, transition_prior, emission_prior, supervised_categories,
              supervised_words, unsupervised_words)

--- a/examples/neutra.py
+++ b/examples/neutra.py
@@ -26,13 +26,13 @@ import jax.numpy as np
 
 import numpyro
 from numpyro import optim
-from numpyro.contrib.autoguide import AutoContinuousELBO, AutoBNAFNormal
+from numpyro.contrib.autoguide import AutoBNAFNormal
 from numpyro.contrib.reparam import NeuTraReparam
 from numpyro.diagnostics import print_summary
 import numpyro.distributions as dist
 from numpyro.distributions import constraints
 from numpyro.distributions.util import logsumexp
-from numpyro.infer import MCMC, NUTS, SVI
+from numpyro.infer import ELBO, MCMC, NUTS, SVI
 
 
 class DualMoonDistribution(dist.Distribution):
@@ -66,7 +66,7 @@ def main(args):
     vanilla_samples = mcmc.get_samples()['x'].copy()
 
     guide = AutoBNAFNormal(dual_moon_model, hidden_factors=[args.hidden_factor, args.hidden_factor])
-    svi = SVI(dual_moon_model, guide, optim.Adam(0.003), AutoContinuousELBO())
+    svi = SVI(dual_moon_model, guide, optim.Adam(0.003), ELBO())
     svi_state = svi.init(random.PRNGKey(1))
 
     print("Start training guide...")

--- a/numpyro/contrib/autoguide/__init__.py
+++ b/numpyro/contrib/autoguide/__init__.py
@@ -10,11 +10,10 @@
 from abc import ABC, abstractmethod
 import warnings
 
-from jax import hessian, random, vmap
+from jax import hessian, random
 from jax.experimental import stax
 from jax.flatten_util import ravel_pytree
 import jax.numpy as np
-from jax.tree_util import tree_map
 
 import numpyro
 from numpyro import handlers
@@ -32,14 +31,12 @@ from numpyro.distributions.transforms import (
     biject_to
 )
 from numpyro.distributions.util import cholesky_of_inverse, sum_rightmost
-from numpyro.handlers import seed, substitute
 from numpyro.infer.elbo import ELBO
-from numpyro.infer.util import constrain_fn, find_valid_initial_params, init_to_uniform, log_density, transform_fn
+from numpyro.infer.util import find_valid_initial_params, init_to_uniform, transform_fn
 from numpyro.util import not_jax_tracer
 
 __all__ = [
     'AutoContinuous',
-    'AutoContinuousELBO',
     'AutoGuide',
     'AutoDiagonalNormal',
     'AutoMultivariateNormal',
@@ -113,14 +110,6 @@ class AutoContinuous(AutoGuide):
     Assumes model structure and latent dimension are fixed, and all latent
     variables are continuous.
 
-    .. note::
-        We recommend using :class:`AutoContinuousELBO` as the
-        objective function `loss` in :class:`~numpyro.infer.svi.SVI`.
-        In addition, we recommend using :meth:`sample_posterior` method
-        for drawing posterior samples from the autoguide as it will
-        automatically do any unpacking and transformations required
-        to constrain the samples to the support of the latent sites.
-
     **Reference:**
 
     1. *Automatic Differentiation Variational Inference*,
@@ -145,19 +134,12 @@ class AutoContinuous(AutoGuide):
                                                                    model_args=args,
                                                                    model_kwargs=kwargs)
         self._inv_transforms = {}
-        self._has_transformed_dist = False
         unconstrained_sites = {}
         for name, site in self.prototype_trace.items():
             if site['type'] == 'sample' and not site['is_observed']:
-                if site['intermediates']:
-                    transform = biject_to(site['fn'].base_dist.support)
-                    self._inv_transforms[name] = transform
-                    unconstrained_sites[name] = transform.inv(site['intermediates'][0][0])
-                    self._has_transformed_dist = True
-                else:
-                    transform = biject_to(site['fn'].support)
-                    self._inv_transforms[name] = transform
-                    unconstrained_sites[name] = transform.inv(site['value'])
+                transform = biject_to(site['fn'].support)
+                self._inv_transforms[name] = transform
+                unconstrained_sites[name] = transform.inv(site['value'])
 
         self._init_latent, unpack_latent = ravel_pytree(init_params)
         # this is to match the behavior of Pyro, where we can apply
@@ -165,7 +147,7 @@ class AutoContinuous(AutoGuide):
         self._unpack_latent = UnpackTransform(unpack_latent)
         self.latent_size = np.size(self._init_latent)
         if self.base_dist is None:
-            self.base_dist = dist.Independent(dist.Normal(np.zeros(self.latent_size), 1.), 1)
+            self.base_dist = dist.Normal(np.zeros(self.latent_size), 1.).to_event(1)
         if self.latent_size == 0:
             raise RuntimeError('{} found no latent variables; Use an empty guide instead'
                                .format(type(self).__name__))
@@ -203,10 +185,7 @@ class AutoContinuous(AutoGuide):
             site = self.prototype_trace[name]
             value = transform(unconstrained_value)
             log_density = - transform.log_abs_det_jacobian(unconstrained_value, value)
-            if site['intermediates']:
-                event_ndim = len(site['fn'].base_dist.event_shape)
-            else:
-                event_ndim = len(site['fn'].event_shape)
+            event_ndim = len(site['fn'].event_shape)
             log_density = sum_rightmost(log_density,
                                         np.ndim(log_density) - np.ndim(value) + event_ndim)
             delta_dist = dist.Delta(value, log_density=log_density, event_ndim=event_ndim)
@@ -214,33 +193,8 @@ class AutoContinuous(AutoGuide):
 
         return result
 
-    def _unpack_and_constrain(self, latent_sample, params):
-        sample_shape = np.shape(latent_sample)[:-1]
-        # XXX: we do not support priors with supports depending on dynamic data
-        # because it adds complexity to the interface.
-        # Users can achieve that behaviour by changing the default `self._args`
-        # but we will not recommend doing so.
-        model_args = self._args
-        model_kwargs = self._kwargs
-
-        def unpack_single_latent(latent):
-            unpacked_samples = self._unpack_latent(latent)
-            if self._has_transformed_dist:
-                # first, substitute to `param` statements in model
-                model = handlers.substitute(self.model, params)
-                return constrain_fn(model, self._inv_transforms, model_args,
-                                    model_kwargs, unpacked_samples)
-            else:
-                return transform_fn(self._inv_transforms, unpacked_samples)
-
-        if sample_shape:
-            latent_sample = np.reshape(latent_sample, (-1, np.shape(latent_sample)[-1]))
-            unpacked_samples = vmap(unpack_single_latent)(latent_sample)
-            unpacked_samples = tree_map(lambda x: np.reshape(x, sample_shape + np.shape(x)[1:]),
-                                        unpacked_samples)
-        else:
-            unpacked_samples = unpack_single_latent(latent_sample)
-        return unpacked_samples
+    def _unpack_and_constrain(self, latent_sample):
+        return transform_fn(self._inv_transforms, self._unpack_latent(latent_sample))
 
     @property
     def base_dist(self):
@@ -255,23 +209,16 @@ class AutoContinuous(AutoGuide):
         # TODO: not allow changing base_dist
         self._base_dist = base_dist
 
-    def get_transform(self, params, unpack=True):
+    def get_transform(self, params):
         """
         Returns the transformation learned by the guide to generate samples from the unconstrained
         (approximate) posterior.
 
         :param dict params: Current parameters of model and autoguide.
-        :param bool unpack: Whether to return a transform that also unpacks the
-            flatten join of latent variables.
         :return: the transform of posterior distribution
         :rtype: :class:`~numpyro.distributions.transforms.Transform`
         """
-        # TODO: with NeuTraRepram, this `unpack` flag is not useful anymore;
-        # we'll make this method behave as `unpack=False` when refactoring this file
-        transform = handlers.substitute(self._get_transform, params)()
-        if unpack:
-            transform = ComposeTransform([transform, self._unpack_latent])
-        return transform
+        return handlers.substitute(self._get_transform, params)()
 
     def sample_posterior(self, rng_key, params, sample_shape=()):
         """
@@ -285,7 +232,7 @@ class AutoContinuous(AutoGuide):
         """
         latent_sample = handlers.substitute(handlers.seed(self._sample_latent, rng_key), params)(
             self.base_dist, sample_shape=sample_shape)
-        return self._unpack_and_constrain(latent_sample, params)
+        return self._unpack_and_constrain(latent_sample)
 
     def median(self, params):
         """
@@ -336,14 +283,14 @@ class AutoDiagonalNormal(AutoContinuous):
         return AffineTransform(loc, scale, domain=constraints.real_vector)
 
     def median(self, params):
-        transform = self.get_transform(params, unpack=False)
-        return self._unpack_and_constrain(transform.loc, params)
+        transform = self.get_transform(params)
+        return self._unpack_and_constrain(transform.loc)
 
     def quantiles(self, params, quantiles):
-        transform = self.get_transform(params, unpack=False)
+        transform = self.get_transform(params)
         quantiles = np.array(quantiles)[..., None]
         latent = dist.Normal(transform.loc, transform.scale).icdf(quantiles)
-        return self._unpack_and_constrain(latent, params)
+        return self._unpack_and_constrain(latent)
 
 
 class AutoMultivariateNormal(AutoContinuous):
@@ -371,14 +318,14 @@ class AutoMultivariateNormal(AutoContinuous):
         return MultivariateAffineTransform(loc, scale_tril)
 
     def median(self, params):
-        transform = self.get_transform(params, unpack=False)
-        return self._unpack_and_constrain(transform.loc, params)
+        transform = self.get_transform(params)
+        return self._unpack_and_constrain(transform.loc)
 
     def quantiles(self, params, quantiles):
-        transform = self.get_transform(params, unpack=False)
+        transform = self.get_transform(params)
         quantiles = np.array(quantiles)[..., None]
         latent = dist.Normal(transform.loc, np.diagonal(transform.scale_tril)).icdf(quantiles)
-        return self._unpack_and_constrain(latent, params)
+        return self._unpack_and_constrain(latent)
 
 
 class AutoLowRankMultivariateNormal(AutoContinuous):
@@ -426,23 +373,20 @@ class AutoLowRankMultivariateNormal(AutoContinuous):
         transform = self._get_transform(params)
         loc, scale_tril = transform.loc, transform.scale_tril
         latent_sample = dist.MultivariateNormal(loc, scale_tril=scale_tril).sample(rng_key, sample_shape)
-        return self._unpack_and_constrain(latent_sample, params)
+        return self._unpack_and_constrain(latent_sample)
 
-    def get_transform(self, params, unpack=True):
-        transform = self._get_transform(params)
-        if unpack:
-            transform = ComposeTransform([transform, self._unpack_latent])
-        return transform
+    def get_transform(self, params):
+        return self._get_transform(params)
 
     def median(self, params):
         loc = params['{}_loc'.format(self.prefix)]
-        return self._unpack_and_constrain(loc, params)
+        return self._unpack_and_constrain(loc)
 
     def quantiles(self, params, quantiles):
-        transform = self.get_transform(params, unpack=False)
+        transform = self.get_transform(params)
         quantiles = np.array(quantiles)[..., None]
         latent = dist.Normal(transform.loc, np.diagonal(transform.scale_tril)).icdf(quantiles)
-        return self._unpack_and_constrain(latent, params)
+        return self._unpack_and_constrain(latent)
 
 
 class AutoLaplaceApproximation(AutoContinuous):
@@ -471,8 +415,8 @@ class AutoLaplaceApproximation(AutoContinuous):
             params1 = params.copy()
             params1['{}_loc'.format(self.prefix)] = z
             # we are doing maximum likelihood, so only require `num_particles=1` and an arbitrary rng_key.
-            return AutoContinuousELBO().loss(random.PRNGKey(0), params1, self.model, self,
-                                             *self._args, **self._kwargs)
+            return ELBO().loss(random.PRNGKey(0), params1, self.model, self,
+                               *self._args, **self._kwargs)
 
         loc = params['{}_loc'.format(self.prefix)]
         precision = hessian(loss_fn)(loc)
@@ -489,23 +433,20 @@ class AutoLaplaceApproximation(AutoContinuous):
         transform = self._get_transform(params)
         loc, scale_tril = transform.loc, transform.scale_tril
         latent_sample = dist.MultivariateNormal(loc, scale_tril=scale_tril).sample(rng_key, sample_shape)
-        return self._unpack_and_constrain(latent_sample, params)
+        return self._unpack_and_constrain(latent_sample)
 
-    def get_transform(self, params, unpack=True):
-        transform = self._get_transform(params)
-        if unpack:
-            transform = ComposeTransform([transform, self._unpack_latent])
-        return transform
+    def get_transform(self, params):
+        return self._get_transform(params)
 
     def median(self, params):
         loc = params['{}_loc'.format(self.prefix)]
-        return self._unpack_and_constrain(loc, params)
+        return self._unpack_and_constrain(loc)
 
     def quantiles(self, params, quantiles):
         transform = self._get_transform(params)
         quantiles = np.array(quantiles)[..., None]
         latent = dist.Normal(transform.loc, np.diagonal(transform.scale_tril)).icdf(quantiles)
-        return self._unpack_and_constrain(latent, params)
+        return self._unpack_and_constrain(latent)
 
 
 class AutoIAFNormal(AutoContinuous):
@@ -610,42 +551,3 @@ class AutoBNAFNormal(AutoContinuous):
             arnn = numpyro.module('{}_arn__{}'.format(self.prefix, i), arn, (self.latent_size,))
             flows.append(BlockNeuralAutoregressiveTransform(arnn))
         return ComposeTransform(flows)
-
-
-class AutoContinuousELBO(ELBO):
-    """
-    An ELBO implementation specific to :class:`AutoContinuous` guides. In those guide, the latent
-    variables of the model are transformed to unconstrained domains. This class provides ELBO of
-    the "transformed" model (i.e. the corresponding model with unconstrained variables) and the
-    guide.
-    """
-    def loss(self, rng_key, param_map, model, guide, *args, **kwargs):
-        assert isinstance(guide, AutoContinuous)
-
-        def single_particle_elbo(rng_key):
-            model_seed, guide_seed = random.split(rng_key)
-            seeded_model = seed(model, model_seed)
-            seeded_guide = seed(guide, guide_seed)
-            guide_log_density, guide_trace = log_density(seeded_guide, args, kwargs, param_map)
-            # first, we substitute `param_map` to `param` primitives of `model`
-            seeded_model = substitute(seeded_model, param_map)
-            # then creates a new `param_map` which holds base values of `sample` primitives
-            base_param_map = {}
-            # in autoguide, a site's value holds intermediate value
-            for name, site in guide_trace.items():
-                if site['type'] == 'sample':
-                    base_param_map[name] = site['value']
-            model_log_density, _ = log_density(seeded_model, args, kwargs, base_param_map,
-                                               skip_dist_transforms=True)
-
-            # log p(z) - log q(z)
-            elbo = model_log_density - guide_log_density
-            # Return (-elbo) since by convention we do gradient descent on a loss and
-            # the ELBO is a lower bound that needs to be maximized.
-            return -elbo
-
-        if self.num_particles == 1:
-            return single_particle_elbo(rng_key)
-        else:
-            rng_keys = random.split(rng_key, self.num_particles)
-            return np.mean(vmap(single_particle_elbo)(rng_keys))

--- a/numpyro/contrib/autoguide/__init__.py
+++ b/numpyro/contrib/autoguide/__init__.py
@@ -10,7 +10,7 @@
 from abc import ABC, abstractmethod
 import warnings
 
-from jax import hessian, random
+from jax import hessian, lax, random, tree_map
 from jax.experimental import stax
 from jax.flatten_util import ravel_pytree
 import jax.numpy as np
@@ -32,7 +32,7 @@ from numpyro.distributions.transforms import (
 )
 from numpyro.distributions.util import cholesky_of_inverse, sum_rightmost
 from numpyro.infer.elbo import ELBO
-from numpyro.infer.util import find_valid_initial_params, init_to_uniform, transform_fn
+from numpyro.infer.util import constrain_fn, find_valid_initial_params, init_to_uniform, transform_fn
 from numpyro.util import not_jax_tracer
 
 __all__ = [
@@ -133,13 +133,17 @@ class AutoContinuous(AutoGuide):
                                                                    init_strategy=self.init_strategy,
                                                                    model_args=args,
                                                                    model_kwargs=kwargs)
+        # TODO: we can just simply use infer/get_model_transforms here
         self._inv_transforms = {}
+        self._replay_model = False
         unconstrained_sites = {}
         for name, site in self.prototype_trace.items():
             if site['type'] == 'sample' and not site['is_observed']:
                 transform = biject_to(site['fn'].support)
                 self._inv_transforms[name] = transform
                 unconstrained_sites[name] = transform.inv(site['value'])
+            elif site['type'] == 'deterministic' and not self._replay_model:
+                self._replay_model = True
 
         self._init_latent, unpack_latent = ravel_pytree(init_params)
         # this is to match the behavior of Pyro, where we can apply
@@ -193,8 +197,24 @@ class AutoContinuous(AutoGuide):
 
         return result
 
-    def _unpack_and_constrain(self, latent_sample):
-        return transform_fn(self._inv_transforms, self._unpack_latent(latent_sample))
+    def _unpack_and_constrain(self, latent_sample, params):
+        if self._replay_model:
+            def unpack_single_latent(latent):
+                unpacked_samples = self._unpack_latent(latent)
+                return constrain_fn(model, self._inv_transforms, self._args, self._kwargs,
+                                    unpacked_samples, return_deterministic=True)
+
+            model = handlers.substitute(self.model, param_map=params)
+            sample_shape = np.shape(latent_sample)[:-1]
+            if sample_shape:
+                latent_sample = np.reshape(latent_sample, (-1, np.shape(latent_sample)[-1]))
+                unpacked_samples = lax.map(unpack_single_latent, latent_sample)
+                return tree_map(lambda x: np.reshape(x, sample_shape + np.shape(x)[1:]),
+                                unpacked_samples)
+            else:
+                return unpack_single_latent(latent_sample)
+        else:
+            return transform_fn(self._inv_transforms, self._unpack_latent(latent_sample))
 
     @property
     def base_dist(self):
@@ -232,7 +252,7 @@ class AutoContinuous(AutoGuide):
         """
         latent_sample = handlers.substitute(handlers.seed(self._sample_latent, rng_key), params)(
             self.base_dist, sample_shape=sample_shape)
-        return self._unpack_and_constrain(latent_sample)
+        return self._unpack_and_constrain(latent_sample, params)
 
     def median(self, params):
         """
@@ -284,13 +304,13 @@ class AutoDiagonalNormal(AutoContinuous):
 
     def median(self, params):
         transform = self.get_transform(params)
-        return self._unpack_and_constrain(transform.loc)
+        return self._unpack_and_constrain(transform.loc, params)
 
     def quantiles(self, params, quantiles):
         transform = self.get_transform(params)
         quantiles = np.array(quantiles)[..., None]
         latent = dist.Normal(transform.loc, transform.scale).icdf(quantiles)
-        return self._unpack_and_constrain(latent)
+        return self._unpack_and_constrain(latent, params)
 
 
 class AutoMultivariateNormal(AutoContinuous):
@@ -319,13 +339,13 @@ class AutoMultivariateNormal(AutoContinuous):
 
     def median(self, params):
         transform = self.get_transform(params)
-        return self._unpack_and_constrain(transform.loc)
+        return self._unpack_and_constrain(transform.loc, params)
 
     def quantiles(self, params, quantiles):
         transform = self.get_transform(params)
         quantiles = np.array(quantiles)[..., None]
         latent = dist.Normal(transform.loc, np.diagonal(transform.scale_tril)).icdf(quantiles)
-        return self._unpack_and_constrain(latent)
+        return self._unpack_and_constrain(latent, params)
 
 
 class AutoLowRankMultivariateNormal(AutoContinuous):
@@ -373,20 +393,20 @@ class AutoLowRankMultivariateNormal(AutoContinuous):
         transform = self._get_transform(params)
         loc, scale_tril = transform.loc, transform.scale_tril
         latent_sample = dist.MultivariateNormal(loc, scale_tril=scale_tril).sample(rng_key, sample_shape)
-        return self._unpack_and_constrain(latent_sample)
+        return self._unpack_and_constrain(latent_sample, params)
 
     def get_transform(self, params):
         return self._get_transform(params)
 
     def median(self, params):
         loc = params['{}_loc'.format(self.prefix)]
-        return self._unpack_and_constrain(loc)
+        return self._unpack_and_constrain(loc, params)
 
     def quantiles(self, params, quantiles):
         transform = self.get_transform(params)
         quantiles = np.array(quantiles)[..., None]
         latent = dist.Normal(transform.loc, np.diagonal(transform.scale_tril)).icdf(quantiles)
-        return self._unpack_and_constrain(latent)
+        return self._unpack_and_constrain(latent, params)
 
 
 class AutoLaplaceApproximation(AutoContinuous):
@@ -433,20 +453,20 @@ class AutoLaplaceApproximation(AutoContinuous):
         transform = self._get_transform(params)
         loc, scale_tril = transform.loc, transform.scale_tril
         latent_sample = dist.MultivariateNormal(loc, scale_tril=scale_tril).sample(rng_key, sample_shape)
-        return self._unpack_and_constrain(latent_sample)
+        return self._unpack_and_constrain(latent_sample, params)
 
     def get_transform(self, params):
         return self._get_transform(params)
 
     def median(self, params):
         loc = params['{}_loc'.format(self.prefix)]
-        return self._unpack_and_constrain(loc)
+        return self._unpack_and_constrain(loc, params)
 
     def quantiles(self, params, quantiles):
         transform = self._get_transform(params)
         quantiles = np.array(quantiles)[..., None]
         latent = dist.Normal(transform.loc, np.diagonal(transform.scale_tril)).icdf(quantiles)
-        return self._unpack_and_constrain(latent)
+        return self._unpack_and_constrain(latent, params)
 
 
 class AutoIAFNormal(AutoContinuous):

--- a/numpyro/contrib/reparam.py
+++ b/numpyro/contrib/reparam.py
@@ -54,9 +54,6 @@ class reparam(Messenger):
 
         new_fn, value = reparam(msg["name"], msg["fn"], msg["value"])
 
-        if new_fn is None:
-            msg['type'] = 'deterministic'
-
         if value is not None:
             if new_fn is None:
                 msg['type'] = 'deterministic'

--- a/numpyro/contrib/reparam.py
+++ b/numpyro/contrib/reparam.py
@@ -148,9 +148,8 @@ class NeuTraReparam(Reparam):
             raise TypeError("NeuTraReparam expected an AutoContinuous guide, but got {}"
                             .format(type(guide)))
         self.guide = guide
-        self.params = params
         try:
-            self.transform = self.guide.get_transform(self.params, unpack=False)
+            self.transform = self.guide.get_transform(params)
         except (NotImplementedError, TypeError):
             raise ValueError("NeuTraReparam only supports guides that implement "
                              "`get_transform` method that does not depend on the "
@@ -200,4 +199,4 @@ class NeuTraReparam(Reparam):
         :rtype: dict
         """
         x_unconstrained = self.transform(latent)
-        return self.guide._unpack_and_constrain(x_unconstrained, self.params)
+        return self.guide._unpack_and_constrain(x_unconstrained)

--- a/numpyro/contrib/reparam.py
+++ b/numpyro/contrib/reparam.py
@@ -186,7 +186,7 @@ class NeuTraReparam(Reparam):
         logdet = transform.log_abs_det_jacobian(unconstrained_value, value)
         logdet = sum_rightmost(logdet, jnp.ndim(logdet) - jnp.ndim(value) + len(fn.event_shape))
         log_density = log_density + fn.log_prob(value) + logdet
-        numpyro.factor("{}_log_prob", log_density)
+        numpyro.factor("_{}_log_prob".format(name), log_density)
         return None, value
 
     def transform_sample(self, latent):

--- a/numpyro/contrib/reparam.py
+++ b/numpyro/contrib/reparam.py
@@ -145,6 +145,7 @@ class NeuTraReparam(Reparam):
             raise TypeError("NeuTraReparam expected an AutoContinuous guide, but got {}"
                             .format(type(guide)))
         self.guide = guide
+        self.params = params
         try:
             self.transform = self.guide.get_transform(params)
         except (NotImplementedError, TypeError):
@@ -196,4 +197,4 @@ class NeuTraReparam(Reparam):
         :rtype: dict
         """
         x_unconstrained = self.transform(latent)
-        return self.guide._unpack_and_constrain(x_unconstrained)
+        return self.guide._unpack_and_constrain(x_unconstrained, self.params)

--- a/numpyro/distributions/distribution.py
+++ b/numpyro/distributions/distribution.py
@@ -176,9 +176,6 @@ class Distribution(object):
         """
         return self.sample(key, sample_shape=sample_shape), []
 
-    def transform_with_intermediates(self, base_value):
-        return base_value, []
-
     def log_prob(self, value):
         """
         Evaluates the log probability density for a batch of samples given by
@@ -536,11 +533,7 @@ class TransformedDistribution(Distribution):
         return x
 
     def sample_with_intermediates(self, key, sample_shape=()):
-        base_value = self.base_dist.sample(key, sample_shape)
-        return self.transform_with_intermediates(base_value)
-
-    def transform_with_intermediates(self, base_value):
-        x = base_value
+        x = self.base_dist.sample(key, sample_shape)
         intermediates = []
         for transform in self.transforms:
             x_tmp = x

--- a/numpyro/distributions/transforms.py
+++ b/numpyro/distributions/transforms.py
@@ -123,12 +123,6 @@ class ComposeTransform(Transform):
 
     @property
     def codomain(self):
-        # like in the support of TransformedDistribution, we loop through transforms
-        # to update domain, codomain
-        domain = self.domain
-        for t in self.parts[1:]:
-            t.domain = domain
-            domain = t.codomain
         return self.parts[-1].codomain
 
     @property

--- a/numpyro/distributions/transforms.py
+++ b/numpyro/distributions/transforms.py
@@ -122,6 +122,12 @@ class ComposeTransform(Transform):
 
     @property
     def codomain(self):
+        # like in the support of TransformedDistribution, we loop through transforms
+        # to update domain, codomain
+        domain = self.domain
+        for t in self.parts[1:]:
+            t.domain = domain
+            domain = t.codomain
         return self.parts[-1].codomain
 
     @property

--- a/numpyro/distributions/transforms.py
+++ b/numpyro/distributions/transforms.py
@@ -498,7 +498,7 @@ class UnpackTransform(Transform):
         batch_shape = x.shape[:-1]
         if batch_shape:
             unpacked = vmap(self.unpack_fn)(x.reshape((-1,) + x.shape[-1:]))
-            return tree_map(lambda x: np.reshape(x, batch_shape + x.shape[-1:]), unpacked)
+            return tree_map(lambda z: np.reshape(z, batch_shape + z.shape[1:]), unpacked)
         else:
             return self.unpack_fn(x)
 

--- a/numpyro/handlers.py
+++ b/numpyro/handlers.py
@@ -270,14 +270,14 @@ class condition(Messenger):
             return
 
         if self.param_map is not None:
-            value = self.param_map.get(self.param_map)
+            value = self.param_map.get(msg['name'])
         else:
             value = self.condition_fn(msg)
 
         if value is not None:
             msg['value'] = value
             if msg['is_observed']:
-                raise ValueError("Cannot condition an already observed site: {}.".format(site_name))
+                raise ValueError("Cannot condition an already observed site: {}.".format(msg['name']))
             msg['is_observed'] = True
 
 
@@ -425,7 +425,7 @@ class substitute(Messenger):
             return
 
         if self.param_map is not None:
-            value = self.param_map.get(self.param_map)
+            value = self.param_map.get(msg['name'])
         else:
             value = self.substitute_fn(msg)
 

--- a/numpyro/infer/__init__.py
+++ b/numpyro/infer/__init__.py
@@ -2,15 +2,17 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from numpyro.infer.elbo import ELBO, RenyiELBO
-from numpyro.infer.mcmc import HMC, MCMC, NUTS, SA
-from numpyro.infer.svi import SVI
-from numpyro.infer.util import (
-    Predictive,
+from numpyro.infer.initialization import (
     init_to_feasible,
     init_to_median,
     init_to_prior,
     init_to_uniform,
     init_to_value,
+)
+from numpyro.infer.mcmc import HMC, MCMC, NUTS, SA
+from numpyro.infer.svi import SVI
+from numpyro.infer.util import (
+    Predictive,
     log_likelihood
 )
 

--- a/numpyro/infer/hmc_util.py
+++ b/numpyro/infer/hmc_util.py
@@ -430,7 +430,7 @@ def warmup_adapter(num_adapt_steps, find_reasonable_step_size=None,
             z_flat, _ = ravel_pytree(z)
             mm_state = cond(is_middle_window,
                             (z_flat, mm_state), lambda args: mm_update(*args),
-                            mm_state, lambda x: x)
+                            mm_state, identity)
 
         t_at_window_end = t == adaptation_schedule[window_idx, 1]
         window_idx = np.where(t_at_window_end, window_idx + 1, window_idx)
@@ -438,7 +438,7 @@ def warmup_adapter(num_adapt_steps, find_reasonable_step_size=None,
                               ss_state, mm_state, window_idx, rng_key)
         state = cond(t_at_window_end & is_middle_window,
                      (z, rng_key_ss, state), lambda args: _update_at_window_end(*args),
-                     state, lambda x: x)
+                     state, identity)
         return state
 
     return init_fn, update_fn
@@ -621,7 +621,7 @@ def _iterative_build_subtree(prototype_tree, vv_update, kinetic_fn,
                                    going_right, energy_current, max_delta_energy)
         new_tree = cond(current_tree.num_proposals == 0,
                         new_leaf,
-                        lambda x: x,
+                        identity,
                         (current_tree, new_leaf, inverse_mass_matrix, going_right, transition_rng_key),
                         lambda x: _combine_tree(*x, False))
 
@@ -637,7 +637,7 @@ def _iterative_build_subtree(prototype_tree, vv_update, kinetic_fn,
                                     lambda x: (index_update(x[0], ckpt_idx_max, r),
                                                index_update(x[1], ckpt_idx_max, r_sum)),
                                     (r_ckpts, r_sum_ckpts),
-                                    lambda x: x)
+                                    identity)
 
         turning = _is_iterative_turning(inverse_mass_matrix, r, r_sum, r_ckpts, r_sum_ckpts,
                                         ckpt_idx_min, ckpt_idx_max)

--- a/numpyro/infer/initialization.py
+++ b/numpyro/infer/initialization.py
@@ -1,0 +1,124 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+from functools import partial
+
+import jax.numpy as np
+
+import numpyro
+import numpyro.distributions as dist
+from numpyro.distributions import biject_to
+from numpyro.distributions.constraints import real
+from numpyro.distributions.transforms import ComposeTransform
+
+
+def _init_to_median(site, num_samples=15, skip_param=False):
+    if site['type'] == 'sample' and not site['is_observed']:
+        if isinstance(site['fn'], dist.TransformedDistribution):
+            fn = site['fn'].base_dist
+        else:
+            fn = site['fn']
+        samples = numpyro.sample('_init', fn,
+                                 sample_shape=(num_samples,) + site['kwargs']['sample_shape'])
+        return np.median(samples, axis=0)
+
+    if site['type'] == 'param' and not skip_param:
+        # return base value of param site
+        constraint = site['kwargs'].pop('constraint', real)
+        transform = biject_to(constraint)
+        value = site['args'][0]
+        if isinstance(transform, ComposeTransform):
+            base_transform = transform.parts[0]
+            value = base_transform(transform.inv(value))
+        return value
+
+
+def init_to_median(num_samples=15):
+    """
+    Initialize to the prior median.
+
+    :param int num_samples: number of prior points to calculate median.
+    """
+    return partial(_init_to_median, num_samples=num_samples)
+
+
+def init_to_prior():
+    """
+    Initialize to a prior sample.
+    """
+    return init_to_median(num_samples=1)
+
+
+def _init_to_uniform(site, radius=2, skip_param=False):
+    if site['type'] == 'sample' and not site['is_observed']:
+        if isinstance(site['fn'], dist.TransformedDistribution):
+            fn = site['fn'].base_dist
+        else:
+            fn = site['fn']
+        value = numpyro.sample('_init', fn, sample_shape=site['kwargs']['sample_shape'])
+        base_transform = biject_to(fn.support)
+        unconstrained_value = numpyro.sample('_unconstrained_init', dist.Uniform(-radius, radius),
+                                             sample_shape=np.shape(base_transform.inv(value)))
+        return base_transform(unconstrained_value)
+
+    if site['type'] == 'param' and not skip_param:
+        # return base value of param site
+        constraint = site['kwargs'].pop('constraint', real)
+        transform = biject_to(constraint)
+        value = site['args'][0]
+        unconstrained_value = numpyro.sample('_unconstrained_init', dist.Uniform(-radius, radius),
+                                             sample_shape=np.shape(transform.inv(value)))
+        if isinstance(transform, ComposeTransform):
+            base_transform = transform.parts[0]
+        else:
+            base_transform = transform
+        return base_transform(unconstrained_value)
+
+
+def init_to_uniform(site=None, radius=2):
+    """
+    Initialize to a random point in the area `(-radius, radius)` of unconstrained domain.
+
+    :param float radius: specifies the range to draw an initial point in the unconstrained domain.
+    """
+    if site is None:
+        return partial(init_to_uniform, radius=radius)
+
+
+def init_to_feasible():
+    """
+    Initialize to an arbitrary feasible point, ignoring distribution
+    parameters.
+    """
+    return init_to_uniform(radius=0)
+
+
+def _init_to_value(site, values={}, skip_param=False):
+    if site['type'] == 'sample' and not site['is_observed']:
+        if site['name'] not in values:
+            return _init_to_uniform(site, skip_param=skip_param)
+
+        value = values[site['name']]
+        if isinstance(site['fn'], dist.TransformedDistribution):
+            value = ComposeTransform(site['fn'].transforms).inv(value)
+        return value
+
+    if site['type'] == 'param' and not skip_param:
+        # return base value of param site
+        constraint = site['kwargs'].pop('constraint', real)
+        transform = biject_to(constraint)
+        value = site['args'][0]
+        if isinstance(transform, ComposeTransform):
+            base_transform = transform.parts[0]
+            value = base_transform(transform.inv(value))
+        return value
+
+
+def init_to_value(values):
+    """
+    Initialize to the value specified in `values`. We defer to
+    :func:`init_to_uniform` strategy for sites which do not appear in `values`.
+
+    :param dict values: dictionary of initial values keyed by site name.
+    """
+    return partial(_init_to_value, values=values)

--- a/numpyro/infer/initialization.py
+++ b/numpyro/infer/initialization.py
@@ -75,14 +75,13 @@ def _init_to_uniform(site, radius=2, skip_param=False):
         return base_transform(unconstrained_value)
 
 
-def init_to_uniform(site=None, radius=2):
+def init_to_uniform(radius=2):
     """
     Initialize to a random point in the area `(-radius, radius)` of unconstrained domain.
 
     :param float radius: specifies the range to draw an initial point in the unconstrained domain.
     """
-    if site is None:
-        return partial(init_to_uniform, radius=radius)
+    return partial(init_to_uniform, radius=radius)
 
 
 def init_to_feasible():

--- a/numpyro/infer/initialization.py
+++ b/numpyro/infer/initialization.py
@@ -81,7 +81,7 @@ def init_to_uniform(radius=2):
 
     :param float radius: specifies the range to draw an initial point in the unconstrained domain.
     """
-    return partial(init_to_uniform, radius=radius)
+    return partial(_init_to_uniform, radius=radius)
 
 
 def init_to_feasible():

--- a/numpyro/infer/mcmc.py
+++ b/numpyro/infer/mcmc.py
@@ -291,8 +291,8 @@ def hmc(potential_fn=None, potential_fn_gen=None, kinetic_fn=None, algo='NUTS'):
         diverging = delta_energy > max_delta_energy
         transition = random.bernoulli(rng_key, accept_prob)
         vv_state, energy = cond(transition,
-                                (vv_state_new, energy_new), lambda args: args,
-                                (vv_state, energy_old), lambda args: args)
+                                (vv_state_new, energy_new), identity,
+                                (vv_state, energy_old), identity)
         return vv_state, energy, num_steps, accept_prob, diverging
 
     def _nuts_next(step_size, inverse_mass_matrix, vv_state,
@@ -343,7 +343,7 @@ def hmc(potential_fn=None, potential_fn_gen=None, kinetic_fn=None, algo='NUTS'):
                            (hmc_state.i, accept_prob, vv_state.z, hmc_state.adapt_state),
                            lambda args: wa_update(*args),
                            hmc_state.adapt_state,
-                           lambda x: x)
+                           identity)
 
         itr = hmc_state.i + 1
         n = np.where(hmc_state.i < wa_steps, itr, itr - wa_steps)

--- a/numpyro/infer/util.py
+++ b/numpyro/infer/util.py
@@ -9,11 +9,10 @@ from jax import device_get, lax, random, value_and_grad, vmap
 from jax.flatten_util import ravel_pytree
 import jax.numpy as np
 
-import numpyro
-import numpyro.distributions as dist
 from numpyro.distributions.constraints import real
-from numpyro.distributions.transforms import ComposeTransform, biject_to
+from numpyro.distributions.transforms import biject_to
 from numpyro.handlers import block, seed, substitute, trace
+from numpyro.infer.initialization import init_to_uniform
 from numpyro.util import not_jax_tracer, while_loop
 
 __all__ = [
@@ -21,15 +20,9 @@ __all__ = [
     'get_potential_fn',
     'log_density',
     'log_likelihood',
-    'init_to_feasible',
-    'init_to_median',
-    'init_to_prior',
-    'init_to_uniform',
-    'init_to_value',
     'potential_energy',
     'initialize_model',
     'Predictive',
-    'transformed_potential_energy',
 ]
 
 
@@ -58,7 +51,7 @@ def log_density(model, model_args, model_kwargs, params):
             if not_jax_tracer(mask) and mask is not None and not np.any(mask):
                 continue
             if intermediates:
-                    log_prob = site['fn'].log_prob(value, intermediates)
+                log_prob = site['fn'].log_prob(value, intermediates)
             else:
                 log_prob = site['fn'].log_prob(value)
 
@@ -96,6 +89,8 @@ def transform_fn(transforms, params, invert=False):
             for k, v in params.items()}
 
 
+# TODO: remove this function, which is unnecessary when dynamic support is removed
+# we still keep it here for `deterministic` behavior
 def constrain_fn(model, transforms, model_args, model_kwargs, params, return_deterministic=False):
     """
     (EXPERIMENTAL INTERFACE) Gets value at each latent site in `model` given
@@ -117,10 +112,10 @@ def constrain_fn(model, transforms, model_args, model_kwargs, params, return_det
     :return: `dict` of transformed params.
     """
     params_constrained = transform_fn(transforms, params)
-    substituted_model = substitute(model, base_param_map=params_constrained)
+    substituted_model = substitute(model, param_map=params_constrained)
     model_trace = trace(substituted_model).get_trace(*model_args, **model_kwargs)
     return {k: v['value'] for k, v in model_trace.items() if (k in params) or
-            (return_deterministic and v['type'] == 'deterministic')}
+            (return_deterministic and (v['type'] == 'deterministic'))}
 
 
 def potential_energy(model, inv_transforms, model_args, model_kwargs, params):
@@ -139,142 +134,13 @@ def potential_energy(model, inv_transforms, model_args, model_kwargs, params):
     :return: potential energy given unconstrained parameters.
     """
     params_constrained = transform_fn(inv_transforms, params)
-    log_joint, model_trace = log_density(model, model_args, model_kwargs, params_constrained,
-                                         skip_dist_transforms=True)
+    log_joint, model_trace = log_density(model, model_args, model_kwargs, params_constrained)
     for name, t in inv_transforms.items():
         t_log_det = np.sum(t.log_abs_det_jacobian(params[name], params_constrained[name]))
         if model_trace[name]['scale'] is not None:
             t_log_det = model_trace[name]['scale'] * t_log_det
         log_joint = log_joint + t_log_det
     return - log_joint
-
-
-def transformed_potential_energy(potential_energy, inv_transform, z):
-    """
-    Given a potential energy `p(x)`, compute potential energy of `p(z)`
-    with `z = transform(x)` (i.e. `x = inv_transform(z)`).
-
-    :param potential_energy: a callable to compute potential energy of original
-        variable `x`.
-    :param ~numpyro.distributions.constraints.Transform inv_transform: a
-        transform from the new variable `z` to `x`.
-    :param z: new variable to compute potential energy
-    :return: potential energy of `z`.
-    """
-    x, intermediates = inv_transform.call_with_intermediates(z)
-    logdet = inv_transform.log_abs_det_jacobian(z, x, intermediates=intermediates)
-    return potential_energy(x) - logdet
-
-
-def _init_to_median(site, num_samples=15, skip_param=False):
-    if site['type'] == 'sample' and not site['is_observed']:
-        if isinstance(site['fn'], dist.TransformedDistribution):
-            fn = site['fn'].base_dist
-        else:
-            fn = site['fn']
-        samples = numpyro.sample('_init', fn,
-                                 sample_shape=(num_samples,) + site['kwargs']['sample_shape'])
-        return np.median(samples, axis=0)
-
-    if site['type'] == 'param' and not skip_param:
-        # return base value of param site
-        constraint = site['kwargs'].pop('constraint', real)
-        transform = biject_to(constraint)
-        value = site['args'][0]
-        if isinstance(transform, ComposeTransform):
-            base_transform = transform.parts[0]
-            value = base_transform(transform.inv(value))
-        return value
-
-
-def init_to_median(num_samples=15):
-    """
-    Initialize to the prior median.
-
-    :param int num_samples: number of prior points to calculate median.
-    """
-    return partial(_init_to_median, num_samples=num_samples)
-
-
-def init_to_prior():
-    """
-    Initialize to a prior sample.
-    """
-    return init_to_median(num_samples=1)
-
-
-def _init_to_uniform(site, radius=2, skip_param=False):
-    if site['type'] == 'sample' and not site['is_observed']:
-        if isinstance(site['fn'], dist.TransformedDistribution):
-            fn = site['fn'].base_dist
-        else:
-            fn = site['fn']
-        value = numpyro.sample('_init', fn, sample_shape=site['kwargs']['sample_shape'])
-        base_transform = biject_to(fn.support)
-        unconstrained_value = numpyro.sample('_unconstrained_init', dist.Uniform(-radius, radius),
-                                             sample_shape=np.shape(base_transform.inv(value)))
-        return base_transform(unconstrained_value)
-
-    if site['type'] == 'param' and not skip_param:
-        # return base value of param site
-        constraint = site['kwargs'].pop('constraint', real)
-        transform = biject_to(constraint)
-        value = site['args'][0]
-        unconstrained_value = numpyro.sample('_unconstrained_init', dist.Uniform(-radius, radius),
-                                             sample_shape=np.shape(transform.inv(value)))
-        if isinstance(transform, ComposeTransform):
-            base_transform = transform.parts[0]
-        else:
-            base_transform = transform
-        return base_transform(unconstrained_value)
-
-
-def init_to_uniform(radius=2):
-    """
-    Initialize to a random point in the area `(-radius, radius)` of unconstrained domain.
-
-    :param float radius: specifies the range to draw an initial point in the unconstrained domain.
-    """
-    return partial(_init_to_uniform, radius=radius)
-
-
-def init_to_feasible():
-    """
-    Initialize to an arbitrary feasible point, ignoring distribution
-    parameters.
-    """
-    return init_to_uniform(radius=0)
-
-
-def _init_to_value(site, values={}, skip_param=False):
-    if site['type'] == 'sample' and not site['is_observed']:
-        if site['name'] not in values:
-            return _init_to_uniform(site, skip_param=skip_param)
-
-        value = values[site['name']]
-        if isinstance(site['fn'], dist.TransformedDistribution):
-            value = ComposeTransform(site['fn'].transforms).inv(value)
-        return value
-
-    if site['type'] == 'param' and not skip_param:
-        # return base value of param site
-        constraint = site['kwargs'].pop('constraint', real)
-        transform = biject_to(constraint)
-        value = site['args'][0]
-        if isinstance(transform, ComposeTransform):
-            base_transform = transform.parts[0]
-            value = base_transform(transform.inv(value))
-        return value
-
-
-def init_to_value(values):
-    """
-    Initialize to the value specified in `values`. We defer to
-    :func:`init_to_uniform` strategy for sites which do not appear in `values`.
-
-    :param dict values: dictionary of initial values keyed by site name.
-    """
-    return partial(_init_to_value, values=values)
 
 
 def find_valid_initial_params(rng_key, model,
@@ -312,27 +178,19 @@ def find_valid_initial_params(rng_key, model,
 
         # Wrap model in a `substitute` handler to initialize from `init_loc_fn`.
         # Use `block` to not record sample primitives in `init_loc_fn`.
+        # TODO: fix the issue that we are using the same subkey for all sites
         seeded_model = substitute(model, substitute_fn=block(seed(init_strategy, subkey)))
         model_trace = trace(seeded_model).get_trace(*model_args, **model_kwargs)
         constrained_values, inv_transforms = {}, {}
         for k, v in model_trace.items():
+            # TODO: filter out discrete sites here
             if v['type'] == 'sample' and not v['is_observed']:
-                if v['intermediates']:
-                    constrained_values[k] = v['intermediates'][0][0]
-                    inv_transforms[k] = biject_to(v['fn'].base_dist.support)
-                else:
-                    constrained_values[k] = v['value']
-                    inv_transforms[k] = biject_to(v['fn'].support)
+                constrained_values[k] = v['value']
+                inv_transforms[k] = biject_to(v['fn'].support)
             elif v['type'] == 'param' and param_as_improper:
+                constrained_values[k] = v['value']
                 constraint = v['kwargs'].pop('constraint', real)
-                transform = biject_to(constraint)
-                if isinstance(transform, ComposeTransform):
-                    base_transform = transform.parts[0]
-                    inv_transforms[k] = base_transform
-                    constrained_values[k] = base_transform(transform.inv(v['value']))
-                else:
-                    inv_transforms[k] = transform
-                    constrained_values[k] = v['value']
+                inv_transforms[k] = biject_to(constraint)
         params = transform_fn(inv_transforms,
                               {k: v for k, v in constrained_values.items()},
                               invert=True)
@@ -349,6 +207,13 @@ def find_valid_initial_params(rng_key, model,
             if device_get(is_valid):
                 return prototype_params, is_valid
 
+        # TODO: we are tracing the model 4 times here, make sure that we just do it one
+        # Historically, we don't know the initial structure of params
+        # so we need the do-while pattern (lax.while_loop requires initial values)
+        # In addition, the body_fn requires tracing through model 2 times: 1 to find the params
+        # the other one is to compute potential_energy...
+        # TODO: add tests to track down the number of time we trace the model
+        # and try to optimize it in follow-up PRs
         _, _, init_params, is_valid = while_loop(cond_fn, body_fn, init_state)
         return init_params, is_valid
 
@@ -360,6 +225,8 @@ def find_valid_initial_params(rng_key, model,
     return init_params, is_valid
 
 
+# TODO: we should combine this with potential_energy
+# to reduce the number of times we trace the model
 def get_model_transforms(rng_key, model, model_args=(), model_kwargs=None):
     model_kwargs = {} if model_kwargs is None else model_kwargs
     seeded_model = seed(model, rng_key if rng_key.ndim == 1 else rng_key[0])
@@ -370,19 +237,10 @@ def get_model_transforms(rng_key, model, model_args=(), model_kwargs=None):
     replay_model = False
     for k, v in model_trace.items():
         if v['type'] == 'sample' and not v['is_observed']:
-            if v['intermediates']:
-                inv_transforms[k] = biject_to(v['fn'].base_dist.support)
-                replay_model = True
-            else:
-                inv_transforms[k] = biject_to(v['fn'].support)
+            inv_transforms[k] = biject_to(v['fn'].support)
         elif v['type'] == 'param':
             constraint = v['kwargs'].pop('constraint', real)
-            transform = biject_to(constraint)
-            if isinstance(transform, ComposeTransform):
-                inv_transforms[k] = transform.parts[0]
-                replay_model = True
-            else:
-                inv_transforms[k] = transform
+            inv_transforms[k] = biject_to(constraint)
         elif v['type'] == 'deterministic':
             replay_model = True
     return inv_transforms, replay_model

--- a/numpyro/infer/util.py
+++ b/numpyro/infer/util.py
@@ -89,8 +89,6 @@ def transform_fn(transforms, params, invert=False):
             for k, v in params.items()}
 
 
-# TODO: remove this function, which is unnecessary when dynamic support is removed
-# we still keep it here for `deterministic` behavior
 def constrain_fn(model, transforms, model_args, model_kwargs, params, return_deterministic=False):
     """
     (EXPERIMENTAL INTERFACE) Gets value at each latent site in `model` given

--- a/numpyro/primitives.py
+++ b/numpyro/primitives.py
@@ -24,12 +24,7 @@ def apply_stack(msg):
         if msg.get("stop"):
             break
     if msg['value'] is None:
-        if msg['type'] == 'sample':
-            msg['value'], msg['intermediates'] = msg['fn'](*msg['args'],
-                                                           sample_intermediates=True,
-                                                           **msg['kwargs'])
-        else:
-            msg['value'] = msg['fn'](*msg['args'], **msg['kwargs'])
+        msg['value'] = msg['fn'](*msg['args'], **msg['kwargs'])
 
     # A Messenger that sets msg["stop"] == True also prevents application
     # of postprocess_message by Messengers above it on the stack

--- a/numpyro/primitives.py
+++ b/numpyro/primitives.py
@@ -8,6 +8,7 @@ from jax import lax
 
 import numpyro
 from numpyro.distributions.discrete import PRNGIdentity
+from numpyro.util import identity
 
 _PYRO_STACK = []
 
@@ -101,10 +102,6 @@ def sample(name, fn, obs=None, rng_key=None, sample_shape=()):
     # ...and use apply_stack to send it to the Messengers
     msg = apply_stack(initial_msg)
     return msg['value']
-
-
-def identity(x, *args, **kwargs):
-    return x
 
 
 def param(name, init_value=None, **kwargs):
@@ -257,6 +254,7 @@ class plate(Messenger):
     def process_message(self, msg):
         if msg['type'] not in ('sample', 'plate'):
             return
+
         cond_indep_stack = msg['cond_indep_stack']
         frame = CondIndepStackFrame(self.name, self.dim, self.subsample_size)
         cond_indep_stack.append(frame)

--- a/numpyro/primitives.py
+++ b/numpyro/primitives.py
@@ -26,7 +26,12 @@ def apply_stack(msg):
         if msg.get("stop"):
             break
     if msg['value'] is None:
-        msg['value'] = msg['fn'](*msg['args'], **msg['kwargs'])
+        if msg['type'] == 'sample':
+            msg['value'], msg['intermediates'] = msg['fn'](*msg['args'],
+                                                           sample_intermediates=True,
+                                                           **msg['kwargs'])
+        else:
+            msg['value'] = msg['fn'](*msg['args'], **msg['kwargs'])
 
     # A Messenger that sets msg["stop"] == True also prevents application
     # of postprocess_message by Messengers above it on the stack

--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -140,7 +140,7 @@ def not_jax_tracer(x):
     return not isinstance(x, Tracer)
 
 
-def identity(x):
+def identity(x, *args, **kwargs):
     return x
 
 

--- a/test/contrib/test_autoguide.py
+++ b/test/contrib/test_autoguide.py
@@ -41,6 +41,7 @@ init_strategy = init_to_median(num_samples=2)
     AutoLaplaceApproximation,
     AutoLowRankMultivariateNormal,
 ])
+@pytest.mark.filterwarnings("ignore:Explicitly requested dtype float64 requested in asarray")
 def test_beta_bernoulli(auto_class):
     data = np.array([[1.0] * 8 + [0.0] * 2,
                      [1.0] * 4 + [0.0] * 6]).T
@@ -74,6 +75,7 @@ def test_beta_bernoulli(auto_class):
     AutoLaplaceApproximation,
     AutoLowRankMultivariateNormal,
 ])
+@pytest.mark.filterwarnings("ignore:Explicitly requested dtype float64 requested in asarray")
 def test_logistic_regression(auto_class):
     N, dim = 3000, 3
     data = random.normal(random.PRNGKey(0), (N, dim))

--- a/test/contrib/test_autoguide.py
+++ b/test/contrib/test_autoguide.py
@@ -41,7 +41,7 @@ init_strategy = init_to_median(num_samples=2)
     AutoLaplaceApproximation,
     AutoLowRankMultivariateNormal,
 ])
-@pytest.mark.filterwarnings("ignore:Explicitly requested dtype float64 requested in asarray")
+@pytest.mark.filterwarnings("ignore:Explicitly requested dtype float64")
 def test_beta_bernoulli(auto_class):
     data = np.array([[1.0] * 8 + [0.0] * 2,
                      [1.0] * 4 + [0.0] * 6]).T
@@ -75,7 +75,7 @@ def test_beta_bernoulli(auto_class):
     AutoLaplaceApproximation,
     AutoLowRankMultivariateNormal,
 ])
-@pytest.mark.filterwarnings("ignore:Explicitly requested dtype float64 requested in asarray")
+@pytest.mark.filterwarnings("ignore:Explicitly requested dtype float64")
 def test_logistic_regression(auto_class):
     N, dim = 3000, 3
     data = random.normal(random.PRNGKey(0), (N, dim))

--- a/test/contrib/test_autoguide.py
+++ b/test/contrib/test_autoguide.py
@@ -41,7 +41,6 @@ init_strategy = init_to_median(num_samples=2)
     AutoLaplaceApproximation,
     AutoLowRankMultivariateNormal,
 ])
-@pytest.mark.filterwarnings("ignore:Explicitly requested dtype float64")
 def test_beta_bernoulli(auto_class):
     data = np.array([[1.0] * 8 + [0.0] * 2,
                      [1.0] * 4 + [0.0] * 6]).T
@@ -75,7 +74,6 @@ def test_beta_bernoulli(auto_class):
     AutoLaplaceApproximation,
     AutoLowRankMultivariateNormal,
 ])
-@pytest.mark.filterwarnings("ignore:Explicitly requested dtype float64")
 def test_logistic_regression(auto_class):
     N, dim = 3000, 3
     data = random.normal(random.PRNGKey(0), (N, dim))
@@ -182,10 +180,10 @@ def test_uniform_normal():
     svi_state = fori_loop(0, 1000, body_fn, svi_state)
     params = svi.get_params(svi_state)
     median = guide.median(params)
-    assert_allclose(median['loc_base'] * median['alpha'], true_coef, rtol=0.05)
+    assert_allclose(median['loc'], true_coef, rtol=0.05)
     # test .quantile method
     median = guide.quantiles(params, [0.2, 0.5])
-    assert_allclose(median['loc_base'][1], true_coef, rtol=0.1)
+    assert_allclose(median['loc'][1], true_coef, rtol=0.1)
 
 
 def test_param():

--- a/test/contrib/test_reparam.py
+++ b/test/contrib/test_reparam.py
@@ -55,7 +55,7 @@ def test_log_normal(shape):
     with reparam(config={"x": TransformReparam()}):
         with handlers.trace() as tr:
             value = handlers.seed(model, 0)()
-    assert isinstance(tr["x"]["fn"], dist.Delta)
+    assert tr["x"]["type"] == "deterministic"
     actual_moments = get_moments(value)
     assert_allclose(actual_moments, expected_moments, atol=0.05)
 

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -61,6 +61,6 @@ def test_autoguide(deterministic):
     guide.sample_posterior(random.PRNGKey(1), params, sample_shape=(100,))
 
     if deterministic:
-        assert GLOBAL["count"] == 5
+        assert GLOBAL["count"] == 6
     else:
         assert GLOBAL["count"] == 5

--- a/test/test_hmc_util.py
+++ b/test/test_hmc_util.py
@@ -418,7 +418,6 @@ def test_gaussian_subposterior(method, diagonal):
         assert_allclose(np.cov(draws.T), cov, atol=0.05)
 
 
-@pytest.mark.filterwarnings('ignore:Explicitly requested dtype float64')
 @pytest.mark.parametrize('method', [consensus, parametric_draws])
 def test_subposterior_structure(method):
     subposteriors = [{'x': np.ones((100, 3)), 'y': np.zeros((100,))} for i in range(10)]

--- a/test/test_hmc_util.py
+++ b/test/test_hmc_util.py
@@ -264,7 +264,7 @@ def test_build_adaptation_schedule(num_steps, expected):
     pytest.param(False, marks=pytest.mark.skipif("CI" in os.environ, reason="slow in Travis"))
 ])
 def test_warmup_adapter(jitted):
-    def find_reasonable_step_size(m_inv, z, rng_key, step_size):
+    def find_reasonable_step_size(step_size, m_inv, z, rng_key):
         return np.where(step_size < 1, step_size * 4, step_size / 4)
 
     num_steps = 150
@@ -279,7 +279,7 @@ def test_warmup_adapter(jitted):
     z = np.ones(3)
     wa_state = wa_init(z, rng_key, init_step_size, mass_matrix_size=mass_matrix_size)
     step_size, inverse_mass_matrix, _, _, _, window_idx, _ = wa_state
-    assert step_size == find_reasonable_step_size(inverse_mass_matrix, z, rng_key, init_step_size)
+    assert step_size == find_reasonable_step_size(init_step_size, inverse_mass_matrix, z, rng_key)
     assert_allclose(inverse_mass_matrix, np.ones(mass_matrix_size))
     assert window_idx == 0
 

--- a/test/test_hmc_util.py
+++ b/test/test_hmc_util.py
@@ -226,7 +226,7 @@ def test_find_reasonable_step_size(jitted, init_step_size):
     fn = (jit(find_reasonable_step_size, static_argnums=(0, 1, 2))
           if jitted else find_reasonable_step_size)
     rng_key = random.PRNGKey(0)
-    step_size = fn(potential_fn, kinetic_fn, p_generator, m_inv, q, rng_key, init_step_size)
+    step_size = fn(potential_fn, kinetic_fn, p_generator, init_step_size, m_inv, q, rng_key)
 
     # Apply 1 velocity verlet step with step_size=eps, we have
     # z_new = eps, r_new = 1 - eps^2 / 2, hence energy_new = 0.5 + eps^4 / 8,

--- a/test/test_infer_util.py
+++ b/test/test_infer_util.py
@@ -11,22 +11,24 @@ import jax.numpy as np
 
 import numpyro
 from numpyro import handlers
+from numpyro.contrib.reparam import TransformReparam, reparam
 import numpyro.distributions as dist
-from numpyro.distributions import constraints, transforms
+from numpyro.distributions import constraints
 from numpyro.distributions.transforms import biject_to
 from numpyro.infer import ELBO, MCMC, NUTS, SVI
-from numpyro.infer.util import (
-    Predictive,
-    constrain_fn,
+from numpyro.infer.initialization import (
     init_to_feasible,
     init_to_median,
     init_to_prior,
-    init_to_uniform,
+    init_to_uniform
+)
+from numpyro.infer.util import (
+    Predictive,
+    constrain_fn,
     initialize_model,
     log_likelihood,
     potential_energy,
     transform_fn,
-    transformed_potential_energy
 )
 import numpyro.optim as optim
 
@@ -134,18 +136,6 @@ def test_log_likelihood():
     assert_allclose(loglik["obs"], dist.Bernoulli(samples["beta"].reshape((100, 1, -1))).log_prob(data))
 
 
-def test_transformed_potential_energy():
-    beta_dist = dist.Beta(np.ones(5), np.ones(5))
-    transform = transforms.AffineTransform(3, 4)
-    inv_transform = transforms.AffineTransform(-0.75, 0.25)
-
-    z = random.normal(random.PRNGKey(0), (5,))
-    pe_expected = -dist.TransformedDistribution(beta_dist, transform).log_prob(z)
-    potential_fn = lambda x: -beta_dist.log_prob(x)  # noqa: E731
-    pe_actual = transformed_potential_energy(potential_fn, inv_transform, z)
-    assert_allclose(pe_actual, pe_expected)
-
-
 def test_model_with_transformed_distribution():
     x_prior = dist.HalfNormal(2)
     y_prior = dist.LogNormal(scale=3.)  # transformed distribution
@@ -165,10 +155,12 @@ def test_model_with_transformed_distribution():
         inv_transforms['y'].log_abs_det_jacobian(params['y'], expected_samples['y'])
     )
 
-    base_inv_transforms = {'x': biject_to(x_prior.support), 'y': biject_to(y_prior.base_dist.support)}
-    actual_samples = constrain_fn(
-        handlers.seed(model, random.PRNGKey(0)), base_inv_transforms,  (), {}, params)
-    actual_potential_energy = potential_energy(model, base_inv_transforms, (), {}, params)
+    base_inv_transforms = {'x': biject_to(x_prior.support), 'y_base': biject_to(y_prior.base_dist.support)}
+    reparam_model = reparam(model, {'y': TransformReparam()})
+    base_params = {'x': params['x'], 'y_base': params['y']}
+    # TODO: find a simple way to get actual samples
+    actual_samples = expected_samples
+    actual_potential_energy = potential_energy(reparam_model, base_inv_transforms, (), {}, base_params)
 
     assert_allclose(expected_samples['x'], actual_samples['x'])
     assert_allclose(expected_samples['y'], actual_samples['y'])

--- a/test/test_infer_util.py
+++ b/test/test_infer_util.py
@@ -186,6 +186,8 @@ def test_model_with_mask_false():
     init_to_prior(),
     init_to_uniform(),
 ])
+# TODO: remove in next release of JAX (current release has a bug at np.quantile)
+@pytest.mark.filterwarnings("ignore:Explicitly requested dtype float64 requested in asarray")
 def test_initialize_model_change_point(init_strategy):
     def model(data):
         alpha = 1 / np.mean(data)
@@ -223,6 +225,7 @@ def test_initialize_model_change_point(init_strategy):
     init_to_prior(),
     init_to_uniform(),
 ])
+@pytest.mark.filterwarnings("ignore:Explicitly requested dtype float64 requested in asarray")
 def test_initialize_model_dirichlet_categorical(init_strategy):
     def model(data):
         concentration = np.array([1.0, 1.0, 1.0])

--- a/test/test_infer_util.py
+++ b/test/test_infer_util.py
@@ -186,8 +186,6 @@ def test_model_with_mask_false():
     init_to_prior(),
     init_to_uniform(),
 ])
-# TODO: remove in next release of JAX (current release has a bug at np.quantile)
-@pytest.mark.filterwarnings("ignore:Explicitly requested dtype float64")
 def test_initialize_model_change_point(init_strategy):
     def model(data):
         alpha = 1 / np.mean(data)
@@ -225,7 +223,6 @@ def test_initialize_model_change_point(init_strategy):
     init_to_prior(),
     init_to_uniform(),
 ])
-@pytest.mark.filterwarnings("ignore:Explicitly requested dtype float64")
 def test_initialize_model_dirichlet_categorical(init_strategy):
     def model(data):
         concentration = np.array([1.0, 1.0, 1.0])

--- a/test/test_infer_util.py
+++ b/test/test_infer_util.py
@@ -187,7 +187,7 @@ def test_model_with_mask_false():
     init_to_uniform(),
 ])
 # TODO: remove in next release of JAX (current release has a bug at np.quantile)
-@pytest.mark.filterwarnings("ignore:Explicitly requested dtype float64 requested in asarray")
+@pytest.mark.filterwarnings("ignore:Explicitly requested dtype float64")
 def test_initialize_model_change_point(init_strategy):
     def model(data):
         alpha = 1 / np.mean(data)
@@ -225,7 +225,7 @@ def test_initialize_model_change_point(init_strategy):
     init_to_prior(),
     init_to_uniform(),
 ])
-@pytest.mark.filterwarnings("ignore:Explicitly requested dtype float64 requested in asarray")
+@pytest.mark.filterwarnings("ignore:Explicitly requested dtype float64")
 def test_initialize_model_dirichlet_categorical(init_strategy):
     def model(data):
         concentration = np.array([1.0, 1.0, 1.0])

--- a/test/test_infer_util.py
+++ b/test/test_infer_util.py
@@ -158,8 +158,9 @@ def test_model_with_transformed_distribution():
     base_inv_transforms = {'x': biject_to(x_prior.support), 'y_base': biject_to(y_prior.base_dist.support)}
     reparam_model = reparam(model, {'y': TransformReparam()})
     base_params = {'x': params['x'], 'y_base': params['y']}
-    # TODO: find a simple way to get actual samples
-    actual_samples = expected_samples
+    actual_samples = constrain_fn(
+        handlers.seed(reparam_model, random.PRNGKey(0)),
+        base_inv_transforms, (), {}, base_params, return_deterministic=True)
     actual_potential_energy = potential_energy(reparam_model, base_inv_transforms, (), {}, base_params)
 
     assert_allclose(expected_samples['x'], actual_samples['x'])

--- a/test/test_mcmc.py
+++ b/test/test_mcmc.py
@@ -14,6 +14,7 @@ import jax.numpy as np
 from jax.scipy.special import logit
 
 import numpyro
+from numpyro.contrib.reparam import TransformReparam, reparam
 import numpyro.distributions as dist
 from numpyro.distributions import constraints
 from numpyro.infer import HMC, MCMC, NUTS, SA
@@ -105,7 +106,8 @@ def test_uniform_normal():
 
     def model(data):
         alpha = numpyro.sample('alpha', dist.Uniform(0, 1))
-        loc = numpyro.sample('loc', dist.Uniform(0, alpha))
+        with reparam(config={'loc': TransformReparam()}):
+            loc = numpyro.sample('loc', dist.Uniform(0, alpha))
         numpyro.sample('obs', dist.Normal(loc, 0.1), obs=data)
 
     data = true_coef + random.normal(random.PRNGKey(0), (1000,))

--- a/test/test_svi.py
+++ b/test/test_svi.py
@@ -145,13 +145,11 @@ def test_elbo_dynamic_support():
         numpyro.sample('x', x_guide)
 
     adam = optim.Adam(0.01)
-    # set base value of x_guide is 0.9
-    x_base = 0.9
-    guide = substitute(guide, base_param_map={'x': x_base})
+    x = 2.
+    guide = substitute(guide, param_map={'x': x})
     svi = SVI(model, guide, adam, ELBO())
     svi_state = svi.init(random.PRNGKey(0))
     actual_loss = svi.evaluate(svi_state)
     assert np.isfinite(actual_loss)
-    x, _ = x_guide.transform_with_intermediates(x_base)
     expected_loss = x_guide.log_prob(x) - x_prior.log_prob(x)
     assert_allclose(actual_loss, expected_loss)


### PR DESCRIPTION
With #599, we no longer need to do "automatic reparameterization" behind the scene for dynamic support. This PR removes stuff related to base_param_map.

Fixes #587 and fixes #594.

### TODO
- [x] remove stuffs in `infer.util`
- [x] make sure all tests pass, probably with the usage of "reparam"
- [x] remove dynamic support in autoguide