### PR TITLE
Allow guides with re-initializable parameters

### DIFF
--- a/numpyro/infer/autoguide.py
+++ b/numpyro/infer/autoguide.py
@@ -147,6 +147,7 @@ class AutoContinuous(AutoGuide):
     :param callable init_strategy: A per-site initialization function.
         See :ref:`init_strategy` section for available functions.
     """
+
     def __init__(self, model, prefix="auto", init_strategy=init_to_uniform):
         self.init_strategy = init_strategy
         super(AutoContinuous, self).__init__(model, prefix=prefix)
@@ -319,6 +320,7 @@ class AutoDiagonalNormal(AutoContinuous):
         guide = AutoDiagonalNormal(model, ...)
         svi = SVI(model, guide, ...)
     """
+
     def __init__(self, model, prefix="auto", init_strategy=init_to_uniform, init_scale=0.1):
         if init_scale <= 0:
             raise ValueError("Expected init_scale > 0. but got {}".format(init_scale))
@@ -368,6 +370,7 @@ class AutoMultivariateNormal(AutoContinuous):
         guide = AutoMultivariateNormal(model, ...)
         svi = SVI(model, guide, ...)
     """
+
     def __init__(self, model, prefix="auto", init_strategy=init_to_uniform, init_scale=0.1):
         if init_scale <= 0:
             raise ValueError("Expected init_scale > 0. but got {}".format(init_scale))
@@ -418,6 +421,7 @@ class AutoLowRankMultivariateNormal(AutoContinuous):
         guide = AutoLowRankMultivariateNormal(model, rank=2, ...)
         svi = SVI(model, guide, ...)
     """
+
     def __init__(self, model, prefix="auto", init_strategy=init_to_uniform, init_scale=0.1, rank=None):
         if init_scale <= 0:
             raise ValueError("Expected init_scale > 0. but got {}".format(init_scale))
@@ -480,6 +484,7 @@ class AutoLaplaceApproximation(AutoContinuous):
         guide = AutoLaplaceApproximation(model, ...)
         svi = SVI(model, guide, ...)
     """
+
     def _setup_prototype(self, *args, **kwargs):
         super(AutoLaplaceApproximation, self)._setup_prototype(*args, **kwargs)
 
@@ -560,6 +565,7 @@ class AutoIAFNormal(AutoContinuous):
     :param callable nonlinearity: the nonlinearity to use in the feedforward network.
         Defaults to :func:`jax.experimental.stax.Elu`.
     """
+
     def __init__(self, model, prefix="auto", init_strategy=init_to_uniform,
                  num_flows=3, hidden_dims=None, skip_connections=False, nonlinearity=stax.Elu):
         self.num_flows = num_flows
