### PR TITLE
Cleanup autoguide before transfering 1-1 to the main module

### DIFF
--- a/numpyro/contrib/autoguide/__init__.py
+++ b/numpyro/contrib/autoguide/__init__.py
@@ -121,7 +121,6 @@ class AutoContinuous(AutoGuide):
     """
     def __init__(self, model, prefix="auto", init_strategy=init_to_uniform):
         self.init_strategy = init_strategy
-        self._base_dist = None
         super(AutoContinuous, self).__init__(model, prefix=prefix)
 
     def _setup_prototype(self, *args, **kwargs):
@@ -138,23 +137,19 @@ class AutoContinuous(AutoGuide):
         # this is to match the behavior of Pyro, where we can apply
         # unpack_latent for a batch of samples
         self._unpack_latent = UnpackTransform(unpack_latent)
+        # FIXME: in Pyro this is latent_dim, should we use latent_dim here?
         self.latent_size = np.size(self._init_latent)
-        if self.base_dist is None:
-            self.base_dist = dist.Normal(np.zeros(self.latent_size), 1.).to_event(1)
         if self.latent_size == 0:
             raise RuntimeError('{} found no latent variables; Use an empty guide instead'
                                .format(type(self).__name__))
 
     @abstractmethod
-    def _get_transform(self):
+    def _get_posterior(self):
         raise NotImplementedError
 
-    def _sample_latent(self, base_dist, *args, **kwargs):
+    def _sample_latent(self, *args, **kwargs):
         sample_shape = kwargs.pop('sample_shape', ())
-        # TODO: no need to create an extra `transform` layer,
-        # each subclass should implement `_sample_latent` and `_get_transform` separately.
-        transform = self._get_transform()
-        posterior = dist.TransformedDistribution(base_dist, transform)
+        posterior = self._get_posterior()
         return numpyro.sample("_{}_latent".format(self.prefix), posterior, sample_shape=sample_shape)
 
     def __call__(self, *args, **kwargs):
@@ -168,7 +163,7 @@ class AutoContinuous(AutoGuide):
             # run model to inspect the model structure
             self._setup_prototype(*args, **kwargs)
 
-        latent = self._sample_latent(self.base_dist, *args, **kwargs)
+        latent = self._sample_latent(*args, **kwargs)
 
         # unpack continuous latent samples
         result = {}
@@ -204,17 +199,13 @@ class AutoContinuous(AutoGuide):
             return unpack_single_latent(latent_sample)
 
     @property
-    def base_dist(self):
+    def get_base_dist(self):
         """
-        Base distribution of the posterior. By default, it is standard normal.
+        Returns the base distribution of the posterior when reparameterized
+        as a :class:`~numpyro.distributions.TransformedDistribution`. This
+        should not depend on the model's `*args, **kwargs`.
         """
-        # TODO: expose this through `get_base_dist` method as in Pyro for consistency
-        return self._base_dist
-
-    @base_dist.setter
-    def base_dist(self, base_dist):
-        # TODO: not allow changing base_dist
-        self._base_dist = base_dist
+        raise NotImplementedError
 
     def get_transform(self, params):
         """
@@ -225,7 +216,23 @@ class AutoContinuous(AutoGuide):
         :return: the transform of posterior distribution
         :rtype: :class:`~numpyro.distributions.transforms.Transform`
         """
-        return handlers.substitute(self._get_transform, params)()
+        posterior = handlers.substitute(self._get_posterior, params)()
+        assert isinstance(posterior, dist.TransformedDistribution), \
+            "posterior is not a transformed distribution"
+        if len(posterior.transforms) > 0:
+            return ComposeTransform(posterior.transforms)
+        else:
+            return posterior.transforms[0]
+
+    def get_posterior(self, params):
+        """
+        Returns the posterior distribution.
+
+        :param dict params: Current parameters of model and autoguide.
+        """
+        base_dist = self.get_base_dist()
+        transform = self.get_transform(params)
+        return dist.TransformedDistribution(base_dist, transform)
 
     def sample_posterior(self, rng_key, params, sample_shape=()):
         """
