### PR TITLE
Allow default doc inheritance in sphinx

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 jax>=0.1.65
 jaxlib>=0.1.45
+funsor>=0.1.2
 tqdm

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -66,11 +66,9 @@ extensions = [
     'sphinx.ext.viewcode',
 ]
 
-# Disable documentation inheritance so as to avoid inheriting
-# docstrings in a different format, e.g. when the parent class
-# is a PyTorch class.
+# Enable documentation inheritance
 
-autodoc_inherit_docstrings = False
+autodoc_inherit_docstrings = True
 
 # autodoc_default_options = {
 #     'member-order': 'bysource',

--- a/docs/source/funsor.rst
+++ b/docs/source/funsor.rst
@@ -1,0 +1,58 @@
+Funsor-based NumPyro
+====================
+
+.. automodule:: numpyro.contrib.funsor
+
+Effect handlers
+---------------
+
+.. autoclass:: numpyro.contrib.funsor.enum_messenger.enum
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :member-order: bysource
+
+.. autoclass:: numpyro.contrib.funsor.enum_messenger.infer_config
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :member-order: bysource
+
+.. autoclass:: numpyro.contrib.funsor.enum_messenger.markov
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :member-order: bysource
+
+.. autoclass:: numpyro.contrib.funsor.enum_messenger.plate
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :member-order: bysource
+
+.. autoclass:: numpyro.contrib.funsor.enum_messenger.to_data
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :member-order: bysource
+
+.. autoclass:: numpyro.contrib.funsor.enum_messenger.to_funsor
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :member-order: bysource
+
+.. autoclass:: numpyro.contrib.funsor.enum_messenger.trace
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :member-order: bysource
+
+Inference Utilities
+-------------------
+
+.. autofunction:: numpyro.contrib.funsor.infer_util.config_enumerate
+
+.. autofunction:: numpyro.contrib.funsor.infer_util.log_density
+
+.. autofunction:: numpyro.contrib.funsor.infer_util.plate_to_enum_plate

--- a/numpyro/distributions/continuous.py
+++ b/numpyro/distributions/continuous.py
@@ -45,12 +45,10 @@ from numpyro.distributions.util import (
     validate_sample,
     vec_to_tril_matrix
 )
-from numpyro.util import copy_docs_from
 
 EULER_MASCHERONI = 0.5772156649015328606065120900824024310421
 
 
-@copy_docs_from(Distribution)
 class Beta(Distribution):
     arg_constraints = {'concentration1': constraints.positive, 'concentration0': constraints.positive}
     support = constraints.unit_interval
@@ -80,7 +78,6 @@ class Beta(Distribution):
         return self.concentration1 * self.concentration0 / (total ** 2 * (total + 1))
 
 
-@copy_docs_from(Distribution)
 class Cauchy(Distribution):
     arg_constraints = {'loc': constraints.real, 'scale': constraints.positive}
     support = constraints.real
@@ -108,7 +105,6 @@ class Cauchy(Distribution):
         return jnp.full(self.batch_shape, jnp.nan)
 
 
-@copy_docs_from(Distribution)
 class Dirichlet(Distribution):
     arg_constraints = {'concentration': constraints.positive}
     support = constraints.simplex
@@ -144,7 +140,6 @@ class Dirichlet(Distribution):
         return self.concentration * (con0 - self.concentration) / (con0 ** 2 * (con0 + 1))
 
 
-@copy_docs_from(Distribution)
 class Exponential(Distribution):
     reparametrized_params = ['rate']
     arg_constraints = {'rate': constraints.positive}
@@ -170,7 +165,6 @@ class Exponential(Distribution):
         return jnp.reciprocal(self.rate ** 2)
 
 
-@copy_docs_from(Distribution)
 class Gamma(Distribution):
     arg_constraints = {'concentration': constraints.positive,
                        'rate': constraints.positive}
@@ -202,7 +196,6 @@ class Gamma(Distribution):
         return self.concentration / jnp.power(self.rate, 2)
 
 