@@ -617,6 +623,7 @@ class AutoBNAFNormal(AutoContinuous):
         input dimension. This corresponds to both :math:`a` and :math:`b` in reference [1].
         The elements of hidden_factors must be integers.
     """
+
     def __init__(self, model, prefix="auto", init_strategy=init_to_uniform, num_flows=1,
                  hidden_factors=[8, 8]):
         self.num_flows = num_flows
@@ -638,6 +645,7 @@ class AutoBNAFNormal(AutoContinuous):
 
     def get_base_dist(self):
         return dist.Normal(jnp.zeros(self.latent_dim), 1).to_event(1)
+
 
 class AutoDelta(AutoGuide, ReinitGuide):
     def __init__(self, model, *, prefix='auto', init_strategy=init_to_uniform(), create_plates=None):
@@ -677,12 +685,12 @@ class AutoDelta(AutoGuide, ReinitGuide):
 
     def find_params(self, rng_keys, *args, **kwargs):
         params = {site['name']: site['value'] for site in self.prototype_trace.values()
-                 if site['type'] == 'sample' and not site['is_observed']}
+                  if site['type'] == 'sample' and not site['is_observed']}
         (init_params, _, _), _ = handlers.block(find_valid_initial_params)(rng_keys, self.model,
-                                                                   init_strategy=self.init_strategy,
-                                                                   model_args=args,
-                                                                   model_kwargs=kwargs,
-                                                                   prototype_params=params)
+                                                                           init_strategy=self.init_strategy,
+                                                                           model_args=args,
+                                                                           model_kwargs=kwargs,
+                                                                           prototype_params=params)
         for name, site in self.prototype_trace.items():
             if site['type'] == 'sample' and not site['is_observed']:
                 param_name = "{}_{}".format(self.prefix, name)

--- a/numpyro/infer/guide.py
+++ b/numpyro/infer/guide.py
@@ -1,0 +1,59 @@
+from abc import ABC, abstractmethod
+from numpyro import handlers
+from numpyro.infer.util import find_valid_initial_params, init_to_uniform
+from numpyro.distributions.constraints import real
+from numpyro.distributions.transforms import biject_to
+import jax.random
+
+__all__ = ['ReinitGuide', 'WrappedGuide']
+
+class ReinitGuide(ABC):
+    @abstractmethod
+    def init_params(self):
+        raise NotImplementedError
+
+    @abstractmethod
+    def find_params(self, rng_keys, *args, **kwargs):
+        raise NotImplementedError
+
+
+class WrappedGuide(ReinitGuide):
+    def __init__(self, fn, reinit_hide_fn=lambda site: site['name'].endswith('$params'), init_strategy=init_to_uniform):
+        self.fn = fn
+        self._init_params = None
+        self.init_strategy = init_strategy(reinit_param=lambda site: not reinit_hide_fn(site))
+        self._reinit_hide_fn = reinit_hide_fn
+
+    def init_params(self):
+        return self._init_params
+
+    def find_params(self, rng_keys, *args, **kwargs):
+        guide_trace = handlers.trace(handlers.seed(self.fn, rng_keys[0])).get_trace(*args, **kwargs)
+
+        def _find_valid_params(rng_key):
+            k1, k2 = jax.random.split(rng_key)
+            guide = handlers.seed(handlers.block(self.fn, self._reinit_hide_fn), k2)
+            guide_trace = handlers.trace(handlers.seed(self.fn, rng_key)).get_trace(*args, **kwargs)
+            prototype_params = {name: site['value'] for name, site in guide_trace.items()
+                                if (site['type'] == 'sample' and not site['is_observed'] and not site['fn'].is_discrete) 
+                                    or (site['type'] == 'param' and not self._reinit_hide_fn(site))}
+            (mapped_params, _, _), _ = handlers.block(find_valid_initial_params)(k1, guide, init_strategy=self.init_strategy,
+                                                                         model_args=args,
+                                                                         model_kwargs=kwargs,
+                                                                         prototype_params=prototype_params)
+            hidden_params = {name: site['value'] for name, site in guide_trace.items()
+                             if site['type'] == 'param' and self._reinit_hide_fn(site)}
+            res_params = {**mapped_params, **hidden_params}
+            return res_params
+
+        init_params = jax.vmap(_find_valid_params)(rng_keys)
+        params = {}
+        for name, site in guide_trace.items():
+            if site['type'] == 'param':
+                constraint = site['kwargs'].pop('constraint', real)
+                param_val = biject_to(constraint)(init_params[name])
+                params[name] = (name, param_val, constraint)
+        self._init_params = {param: (val, constr) for param, val, constr in params.values()}
+
+    def __call__(self, *args, **kwargs):
+        return self.fn(*args, **kwargs)

--- a/numpyro/infer/guide.py
+++ b/numpyro/infer/guide.py
@@ -7,6 +7,7 @@ import jax.random
 
 __all__ = ['ReinitGuide', 'WrappedGuide']
 
+
 class ReinitGuide(ABC):
     @abstractmethod
     def init_params(self):
@@ -35,12 +36,13 @@ class WrappedGuide(ReinitGuide):
             guide = handlers.seed(handlers.block(self.fn, self._reinit_hide_fn), k2)
             guide_trace = handlers.trace(handlers.seed(self.fn, rng_key)).get_trace(*args, **kwargs)
             prototype_params = {name: site['value'] for name, site in guide_trace.items()
-                                if (site['type'] == 'sample' and not site['is_observed'] and not site['fn'].is_discrete) 
-                                    or (site['type'] == 'param' and not self._reinit_hide_fn(site))}
-            (mapped_params, _, _), _ = handlers.block(find_valid_initial_params)(k1, guide, init_strategy=self.init_strategy,
-                                                                         model_args=args,
-                                                                         model_kwargs=kwargs,
-                                                                         prototype_params=prototype_params)
+                                if (site['type'] == 'sample' and not site['is_observed'] and not site['fn'].is_discrete)
+                                or (site['type'] == 'param' and not self._reinit_hide_fn(site))}
+            (mapped_params, _, _), _ = handlers.block(find_valid_initial_params)(k1, guide,
+                                                                                 init_strategy=self.init_strategy,
+                                                                                 model_args=args,
+                                                                                 model_kwargs=kwargs,
+                                                                                 prototype_params=prototype_params)
             hidden_params = {name: site['value'] for name, site in guide_trace.items()
                              if site['type'] == 'param' and self._reinit_hide_fn(site)}
             res_params = {**mapped_params, **hidden_params}

--- a/numpyro/infer/initialization.py
+++ b/numpyro/infer/initialization.py
@@ -30,7 +30,7 @@ def init_to_median(site=None, reinit_param=lambda site: False, num_samples=15):
             return init_to_uniform(site)
 
     if site['type'] == 'param' and reinit_param(site):
-        return site['value'] if site['value'] is not None else site['args'][0]
+        return site['args'][0]
 
 
 def init_to_prior(site=None, reinit_param=lambda site: False):
@@ -69,7 +69,7 @@ def init_to_uniform(site=None, radius=2, reinit_param=lambda site: False):
                 prototype_value = jnp.full(site['fn'].shape(), jnp.nan)
             transform = biject_to(site['fn'].support)
         elif site['type'] == 'param':
-            prototype_value = site['value'] if site['value'] is not None else site['args'][0]
+            prototype_value = site['args'][0]
             constraint = site['kwargs'].pop('constraint', dist.constraints.real)
             transform = biject_to(constraint)
         unconstrained_shape = jnp.shape(transform.inv(prototype_value))

--- a/numpyro/infer/initialization.py
+++ b/numpyro/infer/initialization.py
@@ -3,10 +3,9 @@
 
 from functools import partial
 
-from jax import random
 import jax.numpy as jnp
+from jax import random
 
-import numpyro
 import numpyro.distributions as dist
 from numpyro.distributions import biject_to
 
@@ -51,8 +50,8 @@ def init_to_uniform(site=None, radius=2, reinit_param=lambda site: False):
     if site is None:
         return partial(init_to_uniform, radius=radius, reinit_param=reinit_param)
 
-    if (site['type'] == 'sample' and not site['is_observed'] and not site['fn'].is_discrete) or\
-          (site['type'] == 'param' and reinit_param(site)):
+    if (site['type'] == 'sample' and not site['is_observed'] and not site['fn'].is_discrete) or \
+            (site['type'] == 'param' and reinit_param(site)):
         rng_key = site['kwargs'].get('rng_key')
         sample_shape = site['kwargs'].get('sample_shape', ())
         rng_key, subkey = random.split(rng_key)
@@ -102,6 +101,7 @@ def init_to_value(site=None, values={}, reinit_param=lambda site: False):
             return values[site['name']]
         else:  # defer to default strategy
             return init_to_uniform(site, reinit_param=reinit_param)
+
 
 def init_with_noise(init_strategy, site=None, noise_scale=1.0, reinit_param=lambda site: False):
     if site is None:

--- a/numpyro/infer/initialization.py
+++ b/numpyro/infer/initialization.py
@@ -6,11 +6,12 @@ from functools import partial
 from jax import random
 import jax.numpy as jnp
 
+import numpyro
 import numpyro.distributions as dist
 from numpyro.distributions import biject_to
 
 
-def init_to_median(site=None, num_samples=15):
+def init_to_median(site=None, reinit_param=lambda site: False, num_samples=15):
     """
     Initialize to the prior median. For priors with no `.sample` method implemented,
     we defer to the :func:`init_to_uniform` strategy.
