### PR TITLE
rename param_map to data in handlers

### DIFF
--- a/numpyro/distributions/discrete.py
+++ b/numpyro/distributions/discrete.py
@@ -548,7 +548,7 @@ class Poisson(Distribution):
         super(Poisson, self).__init__(jnp.shape(rate), validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
-        return random.poisson(key, device_put(self.rate), shape=sample_shape + self.batch_shape)
+        return random.poisson(key, self.rate, shape=sample_shape + self.batch_shape)
 
     @validate_sample
     def log_prob(self, value):

--- a/numpyro/handlers.py
+++ b/numpyro/handlers.py
@@ -269,7 +269,12 @@ class condition(Messenger):
        >>> assert exec_trace['a']['value'] == -1
        >>> assert exec_trace['a']['is_observed']
     """
-    def __init__(self, fn=None, data=None, condition_fn=None):
+    def __init__(self, fn=None, data=None, condition_fn=None, param_map=None):
+        if param_map is not None:
+            data = param_map
+            warnings.warn(FutureWarning,
+                          "'param_map' argument is renamed to 'data'. We will remove"
+                          " 'param_map' in a future release.")
         self.condition_fn = condition_fn
         self.data = data
         if sum((x is not None for x in (data, condition_fn))) != 1:
@@ -522,7 +527,12 @@ class substitute(Messenger):
        >>> exec_trace = trace(substitute(model, {'a': -1})).get_trace()
        >>> assert exec_trace['a']['value'] == -1
     """
-    def __init__(self, fn=None, data=None, substitute_fn=None):
+    def __init__(self, fn=None, data=None, substitute_fn=None, param_map=None):
+        if param_map is not None:
+            data = param_map
+            warnings.warn(FutureWarning,
+                          "'param_map' argument is renamed to 'data'. We will remove"
+                          " 'param_map' in a future release.")
         self.substitute_fn = substitute_fn
         self.data = data
         if sum((x is not None for x in (data, substitute_fn))) != 1:

--- a/numpyro/handlers.py
+++ b/numpyro/handlers.py
@@ -241,12 +241,12 @@ class block(Messenger):
 
 class condition(Messenger):
     """
-    Conditions unobserved sample sites to values from `param_map` or `condition_fn`.
+    Conditions unobserved sample sites to values from `data` or `condition_fn`.
     Similar to :class:`~numpyro.handlers.substitute` except that it only affects
     `sample` sites and changes the `is_observed` property to `True`.
 
     :param fn: Python callable with NumPyro primitives.
-    :param dict param_map: dictionary of `numpy.ndarray` values keyed by
+    :param dict data: dictionary of `numpy.ndarray` values keyed by
        site names.
     :param condition_fn: callable that takes in a site dict and returns
        a numpy array or `None` (in which case the handler has no side
@@ -269,25 +269,25 @@ class condition(Messenger):
        >>> assert exec_trace['a']['value'] == -1
        >>> assert exec_trace['a']['is_observed']
     """
-    def __init__(self, fn=None, param_map=None, condition_fn=None):
+    def __init__(self, fn=None, data=None, condition_fn=None):
         self.condition_fn = condition_fn
-        self.param_map = param_map
-        if sum((x is not None for x in (param_map, condition_fn))) != 1:
-            raise ValueError('Only one of `param_map` or `condition_fn` '
+        self.data = data
+        if sum((x is not None for x in (data, condition_fn))) != 1:
+            raise ValueError('Only one of `data` or `condition_fn` '
                              'should be provided.')
         super(condition, self).__init__(fn)
 
     def process_message(self, msg):
         if (msg['type'] != 'sample') or msg.get('_control_flow_done', False):
             if msg['type'] == 'control_flow':
-                if self.param_map is not None:
-                    msg['kwargs']['substitute_stack'].append(('condition', self.param_map))
+                if self.data is not None:
+                    msg['kwargs']['substitute_stack'].append(('condition', self.data))
                 if self.condition_fn is not None:
                     msg['kwargs']['substitute_stack'].append(('condition', self.condition_fn))
             return
 
-        if self.param_map is not None:
-            value = self.param_map.get(msg['name'])
+        if self.data is not None:
+            value = self.data.get(msg['name'])
         else:
             value = self.condition_fn(msg)
 
@@ -489,18 +489,18 @@ class seed(Messenger):
 
 class substitute(Messenger):
     """
-    Given a callable `fn` and a dict `param_map` keyed by site names
+    Given a callable `fn` and a dict `data` keyed by site names
     (alternatively, a callable `substitute_fn`), return a callable
     which substitutes all primitive calls in `fn` with values from
-    `param_map` whose key matches the site name. If the site name
-    is not present in `param_map`, there is no side effect.
+    `data` whose key matches the site name. If the site name
+    is not present in `data`, there is no side effect.
 
     If a `substitute_fn` is provided, then the value at the site is
     replaced by the value returned from the call to `substitute_fn`
     for the given site.
 
     :param fn: Python callable with NumPyro primitives.
-    :param dict param_map: dictionary of `numpy.ndarray` values keyed by
+    :param dict data: dictionary of `numpy.ndarray` values keyed by
         site names.
     :param substitute_fn: callable that takes in a site dict and returns
         a numpy array or `None` (in which case the handler has no side
@@ -522,25 +522,25 @@ class substitute(Messenger):
        >>> exec_trace = trace(substitute(model, {'a': -1})).get_trace()
        >>> assert exec_trace['a']['value'] == -1
     """
-    def __init__(self, fn=None, param_map=None, substitute_fn=None):
+    def __init__(self, fn=None, data=None, substitute_fn=None):
         self.substitute_fn = substitute_fn
-        self.param_map = param_map
-        if sum((x is not None for x in (param_map, substitute_fn))) != 1:
-            raise ValueError('Only one of `param_map` or `substitute_fn` '
+        self.data = data
+        if sum((x is not None for x in (data, substitute_fn))) != 1:
+            raise ValueError('Only one of `data` or `substitute_fn` '
                              'should be provided.')
         super(substitute, self).__init__(fn)
 
     def process_message(self, msg):
         if (msg['type'] not in ('sample', 'param')) or msg.get('_control_flow_done', False):
             if msg['type'] == 'control_flow':
-                if self.param_map is not None:
-                    msg['kwargs']['substitute_stack'].append(('substitute', self.param_map))
+                if self.data is not None:
+                    msg['kwargs']['substitute_stack'].append(('substitute', self.data))
                 if self.substitute_fn is not None:
                     msg['kwargs']['substitute_stack'].append(('substitute', self.substitute_fn))
             return
 
-        if self.param_map is not None:
-            value = self.param_map.get(msg['name'])
+        if self.data is not None:
+            value = self.data.get(msg['name'])
         else:
             value = self.substitute_fn(msg)
 

--- a/numpyro/infer/util.py
+++ b/numpyro/infer/util.py
@@ -151,7 +151,7 @@ def potential_energy(model, model_args, model_kwargs, params):
 
 def _init_to_unconstrained_value(site=None, values={}):
     if site is None:
-        return partial(init_to_value, values=values)
+        return partial(_init_to_unconstrained_value, values=values)
 
 
 def find_valid_initial_params(rng_key, model,
@@ -368,7 +368,7 @@ def initialize_model(rng_key, model,
     if (init_strategy.func is init_to_value) and not replay_model:
         init_values = init_strategy.keywords.get("values")
         unconstrained_values = transform_fn(inv_transforms, init_values, invert=True)
-        init_strategy = partial(_init_to_unconstrained_value, values=unconstrained_values)
+        init_strategy = _init_to_unconstrained_value(values=unconstrained_values)
     prototype_params = transform_fn(inv_transforms, constrained_values, invert=True)
     (init_params, pe, grad), is_valid = find_valid_initial_params(rng_key, model,
                                                                   init_strategy=init_strategy,

--- a/numpyro/infer/util.py
+++ b/numpyro/infer/util.py
@@ -43,7 +43,7 @@ def log_density(model, model_args, model_kwargs, params):
         name.
     :return: log of joint density and a corresponding model trace
     """
-    model = substitute(model, param_map=params)
+    model = substitute(model, data=params)
     model_trace = trace(model).get_trace(*model_args, **model_kwargs)
     log_joint = jnp.array(0.)
     for site in model_trace.values():

--- a/test/test_svi.py
+++ b/test/test_svi.py
@@ -146,7 +146,7 @@ def test_elbo_dynamic_support():
 
     adam = optim.Adam(0.01)
     x = 2.
-    guide = substitute(guide, param_map={'x': x})
+    guide = substitute(guide, data={'x': x})
     svi = SVI(model, guide, adam, ELBO())
     svi_state = svi.init(random.PRNGKey(0))
     actual_loss = svi.evaluate(svi_state)


### PR DESCRIPTION
@neerajprad There is still `param_map` left in [ELBO.loss](http://num.pyro.ai/en/stable/svi.html#numpyro.infer.elbo.ELBO.loss). Should we rename it to `params` to make it consistent with `AutoGuide` or utilities in `infer/util.py`? I just notice when trying to grep `param_map` and have less opinion about it. WDYT?