@@ -237,8 +244,8 @@ class AutoContinuous(AutoGuide):
         :return: a dict containing samples drawn the this guide.
         :rtype: dict
         """
-        latent_sample = handlers.substitute(handlers.seed(self._sample_latent, rng_key), params)(
-            self.base_dist, sample_shape=sample_shape)
+        latent_sample = handlers.substitute(
+            handlers.seed(self._sample_latent, rng_key), params)(sample_shape=sample_shape)
         return self._unpack_and_constrain(latent_sample, params)
 
     def median(self, params):
@@ -282,21 +289,35 @@ class AutoDiagonalNormal(AutoContinuous):
         self._init_scale = init_scale
         super().__init__(model, prefix, init_strategy)
 
-    def _get_transform(self):
+    def _get_posterior(self):
         loc = numpyro.param('{}_loc'.format(self.prefix), self._init_latent)
         scale = numpyro.param('{}_scale'.format(self.prefix),
                               np.full(self.latent_size, self._init_scale),
                               constraint=constraints.positive)
+        return dist.Normal(loc, scale)
+
+    def get_base_dist(self):
+        return dist.Normal(np.zeros(self.latent_size), 1).to_event(1)
+
+    def get_transform(self, params):
+        loc = params['{}_loc'.format(self.prefix)]
+        scale = params['{}_scale'.format(self.prefix)]
         return AffineTransform(loc, scale, domain=constraints.real_vector)
 
-    def median(self, params):
+    def get_posterior(self, params):
+        """
+        Returns a diagonal Normal posterior distribution.
+        """
         transform = self.get_transform(params)
-        return self._unpack_and_constrain(transform.loc, params)
+        return dist.Normal(transform.loc, transform.scale)
+
+    def median(self, params):
+        loc = params['{}_loc'.format(self.prefix)]
+        return self._unpack_and_constrain(loc, params)
 
     def quantiles(self, params, quantiles):
-        transform = self.get_transform(params)
         quantiles = np.array(quantiles)[..., None]
-        latent = dist.Normal(transform.loc, transform.scale).icdf(quantiles)
+        latent = self.get_posterior(params).icdf(quantiles)
         return self._unpack_and_constrain(latent, params)
 
 
@@ -317,16 +338,31 @@ class AutoMultivariateNormal(AutoContinuous):
         self._init_scale = init_scale
         super().__init__(model, prefix, init_strategy)
 
-    def _get_transform(self):
+    def _get_posterior(self):
         loc = numpyro.param('{}_loc'.format(self.prefix), self._init_latent)
         scale_tril = numpyro.param('{}_scale_tril'.format(self.prefix),
                                    np.identity(self.latent_size) * self._init_scale,
                                    constraint=constraints.lower_cholesky)
+        return dist.MultivariateNormal(loc, scale_tril=scale_tril)
+
+    def get_base_dist(self):
+        return dist.Normal(np.zeros(self.latent_size), 1).to_event(1)
+
+    def get_transform(self, params):
+        loc = params['{}_loc'.format(self.prefix)]
+        scale_tril = params['{}_scale_tril'.format(self.prefix)]
         return MultivariateAffineTransform(loc, scale_tril)
 
-    def median(self, params):
+    def get_posterior(self, params):
+        """
+        Returns a multivariate Normal posterior distribution.
+        """
         transform = self.get_transform(params)
-        return self._unpack_and_constrain(transform.loc, params)
+        return dist.MultivariateNormal(transform.loc, transform.scale_tril)
+
+    def median(self, params):
+        loc = params['{}_loc'.format(self.prefix)]
+        return self._unpack_and_constrain(loc, params)
 
     def quantiles(self, params, quantiles):
         transform = self.get_transform(params)
@@ -354,8 +390,7 @@ class AutoLowRankMultivariateNormal(AutoContinuous):
         super(AutoLowRankMultivariateNormal, self).__init__(
             model, prefix=prefix, init_strategy=init_strategy)
 
-    def _sample_latent(self, base_dist, *args, **kwargs):
-        sample_shape = kwargs.pop('sample_shape', ())
+    def _get_posterior(self, *args, **kwargs):
         rank = int(round(self.latent_size ** 0.5)) if self.rank is None else self.rank
         loc = numpyro.param('{}_loc'.format(self.prefix), self._init_latent)
         cov_factor = numpyro.param('{}_cov_factor'.format(self.prefix), np.zeros((self.latent_size, rank)))
@@ -364,26 +399,25 @@ class AutoLowRankMultivariateNormal(AutoContinuous):
                               constraint=constraints.positive)
         cov_diag = scale * scale
         cov_factor = cov_factor * scale[..., None]
-        posterior = dist.LowRankMultivariateNormal(loc, cov_factor, cov_diag)
-        return numpyro.sample("_{}_latent".format(self.prefix), posterior, sample_shape=sample_shape)
+        return dist.LowRankMultivariateNormal(loc, cov_factor, cov_diag)
 
-    def _get_transform(self, params):
+    def get_base_dist(self):
+        return dist.Normal(np.zeros(self.latent_size), 1).to_event(1)
+
+    def get_transform(self, params):
+        posterior = self.get_posterior(params)
+        return MultivariateAffineTransform(posterior.loc, posterior.scale_tril)
+
+    def get_posterior(self, params):
+        """
+        Returns a lowrank multivariate Normal posterior distribution.
+        """
         loc = params['{}_loc'.format(self.prefix)]
         cov_factor = params['{}_cov_factor'.format(self.prefix)]
         scale = params['{}_scale'.format(self.prefix)]
         cov_diag = scale * scale
         cov_factor = cov_factor * scale[..., None]
-        scale_tril = dist.LowRankMultivariateNormal(loc, cov_factor, cov_diag).scale_tril
-        return MultivariateAffineTransform(loc, scale_tril)
-
-    def sample_posterior(self, rng_key, params, sample_shape=()):
-        transform = self._get_transform(params)
-        loc, scale_tril = transform.loc, transform.scale_tril
-        latent_sample = dist.MultivariateNormal(loc, scale_tril=scale_tril).sample(rng_key, sample_shape)
-        return self._unpack_and_constrain(latent_sample, params)
-
-    def get_transform(self, params):
-        return self._get_transform(params)
+        return dist.LowRankMultivariateNormal(loc, cov_factor, cov_diag)
 
     def median(self, params):
         loc = params['{}_loc'.format(self.prefix)]
@@ -419,14 +453,15 @@ class AutoLaplaceApproximation(AutoContinuous):
 
         self._loss_fn = loss_fn
 
-    def _sample_latent(self, base_dist, *args, **kwargs):
+    def _get_posterior(self, *args, **kwargs):
         # sample from Delta guide
-        sample_shape = kwargs.pop('sample_shape', ())
         loc = numpyro.param('{}_loc'.format(self.prefix), self._init_latent)
-        posterior = dist.Delta(loc, event_ndim=1)
-        return numpyro.sample("_{}_latent".format(self.prefix), posterior, sample_shape=sample_shape)
+        return dist.Delta(loc, event_ndim=1)
 
-    def _get_transform(self, params):
+    def get_base_dist(self):
+        return dist.Normal(np.zeros(self.latent_size), 1).to_event(1)
+
+    def get_transform(self, params):
         def loss_fn(z):
             params1 = params.copy()
             params1['{}_loc'.format(self.prefix)] = z
@@ -443,21 +478,23 @@ class AutoLaplaceApproximation(AutoContinuous):
         scale_tril = np.where(np.isnan(scale_tril), 0., scale_tril)
         return MultivariateAffineTransform(loc, scale_tril)
 
-    def sample_posterior(self, rng_key, params, sample_shape=()):
-        transform = self._get_transform(params)
-        loc, scale_tril = transform.loc, transform.scale_tril
-        latent_sample = dist.MultivariateNormal(loc, scale_tril=scale_tril).sample(rng_key, sample_shape)
-        return self._unpack_and_constrain(latent_sample, params)
+    def get_posterior(self, params):
+        """
+        Returns a multivariate Normal posterior distribution.
+        """
+        transform = self.get_transform(params)
+        return dist.MultivariateNormal(transform.loc, scale_tril=transform.scale_tril)
 
-    def get_transform(self, params):
-        return self._get_transform(params)
+    def sample_posterior(self, rng_key, params, sample_shape=()):
+        latent_sample = self.get_posterior(params).sample(rng_key, sample_shape)
+        return self._unpack_and_constrain(latent_sample, params)
 
     def median(self, params):
         loc = params['{}_loc'.format(self.prefix)]
         return self._unpack_and_constrain(loc, params)
 
     def quantiles(self, params, quantiles):
-        transform = self._get_transform(params)
+        transform = self.get_transform(params)
         quantiles = np.array(quantiles)[..., None]
         latent = dist.Normal(transform.loc, np.diagonal(transform.scale_tril)).icdf(quantiles)
         return self._unpack_and_constrain(latent, params)
@@ -476,33 +513,29 @@ class AutoIAFNormal(AutoContinuous):
         guide = AutoIAFNormal(model, hidden_dims=[20], skip_connections=True, ...)
         svi = SVI(model, guide, ...)
 
-    :param jax.random.PRNGKey rng_key: random key to be used as the source of randomness
-        to initialize the guide.
     :param callable model: a generative model.
     :param str prefix: a prefix that will be prefixed to all param internal sites.
     :param callable init_strategy: A per-site initialization function.
     :param int num_flows: the number of flows to be used, defaults to 3.
-    :param `**arn_kwargs`: keywords for constructing autoregressive neural networks, which includes:
-
-        * **hidden_dims** (``list[int]``) - the dimensionality of the hidden units per layer.
-          Defaults to ``[latent_size, latent_size]``.
-        * **skip_connections** (``bool``) - whether to add skip connections from the input to the
-          output of each flow. Defaults to False.
-        * **nonlinearity** (``callable``) - the nonlinearity to use in the feedforward network.
-          Defaults to :func:`jax.experimental.stax.Relu`.
+    :param list hidden_dims: the dimensionality of the hidden units per layer.
+        Defaults to ``[latent_size, latent_size]``.
+    :param bool skip_connections: whether to add skip connections from the input to the
+        output of each flow. Defaults to False.
+    :param callable nonlinearity: the nonlinearity to use in the feedforward network.
+        Defaults to :func:`jax.experimental.stax.Elu`.
     """
     def __init__(self, model, prefix="auto", init_strategy=init_to_uniform,
-                 num_flows=3, **arn_kwargs):
+                 num_flows=3, hidden_dims=None, skip_connections=False, nonlinearity=stax.Elu):
         self.num_flows = num_flows
         # 2-layer, stax.Elu, skip_connections=False by default following the experiments in
         # IAF paper (https://arxiv.org/abs/1606.04934)
         # and Neutra paper (https://arxiv.org/abs/1903.03704)