@@ -18,7 +19,7 @@ def init_to_median(site=None, num_samples=15):
     :param int num_samples: number of prior points to calculate median.
     """
     if site is None:
-        return partial(init_to_median, num_samples=num_samples)
+        return partial(init_to_median, num_samples=num_samples, reinit_param=reinit_param)
 
     if site['type'] == 'sample' and not site['is_observed'] and not site['fn'].is_discrete:
         rng_key = site['kwargs'].get('rng_key')
@@ -29,56 +30,64 @@ def init_to_median(site=None, num_samples=15):
         except NotImplementedError:
             return init_to_uniform(site)
 
+    if site['type'] == 'param' and reinit_param(site):
+        return site['value'] if site['value'] is not None else site['args'][0]
 
-def init_to_prior(site=None):
+
+def init_to_prior(site=None, reinit_param=lambda site: False):
     """
     Initialize to a prior sample. For priors with no `.sample` method implemented,
     we defer to the :func:`init_to_uniform` strategy.
     """
-    return init_to_median(site, num_samples=1)
+    return init_to_median(site, num_samples=1, reinit_param=reinit_param)
 
 
-def init_to_uniform(site=None, radius=2):
+def init_to_uniform(site=None, radius=2, reinit_param=lambda site: False):
     """
     Initialize to a random point in the area `(-radius, radius)` of unconstrained domain.
 
     :param float radius: specifies the range to draw an initial point in the unconstrained domain.
     """
     if site is None:
-        return partial(init_to_uniform, radius=radius)
+        return partial(init_to_uniform, radius=radius, reinit_param=reinit_param)
 
-    if site['type'] == 'sample' and not site['is_observed'] and not site['fn'].is_discrete:
+    if (site['type'] == 'sample' and not site['is_observed'] and not site['fn'].is_discrete) or\
+          (site['type'] == 'param' and reinit_param(site)):
         rng_key = site['kwargs'].get('rng_key')
-        sample_shape = site['kwargs'].get('sample_shape')
+        sample_shape = site['kwargs'].get('sample_shape', ())
         rng_key, subkey = random.split(rng_key)
 
         # this is used to interpret the changes of event_shape in
         # domain and codomain spaces
-        try:
-            prototype_value = site['fn'].sample(subkey, sample_shape=())
-        except NotImplementedError:
-            # XXX: this works for ImproperUniform prior,
-            # we can't use this logic for general priors
-            # because some distributions such as TransformedDistribution might
-            # have wrong event_shape.
-            prototype_value = jnp.full(site['fn'].shape(), jnp.nan)
-
-        transform = biject_to(site['fn'].support)
+        if site['type'] == 'sample':
+            try:
+                prototype_value = site['fn'].sample(subkey, sample_shape=())
+            except NotImplementedError:
+                # XXX: this works for ImproperUniform prior,
+                # we can't use this logic for general priors
+                # because some distributions such as TransformedDistribution might
+                # have wrong event_shape.
+                prototype_value = jnp.full(site['fn'].shape(), jnp.nan)
+            transform = biject_to(site['fn'].support)
+        elif site['type'] == 'param':
+            prototype_value = site['value'] if site['value'] is not None else site['args'][0]
+            constraint = site['kwargs'].pop('constraint', dist.constraints.real)
+            transform = biject_to(constraint)
         unconstrained_shape = jnp.shape(transform.inv(prototype_value))
         unconstrained_samples = dist.Uniform(-radius, radius).sample(
             rng_key, sample_shape=sample_shape + unconstrained_shape)
         return transform(unconstrained_samples)
 
 
-def init_to_feasible(site=None):
+def init_to_feasible(site=None, reinit_param=lambda site: False):
     """
     Initialize to an arbitrary feasible point, ignoring distribution
     parameters.
     """
-    return init_to_uniform(site, radius=0)
+    return init_to_uniform(site, radius=0, reinit_param=reinit_param)
 
 
-def init_to_value(site=None, values={}):
+def init_to_value(site=None, values={}, reinit_param=lambda site: False):
     """
     Initialize to the value specified in `values`. We defer to
     :func:`init_to_uniform` strategy for sites which do not appear in `values`.
