### PR TITLE
Support `hide` argument in block handler

### DIFF
--- a/numpyro/contrib/distributions/distribution.py
+++ b/numpyro/contrib/distributions/distribution.py
@@ -9,10 +9,25 @@
 # Copyright (c) 2003-2019 SciPy Developers.
 # All rights reserved.
 from contextlib import contextmanager
+try:
+    from scipy._lib._util import getargspec_no_self
+except ImportError:
+    from collections import namedtuple
+    from scipy._lib._util import getfullargspec_no_self
 
-from scipy._lib._util import getargspec_no_self
+    ArgSpec = namedtuple('ArgSpec', ['args', 'varargs', 'keywords', 'defaults'])
+
+    def getargspec_no_self(obj):
+        return ArgSpec(*getfullargspec_no_self(obj)[:4])
 import scipy.stats as osp_stats
-from scipy.stats._distn_infrastructure import instancemethod, rv_frozen, rv_generic
+from scipy.stats._distn_infrastructure import rv_frozen, rv_generic
+try:
+    from scipy.stats._distn_infrastructure import instancemethod
+except ImportError:
+    import types
+
+    def instancemethod(func, obj, cls):
+        return types.MethodType(func, obj)
 
 from jax import lax
 import jax.numpy as jnp

--- a/numpyro/handlers.py
+++ b/numpyro/handlers.py
@@ -218,8 +218,13 @@ class block(Messenger):
        >>> assert 'a' not in trace_block_a
        >>> assert 'b' in trace_block_a
     """
-    def __init__(self, fn=None, hide_fn=lambda msg: True):
-        self.hide_fn = hide_fn
+    def __init__(self, fn=None, hide_fn=None, hide=None):
+        if hide_fn is not None:
+            self.hide_fn = hide_fn
+        elif hide is not None:
+            self.hide_fn = lambda msg: msg.get('name') in hide
+        else:
+            self.hide_fn = lambda msg: True
         super(block, self).__init__(fn)
 
     def process_message(self, msg):

--- a/test/test_handlers.py
+++ b/test/test_handlers.py
@@ -240,3 +240,11 @@ def test_plate_stack(shape):
 
     x = handlers.seed(guide, 0)()
     assert x.shape == shape
+
+
+def test_block():
+    with handlers.trace() as trace:
+        with handlers.block(hide=['x']):
+            with handlers.seed(rng_seed=0):
+                numpyro.sample('x', dist.Normal())
+    assert 'x' not in trace


### PR DESCRIPTION
Fixes #640. The `hide` argument is useful when we want to compute the conditional distribution p(y|x=x0), which is `block(condition_or_substitute_or_do(fn, {'x': x0}), hide=['x']))`