### PR TITLE
support Expand Reparam

### DIFF
--- a/numpyro/contrib/autoguide/__init__.py
+++ b/numpyro/contrib/autoguide/__init__.py
@@ -181,7 +181,7 @@ class AutoContinuous(AutoGuide):
             event_ndim = len(site['fn'].event_shape)
             log_density = sum_rightmost(log_density,
                                         np.ndim(log_density) - np.ndim(value) + event_ndim)
-            delta_dist = dist.Delta(value, log_density=log_density, event_ndim=event_ndim)
+            delta_dist = dist.Delta(value, log_density=log_density, event_dim=event_ndim)
             result[name] = numpyro.sample(name, delta_dist)
 
         return result
@@ -423,7 +423,7 @@ class AutoLaplaceApproximation(AutoContinuous):
         # sample from Delta guide
         sample_shape = kwargs.pop('sample_shape', ())
         loc = numpyro.param('{}_loc'.format(self.prefix), self._init_latent)
-        posterior = dist.Delta(loc, event_ndim=1)
+        posterior = dist.Delta(loc, event_dim=1)
         return numpyro.sample("_{}_latent".format(self.prefix), posterior, sample_shape=sample_shape)
 
     def _get_transform(self, params):

--- a/numpyro/distributions/discrete.py
+++ b/numpyro/distributions/discrete.py
@@ -366,11 +366,11 @@ class Delta(Distribution):
     support = constraints.real
     is_discrete = True
 
-    def __init__(self, value=0., log_density=0., event_ndim=0, validate_args=None):
-        if event_ndim > np.ndim(value):
+    def __init__(self, value=0., log_density=0., event_dim=0, validate_args=None):
+        if event_dim > np.ndim(value):
             raise ValueError('Expected event_dim <= v.dim(), actual {} vs {}'
-                             .format(event_ndim, np.ndim(value)))
-        batch_dim = np.ndim(value) - event_ndim
+                             .format(event_dim, np.ndim(value)))
+        batch_dim = np.ndim(value) - event_dim
         batch_shape = np.shape(value)[:batch_dim]
         event_shape = np.shape(value)[batch_dim:]
         self.value = lax.convert_element_type(value, canonicalize_dtype(np.float64))

--- a/numpyro/distributions/distribution.py
+++ b/numpyro/distributions/distribution.py
@@ -150,6 +150,29 @@ class Distribution(object):
         """
         return self._event_shape
 
+    @property
+    def event_dim(self):
+        """
+        :return: Number of dimensions of individual events.
+        :rtype: int
+        """
+        return len(self.event_shape)
+
+    def shape(self, sample_shape=()):
+        """
+        The tensor shape of samples from this distribution.
+
+        Samples are of shape::
+
+            d.shape(sample_shape) == sample_shape + d.batch_shape + d.event_shape
+
+        :param tuple sample_shape: the size of the iid batch to be drawn from the
+            distribution.
+        :return: shape of samples.
+        :rtype: tuple
+        """
+        return sample_shape + self.batch_shape + self.event_shape
+
     def sample(self, key, sample_shape=()):
         """
         Returns a sample from the distribution having shape given by
@@ -228,6 +251,8 @@ class Distribution(object):
         """
         if reinterpreted_batch_ndims is None:
             reinterpreted_batch_ndims = len(self.batch_shape)
+        elif reinterpreted_batch_ndims == 0:
+            return self
         return Independent(self, reinterpreted_batch_ndims)
 
     def enumerate_support(self, expand=True):
@@ -246,7 +271,24 @@ class Distribution(object):
         :return: an instance of `ExpandedDistribution`.
         :rtype: :class:`ExpandedDistribution`
         """
+        batch_shape = tuple(batch_shape)
+        if batch_shape == self.batch_shape:
+            return self
         return ExpandedDistribution(self, batch_shape)
