### PR TITLE
Add less_than constraint

### DIFF
--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -457,6 +457,10 @@ interval
 --------
 .. autofunction:: numpyro.distributions.constraints.interval
 
+less_than
+---------
+.. autofunction:: numpyro.distributions.constraints.less_than
+
 lower_cholesky
 --------------
 .. autodata:: numpyro.distributions.constraints.lower_cholesky

--- a/numpyro/distributions/constraints.py
+++ b/numpyro/distributions/constraints.py
@@ -36,6 +36,7 @@ __all__ = [
     'integer_greater_than',
     'interval',
     'is_dependent',
+    'less_than',
     'lower_cholesky',
     'multinomial',
     'nonnegative_integer',
@@ -112,6 +113,14 @@ class _GreaterThan(Constraint):
 
     def __call__(self, x):
         return x > self.lower_bound
+
+
+class _LessThan(Constraint):
+    def __init__(self, upper_bound):
+        self.upper_bound = upper_bound
+
+    def __call__(self, x):
+        return x < self.upper_bound
 
 
 class _IntegerInterval(Constraint):
@@ -193,6 +202,7 @@ corr_cholesky = _CorrCholesky()
 corr_matrix = _CorrMatrix()
 dependent = _Dependent()
 greater_than = _GreaterThan
+less_than = _LessThan
 integer_interval = _IntegerInterval
 integer_greater_than = _IntegerGreaterThan
 interval = _Interval

--- a/numpyro/distributions/transforms.py
+++ b/numpyro/distributions/transforms.py
@@ -20,6 +20,7 @@ from numpyro.distributions.util import (
     sum_rightmost,
     vec_to_tril_matrix
 )
+from numpyro.util import not_jax_tracer
 
 __all__ = [
     'biject_to',
@@ -79,7 +80,10 @@ class AbsTransform(Transform):
 
 
 class AffineTransform(Transform):
-    # TODO: currently, just support scale > 0
+    """
+    .. note:: When `scale` is a JAX tracer, we always assume that `scale > 0`
+        when calculating `codomain`.
+    """
     def __init__(self, loc, scale, domain=constraints.real):
         self.loc = loc
         self.scale = scale
@@ -92,10 +96,24 @@ class AffineTransform(Transform):
         elif self.domain is constraints.real_vector:
             return constraints.real_vector
         elif isinstance(self.domain, constraints.greater_than):
-            return constraints.greater_than(self.__call__(self.domain.lower_bound))
+            if not_jax_tracer(self.scale) and jnp.all(self.scale < 0):
+                return constraints.less_than(self(self.domain.lower_bound))
+            # we suppose scale > 0 for any tracer
+            else:  
+                return constraints.greater_than(self(self.domain.lower_bound))
+        elif isinstance(self.domain, constraints.less_than):
+            if not_jax_tracer(self.scale) and jnp.all(self.scale < 0):
+                return constraints.greater_than(self(self.domain.upper_bound))
+            # we suppose scale > 0 for any tracer
+            else:  
+                return constraints.less_than(self(self.domain.upper_bound))
         elif isinstance(self.domain, constraints.interval):
-            return constraints.interval(self.__call__(self.domain.lower_bound),
-                                        self.__call__(self.domain.upper_bound))
+            if not_jax_tracer(self.scale) and jnp.all(self.scale < 0):
+                return constraints.interval(self(self.domain.upper_bound),
+                                            self(self.domain.lower_bound))
+            else:
+                return constraints.interval(self(self.domain.lower_bound),
+                                            self(self.domain.upper_bound))
         else:
             raise NotImplementedError
 
@@ -569,6 +587,13 @@ def _transform_to_greater_than(constraint):
         return ExpTransform()
     return ComposeTransform([ExpTransform(),
                              AffineTransform(constraint.lower_bound, 1,
+                                             domain=constraints.positive)])
+
+
+@biject_to.register(constraints.less_than)
+def _transform_to_less_than(constraint):
+    return ComposeTransform([ExpTransform(),
+                             AffineTransform(constraint.upper_bound, -1,
                                              domain=constraints.positive)])
 
 

--- a/numpyro/distributions/transforms.py
+++ b/numpyro/distributions/transforms.py
@@ -99,13 +99,13 @@ class AffineTransform(Transform):
             if not_jax_tracer(self.scale) and jnp.all(self.scale < 0):
                 return constraints.less_than(self(self.domain.lower_bound))
             # we suppose scale > 0 for any tracer
-            else:  
+            else:
                 return constraints.greater_than(self(self.domain.lower_bound))
         elif isinstance(self.domain, constraints.less_than):
             if not_jax_tracer(self.scale) and jnp.all(self.scale < 0):
                 return constraints.greater_than(self(self.domain.upper_bound))
             # we suppose scale > 0 for any tracer
-            else:  
+            else:
                 return constraints.less_than(self(self.domain.upper_bound))
         elif isinstance(self.domain, constraints.interval):
             if not_jax_tracer(self.scale) and jnp.all(self.scale < 0):

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -764,6 +764,8 @@ def test_categorical_log_prob_grad():
     (constraints.interval(-3, 5), 0, True),
     (constraints.interval(-3, 5), jnp.array([-5, -3, 0, 5, 7]),
      jnp.array([False, False, True, False, False])),
+    (constraints.less_than(1), -2, True),
+    (constraints.less_than(1), jnp.array([-1, 1, 5]), jnp.array([True, False, False])),
     (constraints.lower_cholesky, jnp.array([[1., 0.], [-2., 0.1]]), True),
     (constraints.lower_cholesky, jnp.array([[[1., 0.], [-2., -0.1]], [[1., 0.1], [2., 0.2]]]),
      jnp.array([False, False])),
@@ -795,6 +797,7 @@ def test_constraints(constraint, x, expected):
     constraints.corr_matrix,
     constraints.greater_than(2),
     constraints.interval(-3, 5),
+    constraints.less_than(1),
     constraints.lower_cholesky,
     constraints.ordered_vector,
     constraints.positive,
@@ -815,6 +818,8 @@ def test_biject_to(constraint, shape):
         assert transform.codomain.lower_bound == constraint.lower_bound
     elif isinstance(constraint, constraints._GreaterThan):
         assert transform.codomain.lower_bound == constraint.lower_bound
+    elif isinstance(constraint, constraints._LessThan):
+        assert transform.codomain.upper_bound == constraint.upper_bound
     if len(shape) < event_dim:
         return
     rng_key = random.PRNGKey(0)


### PR DESCRIPTION
Addresses #663. I was wrong there that Pyro didn't have this constraint.

This PR adds `less_than` constraint and its corresponding bijective. For that purpose, I also support the case `scale < 0` in AffineTransform in case `scale` is not a tracer. If `scale` is a tracer or not `< 0`, we still assume that `scale > 0` because, e.g, there is no defined codomain for `ComposedTransform([ExpTransform(), AffineTransform(0, scale=jnp.array([-1, 1]), domain=constraints.positive)])`

cc @vanAmsterdam After this, you don't need to change your code to use `reparam` handler.