-        self._hidden_dims = arn_kwargs.get('hidden_dims')
-        self._skip_connections = arn_kwargs.get('skip_connections', False)
-        self._nonlinearity = arn_kwargs.get('nonlinearity', stax.Elu)
+        self._hidden_dims = hidden_dims
+        self._skip_connections = skip_connections
+        self._nonlinearity = nonlinearity
         super(AutoIAFNormal, self).__init__(model, prefix=prefix, init_strategy=init_strategy)
 
-    def _get_transform(self):
+    def _get_posterior(self):
         if self.latent_size == 1:
             raise ValueError('latent dim = 1. Consider using AutoDiagonalNormal instead')
         hidden_dims = [self.latent_size, self.latent_size] if self._hidden_dims is None else self._hidden_dims
@@ -516,7 +549,10 @@ class AutoIAFNormal(AutoContinuous):
                                    nonlinearity=self._nonlinearity)
             arnn = numpyro.module('{}_arn__{}'.format(self.prefix, i), arn, (self.latent_size,))
             flows.append(InverseAutoregressiveTransform(arnn))
-        return ComposeTransform(flows)
+        return dist.TransformedDistribution(self.get_base_dist(), flows)
+
+    def get_base_dist(self):
+        return dist.Normal(np.zeros(self.latent_size), 1).to_event(1)
 
 
 class AutoBNAFNormal(AutoContinuous):
