### PR TITLE
Support MCMC kernel classes to specify sample and default fields

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 jax>=0.1.65
 jaxlib>=0.1.45
+funsor>=0.1.2
 tqdm

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 jax>=0.1.65
 jaxlib>=0.1.45
-funsor>=0.1.2
+git+git://github.com/pyro-ppl/funsor@master#egg=funsor
 tqdm

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -30,7 +30,6 @@ NumPyro documentation
    svi
    autoguide
    reparam
-   funsor
    optimizers
    diagnostics
    utilities

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -30,6 +30,7 @@ NumPyro documentation
    svi
    autoguide
    reparam
+   funsor
    optimizers
    diagnostics
    utilities

--- a/numpyro/infer/hmc.py
+++ b/numpyro/infer/hmc.py
@@ -432,6 +432,14 @@ class HMC(MCMCKernel):
     def model(self):
         return self._model
 
+    @property
+    def sample_field(self):
+        return 'z'
+
+    @property
+    def default_fields(self):
+        return ('z', 'diverging')
+
     @copy_docs_from(MCMCKernel.init)
     def init(self, rng_key, num_warmup, init_params=None, model_args=(), model_kwargs={}):
         # non-vectorized

--- a/numpyro/infer/hmc.py
+++ b/numpyro/infer/hmc.py
@@ -433,10 +433,12 @@ class HMC(MCMCKernel):
         return self._model
 
     @property
+    @copy_docs_from(MCMCKernel.sample_field)
     def sample_field(self):
         return 'z'
 
     @property
+    @copy_docs_from(MCMCKernel.default_fields)
     def default_fields(self):
         return ('z', 'diverging')
 

--- a/numpyro/infer/mcmc.py
+++ b/numpyro/infer/mcmc.py
@@ -68,6 +68,8 @@ class MCMCKernel(ABC):
         >>> MHState = namedtuple("MHState", ["z", "rng_key"])
 
         >>> class MetropolisHastings(numpyro.infer.mcmc.MCMCKernel):
+        ...     sample_field = "z"
+        ...
         ...     def __init__(self, potential_fn, step_size=0.1):
         ...         self.potential_fn = potential_fn
         ...         self.step_size = step_size
@@ -129,8 +131,7 @@ class MCMCKernel(ABC):
 
         :param state: Arbitrary data structure representing the state for the
             kernel. For HMC, this is given by :data:`~numpyro.infer.hmc.HMCState`.
-            In general, this could be any class or a `namedtuple` that supports
-            `getattr`.
+            In general, this could be any class that supports `getattr`.
         :param model_args: Arguments provided to the model.
         :param model_kwargs: Keyword arguments provided to the model.
         :return: Next `state`.
@@ -138,24 +139,22 @@ class MCMCKernel(ABC):
         raise NotImplementedError
 
     @property
-    @abstractmethod
     def sample_field(self):
         """
-        The attribute of the `state` object passed to :meth:`sample`that denotes
+        The attribute of the `state` object passed to :meth:`sample` that denotes
         the MCMC sample. This is used by :meth:`postprocess_fn` and for reporting
-        results in :meth:`~numpyro.infer.MCMC.print_summary`.
+        results in :meth:`MCMC.print_summary()
+        <numpyro.infer.mcmc.MCMC.print_summary>`.
         """
         raise NotImplementedError
 
     @property
-    @abstractmethod
     def default_fields(self):
         """
-        The attributes of the `state` object to be collected during the MCMC run.
-        These attributes are collected by default by :meth:`~numpyro.infer.MCMC.run`
-        and can be retrieved from :meth:`~numpyro.infer.MCMC.get_samples`.
+        The attributes of the `state` object to be collected by default during
+        the MCMC run (when :meth:`MCMC.run() <numpyro.infer.MCMC.run>` is called).
         """
-        raise NotImplementedError
+        return (self.sample_field,)
 
 
 def _get_value_from_index(xs, i):

--- a/numpyro/infer/mcmc.py
+++ b/numpyro/infer/mcmc.py
@@ -54,10 +54,6 @@ class MCMCKernel(ABC):
     Defines the interface for the Markov transition kernel that is
     used for :class:`~numpyro.infer.MCMC` inference.
 
-    If the MCMC state is a namedtuple with `z` field, the
-    method :meth:`MCMC.get_samples()` will return the result in `z` field.
-    Otherwise, that method will return the collection of full states.
-
     **Example:**
 
     .. doctest::
@@ -133,9 +129,31 @@ class MCMCKernel(ABC):
 
         :param state: Arbitrary data structure representing the state for the
             kernel. For HMC, this is given by :data:`~numpyro.infer.hmc.HMCState`.
