### PR TITLE
Port LocScaleReparam

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,18 +91,15 @@ Expected log joint density: -54.55
 The values above 1 for the split Gelman Rubin diagnostic (`r_hat`) indicates that the chain has not fully converged. The low value for the effective sample size (`n_eff`), particularly for `tau`, and the number of divergent transitions looks problematic. Fortunately, this is a common pathology that can be rectified by using a [non-centered paramaterization](https://mc-stan.org/docs/2_18/stan-users-guide/reparameterization-section.html) for `tau` in our model. This is straightforward to do in NumPyro by using a [TransformedDistribution](http://num.pyro.ai/en/latest/distributions.html#transformeddistribution) instance together with a [reparameterization](http://num.pyro.ai/en/latest/handlers.html#reparam) effect handler. Let us rewrite the same model but instead of sampling `theta` from a `Normal(mu, tau)`, we will instead sample it from a base `Normal(0, 1)` distribution that is transformed using an [AffineTransform](http://num.pyro.ai/en/latest/distributions.html#affinetransform). Note that by doing so, NumPyro runs HMC by generating samples `theta_base` for the base `Normal(0, 1)` distribution instead. We see that the resulting chain does not suffer from the same pathology — the Gelman Rubin diagnostic is 1 for all the parameters and the effective sample size looks quite good!
 
 ```python
->>> from numpyro.infer.reparam import TransformReparam
+>>> from numpyro.infer.reparam import LocScaleReparam
 
 >>> # Eight Schools example - Non-centered Reparametrization
 ... def eight_schools_noncentered(J, sigma, y=None):
 ...     mu = numpyro.sample('mu', dist.Normal(0, 5))
 ...     tau = numpyro.sample('tau', dist.HalfCauchy(5))
 ...     with numpyro.plate('J', J):
-...         with numpyro.handlers.reparam(config={'theta': TransformReparam()}):
-...             theta = numpyro.sample(
-...                 'theta',
-...                 dist.TransformedDistribution(dist.Normal(0., 1.),
-...                                              dist.transforms.AffineTransform(mu, tau)))
+...         with numpyro.handlers.reparam(config={'theta': LocScaleReparam(0)}):
+...             theta = numpyro.sample('theta', dist.Normal(mu, tau))
 ...         numpyro.sample('obs', dist.Normal(theta, sigma), obs=y)
 
 >>> nuts_kernel = NUTS(eight_schools_noncentered)
@@ -152,7 +149,7 @@ Now, let us assume that we have a new school for which we have not observed any 
 ...     return numpyro.sample('obs', dist.Normal(mu, tau))
 
 >>> predictive = Predictive(new_school, mcmc.get_samples())
->>> samples_predictive = predictive.get_samples(random.PRNGKey(1))
+>>> samples_predictive = predictive(random.PRNGKey(1))
 >>> print(np.mean(samples_predictive['obs']))  # doctest: +SKIP
 3.9886456
 

--- a/docs/source/reparam.rst
+++ b/docs/source/reparam.rst
@@ -16,6 +16,15 @@ shaped. These can be used with a variety of inference algorithms, e.g.
     :member-order: bysource
     :special-members: __call___
 
+Loc-Scale Decentering
+---------------------
+.. autoclass:: numpyro.infer.reparam.LocScaleReparam
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :member-order: bysource
+    :special-members: __call__
+
 Neural Transport
 ----------------
 .. autoclass:: numpyro.infer.reparam.NeuTraReparam

--- a/examples/funnel.py
+++ b/examples/funnel.py
@@ -36,9 +36,8 @@ import jax.numpy as jnp
 
 import numpyro
 import numpyro.distributions as dist
-from numpyro.distributions.transforms import AffineTransform
 from numpyro.infer import MCMC, NUTS, Predictive
-from numpyro.infer.reparam import TransformReparam
+from numpyro.infer.reparam import LocScaleReparam
 
 
 def model(dim=10):
@@ -48,9 +47,8 @@ def model(dim=10):
 
 def reparam_model(dim=10):
     y = numpyro.sample('y', dist.Normal(0, 3))
-    with numpyro.handlers.reparam(config={'x': TransformReparam()}):
-        numpyro.sample('x', dist.TransformedDistribution(
-            dist.Normal(jnp.zeros(dim - 1), 1), AffineTransform(0, jnp.exp(y / 2))))
+    with numpyro.handlers.reparam(config={'x': LocScaleReparam(0)}):
+        numpyro.sample('x', dist.Normal(jnp.zeros(dim - 1), jnp.exp(y / 2)))
 
 
 def run_inference(model, args, rng_key):

--- a/numpyro/distributions/distribution.py
+++ b/numpyro/distributions/distribution.py
@@ -396,13 +396,6 @@ class ExpandedDistribution(Distribution):
         log_prob = self.base_dist.log_prob(value)
         return jnp.broadcast_to(log_prob, shape)
 
-    def to_event(self, reinterpreted_batch_ndims=None):
-        if reinterpreted_batch_ndims is None:
-            reinterpreted_batch_ndims = len(self.batch_shape)
-        elif reinterpreted_batch_ndims == 0:
-            return self
-        return Independent(self.base_dist, reinterpreted_batch_ndims)
-
     def enumerate_support(self, expand=True):
         samples = self.base_dist.enumerate_support(expand=False)
         enum_shape = samples.shape[:1]

--- a/numpyro/infer/reparam.py
+++ b/numpyro/infer/reparam.py
@@ -7,8 +7,8 @@ import jax.numpy as jnp
 
 import numpyro
 import numpyro.distributions as dist
-from numpyro.distributions import biject_to
-from numpyro.distributions.util import sum_rightmost
+from numpyro.distributions import biject_to, constraints
+from numpyro.distributions.util import is_identically_one, sum_rightmost
 from numpyro.infer.autoguide import AutoContinuous
 
 
@@ -26,6 +26,93 @@ class Reparam(ABC):
         """
         return fn, obs
 
+    def _unwrap(self, fn):
+        """
+        Unwrap Independent(...) distributions.
+        """
+        event_dim = fn.event_dim
+        while isinstance(fn, dist.Independent):
+            fn = fn.base_dist
+        return fn, event_dim
+
+    def _wrap(self, fn, event_dim):
+        """
+        Wrap in Independent distributions.
+        """
+        if fn.event_dim < event_dim:
+            fn = fn.to_event(event_dim - fn.event_dim)
+        assert fn.event_dim == event_dim
+        return fn
+
+    def _unexpand(self, fn):
+        """
+        Unexpand ExpandedDistribution(...) distributions.
+        """
+        batch_shape = fn.batch_shape
+        if isinstance(fn, dist.ExpandedDistribution):
+            fn = fn.base_dist
+        return fn, batch_shape
+
+
+class LocScaleReparam(Reparam):
+    """
+    Generic decentering reparameterizer [1] for latent variables parameterized
+    by ``loc`` and ``scale`` (and possibly additional ``shape_params``).
+
+    This reparameterization works only for latent variables, not likelihoods.
+
+    **References:**
+
+    1. *Automatic Reparameterisation of Probabilistic Programs*,
+       Maria I. Gorinova, Dave Moore, Matthew D. Hoffman (2019)
+
+    :param float centered: optional centered parameter. If None (default) learn
+        a per-site per-element centering parameter in ``[0,1]``. If 0, fully
+        decenter the distribution; if 1, preserve the centered distribution
+        unchanged.
+    :param shape_params: list of additional parameter names to copy unchanged from
+        the centered to decentered distribution.
+    :type shape_params: tuple or list
+    """
+    def __init__(self, centered=None, shape_params=()):
+        assert centered is None or isinstance(centered, (int, float))
+        assert isinstance(shape_params, (tuple, list))
+        assert all(isinstance(name, str) for name in shape_params)
+        if isinstance(centered, (int, float)):
+            assert 0 <= centered and centered <= 1
+        self.centered = centered
+        self.shape_params = shape_params
+
+    def __call__(self, name, fn, obs):
+        assert obs is None, "LocScaleReparam does not support observe statements"
+        centered = self.centered
+        if is_identically_one(centered):
+            return name, fn, obs
+        event_shape = fn.event_shape
+        fn, event_dim = self._unwrap(fn)
+        fn, batch_shape = self._unexpand(fn)
+
+        # Apply a partial decentering transform.
+        params = {key: getattr(fn, key) for key in self.shape_params}
+        if self.centered is None:
+            centered = numpyro.param("{}_centered".format(name),
+                                     jnp.full(event_shape, 0.5),
+                                     constraint=constraints.unit_interval)
+        params["loc"] = fn.loc * centered
+        params["scale"] = fn.scale ** centered
+        decentered_fn = type(fn)(**params).expand(batch_shape)
+
+        # Draw decentered noise.
+        decentered_value = numpyro.sample("{}_decentered".format(name),
+                                          self._wrap(decentered_fn, event_dim))
+
+        # Differentiably transform.
+        delta = decentered_value - centered * fn.loc
+        value = fn.loc + jnp.power(fn.scale, 1 - centered) * delta
+
+        # Simulate a pyro.deterministic() site.
+        return None, value
+
 
 class TransformReparam(Reparam):
     """
@@ -40,9 +127,7 @@ class TransformReparam(Reparam):
     """
     def __call__(self, name, fn, obs):
         assert obs is None, "TransformReparam does not support observe statements"
-        batch_shape = fn.batch_shape
-        if isinstance(fn, dist.ExpandedDistribution):
-            fn = fn.base_dist
+        fn, batch_shape = self._unexpand(fn)
         assert isinstance(fn, dist.TransformedDistribution)
 
         # Draw noise from the base distribution.


### PR DESCRIPTION
Addresses #675.

 This port Pyro [LocScaleRepram](https://github.com/pyro-ppl/pyro/blob/dev/pyro/infer/reparam/loc_scale.py) to NumPyro with the following differences:
+ array input for `center` parameter is not supported.
+ an extra logic for `expand` is needed because in NumPyro, we expand distributions under `plate` using the wrapper `ExpandedDistribution`. To simplify the implementation, I made `Independent(...).expand(batch_shape)` returns an `Independent(ExpandedDistribution(...))` distribution instead of an `ExpandedDistribution`.