### PR TITLE
Move get_diagnostic str to sampler method

### DIFF
--- a/numpyro/infer/hmc.py
+++ b/numpyro/infer/hmc.py
@@ -440,6 +440,11 @@ class HMC(MCMCKernel):
     def default_fields(self):
         return ('z', 'diverging')
 
+    def get_diagnostics_str(self, state):
+        return '{} steps of size {:.2e}. acc. prob={:.2f}'.format(state.num_steps,
+                                                                  state.adapt_state.step_size,
+                                                                  state.mean_accept_prob)
+
     def init(self, rng_key, num_warmup, init_params=None, model_args=(), model_kwargs={}):
         # non-vectorized
         if rng_key.ndim == 1:

--- a/numpyro/infer/sa.py
+++ b/numpyro/infer/sa.py
@@ -305,6 +305,9 @@ class SA(MCMCKernel):
     def default_fields(self):
         return ('z', 'diverging')
 
+    def get_diagnostics_str(self, state):
+        return 'acc. prob={:.2f}'.format(state.mean_accept_prob)
+
     def postprocess_fn(self, args, kwargs):
         if self._postprocess_fn is None:
             return identity


### PR DESCRIPTION
This allows a user customize diagnostic str of a sampler as he/she likes.