+            In general, this could be any class or a `namedtuple` that supports
+            `getattr`.
         :param model_args: Arguments provided to the model.
         :param model_kwargs: Keyword arguments provided to the model.
         :return: Next `state`.
+        """
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def sample_field(self):
+        """
+        The attribute of the `state` object passed to :meth:`sample`that denotes
+        the MCMC sample. This is used by :meth:`postprocess_fn` and for reporting
+        results in :meth:`~numpyro.infer.MCMC.print_summary`.
+        """
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def default_fields(self):
+        """
+        The attributes of the `state` object to be collected during the MCMC run.
+        These attributes are collected by default by :meth:`~numpyro.infer.MCMC.run`
+        and can be retrieved from :meth:`~numpyro.infer.MCMC.get_samples`.
         """
         raise NotImplementedError
 
@@ -229,6 +247,8 @@ class MCMC(object):
                  progress_bar=True,
                  jit_model_args=False):
         self.sampler = sampler
+        self.sample_field = sampler.sample_field
+        self.default_fields = sampler.default_fields
         self.num_warmup = num_warmup
         self.num_samples = num_samples
         self.num_chains = num_chains
@@ -286,7 +306,7 @@ class MCMC(object):
         except TypeError:
             return None
 
-    def _single_chain_mcmc(self, rng_key, init_state, init_params, args, kwargs, collect_fields=('z',)):
+    def _single_chain_mcmc(self, rng_key, init_state, init_params, args, kwargs, collect_fields):
         if init_state is None:
             init_state = self.sampler.init(rng_key, self.num_warmup, init_params,
                                            model_args=args, model_kwargs=kwargs)
@@ -298,15 +318,6 @@ class MCMC(object):
         init_val = (init_state, args, kwargs) if self._jit_model_args else (init_state,)
         lower_idx = self._collection_params["lower"]
         upper_idx = self._collection_params["upper"]
-        # filter out fields not available in init_state
-        avail_fields = []
-        for field in collect_fields:
-            try:
-                attrgetter(field)(init_state)
-                avail_fields.append(field)
-            except AttributeError:
-                pass
-        collect_fields = tuple(avail_fields) if 'z' in avail_fields else ()
 
         collect_vals = fori_collect(lower_idx,
                                     upper_idx,
@@ -321,21 +332,19 @@ class MCMC(object):
         states, last_val = collect_vals
         # Get first argument of type `HMCState`
         last_state = last_val[0]
-        if len(collect_fields) <= 1:
-            # if collect_fields == (), we put the result in `z` field
-            collect_fields = ('z',)
+        if len(collect_fields) == 1:
             states = (states,)
         states = dict(zip(collect_fields, states))
         # Apply constraints if number of samples is non-zero
-        site_values = tree_flatten(states['z'])[0]
+        site_values = tree_flatten(states[self.sample_field])[0]
         if len(site_values) > 0 and site_values[0].size > 0:
-            states['z'] = lax.map(postprocess_fn, states['z'])
+            states[self.sample_field] = lax.map(postprocess_fn, states[self.sample_field])
         return states, last_state
 
-    def _single_chain_jit_args(self, init, collect_fields=('z',)):
+    def _single_chain_jit_args(self, init, collect_fields):
         return self._single_chain_mcmc(*init, collect_fields=collect_fields)
 
-    def _single_chain_nojit_args(self, init, model_args, model_kwargs, collect_fields=('z',)):
+    def _single_chain_nojit_args(self, init, model_args, model_kwargs, collect_fields):
         return self._single_chain_mcmc(*init, model_args, model_kwargs, collect_fields=collect_fields)
 
     def _set_collection_params(self, lower=None, upper=None, collection_size=None):
@@ -365,8 +374,9 @@ class MCMC(object):
         :param random.PRNGKey rng_key: Random number generator key to be used for the sampling.
         :param args: Arguments to be provided to the :meth:`numpyro.infer.mcmc.MCMCKernel.init` method.
             These are typically the arguments needed by the `model`.
-        :param extra_fields: Extra fields (aside from `z`, `diverging`) from :data:`numpyro.infer.mcmc.HMCState`
-            to collect during the MCMC run.
+        :param extra_fields: Extra fields (aside from the sampler's `default_fields`) from
+            the state tuple (e.g. :data:`numpyro.infer.mcmc.HMCState` for HMC) to collect during
+            the MCMC run.
         :type extra_fields: tuple or list
         :param bool collect_warmup: Whether to collect samples from the warmup phase. Defaults
             to `False`.
@@ -430,7 +440,8 @@ class MCMC(object):
                 raise ValueError('`init_params` must have the same leading dimension'
                                  ' as `num_chains`.')
         assert isinstance(extra_fields, (tuple, list))
-        collect_fields = tuple(set(('z', 'diverging') + tuple(extra_fields)))
+        collect_fields = tuple(set((self.sampler.sample_field,) + tuple(self.sampler.default_fields) +
+                                   tuple(extra_fields)))
         if self.num_chains == 1:
             states_flat, last_state = self._single_chain_mcmc(rng_key, init_state, init_params,
                                                               args, kwargs, collect_fields)
@@ -480,7 +491,8 @@ class MCMC(object):
             but can be any :func:`jaxlib.pytree`, more generally (e.g. when defining a
             `potential_fn` for HMC that takes `list` args).
         """
