### PR TITLE
Add Sample Adaptive MCMC algo to baseball example

### DIFF
--- a/examples/baseball.py
+++ b/examples/baseball.py
@@ -34,7 +34,8 @@ the No U-Turn Sampler, which provides an efficient and automated way (i.e. limit
 hyper-parameters) of running HMC on different problems.
 
 Note that the Sample Adaptive (SA) kernel, which is implemented based on [5],
-requires large `num_warmup` and `num_samples` (e.g. 15,000 and 300,000).
+requires large `num_warmup` and `num_samples` (e.g. 15,000 and 300,000). So
+it is better to disable progress bar to avoid dispatching overhead.
 
 **References:**
 

--- a/examples/baseball.py
+++ b/examples/baseball.py
@@ -9,7 +9,7 @@ Original example from Pyro:
 https://github.com/pyro-ppl/pyro/blob/dev/examples/baseball.py
 
 Example has been adapted from [1]. It demonstrates how to do Bayesian inference using
-NUTS (or, HMC) in Pyro, and use of some common inference utilities.
+various MCMC kernels in Pyro (HMC, NUTS, SA), and use of some common inference utilities.
 
 As in the Stan tutorial, this uses the small baseball dataset of Efron and Morris [2]
 to estimate players' batting average which is the fraction of times a player got a
@@ -33,6 +33,9 @@ more comprehensive understanding of HMC and its variants, and to [4] for details
 the No U-Turn Sampler, which provides an efficient and automated way (i.e. limited
 hyper-parameters) of running HMC on different problems.
 