@@ -86,10 +95,31 @@ def init_to_value(site=None, values={}):
     :param dict values: dictionary of initial values keyed by site name.
     """
     if site is None:
-        return partial(init_to_value, values=values)
+        return partial(init_to_value, values=values, reinit_param=reinit_param)
 
-    if site['type'] == 'sample' and not site['is_observed']:
+    if (site['type'] == 'sample' and not site['is_observed']) or (site['type'] == 'param' and reinit_param(site)):
         if site['name'] in values:
             return values[site['name']]
         else:  # defer to default strategy
-            return init_to_uniform(site)
+            return init_to_uniform(site, reinit_param=reinit_param)
+
+def init_with_noise(init_strategy, site=None, noise_scale=1.0, reinit_param=lambda site: False):
+    if site is None:
+        return partial(init_with_noise, init_strategy, noise_scale=noise_scale, reinit_param=reinit_param)
+    vals = init_strategy(site, reinit_param=reinit_param)
+    if isinstance(site['fn'], dist.TransformedDistribution):
+        fn = site['fn'].base_dist
+    else:
+        fn = site['fn']
+    if vals is not None:
+        if site['type'] == 'param':
+            constraint = site['kwargs'].pop('constraint', dist.constraints.real)
+            base_transform = biject_to(constraint)
+        elif site['type'] == 'sample':
+            base_transform = biject_to(fn.support)
+        rng_key = site['kwargs'].get('rng_key')
+        sample_shape = site['kwargs'].get('sample_shape', ())
+        unconstrained_init = dist.Normal(loc=base_transform.inv(vals), scale=noise_scale).sample(rng_key, sample_shape)
+        return base_transform(unconstrained_init)
+    else:
+        return None

--- a/numpyro/infer/util.py
+++ b/numpyro/infer/util.py
@@ -10,6 +10,7 @@ from jax.flatten_util import ravel_pytree
 import jax.numpy as jnp
 
 import numpyro
+import numpyro.distributions as dist
 from numpyro.distributions.constraints import _GreaterThan, _Interval, real, real_vector
 from numpyro.distributions.transforms import biject_to
 from numpyro.distributions.util import is_identically_one, sum_rightmost
@@ -116,7 +117,7 @@ def _unconstrain_reparam(params, site):
     if name in params:
         p = params[name]
         if site['type'] == 'sample':
-            support = site['fn'].support 
+            support = site['fn'].support
             event_dim = len(site['fn'].event_shape)
         elif site['type'] == 'param':
             support = site['kwargs'].pop('constraint', real)


### PR DESCRIPTION
The first split of #649 .

It introduces re-initializable guides, which can re-initialize their parameters.
This is useful for Stein inference since the parameters are treated as particles, and we want the particles to be initialized independently instead of all clumped together which would hurt inference.

An alternative would be to have similar strategies which can be called explicitly with a shape and can be used directly in `numpyro.param`. I do not know which you prefer, so I tried to reuse the existing interface 😄 