### PR TITLE
Add scope handler

### DIFF
--- a/docs/source/handlers.rst
+++ b/docs/source/handlers.rst
@@ -51,6 +51,14 @@ scale
     :show-inheritance:
     :member-order: bysource
 
+scope
+-----
+.. autoclass:: numpyro.handlers.scope
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :member-order: bysource
+
 seed
 ----
 .. autoclass:: numpyro.handlers.seed

--- a/test/test_handlers.py
+++ b/test/test_handlers.py
@@ -240,3 +240,19 @@ def test_plate_stack(shape):
 
     x = handlers.seed(guide, 0)()
     assert x.shape == shape
+
+
+def test_scope():
+    def fn():
+        return numpyro.sample('x', dist.Normal())
+
+    with handlers.trace() as trace:
+        with handlers.seed(rng_seed=1):
+            with handlers.scope(prefix='a'):
+                fn()
+            with handlers.scope(prefix='b'):
+                with handlers.scope(prefix='a'):
+                    fn()
+
+    assert 'a/x' in trace
+    assert 'b/a/x' in trace


### PR DESCRIPTION
Fixes #593. This is also useful when users use `scan` for prediction: they can use the same transition function but with different scope `train` and `forecast`.

I don't have a strong opinion on `namespace` vs `scope` or `::` vs `/` so I am happy to change them if reviewers feel that the current names are not conventional. The current name matches `pyro.contril.namespace.scope` behavior.