### PR TITLE
Add lift handler

### DIFF
--- a/docs/source/handlers.rst
+++ b/docs/source/handlers.rst
@@ -19,6 +19,14 @@ condition
     :show-inheritance:
     :member-order: bysource
 
+lift
+----
+.. autoclass:: numpyro.handlers.lift
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :member-order: bysource
+
 mask
 ----
 .. autoclass:: numpyro.handlers.mask

--- a/numpyro/handlers.py
+++ b/numpyro/handlers.py
@@ -315,6 +315,10 @@ class lift(Messenger):
 
     Consider the following NumPyro program:
 
+        >>> import numpyro
+        >>> import numpyro.distributions as dist
+        >>> from numpyro.handlers import lift
+
         >>> def model(x):
         ...     s = numpyro.param("s", 0.5)
         ...     z = numpyro.sample("z", dist.Normal(x, s))

--- a/numpyro/handlers.py
+++ b/numpyro/handlers.py
@@ -84,12 +84,14 @@ import warnings
 from jax import lax, random
 import jax.numpy as jnp
 
+import numpyro
 from numpyro.primitives import Messenger
 from numpyro.util import not_jax_tracer
 
 __all__ = [
     'block',
     'condition',
+    'lift',
     'mask',
     'reparam',
     'replay',
@@ -305,6 +307,69 @@ class condition(Messenger):
             msg['is_observed'] = True
 
 
+class lift(Messenger):
+    """
+    Given a stochastic function with ``param`` calls and a prior distribution,
+    create a stochastic function where all param calls are replaced by sampling from prior.
+    Prior should be a distribution or a dict of names to distributions.
+
+    Consider the following NumPyro program:
+
+        >>> def model(x):
+        ...     s = numpyro.param("s", 0.5)
+        ...     z = numpyro.sample("z", dist.Normal(x, s))
+        ...     return z ** 2
+        >>> lifted_model = lift(model, prior={"s": dist.Exponential(0.3)})
+
+    ``lift`` makes ``param`` statements behave like ``sample`` statements
+    using the distributions in ``prior``.  In this example, site `s` will now behave
+    as if it was replaced with ``s = numpyro.sample("s", dist.Exponential(0.3))``.
+
+    :param fn: function whose parameters will be lifted to random values
+    :param prior: prior function in the form of a Distribution or a dict of Distributions
+    """
+
+    def __init__(self, fn=None, prior=None):
+        super().__init__(fn)
+        self.prior = prior
+        self._samples_cache = {}
+
+    def __enter__(self):
+        self._samples_cache = {}
+        return super().__enter__()
+
+    def __exit__(self, *args, **kwargs):
+        self._samples_cache = {}
+        return super().__exit__(*args, **kwargs)
+
+    def process_message(self, msg):
+        if msg["type"] != "param":
+            return
+
+        name = msg["name"]
+        fn = self.prior.get(name) if isinstance(self.prior, dict) else self.prior
+        if isinstance(fn, numpyro.distributions.Distribution):
+            msg["type"] = "sample"
+            msg["fn"] = fn
+            msg["args"] = ()
+            msg["kwargs"] = {"rng_key": msg["kwargs"].get("rng_key", None),
+                             "sample_shape": msg["kwargs"].get("sample_shape", ())}
+            msg["intermediates"] = []
+        else:
+            # otherwise leave as is
+            return
+
+        if name in self._samples_cache:
+            # Multiple pyro.param statements with the same
+            # name. Block the site and fix the value.
+            msg["value"] = self._samples_cache[name]["value"]
+            msg["is_observed"] = True
+            msg["stop"] = True
+        else:
+            self._samples_cache[name] = msg
+            msg["is_observed"] = False
+
+
 class mask(Messenger):
     """
     This messenger masks out some of the sample statements elementwise.
@@ -398,7 +463,7 @@ class scale(Messenger):
         super().__init__(fn)
 
     def process_message(self, msg):
-        if msg['type'] not in ('sample', 'plate'):
+        if msg['type'] not in ('param', 'sample', 'plate'):
             return
 
         msg["scale"] = self.scale if msg.get('scale') is None else self.scale * msg['scale']

--- a/numpyro/handlers.py
+++ b/numpyro/handlers.py
@@ -318,7 +318,7 @@ class lift(Messenger):
         >>> import numpyro
         >>> import numpyro.distributions as dist
         >>> from numpyro.handlers import lift
-
+        >>>
         >>> def model(x):
         ...     s = numpyro.param("s", 0.5)
         ...     z = numpyro.sample("z", dist.Normal(x, s))

--- a/numpyro/primitives.py
+++ b/numpyro/primitives.py
@@ -136,6 +136,7 @@ def param(name, init_value=None, **kwargs):
         'args': (init_value,),
         'kwargs': kwargs,
         'value': None,
+        'scale': None,
         'cond_indep_stack': [],
     }
 
@@ -255,7 +256,7 @@ class plate(Messenger):
         return tuple(batch_shape)
 
     def process_message(self, msg):
-        if msg['type'] not in ('sample', 'plate'):
+        if msg['type'] not in ('param', 'sample', 'plate'):
             if msg['type'] == 'control_flow':
                 raise RuntimeError('Cannot use control flow primitive under a `plate` primitive.'
                                    ' Please move those `plate` statements into the control flow'
@@ -265,8 +266,8 @@ class plate(Messenger):
         cond_indep_stack = msg['cond_indep_stack']
         frame = CondIndepStackFrame(self.name, self.dim, self.subsample_size)
         cond_indep_stack.append(frame)
-        expected_shape = self._get_batch_shape(cond_indep_stack)
         if msg['type'] == 'sample':
+            expected_shape = self._get_batch_shape(cond_indep_stack)
             dist_batch_shape = msg['fn'].batch_shape
             if 'sample_shape' in msg['kwargs']:
                 dist_batch_shape = msg['kwargs']['sample_shape'] + dist_batch_shape

--- a/test/test_handlers.py
+++ b/test/test_handlers.py
@@ -11,6 +11,7 @@ import jax.numpy as jnp
 import numpyro
 from numpyro import handlers
 import numpyro.distributions as dist
+from numpyro.distributions import constraints
 from numpyro.infer.util import log_density
 from numpyro.util import optional
 
@@ -265,3 +266,48 @@ def test_scope():
 
     assert 'a/x' in trace
     assert 'b/a/x' in trace
+
+
+def test_lift():
+    def model():
+        loc1 = numpyro.param("loc1", 0.)
+        scale1 = numpyro.param("scale1", 1., constraint=constraints.positive)
+        numpyro.sample("latent1", dist.Normal(loc1, scale1))
+
+        loc2 = numpyro.param("loc2", 1.)
+        scale2 = numpyro.param("scale2", 2., constraint=constraints.positive)
+        latent2 = numpyro.sample("latent2", dist.Normal(loc2, scale2))
+        return latent2
+
+    loc1_prior = dist.Normal()
+    scale1_prior = dist.LogNormal()
+    prior = {"loc1": loc1_prior, "scale1": scale1_prior}
+
+    with handlers.trace() as tr:
+        with handlers.seed(rng_seed=1):
+            model()
+
+    with handlers.trace() as lifted_tr:
+        with handlers.seed(rng_seed=2):
+            with handlers.lift(prior=prior):
+                model()
+
+    for name in tr.keys():
+        assert name in lifted_tr
+        if name in prior:
+            assert lifted_tr[name]['fn'] is prior[name]
+            assert lifted_tr[name]['type'] == 'sample'
+            assert lifted_tr[name]['value'] not in (0., 1.)
+        elif name in ('loc2', 'scale2'):
+            assert lifted_tr[name]['type'] == 'param'
+
+
+def test_lift_memoize():
+    def model():
+        a = numpyro.param("loc")
+        b = numpyro.param("loc")
+        assert a == b
+
+    with handlers.seed(rng_seed=1):
+        with handlers.lift(prior=dist.Normal(0, 1)):
+            model()


### PR DESCRIPTION
Addresses #661. This handler seems to be useful for #649, where initial valid params needed to be found using init strategies, rather than hard-coded in `init_value` arg.