### PR TITLE
Update jax version to test Travis with latest jax release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
     # Keep track of pyro-api master branch
     - pip install https://github.com/pyro-ppl/pyro-api/archive/master.zip
     - pip install jaxlib
-    - pip install jax==0.1.67
+    - pip install jax>=0.1.70
     - pip install .[examples,test]
     - pip freeze
 

--- a/examples/hmm.py
+++ b/examples/hmm.py
@@ -36,10 +36,10 @@ from scipy.stats import gaussian_kde
 
 from jax import lax, random
 import jax.numpy as np
+from jax.scipy.special import logsumexp
 
 import numpyro
 import numpyro.distributions as dist
-from numpyro.distributions.util import logsumexp
 from numpyro.infer import MCMC, NUTS
 
 

--- a/examples/neutra.py
+++ b/examples/neutra.py
@@ -23,6 +23,7 @@ import seaborn as sns
 
 from jax import lax, random
 import jax.numpy as np
+from jax.scipy.special import logsumexp
 
 import numpyro
 from numpyro import optim
@@ -31,7 +32,6 @@ from numpyro.contrib.reparam import NeuTraReparam
 from numpyro.diagnostics import print_summary
 import numpyro.distributions as dist
 from numpyro.distributions import constraints
-from numpyro.distributions.util import logsumexp
 from numpyro.infer import ELBO, MCMC, NUTS, SVI
 
 