-        return self._states['z'] if group_by_chain else self._states_flat['z']
+        return self._states[self.sample_field] if group_by_chain \
+            else self._states_flat[self.sample_field]
 
     def get_extra_fields(self, group_by_chain=False):
         """
@@ -492,13 +504,14 @@ class MCMC(object):
             `extra_fields` keyword of :meth:`run`.
         """
         states = self._states if group_by_chain else self._states_flat
-        return {k: v for k, v in states.items() if k != 'z'}
+        return {k: v for k, v in states.items() if k != self.sample_field}
 
     def print_summary(self, prob=0.9, exclude_deterministic=True):
         # Exclude deterministic sites by default
-        sites = self._states['z']
+        sites = self._states[self.sample_field]
         if isinstance(sites, dict) and exclude_deterministic:
-            sites = {k: v for k, v in self._states['z'].items() if k in self._last_state.z}
+            sites = {k: v for k, v in self._states[self.sample_field].items()
+                     if k in self._last_state.z}
         print_summary(sites, prob=prob)
         extra_fields = self.get_extra_fields()
         if 'diverging' in extra_fields:

--- a/numpyro/infer/mcmc.py
+++ b/numpyro/infer/mcmc.py
@@ -441,7 +441,7 @@ class MCMC(object):
                 raise ValueError('`init_params` must have the same leading dimension'
                                  ' as `num_chains`.')
         assert isinstance(extra_fields, (tuple, list))
-        collect_fields = tuple(set((self.sampler._sample_field,) + tuple(self.sampler.default_fields) +
+        collect_fields = tuple(set((self._sample_field,) + tuple(self._default_fields) +
                                    tuple(extra_fields)))
         if self.num_chains == 1:
             states_flat, last_state = self._single_chain_mcmc(rng_key, init_state, init_params,

--- a/numpyro/infer/mcmc.py
+++ b/numpyro/infer/mcmc.py
@@ -374,8 +374,8 @@ class MCMC(object):
         :param random.PRNGKey rng_key: Random number generator key to be used for the sampling.
         :param args: Arguments to be provided to the :meth:`numpyro.infer.mcmc.MCMCKernel.init` method.
             These are typically the arguments needed by the `model`.
-        :param extra_fields: Extra fields (aside from the sampler's `default_fields`) from
-            the state tuple (e.g. :data:`numpyro.infer.mcmc.HMCState` for HMC) to collect during
+        :param extra_fields: Extra fields (aside from :meth:`~numpyro.infer.MCMCKernel.default_fields`)
+            from the state object (e.g. :data:`numpyro.infer.mcmc.HMCState` for HMC) to collect during
             the MCMC run.
         :type extra_fields: tuple or list
         :param bool collect_warmup: Whether to collect samples from the warmup phase. Defaults

--- a/numpyro/infer/sa.py
+++ b/numpyro/infer/sa.py
@@ -299,10 +299,12 @@ class SA(MCMCKernel):
         return init_state
 
     @property
+    @copy_docs_from(MCMCKernel.sample_field)
     def sample_field(self):
         return 'z'
 
     @property
+    @copy_docs_from(MCMCKernel.default_fields)
     def default_fields(self):
         return ('z', 'diverging')
 

--- a/numpyro/infer/sa.py
+++ b/numpyro/infer/sa.py
@@ -298,6 +298,14 @@ class SA(MCMCKernel):
             self._sample_fn = sample_fn
         return init_state
 
+    @property
+    def sample_field(self):
+        return 'z'
+
+    @property
+    def default_fields(self):
+        return ('z', 'diverging')
+
     @copy_docs_from(MCMCKernel.postprocess_fn)
     def postprocess_fn(self, args, kwargs):
         if self._postprocess_fn is None:


### PR DESCRIPTION
This adds a `sample_field` property to `MCMCKernel` class and an optional `default_fields` class so that we don't need to make assumption about the naming of any data fields used by user defined kernels.