@@ -529,7 +565,7 @@ class AutoBNAFNormal(AutoContinuous):
 
     Usage::
 
-        guide = AutoBNAFNormal(rng, model, get_params, num_flows=1, hidden_factors=[50, 50])
+        guide = AutoBNAFNormal(model, num_flows=1, hidden_factors=[50, 50], ...)
         svi = SVI(model, guide, ...)
 
     **References**
@@ -537,8 +573,6 @@ class AutoBNAFNormal(AutoContinuous):
     1. *Block Neural Autoregressive Flow*,
        Nicola De Cao, Ivan Titov, Wilker Aziz
 
-    :param jax.random.PRNGKey rng: random key to be used as the source of randomness
-        to initialize the guide.
     :param callable model: a generative model.
     :param str prefix: a prefix that will be prefixed to all param internal sites.
     :param callable init_strategy: A per-site initialization function.
@@ -553,7 +587,7 @@ class AutoBNAFNormal(AutoContinuous):
         self._hidden_factors = hidden_factors
         super(AutoBNAFNormal, self).__init__(model, prefix=prefix, init_strategy=init_strategy)
 
-    def _get_transform(self):
+    def _get_posterior(self):
         if self.latent_size == 1:
             raise ValueError('latent dim = 1. Consider using AutoDiagonalNormal instead')
         flows = []