--- a/numpyro/distributions/discrete.py
+++ b/numpyro/distributions/discrete.py
@@ -38,12 +38,10 @@ from numpyro.distributions.util import (
     binary_cross_entropy_with_logits,
     binomial,
     categorical,
-    categorical_logits,
     clamp_probs,
     get_dtype,
     lazy_property,
     multinomial,
-    poisson,
     promote_shapes,
     sum_rightmost,
     validate_sample,
@@ -317,7 +315,7 @@ class CategoricalLogits(Distribution):
                                                 validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
-        return categorical_logits(key, self.logits, shape=sample_shape + self.batch_shape)
+        return random.categorical(key, self.logits, shape=sample_shape + self.batch_shape)
 
     @validate_sample
     def log_prob(self, value):
@@ -543,7 +541,7 @@ class Poisson(Distribution):
         super(Poisson, self).__init__(np.shape(rate), validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
-        return poisson(key, self.rate, shape=sample_shape + self.batch_shape)
+        return random.poisson(key, self.rate, shape=sample_shape + self.batch_shape)
 
     @validate_sample
     def log_prob(self, value):
@@ -580,7 +578,7 @@ class ZeroInflatedPoisson(Distribution):
         key_bern, key_poisson = random.split(key)
         shape = sample_shape + self.batch_shape
         mask = random.bernoulli(key_bern, self.gate, shape)
-        samples = poisson(key_poisson, self.rate, shape)
+        samples = random.poisson(key_poisson, self.rate, shape)
         return np.where(mask, 0, samples)
 
     @validate_sample

--- a/numpyro/distributions/discrete.py
+++ b/numpyro/distributions/discrete.py
@@ -541,7 +541,7 @@ class Poisson(Distribution):
         super(Poisson, self).__init__(np.shape(rate), validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
-        return random.poisson(key, self.rate, shape=sample_shape + self.batch_shape)
+        return random.poisson(key, device_put(self.rate), shape=sample_shape + self.batch_shape)
 
     @validate_sample
     def log_prob(self, value):
@@ -578,7 +578,7 @@ class ZeroInflatedPoisson(Distribution):
         key_bern, key_poisson = random.split(key)
         shape = sample_shape + self.batch_shape
         mask = random.bernoulli(key_bern, self.gate, shape)
-        samples = random.poisson(key_poisson, self.rate, shape)
+        samples = random.poisson(key_poisson, device_put(self.rate), shape)
         return np.where(mask, 0, samples)
 
     @validate_sample

--- a/numpyro/distributions/transforms.py
+++ b/numpyro/distributions/transforms.py
@@ -347,9 +347,10 @@ class MultivariateAffineTransform(Transform):
     event_dim = 1
 
     def __init__(self, loc, scale_tril):
-        # TODO: relax this condition per user request
         if np.ndim(scale_tril) != 2:
-            raise ValueError("Only support 2-dimensional scale_tril matrix.")
+            raise ValueError("Only support 2-dimensional scale_tril matrix. "
+                             "Please make a feature request if you need to "
+                             "use this transform with batched scale_tril.")
         self.loc = loc
         self.scale_tril = scale_tril
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     author_email='npradhan@uber.com',
     install_requires=[
         # TODO: pin to a specific version for the release (until JAX's API becomes stable)
-        'jax==0.1.67',
+        'jax>=0.1.70',
         # check min version here: https://github.com/google/jax/blob/master/jax/lib/__init__.py#L20
         'jaxlib>=0.1.47',
         'tqdm',

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -26,7 +26,6 @@ from numpyro.distributions.transforms import MultivariateAffineTransform, Permut
 from numpyro.distributions.util import (
     matrix_to_tril_vec,
     multinomial,
-    poisson,
     signed_stick_breaking_tril,
     vec_to_tril_matrix
 )
@@ -222,7 +221,7 @@ def gen_values_within_bounds(constraint, size, key=random.PRNGKey(11)):
         upper_bound = np.broadcast_to(constraint.upper_bound, size)
         return random.randint(key, size, lower_bound, upper_bound + 1)
     elif isinstance(constraint, constraints._IntegerGreaterThan):
-        return constraint.lower_bound + poisson(key, 5, shape=size)
+        return constraint.lower_bound + random.poisson(key, 5, shape=size)
     elif isinstance(constraint, constraints._Interval):
         lower_bound = np.broadcast_to(constraint.lower_bound, size)
         upper_bound = np.broadcast_to(constraint.upper_bound, size)
@@ -262,7 +261,7 @@ def gen_values_outside_bounds(constraint, size, key=random.PRNGKey(11)):
         lower_bound = np.broadcast_to(constraint.lower_bound, size)
         return random.randint(key, size, lower_bound - 1, lower_bound)
     elif isinstance(constraint, constraints._IntegerGreaterThan):
-        return constraint.lower_bound - poisson(key, 5, shape=size)
+        return constraint.lower_bound - random.poisson(key, 5, shape=size)
     elif isinstance(constraint, constraints._Interval):
         upper_bound = np.broadcast_to(constraint.upper_bound, size)
         return random.uniform(key, size, minval=upper_bound, maxval=upper_bound + 1.)

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -221,7 +221,7 @@ def gen_values_within_bounds(constraint, size, key=random.PRNGKey(11)):
         upper_bound = np.broadcast_to(constraint.upper_bound, size)
         return random.randint(key, size, lower_bound, upper_bound + 1)
     elif isinstance(constraint, constraints._IntegerGreaterThan):
-        return constraint.lower_bound + random.poisson(key, 5, shape=size)
+        return constraint.lower_bound + random.poisson(key, np.array(5), shape=size)
     elif isinstance(constraint, constraints._Interval):
         lower_bound = np.broadcast_to(constraint.lower_bound, size)
         upper_bound = np.broadcast_to(constraint.upper_bound, size)
@@ -261,7 +261,7 @@ def gen_values_outside_bounds(constraint, size, key=random.PRNGKey(11)):
         lower_bound = np.broadcast_to(constraint.lower_bound, size)
         return random.randint(key, size, lower_bound - 1, lower_bound)
     elif isinstance(constraint, constraints._IntegerGreaterThan):
-        return constraint.lower_bound - random.poisson(key, 5, shape=size)
+        return constraint.lower_bound - random.poisson(key, np.array(5), shape=size)
     elif isinstance(constraint, constraints._Interval):
         upper_bound = np.broadcast_to(constraint.upper_bound, size)
         return random.uniform(key, size, minval=upper_bound, maxval=upper_bound + 1.)

--- a/test/test_distributions_util.py
+++ b/test/test_distributions_util.py
@@ -16,7 +16,6 @@ from numpyro.distributions.util import (
     categorical,
     cholesky_update,
     multinomial,
-    poisson,
     vec_to_tril_matrix,
     binomial)
 
@@ -105,15 +104,6 @@ def test_multinomial_stats(p, n):
     n = float(n) if isinstance(n, Number) else np.expand_dims(n.astype(p.dtype), -1)
     p = np.broadcast_to(p, z.shape)
     assert_allclose(z / n, p, atol=0.01)
-
-
-def test_poisson():
-    mu = rate = 1000
-    N = 2 ** 18
-
-    key = random.PRNGKey(64)
-    B = poisson(key, rate=rate, shape=(N,))
-    assert_allclose(B.mean(), mu, rtol=0.001)
 
 
 @pytest.mark.parametrize("shape", [


### PR DESCRIPTION
Also, remove `poisson` and `categorical_logits` sampler because we have an upstream version now. `logsumexp` issue and warning issue, which has blocked us from testing the latest jax release in Travis) is also fixed upstream.