### PR TITLE
expose MCMCKernel to docs

### DIFF
--- a/docs/source/mcmc.rst
+++ b/docs/source/mcmc.rst
@@ -10,6 +10,12 @@ Hamiltonian Monte Carlo
     :show-inheritance:
     :member-order: bysource
 
+.. autoclass:: numpyro.infer.mcmc.MCMCKernel
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :member-order: bysource
+
 .. autoclass:: numpyro.infer.hmc.HMC
     :members:
     :undoc-members:

--- a/numpyro/infer/hmc.py
+++ b/numpyro/infer/hmc.py
@@ -479,8 +479,8 @@ class HMC(MCMCKernel):
 
     def sample(self, state, model_args, model_kwargs):
         """
-        Run HMC from the given :data:`~numpyro.infer.mcmc.HMCState` and return the resulting
-        :data:`~numpyro.infer.mcmc.HMCState`.
+        Run HMC from the given :data:`~numpyro.infer.hmc.HMCState` and return the resulting
+        :data:`~numpyro.infer.hmc.HMCState`.
 
         :param HMCState state: Represents the current state.
         :param model_args: Arguments provided to the model.

--- a/numpyro/infer/mcmc.py
+++ b/numpyro/infer/mcmc.py
@@ -17,6 +17,12 @@ from jax.tree_util import tree_flatten, tree_map, tree_multimap
 from numpyro.diagnostics import print_summary
 from numpyro.util import cached_by, fori_collect, identity
 
+__all__ = [
+    'MCMCKernel',
+    'MCMC',
+    'hmc',
+]
+
 
 def hmc(potential_fn=None, potential_fn_gen=None, kinetic_fn=None, algo='NUTS'):
     from numpyro.infer.hmc import hmc
@@ -71,6 +77,8 @@ class MCMCKernel(ABC):
             be consistent with the input type to `potential_fn`.
         :param model_args: Arguments provided to the model.
         :param model_kwargs: Keyword arguments provided to the model.
+        :return: The initial state, which has arbitrary data structure representing the
+            state of the kernel.
         """
         raise NotImplementedError
 
@@ -81,7 +89,7 @@ class MCMCKernel(ABC):
         transition kernel.
 
         :param state: Arbitrary data structure representing the state for the
-            kernel. For HMC, this is given by :data:`~numpyro.infer.mcmc.HMCState`.
+            kernel. For HMC, this is given by :data:`~numpyro.infer.hmc.HMCState`.
         :param model_args: Arguments provided to the model.
         :param model_kwargs: Keyword arguments provided to the model.
         :return: Next `state`.


### PR DESCRIPTION
By exposing to docs, it will be easier for users to know how to define a custom MCMCKernel (e.g. #674).