### PR TITLE
Add Improper Distribution

### DIFF
--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -17,6 +17,14 @@ ExpandedDistribution
     :show-inheritance:
     :member-order: bysource
 
+Improper
+--------
+.. autoclass:: numpyro.distributions.distribution.Improper
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :member-order: bysource
+
 Independent
 -----------
 .. autoclass:: numpyro.distributions.distribution.Independent

--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -17,9 +17,9 @@ ExpandedDistribution
     :show-inheritance:
     :member-order: bysource
 
-Improper
---------
-.. autoclass:: numpyro.distributions.distribution.Improper
+ImproperUniform
+---------------
+.. autoclass:: numpyro.distributions.distribution.ImproperUniform
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -380,6 +380,14 @@ ZeroInflatedPoisson
 Constraints
 ===========
 
+Constraint
+----------
+.. autoclass:: numpyro.distributions.constraints.Constraint
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :member-order: bysource
+
 boolean
 -------
 .. autodata:: numpyro.distributions.constraints.boolean

--- a/numpyro/distributions/__init__.py
+++ b/numpyro/distributions/__init__.py
@@ -51,7 +51,7 @@ from numpyro.distributions.discrete import (
 from numpyro.distributions.distribution import (
     Distribution,
     ExpandedDistribution,
-    Improper,
+    ImproperUniform,
     Independent,
     MaskedDistribution,
     TransformedDistribution,
@@ -88,7 +88,7 @@ __all__ = [
     'Gumbel',
     'HalfCauchy',
     'HalfNormal',
-    'Improper',
+    'ImproperUniform',
     'Independent',
     'InverseGamma',
     'LKJ',

--- a/numpyro/distributions/__init__.py
+++ b/numpyro/distributions/__init__.py
@@ -51,6 +51,7 @@ from numpyro.distributions.discrete import (
 from numpyro.distributions.distribution import (
     Distribution,
     ExpandedDistribution,
+    Improper,
     Independent,
     MaskedDistribution,
     TransformedDistribution,
@@ -87,6 +88,7 @@ __all__ = [
     'Gumbel',
     'HalfCauchy',
     'HalfNormal',
+    'Improper',
     'Independent',
     'InverseGamma',
     'LKJ',

--- a/numpyro/distributions/constraints.py
+++ b/numpyro/distributions/constraints.py
@@ -54,8 +54,21 @@ import jax.numpy as np
 
 
 class Constraint(object):
+    """
+    Abstract base class for constraints.
+
+    A constraint object represents a region over which a variable is valid,
+    e.g. within which a variable can be optimized.
+    """
     def __call__(self, x):
         raise NotImplementedError
+
+    def check(self, value):
+        """
+        Returns a byte tensor of `sample_shape + batch_shape` indicating
+        whether each event in value satisfies this constraint.
+        """
+        return self(value)
 
 
 class _Boolean(Constraint):

--- a/numpyro/distributions/distribution.py
+++ b/numpyro/distributions/distribution.py
@@ -354,36 +354,45 @@ class ImproperUniform(Distribution):
     """
     A helper distribution with zero :meth:`log_prob` over the `support` domain.
 
-    .. note:: `sample` method is not implemented for this distribution.
+    .. note:: `sample` method is not implemented for this distribution. In autoguide and mcmc,
+        initial parameters for improper sites are derived `init_to_uniform` or `init_to_value`
+        strategies.
 
-    **Usage**::
+    **Usage:**
 
-        >>> from numpyro.distributions import constraints
-        >>>
-        >>> def model():
-        ...     # ordered vector with length 10
-        ...     x = sample('x', ImproperUniform(constraints.ordered_vector, (), event_shape=(10,))
-        ...
-        ...     # real matrix with shape (3, 4)
-        ...     y = sample('y', ImproperUniform(constraints.real, (), event_shape=(3, 4))
-        ...
-        ...     # a shape-(6, 8) batch of length-5 vectors greater than 3
-        ...     z = sample('z', ImproperUniform(constraints.greater_than(3), (6, 8), event_shape=(5,))
+    .. doctest::
+
+       >>> from numpyro import sample
+       >>> from numpyro.distributions import ImproperUniform, Normal, constraints
+       >>>
+       >>> def model():
+       ...     # ordered vector with length 10
+       ...     x = sample('x', ImproperUniform(constraints.ordered_vector, (), event_shape=(10,)))
+       ...
+       ...     # real matrix with shape (3, 4)
+       ...     y = sample('y', ImproperUniform(constraints.real, (), event_shape=(3, 4)))
+       ...
+       ...     # a shape-(6, 8) batch of length-5 vectors greater than 3
+       ...     z = sample('z', ImproperUniform(constraints.greater_than(3), (6, 8), event_shape=(5,)))
 
     If you want to set improper prior over all values greater than `a`, where `a` is
     another random variable, you might use
 
-        >>> x = sample('x', ImproperUniform(constraints.greater_than(a), (), event_shape=()))
+       >>> def model():
+       ...     a = sample('a', Normal(0, 1))
+       ...     x = sample('x', ImproperUniform(constraints.greater_than(a), (), event_shape=()))
 
     or if you want to reparameterize it
 
-        >>> from numpyro.distributions import constraints, transforms
-        >>> from numpyro.contrib.reparam import reparam, TransformReparam
-        >>>
-        >>> with reparam(config={'x': TransformReparam()}):
-        ...     x = sample('x',
-        ...                TransformedDistribution(ImproperUniform(constraints.positive, (), ()),
-        ...                                        transforms.AffineTransform(a, 1)))
+       >>> from numpyro.distributions import TransformedDistribution, transforms
+       >>> from numpyro.contrib.reparam import reparam, TransformReparam
+       >>>
+       >>> def model():
+       ...     a = sample('a', Normal(0, 1))
+       ...     with reparam(config={'x': TransformReparam()}):
+       ...         x = sample('x',
+       ...                    TransformedDistribution(ImproperUniform(constraints.positive, (), ()),
+       ...                                            transforms.AffineTransform(a, 1)))
 
     :param ~numpyro.distributions.constraints.Constraint support: the support of this distribution.
     :param tuple batch_shape: batch shape of this distribution. It is usually safe to

--- a/numpyro/distributions/distribution.py
+++ b/numpyro/distributions/distribution.py
@@ -32,7 +32,7 @@ import warnings
 import jax.numpy as np
 from jax import lax
 
-from numpyro.distributions.constraints import Constraint, is_dependent, real  # noqa: F401
+from numpyro.distributions.constraints import is_dependent, real
 from numpyro.distributions.transforms import Transform
 from numpyro.distributions.util import lazy_property, sum_rightmost, validate_sample
 from numpyro.util import not_jax_tracer
@@ -385,7 +385,7 @@ class ImproperUniform(Distribution):
         ...                TransformedDistribution(ImproperUniform(constraints.positive, (), ()),
         ...                                        transforms.AffineTransform(a, 1)))
 
-    :param Constraint support: the support of this distribution.
+    :param ~numpyro.distributions.constraints.Constraint support: the support of this distribution.
     :param tuple batch_shape: batch shape of this distribution. It is usually safe to
         set `batch_shape=()`.
     :param tuple event_shape: event shape of this distribution.

--- a/numpyro/distributions/distribution.py
+++ b/numpyro/distributions/distribution.py
@@ -401,7 +401,7 @@ class ImproperUniform(Distribution):
     A helper distribution with zero :meth:`log_prob` over the `support` domain.
 
     .. note:: `sample` method is not implemented for this distribution. In autoguide and mcmc,
-        initial parameters for improper sites are derived `init_to_uniform` or `init_to_value`
+        initial parameters for improper sites are derived from `init_to_uniform` or `init_to_value`
         strategies.
 
     **Usage:**

--- a/numpyro/infer/initialization.py
+++ b/numpyro/infer/initialization.py
@@ -51,20 +51,20 @@ def init_to_uniform(site=None, radius=2):
         rng_key = site['kwargs'].get('rng_key')
         sample_shape = site['kwargs'].get('sample_shape')
         rng_key, subkey = random.split(rng_key)
-        transform = biject_to(site['fn'].support)
+
         # this is used to interpret the changes of event_shape in
         # domain and codomain spaces
         try:
             prototype_value = site['fn'].sample(subkey, sample_shape=())
-            unconstrained_shape = np.shape(transform.inv(prototype_value))
         except NotImplementedError:
             # XXX: this works for ImproperUniform prior,
             # we can't use this logic for general priors
             # because some distributions such as TransformedDistribution might
             # have wrong event_shape.
             prototype_value = np.full(site['fn'].shape(), np.nan)
-            unconstrained_shape = np.shape(transform.inv(prototype_value))
 
+        transform = biject_to(site['fn'].support)
+        unconstrained_shape = np.shape(transform.inv(prototype_value))
         unconstrained_samples = dist.Uniform(-radius, radius).sample(
             rng_key, sample_shape=sample_shape + unconstrained_shape)
         return transform(unconstrained_samples)

--- a/numpyro/infer/initialization.py
+++ b/numpyro/infer/initialization.py
@@ -62,9 +62,8 @@ def init_to_uniform(site=None, radius=2):
             # we can't use this logic for general priors
             # because some distributions such as TransformedDistribution might
             # have wrong event_shape.
-            prototype_value = np.full(site['fn'].event_shape, np.nan)
-            unconstrained_event_shape = np.shape(transform.inv(prototype_value))
-            unconstrained_shape = site['fn'].batch_shape + unconstrained_event_shape
+            prototype_value = np.full(site['fn'].shape(), np.nan)
+            unconstrained_shape = np.shape(transform.inv(prototype_value))
 
         unconstrained_samples = dist.Uniform(-radius, radius).sample(
             rng_key, sample_shape=sample_shape + unconstrained_shape)

--- a/numpyro/infer/initialization.py
+++ b/numpyro/infer/initialization.py
@@ -12,7 +12,8 @@ from numpyro.distributions import biject_to
 
 def init_to_median(site=None, num_samples=15):
     """
-    Initialize to the prior median.
+    Initialize to the prior median. For priors with no `.sample` method implemented,
+    we defer to the :func:`init_to_uniform` strategy.
 
     :param int num_samples: number of prior points to calculate median.
     """
@@ -22,13 +23,17 @@ def init_to_median(site=None, num_samples=15):
     if site['type'] == 'sample' and not site['is_observed']:
         rng_key = site['kwargs'].get('rng_key')
         sample_shape = site['kwargs'].get('sample_shape')
-        samples = site['fn'].sample(rng_key, sample_shape=(num_samples,) + sample_shape)
-        return np.median(samples, axis=0)
+        try:
+            samples = site['fn'].sample(rng_key, sample_shape=(num_samples,) + sample_shape)
+            return np.median(samples, axis=0)
+        except NotImplementedError:
+            return init_to_uniform(site)
 
 
 def init_to_prior(site=None):
     """
-    Initialize to a prior sample.
+    Initialize to a prior sample. For priors with no `.sample` method implemented,
+    we defer to the :func:`init_to_uniform` strategy.
     """
     return init_to_median(site, num_samples=1)
 
@@ -47,13 +52,23 @@ def init_to_uniform(site=None, radius=2):
         rng_key = site['kwargs'].get('rng_key')
         sample_shape = site['kwargs'].get('sample_shape')
         rng_key, subkey = random.split(rng_key)
+        transform = biject_to(fn.support)
         # this is used to interpret the changes of event_shape in
         # domain and codomain spaces
-        prototype_value = fn.sample(subkey, sample_shape=())
-        transform = biject_to(fn.support)
-        unconstrained_event_shape = np.shape(transform.inv(prototype_value))
+        try:
+            prototype_value = fn.sample(subkey, sample_shape=())
+            unconstrained_shape = np.shape(transform.inv(prototype_value))
+        except NotImplementedError:
+            # XXX: this works for ImproperUniform prior,
+            # we can't use this logic for general priors
+            # because some distributions such as TransformedDistribution might
+            # have wrong event_shape.
+            prototype_value = np.full(fn.event_shape, np.nan)
+            unconstrained_event_shape = np.shape(transform.inv(prototype_value))
+            unconstrained_shape = fn.batch_shape + unconstrained_event_shape
+
         unconstrained_samples = dist.Uniform(-radius, radius).sample(
-            rng_key, sample_shape=sample_shape + unconstrained_event_shape)
+            rng_key, sample_shape=sample_shape + unconstrained_shape)
         return transform(unconstrained_samples)
 
 

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -57,6 +57,18 @@ def _lowrank_mvn_to_scipy(loc, cov_fac, cov_diag):
     return osp.multivariate_normal(mean=mean, cov=cov)
 
 
+class _ImproperWrapper(dist.ImproperUniform):
+    def sample(self, key, sample_shape=()):
+        transform = biject_to(self.support)
+        prototype_value = np.zeros(self.event_shape)
+        unconstrained_event_shape = np.shape(transform.inv(prototype_value))
+        shape = sample_shape + self.batch_shape + unconstrained_event_shape
+        unconstrained_samples = random.uniform(key, shape,
+                                               minval=-2,
+                                               maxval=2)
+        return transform(unconstrained_samples)
+
+
 _DIST_MAP = {
     dist.BernoulliProbs: lambda probs: osp.bernoulli(p=probs),
     dist.BernoulliLogits: lambda logits: osp.bernoulli(p=_to_probs_bernoulli(logits)),
@@ -112,6 +124,7 @@ CONTINUOUS = [
     T(dist.HalfCauchy, np.array([1., 2.])),
     T(dist.HalfNormal, 1.),
     T(dist.HalfNormal, np.array([1., 2.])),
+    T(_ImproperWrapper, constraints.positive, (), (3,)),
     T(dist.InverseGamma, np.array([1.7]), np.array([[2.], [3.]])),
     T(dist.InverseGamma, np.array([0.5, 1.3]), np.array([[1.], [3.]])),
     T(dist.LKJ, 2, 0.5, "onion"),
@@ -556,6 +569,8 @@ def test_gamma_poisson_log_prob(shape):
 def test_log_prob_gradient(jax_dist, sp_dist, params):
     if jax_dist in [dist.LKJ, dist.LKJCholesky]:
         pytest.skip('we have separated tests for LKJCholesky distribution')
+    if jax_dist is _ImproperWrapper:
+        pytest.skip('no param for ImproperUniform to test for log_prob gradient')
 
     rng_key = random.PRNGKey(0)
     value = jax_dist(*params).sample(rng_key)
@@ -584,6 +599,9 @@ def test_log_prob_gradient(jax_dist, sp_dist, params):
 
 @pytest.mark.parametrize('jax_dist, sp_dist, params', CONTINUOUS + DISCRETE)
 def test_mean_var(jax_dist, sp_dist, params):
+    if jax_dist is _ImproperWrapper:
+        pytest.skip("Improper distribution does not has mean/var implemented")
+
     n = 20000 if jax_dist in [dist.LKJ, dist.LKJCholesky] else 200000
     d_jax = jax_dist(*params)
     k = random.PRNGKey(0)
@@ -653,7 +671,7 @@ def test_distribution_constraints(jax_dist, sp_dist, params, prepend_shape):
     key = random.PRNGKey(1)
     dependent_constraint = False
     for i in range(len(params)):
-        if jax_dist in (dist.LKJ, dist.LKJCholesky) and dist_args[i] != "concentration":
+        if jax_dist in (_ImproperWrapper, dist.LKJ, dist.LKJCholesky) and dist_args[i] != "concentration":
             continue
         if params[i] is None:
             oob_params[i] = None
@@ -670,7 +688,7 @@ def test_distribution_constraints(jax_dist, sp_dist, params, prepend_shape):
     assert jax_dist(*oob_params)
 
     # Invalid parameter values throw ValueError
-    if not dependent_constraint and jax_dist is not dist.ImproperUniform:
+    if not dependent_constraint and jax_dist is not _ImproperWrapper:
         with pytest.raises(ValueError):
             jax_dist(*oob_params, validate_args=True)
 

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -112,7 +112,6 @@ CONTINUOUS = [
     T(dist.HalfCauchy, np.array([1., 2.])),
     T(dist.HalfNormal, 1.),
     T(dist.HalfNormal, np.array([1., 2.])),
-    T(dist.ImproperUniform, constraints.positive, (3,)),
     T(dist.InverseGamma, np.array([1.7]), np.array([[2.], [3.]])),
     T(dist.InverseGamma, np.array([0.5, 1.3]), np.array([[1.], [3.]])),
     T(dist.LKJ, 2, 0.5, "onion"),
@@ -557,10 +556,8 @@ def test_gamma_poisson_log_prob(shape):
 def test_log_prob_gradient(jax_dist, sp_dist, params):
     if jax_dist in [dist.LKJ, dist.LKJCholesky]:
         pytest.skip('we have separated tests for LKJCholesky distribution')
-    if jax_dist is dist.ImproperUniform:
-        pytest.skip('no param for ImproperUniform to test for log_prob gradient')
-    rng_key = random.PRNGKey(0)
 
+    rng_key = random.PRNGKey(0)
     value = jax_dist(*params).sample(rng_key)
 
     def fn(*args):
@@ -587,9 +584,6 @@ def test_log_prob_gradient(jax_dist, sp_dist, params):
 
 @pytest.mark.parametrize('jax_dist, sp_dist, params', CONTINUOUS + DISCRETE)
 def test_mean_var(jax_dist, sp_dist, params):
-    if jax_dist is dist.ImproperUniform:
-        pytest.skip("Improper distribution does not has mean/var implemented")
-
     n = 20000 if jax_dist in [dist.LKJ, dist.LKJCholesky] else 200000
     d_jax = jax_dist(*params)
     k = random.PRNGKey(0)
@@ -659,7 +653,7 @@ def test_distribution_constraints(jax_dist, sp_dist, params, prepend_shape):
     key = random.PRNGKey(1)
     dependent_constraint = False
     for i in range(len(params)):
-        if jax_dist in (dist.ImproperUniform, dist.LKJ, dist.LKJCholesky) and dist_args[i] != "concentration":
+        if jax_dist in (dist.LKJ, dist.LKJCholesky) and dist_args[i] != "concentration":
             continue
         if params[i] is None:
             oob_params[i] = None
@@ -797,6 +791,10 @@ def test_biject_to(constraint, shape):
     rng_key = random.PRNGKey(0)
     x = random.normal(rng_key, shape)
     y = transform(x)
+
+    # test inv work for NaN arrays:
+    x_nan = transform.inv(np.full(np.shape(y), np.nan))
+    assert (x_nan.shape == x.shape)
 
     # test codomain
     batch_shape = shape if event_dim == 0 else shape[:-1]

--- a/test/test_infer_util.py
+++ b/test/test_infer_util.py
@@ -255,7 +255,8 @@ def test_initialize_model_dirichlet_categorical(init_strategy):
             assert_allclose(p[i], init_params_i[0][name], atol=1e-6)
 
 
-def test_improper_expand():
+@pytest.mark.parametrize('event_shape', [(3,), ()])
+def test_improper_expand(event_shape):
 
     def model():
         population = np.array([1000., 2000., 3000.])
@@ -263,7 +264,7 @@ def test_improper_expand():
             numpyro.sample("incidence",
                            dist.ImproperUniform(support=constraints.interval(0, population),
                                                 batch_shape=(3,),
-                                                event_shape=(3,)))
+                                                event_shape=event_shape))
 
     model_info = initialize_model(random.PRNGKey(0), model)
-    assert model_info.param_info.z['incidence'].shape == (3, 3)
+    assert model_info.param_info.z['incidence'].shape == (3,) + event_shape

--- a/test/test_infer_util.py
+++ b/test/test_infer_util.py
@@ -261,10 +261,11 @@ def test_improper_expand(event_shape):
     def model():
         population = np.array([1000., 2000., 3000.])
         with numpyro.plate("region", 3):
-            numpyro.sample("incidence",
-                           dist.ImproperUniform(support=constraints.interval(0, population),
-                                                batch_shape=(3,),
-                                                event_shape=event_shape))
+            d = dist.ImproperUniform(support=constraints.interval(0, population),
+                                     batch_shape=(3,),
+                                     event_shape=event_shape)
+            incidence = numpyro.sample("incidence", d)
+            assert d.log_prob(incidence).shape == (3,)
 
     model_info = initialize_model(random.PRNGKey(0), model)
     assert model_info.param_info.z['incidence'].shape == (3,) + event_shape

--- a/test/test_infer_util.py
+++ b/test/test_infer_util.py
@@ -253,3 +253,17 @@ def test_initialize_model_dirichlet_categorical(init_strategy):
         for name, p in init_params[0].items():
             # XXX: the result is equal if we disable fast-math-mode
             assert_allclose(p[i], init_params_i[0][name], atol=1e-6)
+
+
+def test_improper_expand():
+
+    def model():
+        population = np.array([1000., 2000., 3000.])
+        with numpyro.plate("region", 3):
+            numpyro.sample("incidence",
+                           dist.ImproperUniform(support=constraints.interval(0, population),
+                                                batch_shape=(3,),
+                                                event_shape=(3,)))
+
+    model_info = initialize_model(random.PRNGKey(0), model)
+    assert model_info.param_info.z['incidence'].shape == (3, 3)

--- a/test/test_mcmc.py
+++ b/test/test_mcmc.py
@@ -257,7 +257,7 @@ def test_improper_prior():
 
     def model(data):
         mean = numpyro.sample('mean', dist.Normal(0, 1).mask(False))
-        std = numpyro.sample('std', dist.Improper(dist.constraints.positive, ()))
+        std = numpyro.sample('std', dist.ImproperUniform(dist.constraints.positive, ()))
         return numpyro.sample('obs', dist.Normal(mean, std), obs=data)
 
     data = dist.Normal(true_mean, true_std).sample(random.PRNGKey(1), (2000,))

--- a/test/test_mcmc.py
+++ b/test/test_mcmc.py
@@ -257,7 +257,7 @@ def test_improper_prior():
 
     def model(data):
         mean = numpyro.sample('mean', dist.Normal(0, 1).mask(False))
-        std = numpyro.sample('std', dist.ImproperUniform(dist.constraints.positive, ()))
+        std = numpyro.sample('std', dist.ImproperUniform(dist.constraints.positive, (), ()))
         return numpyro.sample('obs', dist.Normal(mean, std), obs=data)
 
     data = dist.Normal(true_mean, true_std).sample(random.PRNGKey(1), (2000,))

--- a/test/test_mcmc.py
+++ b/test/test_mcmc.py
@@ -257,7 +257,7 @@ def test_improper_prior():
 
     def model(data):
         mean = numpyro.sample('mean', dist.Normal(0, 1).mask(False))
-        std = numpyro.sample('std', dist.LogNormal(0, 1).mask(False))
+        std = numpyro.sample('std', dist.Improper(dist.constraints.positive, ()))
         return numpyro.sample('obs', dist.Normal(mean, std), obs=data)
 
     data = dist.Normal(true_mean, true_std).sample(random.PRNGKey(1), (2000,))


### PR DESCRIPTION
This mimics https://github.com/pyro-ppl/pyro/pull/2516 but adds an invalid `sample` method to generate random samples in the `support`. I also add `batch_shape=()` by default to make the usage of this distribution less verbose (there are some distributions in NumPyro also have the argument `batch_shape=()` by default).

@fritzo I should ask this in your PR: should this distribution have `validate_args` argument?

cc @vanAmsterdam: hopes that this will unblock your work using `master` branch