-@copy_docs_from(Distribution)
 class Chi2(Gamma):
     arg_constraints = {'df': constraints.positive}
 
@@ -211,7 +204,6 @@ class Chi2(Gamma):
         super(Chi2, self).__init__(0.5 * df, 0.5, validate_args=validate_args)
 
 
-@copy_docs_from(Distribution)
 class GaussianRandomWalk(Distribution):
     arg_constraints = {'scale': constraints.positive, 'num_steps': constraints.positive_integer}
     support = constraints.real_vector
@@ -253,7 +245,6 @@ class GaussianRandomWalk(Distribution):
         return cls(*params, num_steps=aux_data)
 
 
-@copy_docs_from(Distribution)
 class HalfCauchy(Distribution):
     reparametrized_params = ['scale']
     support = constraints.positive
@@ -280,7 +271,6 @@ class HalfCauchy(Distribution):
         return jnp.full(self.batch_shape, jnp.inf)
 
 
-@copy_docs_from(Distribution)
 class HalfNormal(Distribution):
     reparametrized_params = ['scale']
     support = constraints.positive
@@ -307,7 +297,6 @@ class HalfNormal(Distribution):
         return (1 - 2 / jnp.pi) * self.scale ** 2
 
 
-@copy_docs_from(Distribution)
 class InverseGamma(TransformedDistribution):
     arg_constraints = {'concentration': constraints.positive, 'rate': constraints.positive}
     support = constraints.positive
@@ -339,7 +328,6 @@ class InverseGamma(TransformedDistribution):
         return super(TransformedDistribution, self).tree_flatten()
 
 
-@copy_docs_from(Distribution)
 class Gumbel(Distribution):
     arg_constraints = {'loc': constraints.real, 'scale': constraints.positive}
     support = constraints.real
@@ -372,7 +360,6 @@ class Gumbel(Distribution):
                                 self.batch_shape)
 
 
-@copy_docs_from(Distribution)
 class Laplace(Distribution):
     arg_constraints = {'loc': constraints.real, 'scale': constraints.positive}
     support = constraints.real
@@ -402,7 +389,6 @@ class Laplace(Distribution):
         return jnp.broadcast_to(2 * self.scale ** 2, self.batch_shape)
 
 
-@copy_docs_from(Distribution)
 class LKJ(TransformedDistribution):
     r"""
     LKJ distribution for correlation matrices. The distribution is controlled by ``concentration``
@@ -451,7 +437,6 @@ class LKJ(TransformedDistribution):
         return cls(dimension, *params, sample_method=sample_method)
 
 
-@copy_docs_from(Distribution)
 class LKJCholesky(Distribution):
     r"""
     LKJ distribution for lower Cholesky factors of correlation matrices. The distribution is
@@ -625,7 +610,6 @@ class LKJCholesky(Distribution):
         return cls(dimension, *params, sample_method=sample_method)
 
 
-@copy_docs_from(Distribution)
 class LogNormal(TransformedDistribution):
     arg_constraints = {'loc': constraints.real, 'scale': constraints.positive}
     reparametrized_params = ['loc', 'scale']
@@ -691,7 +675,6 @@ def _batch_mahalanobis(bL, bx):
     return jnp.reshape(M, out_shape)
 
 
