### PR TITLE
Support ImproperUniform in SVI

### DIFF
--- a/numpyro/infer/svi.py
+++ b/numpyro/infer/svi.py
@@ -7,7 +7,7 @@ from jax import random, value_and_grad
 
 from numpyro.distributions import constraints
 from numpyro.distributions.transforms import biject_to
-from numpyro.handlers import seed, trace
+from numpyro.handlers import replay, seed, trace
 from numpyro.infer.util import transform_fn
 
 SVIState = namedtuple('SVIState', ['optim_state', 'rng_key'])
@@ -55,7 +55,7 @@ class SVI(object):
         model_init = seed(self.model, model_seed)
         guide_init = seed(self.guide, guide_seed)
         guide_trace = trace(guide_init).get_trace(*args, **kwargs, **self.static_kwargs)
-        model_trace = trace(model_init).get_trace(*args, **kwargs, **self.static_kwargs)
+        model_trace = trace(replay(model_init, guide_trace)).get_trace(*args, **kwargs, **self.static_kwargs)
         params = {}
         inv_transforms = {}
         # NB: params in model_trace will be overwritten by params in guide_trace

--- a/test/test_autoguide.py
+++ b/test/test_autoguide.py
@@ -6,7 +6,7 @@ from functools import partial
 from numpy.testing import assert_allclose
 import pytest
 
-from jax import random
+from jax import lax, random
 import jax.numpy as jnp
 from jax.test_util import check_eq
 
@@ -284,3 +284,19 @@ def test_laplace_approximation_warning():
     params = svi.get_params(svi_state)
     with pytest.warns(UserWarning, match="Hessian of log posterior"):
         guide.sample_posterior(random.PRNGKey(1), params)
+
+
+def test_improper():
+    y = random.normal(random.PRNGKey(0), (100,))
+
+    def model(y):
+        lambda1 = numpyro.sample('lambda1', dist.ImproperUniform(dist.constraints.real, (), ()))
+        lambda2 = numpyro.sample('lambda2', dist.ImproperUniform(dist.constraints.real, (), ()))
+        sigma = numpyro.sample('sigma', dist.ImproperUniform(dist.constraints.positive, (), ()))
+        mu = numpyro.deterministic('mu', lambda1 + lambda2)
+        numpyro.sample('y', dist.Normal(mu, sigma), obs=y)
+
+    guide = AutoDiagonalNormal(model)
+    svi = SVI(model, guide, optim.Adam(0.003), ELBO(), y=y)
+    svi_state = svi.init(random.PRNGKey(2))
+    lax.scan(lambda state, i: svi.update(state), svi_state, jnp.zeros(10000))


### PR DESCRIPTION
This fixes an issue in `svi_init` to avoid calling `sample()` method of `ImproperUniform`. I think using `replay` in `svi_init` is better than the current implementation.