@@ -564,4 +598,7 @@ class AutoBNAFNormal(AutoContinuous):
             arn = BlockNeuralAutoregressiveNN(self.latent_size, self._hidden_factors, residual)
             arnn = numpyro.module('{}_arn__{}'.format(self.prefix, i), arn, (self.latent_size,))
             flows.append(BlockNeuralAutoregressiveTransform(arnn))
-        return ComposeTransform(flows)
+        return dist.TransformedDistribution(self.get_base_dist(), flows)
+
+    def get_base_dist(self):
+        return dist.Normal(np.zeros(self.latent_size), 1).to_event(1)

--- a/numpyro/contrib/reparam.py
+++ b/numpyro/contrib/reparam.py
@@ -170,7 +170,7 @@ class NeuTraReparam(Reparam):
         if not self._x_unconstrained:  # On first sample site.
             # Sample a shared latent.
             z_unconstrained = numpyro.sample("{}_shared_latent".format(self.guide.prefix),
-                                             self.guide.base_dist.mask(False))
+                                             self.guide.get_base_dist().mask(False))
 
             # Differentiably transform.
             x_unconstrained = self.transform(z_unconstrained)


### PR DESCRIPTION
This PR matches the interface of autoguide to be similar to Pyro. There are two differences:
+ here we use `latent_size` while Pyro uses `latent_dim`, should we make a switch? I remember that we already discussed this difference, but can't recall the resolution.
+ post-inference methods require `params` argument. I think this is necessary because there is no global param store for SVI. I also feel this way is more explicit.

I have optimized the implementation a bit by using `_get_posterior` rather than `_get_transform`. The first method can return `Normal(loc, scale)` while the later one has to go through an extra `transform` layer. This optimization also matches the behavior in Pyro.

I also added `get_posterior` method and replace the property `base_dist` by the method `get_base_dist` to match Pyro.

Hopefully, all tests will pass without any change.