+
+    def expand_by(self, sample_shape):
+        """
+        Expands a distribution by adding ``sample_shape`` to the left side of
+        its :attr:`~numpyro.distributions.distribution.Distribution.batch_shape`.
+        To expand internal dims of ``self.batch_shape`` from 1 to something
+        larger, use :meth:`expand` instead.
+
+        :param tuple sample_shape: The size of the iid batch to be drawn
+            from the distribution.
+        :return: An expanded version of this distribution.
+        :rtype: :class:`ExpandedDistribution`
+        """
+        return self.expand(tuple(sample_shape) + self._batch_shape)
 
     def mask(self, mask):
         """
@@ -259,6 +301,8 @@ class Distribution(object):
         :return: A masked copy of this distribution.
         :rtype: :class:`MaskedDistribution`
         """
+        if mask is True:
+            return self
         return MaskedDistribution(self, mask)
 
 
@@ -266,6 +310,8 @@ class ExpandedDistribution(Distribution):
     arg_constraints = {}
 
     def __init__(self, base_dist, batch_shape=()):
+        if isinstance(base_dist, ExpandedDistribution):
+            base_dist = base_dist.base_dist
         self.base_dist = base_dist
         super().__init__(base_dist.batch_shape, base_dist.event_shape)
         # adjust batch shape
@@ -512,6 +558,13 @@ class TransformedDistribution(Distribution):
         else:
             self.base_dist = base_distribution
             self.transforms = transforms
+        # NB: here we assume that base_dist.shape == transformed_dist.shape
+        # but that might not be True for some transforms such as StickBreakingTransform
+        # because the event dimension is transformed from (n - 1,) to (n,).
+        # Currently, we have no mechanism to fix this issue. Given that
+        # this is just an edge case, we might skip this issue but need
+        # to pay attention to any inference function that inspects
+        # transformed distribution's shape.
         shape = base_distribution.batch_shape + base_distribution.event_shape
         event_dim = max([len(base_distribution.event_shape)] + [t.event_dim for t in transforms])
         batch_shape = shape[:len(shape) - event_dim]

--- a/numpyro/handlers.py
+++ b/numpyro/handlers.py
@@ -295,6 +295,9 @@ class mask(Messenger):
         super(mask, self).__init__(fn)
 
     def process_message(self, msg):
+        if msg['type'] != 'sample':
+            return
+
         msg['mask'] = self.mask if msg['mask'] is None else self.mask & msg['mask']
 
 
@@ -315,6 +318,9 @@ class scale(Messenger):
         super(scale, self).__init__(fn)
 
     def process_message(self, msg):
+        if msg['type'] not in ('sample', 'plate'):
+            return
+
         msg["scale"] = self.scale if msg.get('scale') is None else self.scale * msg['scale']
 
 

--- a/numpyro/primitives.py
+++ b/numpyro/primitives.py
@@ -137,8 +137,6 @@ def param(name, init_value=None, **kwargs):
         'args': (init_value,),
         'kwargs': kwargs,
         'value': None,
-        'mask': None,
-        'scale': None,
         'cond_indep_stack': [],
     }
 

--- a/test/contrib/test_reparam.py
+++ b/test/contrib/test_reparam.py
@@ -45,11 +45,10 @@ def test_log_normal(shape):
                                           dist.Normal(np.zeros_like(loc),
                                                       np.ones_like(scale)),
                                           [AffineTransform(loc, scale),
-                                           ExpTransform()]))
+                                           ExpTransform()]).expand_by([100000]))
 
     with handlers.trace() as tr:
         value = handlers.seed(model, 0)()
-    assert isinstance(tr["x"]["fn"], dist.TransformedDistribution)
     expected_moments = get_moments(value)
 
     with reparam(config={"x": TransformReparam()}):


### PR DESCRIPTION
Addresses #610.

I also add some missing methods from pyro TorchDistribution and rename `event_ndim` to `event_dim` in Delta distribution for consistency.

@neerajprad I can't find a proper way to support MaskedDistribution. Basically, mask(t(dist)) is different from `t(mask(dist))`. The difference between two log_probs is the log determinant of the transform. Adding jacobian adjustment will complicate the code. In addition, the composition of `Masked(Expand(Masked))` is complicated to deal with. :( It seems to be a regression, but I think users can use `Uniform`, which works with TransformReparam, for `Improper(interval)` (~we miss support for the dynamic improper `greater_than`~).