### PR TITLE
Improve compiling time for the option `find_heuristic_step_size=True`

### DIFF
--- a/numpyro/infer/hmc.py
+++ b/numpyro/infer/hmc.py
@@ -233,7 +233,7 @@ def hmc(potential_fn=None, potential_fn_gen=None, kinetic_fn=None, algo='NUTS'):
                                             find_reasonable_step_size=find_reasonable_ss)
 
         rng_key_hmc, rng_key_wa, rng_key_momentum = random.split(rng_key, 3)
-        wa_state = wa_init(z, rng_key_wa, step_size,
+        wa_state = wa_init((z, pe, z_grad), rng_key_wa, step_size,
                            inverse_mass_matrix=inverse_mass_matrix,
                            mass_matrix_size=jnp.size(ravel_pytree(z)[0]))
         r = momentum_generator(z, wa_state.mass_matrix_sqrt, rng_key_momentum)
@@ -311,8 +311,9 @@ def hmc(potential_fn=None, potential_fn_gen=None, kinetic_fn=None, algo='NUTS'):
                                                                     model_kwargs,
                                                                     rng_key_transition)
         # not update adapt_state after warmup phase
+        z_info = (vv_state.z, vv_state.potential_energy, vv_state.z_grad)
         adapt_state = cond(hmc_state.i < wa_steps,
-                           (hmc_state.i, accept_prob, vv_state.z, hmc_state.adapt_state),
+                           (hmc_state.i, accept_prob, z_info, hmc_state.adapt_state),
                            lambda args: wa_update(*args),
                            hmc_state.adapt_state,
                            identity)

--- a/numpyro/infer/hmc.py
+++ b/numpyro/infer/hmc.py
@@ -232,7 +232,8 @@ def hmc(potential_fn=None, potential_fn_gen=None, kinetic_fn=None, algo='NUTS'):
                                             find_reasonable_step_size=find_reasonable_ss)
 
         rng_key_hmc, rng_key_wa, rng_key_momentum = random.split(rng_key, 3)
-        wa_state = wa_init((z, pe, z_grad), rng_key_wa, step_size,
+        z_info = IntegratorState(z=z, potential_energy=pe, z_grad=z_grad)
+        wa_state = wa_init(z_info, rng_key_wa, step_size,
                            inverse_mass_matrix=inverse_mass_matrix,
                            mass_matrix_size=jnp.size(ravel_pytree(z)[0]))
         r = momentum_generator(z, wa_state.mass_matrix_sqrt, rng_key_momentum)
@@ -310,9 +311,8 @@ def hmc(potential_fn=None, potential_fn_gen=None, kinetic_fn=None, algo='NUTS'):
                                                                     model_kwargs,
                                                                     rng_key_transition)
         # not update adapt_state after warmup phase