-@copy_docs_from(Distribution)
 class MultivariateNormal(Distribution):
     arg_constraints = {'loc': constraints.real_vector,
                        'covariance_matrix': constraints.positive_definite,
@@ -809,7 +792,6 @@ def _batch_lowrank_mahalanobis(W, D, x, capacitance_tril):
     return mahalanobis_term1 - mahalanobis_term2
 
 
-@copy_docs_from(Distribution)
 class LowRankMultivariateNormal(Distribution):
     arg_constraints = {
         "loc": constraints.real_vector,
@@ -917,7 +899,6 @@ class LowRankMultivariateNormal(Distribution):
         return jnp.broadcast_to(H, self.batch_shape)
 
 
-@copy_docs_from(Distribution)
 class Normal(Distribution):
     arg_constraints = {'loc': constraints.real, 'scale': constraints.positive}
     support = constraints.real
@@ -950,7 +931,6 @@ class Normal(Distribution):
         return jnp.broadcast_to(self.scale ** 2, self.batch_shape)
 
 
-@copy_docs_from(Distribution)
 class Pareto(TransformedDistribution):
     arg_constraints = {'scale': constraints.positive, 'alpha': constraints.positive}
 
@@ -982,7 +962,6 @@ class Pareto(TransformedDistribution):
         return super(TransformedDistribution, self).tree_flatten()
 
 
-@copy_docs_from(Distribution)
 class StudentT(Distribution):
     arg_constraints = {'df': constraints.positive, 'loc': constraints.real, 'scale': constraints.positive}
     support = constraints.real
@@ -1046,7 +1025,6 @@ class _BaseTruncatedCauchy(Distribution):
         return - jnp.log1p((value - self.base_loc) ** 2) - normalize_term
 
 
-@copy_docs_from(Distribution)
 class TruncatedCauchy(TransformedDistribution):
     arg_constraints = {'low': constraints.real, 'loc': constraints.real,
                        'scale': constraints.positive}
@@ -1113,7 +1091,6 @@ class _BaseTruncatedNormal(Distribution):
         return self._normal.log_prob(value) - log_ndtr(self.base_loc)
 
 
-@copy_docs_from(Distribution)
 class TruncatedNormal(TransformedDistribution):
     arg_constraints = {'low': constraints.real, 'loc': constraints.real,
                        'scale': constraints.positive}
@@ -1173,7 +1150,6 @@ class _BaseUniform(Distribution):
         return - jnp.zeros(batch_shape)
 
 
-@copy_docs_from(Distribution)
 class Uniform(TransformedDistribution):
     arg_constraints = {'low': constraints.dependent, 'high': constraints.dependent}
     reparametrized_params = ['low', 'high']
@@ -1213,7 +1189,6 @@ class Uniform(TransformedDistribution):
         return d
 
 
-@copy_docs_from(Distribution)
 class Logistic(Distribution):
     arg_constraints = {'loc': constraints.real, 'scale': constraints.positive}
     support = constraints.real
@@ -1244,7 +1219,6 @@ class Logistic(Distribution):
         return jnp.broadcast_to(var, self.batch_shape)
 
 
-@copy_docs_from(Distribution)
 class TruncatedPolyaGamma(Distribution):
     truncation_point = 2.5
     num_log_prob_terms = 7

--- a/numpyro/distributions/directional.py
+++ b/numpyro/distributions/directional.py
@@ -8,10 +8,8 @@ import jax.numpy as jnp
 from numpyro.distributions import constraints
 from numpyro.distributions.distribution import Distribution
 from numpyro.distributions.util import promote_shapes, validate_sample, von_mises_centered
-from numpyro.util import copy_docs_from
 
 
-@copy_docs_from(Distribution)
 class VonMises(Distribution):
     arg_constraints = {'loc': constraints.real, 'concentration': constraints.positive}
 

--- a/numpyro/distributions/discrete.py
+++ b/numpyro/distributions/discrete.py
@@ -48,7 +48,7 @@ from numpyro.distributions.util import (
     sum_rightmost,
     validate_sample
 )
-from numpyro.util import copy_docs_from, not_jax_tracer
+from numpyro.util import not_jax_tracer
 
 
 def _to_probs_bernoulli(logits):
@@ -69,7 +69,6 @@ def _to_logits_multinom(probs):
     return jnp.clip(jnp.log(probs), a_min=minval)
 
 
-@copy_docs_from(Distribution)
 class BernoulliProbs(Distribution):
     arg_constraints = {'probs': constraints.unit_interval}
     support = constraints.boolean
@@ -102,7 +101,6 @@ class BernoulliProbs(Distribution):
         return values
 
 
-@copy_docs_from(Distribution)
 class BernoulliLogits(Distribution):
     arg_constraints = {'logits': constraints.real}
     support = constraints.boolean
@@ -148,7 +146,6 @@ def Bernoulli(probs=None, logits=None, validate_args=None):
         raise ValueError('One of `probs` or `logits` must be specified.')
 
 
-@copy_docs_from(Distribution)
 class BinomialProbs(Distribution):
     arg_constraints = {'probs': constraints.unit_interval,
                        'total_count': constraints.nonnegative_integer}
@@ -196,7 +193,6 @@ class BinomialProbs(Distribution):
         return values
 
 
-@copy_docs_from(Distribution)
 class BinomialLogits(Distribution):
     arg_constraints = {'logits': constraints.real,
                        'total_count': constraints.nonnegative_integer}
@@ -259,7 +255,6 @@ def Binomial(total_count=1, probs=None, logits=None, validate_args=None):
         raise ValueError('One of `probs` or `logits` must be specified.')
 
 
-@copy_docs_from(Distribution)
 class CategoricalProbs(Distribution):
     arg_constraints = {'probs': constraints.simplex}
     has_enumerate_support = True
@@ -303,7 +298,6 @@ class CategoricalProbs(Distribution):
         return values
 
 
-@copy_docs_from(Distribution)
 class CategoricalLogits(Distribution):
     arg_constraints = {'logits': constraints.real_vector}
     has_enumerate_support = True
@@ -360,7 +354,6 @@ def Categorical(probs=None, logits=None, validate_args=None):
         raise ValueError('One of `probs` or `logits` must be specified.')
 
 
-@copy_docs_from(Distribution)
 class Delta(Distribution):
     arg_constraints = {'value': constraints.real, 'log_density': constraints.real}
     support = constraints.real
@@ -447,7 +440,6 @@ class PRNGIdentity(Distribution):
                            sample_shape + self.event_shape)
 
 
-@copy_docs_from(Distribution)
 class MultinomialProbs(Distribution):
     arg_constraints = {'probs': constraints.simplex,
                        'total_count': constraints.nonnegative_integer}
@@ -486,7 +478,6 @@ class MultinomialProbs(Distribution):
         return constraints.multinomial(self.total_count)
 
 
-@copy_docs_from(Distribution)
 class MultinomialLogits(Distribution):
     arg_constraints = {'logits': constraints.real_vector,
                        'total_count': constraints.nonnegative_integer}
@@ -539,7 +530,6 @@ def Multinomial(total_count=1, probs=None, logits=None, validate_args=None):
         raise ValueError('One of `probs` or `logits` must be specified.')
 
 
-@copy_docs_from(Distribution)
 class Poisson(Distribution):
     arg_constraints = {'rate': constraints.positive}
     support = constraints.nonnegative_integer

--- a/numpyro/distributions/util.py
+++ b/numpyro/distributions/util.py
@@ -463,6 +463,10 @@ class lazy_property(object):
         self.wrapped = wrapped
         update_wrapper(self, wrapped)
 
+    # This is to prevent warnings from sphinx
+    def __call__(self, *args, **kwargs):
+        return self.wrapped(*args, **kwargs)
+
     def __get__(self, instance, obj_type=None):
         if instance is None:
             return self

--- a/numpyro/infer/hmc.py
+++ b/numpyro/infer/hmc.py
@@ -18,7 +18,7 @@ from numpyro.infer.hmc_util import (
 )
 from numpyro.infer.mcmc import MCMCKernel
 from numpyro.infer.util import ParamInfo, init_to_uniform, initialize_model
-from numpyro.util import cond, copy_docs_from, fori_loop, identity
+from numpyro.util import cond, fori_loop, identity
 
 HMCState = namedtuple('HMCState', ['i', 'z', 'z_grad', 'potential_energy', 'energy', 'num_steps', 'accept_prob',
                                    'mean_accept_prob', 'diverging', 'adapt_state', 'rng_key'])
@@ -432,7 +432,6 @@ class HMC(MCMCKernel):
     def model(self):
         return self._model
 
-    @copy_docs_from(MCMCKernel.init)
     def init(self, rng_key, num_warmup, init_params=None, model_args=(), model_kwargs={}):
         # non-vectorized
         if rng_key.ndim == 1:
@@ -471,7 +470,6 @@ class HMC(MCMCKernel):
             self._sample_fn = sample_fn
         return init_state
 
-    @copy_docs_from(MCMCKernel.postprocess_fn)
     def postprocess_fn(self, args, kwargs):
         if self._postprocess_fn is None:
             return identity

--- a/numpyro/infer/sa.py
+++ b/numpyro/infer/sa.py
@@ -9,7 +9,7 @@ import numpyro.distributions as dist
 from numpyro.distributions.util import cholesky_update
 from numpyro.infer.mcmc import MCMCKernel
 from numpyro.infer.util import init_to_uniform, initialize_model
-from numpyro.util import copy_docs_from, identity
+from numpyro.util import identity
 
 
 def _get_proposal_loc_and_scale(samples, loc, scale, new_sample):
@@ -265,7 +265,6 @@ class SA(MCMCKernel):
             self._sample_fn = sample_fn
         return init_params
 
-    @copy_docs_from(MCMCKernel.init)
     def init(self, rng_key, num_warmup, init_params=None, model_args=(), model_kwargs={}):
         # non-vectorized
         if rng_key.ndim == 1:
@@ -298,7 +297,6 @@ class SA(MCMCKernel):
             self._sample_fn = sample_fn
         return init_state
 
-    @copy_docs_from(MCMCKernel.postprocess_fn)
     def postprocess_fn(self, args, kwargs):
         if self._postprocess_fn is None:
             return identity

--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -17,7 +17,6 @@ from jax.dtypes import canonicalize_dtype
 import jax.numpy as jnp
 from jax.tree_util import tree_flatten, tree_map, tree_unflatten
 
-_DATA_TYPES = {}
 _DISABLE_CONTROL_FLOW_PRIM = False
 
 
@@ -233,44 +232,6 @@ def fori_collect(lower, upper, body_fun, init_val, transform=identity,
 
     unravel_collection = vmap(unravel_fn)(collection)
     return (unravel_collection, last_val) if return_last_val else unravel_collection
-
-
-def copy_docs_from(source_class, full_text=False):
-    """
-    Decorator to copy class and method docs from source to destin class.
-    """
-
-    def decorator(destin_class):
-        # This works only in python 3.3+:
-        # if not destin_class.__doc__:
-        #     destin_class.__doc__ = source_class.__doc__
-        for name in dir(destin_class):
-            if name.startswith('_'):
-                continue
-            destin_attr = getattr(destin_class, name)
-            destin_attr = getattr(destin_attr, '__func__', destin_attr)
-            source_attr = getattr(source_class, name, None)
-            source_doc = getattr(source_attr, '__doc__', None)
-            if source_doc and not getattr(destin_attr, '__doc__', None):
-                if full_text or source_doc.startswith('See '):
-                    destin_doc = source_doc
-                else:
-                    destin_doc = 'See :meth:`{}.{}.{}`'.format(
-                        source_class.__module__, source_class.__name__, name)
-                if isinstance(destin_attr, property):
-                    # Set docs for object properties.
-                    # Since __doc__ is read-only, we need to reset the property
-                    # with the updated doc.
-                    updated_property = property(destin_attr.fget,
-                                                destin_attr.fset,
-                                                destin_attr.fdel,
-                                                destin_doc)
-                    setattr(destin_class, name, updated_property)
-                else:
-                    destin_attr.__doc__ = destin_doc
-        return destin_class
-
-    return decorator
 
 
 pytree_metadata = namedtuple('pytree_metadata', ['flat', 'shape', 'size', 'dtype'])


### PR DESCRIPTION
Our `copy_from_docs` utility function is not working currently, i.e. there is not docstring produces for the annotated methods. This removes the function and relies on sphinx's default docstring inheritance mechanism. Also adds the missing `funsor.rst` file to the docs source.