+Note that the Sample Adaptive (SA) kernel, which is implemented based on [5],
+requires large `num_warmup` and `num_samples` (e.g. 15,000 and 300,000).
+
 **References:**
 
     1. Carpenter B. (2016), `"Hierarchical Partial Pooling for Repeated Binary Trials"
@@ -43,6 +46,9 @@ hyper-parameters) of running HMC on different problems.
        (https://arxiv.org/pdf/1206.1901.pdf)
     4. Hoffman, M. D. and Gelman, A. (2014), "The No-U-turn sampler: Adaptively setting
        path lengths in Hamiltonian Monte Carlo", (https://arxiv.org/abs/1111.4246)
+    5. Michael Zhu (2019), "Sample Adaptive MCMC",
+       (https://papers.nips.cc/paper/9107-sample-adaptive-mcmc)
+
 """
 
 import argparse
@@ -55,7 +61,7 @@ from jax.scipy.special import logsumexp
 import numpyro
 import numpyro.distributions as dist
 from numpyro.examples.datasets import BASEBALL, load_dataset
-from numpyro.infer import MCMC, NUTS, Predictive, log_likelihood
+from numpyro.infer import HMC, MCMC, NUTS, Predictive, SA, log_likelihood
 
 
 def fully_pooled(at_bats, hits=None):
@@ -130,9 +136,15 @@ def partially_pooled_with_logit(at_bats, hits=None):
 
 
 def run_inference(model, at_bats, hits, rng_key, args):
-    kernel = NUTS(model)
+    if args.algo == "NUTS":
+        kernel = NUTS(model)
+    elif args.algo == "HMC":
+        kernel = HMC(model)
+    elif args.algo == "SA":
+        kernel = SA(model)
     mcmc = MCMC(kernel, args.num_warmup, args.num_samples, num_chains=args.num_chains,
-                progress_bar=False if "NUMPYRO_SPHINXBUILD" in os.environ else True)
+                progress_bar=False if (
+                    "NUMPYRO_SPHINXBUILD" in os.environ or args.disable_progbar) else True)
     mcmc.run(rng_key, at_bats, hits)
     return mcmc.get_samples()
 
@@ -188,6 +200,10 @@ if __name__ == "__main__":
     parser.add_argument("-n", "--num-samples", nargs="?", default=3000, type=int)
     parser.add_argument("--num-warmup", nargs='?', default=1500, type=int)
     parser.add_argument("--num-chains", nargs='?', default=1, type=int)
+    parser.add_argument('--algo', default='NUTS', type=str,
+                        help='whether to run "HMC", "NUTS", or "SA"')
+    parser.add_argument('-dp', '--disable-progbar', action="store_true", default=False,
+                        help="whether to disable progress bar")
     parser.add_argument('--device', default='cpu', type=str, help='use "cpu" or "gpu".')
     args = parser.parse_args()
 

--- a/numpyro/infer/mcmc.py
+++ b/numpyro/infer/mcmc.py
@@ -770,7 +770,7 @@ def _sa(potential_fn=None, potential_fn_gen=None):
             if cov.shape == ():  # JAX returns scalar for 1D input
                 cov = cov.reshape((1, 1))
             cholesky = jnp.linalg.cholesky(cov)
-            scale = jnp.where(jnp.isnan(cholesky), scale, cholesky)
+            scale = jnp.where(jnp.any(jnp.isnan(cholesky)), scale, cholesky)
         else:
             scale = jnp.std(zs, 0)
 

--- a/numpyro/infer/mcmc.py
+++ b/numpyro/infer/mcmc.py
@@ -762,7 +762,7 @@ def _sa(potential_fn=None, potential_fn_gen=None):
             pe_fn = potential_fn_gen(*model_args, **model_kwargs)
         zs, pes, loc, scale = sa_state.adapt_state
         # we recompute loc/scale after each iteration to avoid precision loss
-        # XXX: consider to expose a setting to do this job pediodically
+        # XXX: consider to expose a setting to do this job periodically
         # to save some computations
         loc = jnp.mean(zs, 0)
         if scale.ndim == 2:

--- a/numpyro/infer/mcmc.py
+++ b/numpyro/infer/mcmc.py
@@ -746,7 +746,7 @@ def _sa(potential_fn=None, potential_fn_gen=None):
                 cov = cov.reshape((1, 1))
             cholesky = jnp.linalg.cholesky(cov)
             # if cholesky is NaN, we use the scale from `sample_proposal` here
-            inv_mass_matrix_sqrt = jnp.where(jnp.isnan(cholesky), inv_mass_matrix_sqrt, cholesky)
+            inv_mass_matrix_sqrt = jnp.where(jnp.any(jnp.isnan(cholesky)), inv_mass_matrix_sqrt, cholesky)
         else:
             inv_mass_matrix_sqrt = jnp.std(zs, 0)
         adapt_state = SAAdaptState(zs, pes, jnp.mean(zs, 0), inv_mass_matrix_sqrt)

--- a/numpyro/infer/mcmc.py
+++ b/numpyro/infer/mcmc.py
@@ -664,10 +664,6 @@ def _sample_proposal(inv_mass_matrix_sqrt, rng_key, batch_shape=()):
     return r
 
 
-# XXX: probably we need to recompute `loc`, `inv_mass_matrix_sqrt` from `zs`
-# because we might lose precision after many iterations of using _get_proposal_loc_and_scale;
-# If we recompute, we don't need to store `loc` and `inv_mass_matrix_sqrt` here.
-# We may also update those values every 10D iterations...
 SAAdaptState = namedtuple('SAAdaptState', ['zs', 'pes', 'loc', 'inv_mass_matrix_sqrt'])
 SAState = namedtuple('SAState', ['i', 'z', 'potential_energy', 'accept_prob',
                                  'mean_accept_prob', 'diverging', 'adapt_state', 'rng_key'])
@@ -748,7 +744,9 @@ def _sa(potential_fn=None, potential_fn_gen=None):
             cov = jnp.cov(zs, rowvar=False, bias=True)
             if cov.shape == ():  # JAX returns scalar for 1D input
                 cov = cov.reshape((1, 1))
-            inv_mass_matrix_sqrt = jnp.linalg.cholesky(cov)
+            cholesky = jnp.linalg.cholesky(cov)
+            # if cholesky is NaN, we use the scale from `sample_proposal` here
+            inv_mass_matrix_sqrt = jnp.where(jnp.isnan(cholesky), inv_mass_matrix_sqrt, cholesky)
         else:
             inv_mass_matrix_sqrt = jnp.std(zs, 0)
         adapt_state = SAAdaptState(zs, pes, jnp.mean(zs, 0), inv_mass_matrix_sqrt)
@@ -763,6 +761,19 @@ def _sa(potential_fn=None, potential_fn_gen=None):
         if potential_fn_gen:
             pe_fn = potential_fn_gen(*model_args, **model_kwargs)
         zs, pes, loc, scale = sa_state.adapt_state
+        # we recompute loc/scale after each iteration to avoid precision loss
+        # XXX: consider to expose a setting to do this job pediodically
+        # to save some computations
+        loc = jnp.mean(zs, 0)
+        if scale.ndim == 2:
+            cov = jnp.cov(zs, rowvar=False, bias=True)
+            if cov.shape == ():  # JAX returns scalar for 1D input
+                cov = cov.reshape((1, 1))
+            cholesky = jnp.linalg.cholesky(cov)
+            scale = jnp.where(jnp.isnan(cholesky), scale, cholesky)
+        else:
+            scale = jnp.std(zs, 0)
+
         rng_key, rng_key_z, rng_key_reject, rng_key_accept = random.split(sa_state.rng_key, 4)
         _, unravel_fn = ravel_pytree(sa_state.z)
 


### PR DESCRIPTION
Addresses #557.

I have changed the behavior of SA a bit to recompute loc/scale at each step because I think this is the better default behavior.  The reason is with SA, we need a lot of samples (100,000 - 1,000,000) so after a while, `scale` term will diverge from the true value. It is nice to have a config setting to control how often we recompute, but for now, it seems not necessary.

I also resolve the `nan` issue when the initial scale is NaN.