-        z_info = (vv_state.z, vv_state.potential_energy, vv_state.z_grad)
         adapt_state = cond(hmc_state.i < wa_steps,
-                           (hmc_state.i, accept_prob, z_info, hmc_state.adapt_state),
+                           (hmc_state.i, accept_prob, vv_state, hmc_state.adapt_state),
                            lambda args: wa_update(*args),
                            hmc_state.adapt_state,
                            identity)

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     author_email='npradhan@uber.com',
     install_requires=[
         # TODO: use the release version of funsor for the release
-        'funsor @ git+https://github.com/pyro-ppl/funsor.git@b4db46acc5ab615abd2e1297f65ff5e70e961876#egg=funsor'
+        'funsor @ git+https://github.com/pyro-ppl/funsor.git@b4db46acc5ab615abd2e1297f65ff5e70e961876#egg=funsor',
         # TODO: pin to a specific version for the release (until JAX's API becomes stable)
         'jax>=0.1.70',
         # check min version here: https://github.com/google/jax/blob/master/jax/lib/__init__.py#L20

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -23,16 +23,18 @@ def model(deterministic=True):
 
 
 @pytest.mark.parametrize('deterministic', [True, False])
-def test_mcmc_one_chain(deterministic):
+@pytest.mark.parametrize('find_heuristic_step_size', [True, False])
+def test_mcmc_one_chain(deterministic, find_heuristic_step_size):
     GLOBAL["count"] = 0
-    mcmc = MCMC(NUTS(model), 100, 100)
+    mcmc = MCMC(NUTS(model, find_heuristic_step_size=find_heuristic_step_size), 100, 100)
     mcmc.run(random.PRNGKey(0), deterministic=deterministic)
     mcmc.get_samples()
 
+    num_traces_for_heuristic = 2 if find_heuristic_step_size else 0
     if deterministic:
-        assert GLOBAL["count"] == 4
+        assert GLOBAL["count"] == 4 + num_traces_for_heuristic
     else:
-        assert GLOBAL["count"] == 3
+        assert GLOBAL["count"] == 3 + num_traces_for_heuristic
 
 
 @pytest.mark.parametrize('deterministic', [True, False])

--- a/test/test_hmc_util.py
+++ b/test/test_hmc_util.py
@@ -277,7 +277,7 @@ def test_warmup_adapter(jitted):
 
     rng_key = random.PRNGKey(0)
     z = jnp.ones(3)
-    wa_state = wa_init(z, rng_key, init_step_size, mass_matrix_size=mass_matrix_size)
+    wa_state = wa_init((z, None, None), rng_key, init_step_size, mass_matrix_size=mass_matrix_size)
     step_size, inverse_mass_matrix, _, _, _, window_idx, _ = wa_state
     assert step_size == find_reasonable_step_size(init_step_size, inverse_mass_matrix, z, rng_key)
     assert_allclose(inverse_mass_matrix, jnp.ones(mass_matrix_size))

--- a/test/test_hmc_util.py
+++ b/test/test_hmc_util.py
@@ -227,7 +227,7 @@ def test_find_reasonable_step_size(jitted, init_step_size):
           if jitted else find_reasonable_step_size)
     rng_key = random.PRNGKey(0)
     step_size = fn(potential_fn, kinetic_fn, p_generator, init_step_size, m_inv,
-                   (q, None, None), rng_key)
+                   (q, None, None, None), rng_key)
 
     # Apply 1 velocity verlet step with step_size=eps, we have
     # z_new = eps, r_new = 1 - eps^2 / 2, hence energy_new = 0.5 + eps^4 / 8,
@@ -278,7 +278,7 @@ def test_warmup_adapter(jitted):
 
     rng_key = random.PRNGKey(0)
     z = jnp.ones(3)
-    wa_state = wa_init((z, None, None), rng_key, init_step_size, mass_matrix_size=mass_matrix_size)
+    wa_state = wa_init((z, None, None, None), rng_key, init_step_size, mass_matrix_size=mass_matrix_size)
     step_size, inverse_mass_matrix, _, _, _, window_idx, _ = wa_state
     assert step_size == find_reasonable_step_size(init_step_size, inverse_mass_matrix, z, rng_key)
     assert_allclose(inverse_mass_matrix, jnp.ones(mass_matrix_size))

--- a/test/test_hmc_util.py
+++ b/test/test_hmc_util.py
@@ -226,7 +226,8 @@ def test_find_reasonable_step_size(jitted, init_step_size):
     fn = (jit(find_reasonable_step_size, static_argnums=(0, 1, 2))
           if jitted else find_reasonable_step_size)
     rng_key = random.PRNGKey(0)
-    step_size = fn(potential_fn, kinetic_fn, p_generator, init_step_size, m_inv, q, rng_key)
+    step_size = fn(potential_fn, kinetic_fn, p_generator, init_step_size, m_inv,
+                   (q, None, None), rng_key)
 
     # Apply 1 velocity verlet step with step_size=eps, we have
     # z_new = eps, r_new = 1 - eps^2 / 2, hence energy_new = 0.5 + eps^4 / 8,


### PR DESCRIPTION
Addresses #585.

This optimization has been low-priority to me because I thought that `find_heuristic_step_size=True` is not important to use. But recently, @vanAmsterdam mentioned in #663 that our MCMC might have some regressions w.r.t. the last release. Though I suspected that random seed plays a role there, while waiting for the feedback in #663, it is still good to optimize compiling if users want to enable that option.

Tested on https://github.com/pyro-ppl/numpyro/issues/543, with `find_heuristic_step_size=True`, compiling time is reduced from almost 1 minute (master branch) to 12s (this PR). Note that only took about 1-2s with `find_heuristic_step_size=False`.