### PR TITLE
Rename mask_array to mask to match Pyro api

### DIFF
--- a/numpyro/handlers.py
+++ b/numpyro/handlers.py
@@ -373,13 +373,17 @@ class mask(Messenger):
     """
     This messenger masks out some of the sample statements elementwise.
 
-    :param mask_array: a DeviceArray with `bool` dtype for masking elementwise masking
+    :param mask: a DeviceArray with `bool` dtype for masking elementwise masking
         of sample sites.
     """
-    def __init__(self, fn=None, mask_array=True):
-        if lax.dtype(mask_array) != 'bool':
+    def __init__(self, fn=None, mask=True, mask_array=None):
+        if mask_array is not None:
+            mask = mask_array
+            warnings.warn("'mask_array' argument is renamed to 'mask'. We will remove"
+                          " 'mask_array' in a future release.", FutureWarning)
+        if lax.dtype(mask) != 'bool':
             raise ValueError("`mask` should be a bool array.")
-        self.mask = mask_array
+        self.mask = mask
         super(mask, self).__init__(fn)
 
     def process_message(self, msg):

--- a/numpyro/handlers.py
+++ b/numpyro/handlers.py
@@ -384,7 +384,7 @@ class mask(Messenger):
         if lax.dtype(mask) != 'bool':
             raise ValueError("`mask` should be a bool array.")
         self.mask = mask
-        super(mask, self).__init__(fn)
+        super().__init__(fn)
 
     def process_message(self, msg):
         if msg['type'] != 'sample':

--- a/test/test_handlers.py
+++ b/test/test_handlers.py
@@ -26,7 +26,7 @@ def test_mask(mask_last, use_jit):
     def model(data, mask):
         with numpyro.plate('N', N):
             x = numpyro.sample('x', dist.Normal(0, 1))
-            with handlers.mask(mask_array=mask):
+            with handlers.mask(mask=mask):
                 numpyro.sample('y', dist.Delta(x, log_density=1.))
                 with handlers.scale(scale=2):
                     numpyro.sample('obs', dist.Normal(x, 1), obs=data)

--- a/test/test_infer_util.py
+++ b/test/test_infer_util.py
@@ -185,7 +185,7 @@ def test_model_with_transformed_distribution():
 def test_model_with_mask_false():
     def model():
         x = numpyro.sample("x", dist.Normal())
-        with numpyro.handlers.mask(mask_array=False):
+        with numpyro.handlers.mask(mask=False):
             numpyro.sample("y", dist.Normal(x), obs=1)
 
     kernel = NUTS(model)


### PR DESCRIPTION
While working on the hmm_enum example, I notice that this difference in NumPyro w.r.t. Pyro api. As `scale`, it is better to keep the same api.