### PR TITLE
make jit model args work for chains

### DIFF
--- a/numpyro/infer/mcmc.py
+++ b/numpyro/infer/mcmc.py
@@ -319,7 +319,7 @@ class MCMC(object):
             postprocess_fn = self.sampler.postprocess_fn(args, kwargs)
         else:
             postprocess_fn = self.postprocess_fn
-        diagnostics = lambda x: get_diagnostics_str(x[0]) if rng_key.ndim == 1 else None   # noqa: E731
+        diagnostics = lambda x: get_diagnostics_str(x[0]) if rng_key.ndim == 1 else ''  # noqa: E731
         init_val = (init_state, args, kwargs) if self._jit_model_args else (init_state,)
         lower_idx = self._collection_params["lower"]
         upper_idx = self._collection_params["upper"]

--- a/numpyro/infer/mcmc.py
+++ b/numpyro/infer/mcmc.py
@@ -447,6 +447,8 @@ class MCMC(object):
             states = tree_map(lambda x: x[jnp.newaxis, ...], states_flat)
         else:
             if self._jit_model_args and chain_method == 'parallel':
+                # XXX: it is not clear that this branch is useful
+                # we might remove this branch eventually to clean up the code
                 partial_map_fn = partial(self._single_chain_mcmc,
                                          collect_fields=collect_fields)
                 map_args = ((rng_key, init_state, init_params), args, kwargs)

--- a/test/test_mcmc.py
+++ b/test/test_mcmc.py
@@ -435,7 +435,7 @@ def test_chain_inside_jit(kernel_cls, chain_method):
 ])
 @pytest.mark.parametrize('compile_args', [
     False,
-    True
+    True,
 ])
 @pytest.mark.skipif('CI' in os.environ, reason="Compiling time the whole sampling process is slow.")
 def test_chain_jit_args_smoke(chain_method, compile_args):

--- a/test/test_mcmc.py
+++ b/test/test_mcmc.py
@@ -438,18 +438,21 @@ def test_chain_inside_jit(kernel_cls, chain_method):
     True
 ])
 @pytest.mark.skipif('CI' in os.environ, reason="Compiling time the whole sampling process is slow.")
-def test_chain_smoke(chain_method, compile_args):
+def test_chain_jit_args_smoke(chain_method, compile_args):
     def model(data):
         concentration = jnp.array([1.0, 1.0, 1.0])
         p_latent = numpyro.sample('p_latent', dist.Dirichlet(concentration))
         numpyro.sample('obs', dist.Categorical(p_latent), obs=data)
         return p_latent
 
-    data = dist.Categorical(jnp.array([0.1, 0.6, 0.3])).sample(random.PRNGKey(1), (2000,))
+    data1 = dist.Categorical(jnp.array([0.1, 0.6, 0.3])).sample(random.PRNGKey(1), (50,))
+    data2 = dist.Categorical(jnp.array([0.2, 0.4, 0.4])).sample(random.PRNGKey(1), (50,))
     kernel = NUTS(model)
     mcmc = MCMC(kernel, 2, 5, num_chains=2, chain_method=chain_method, jit_model_args=compile_args)
-    mcmc.warmup(random.PRNGKey(0), data)
-    mcmc.run(random.PRNGKey(1), data)
+    mcmc.warmup(random.PRNGKey(0), data1)
+    mcmc.run(random.PRNGKey(1), data1)
+    # this should be fast if jit_model_args=True
+    mcmc.run(random.PRNGKey(2), data2)
 
 
 def test_extra_fields():


### PR DESCRIPTION
Fixes #691. It is surprised to me that there was no test to detect this issue previously.

### Test on `test_chain_jit_args_smoke`

```
# sequential
warmup: 100%|██████████████| 2/2 [00:06<00:00,  3.18s/it, 3 steps of size 5.89e-01. acc. prob=0.00]
warmup: 100%|██████████████| 2/2 [00:00<00:00, 52.53it/s, 1 steps of size 5.89e-01. acc. prob=0.00]
sample: 100%|█████████████| 5/5 [00:00<00:00, 114.76it/s, 1 steps of size 5.89e-01. acc. prob=0.89]
sample: 100%|█████████████| 5/5 [00:00<00:00, 144.18it/s, 1 steps of size 5.89e-01. acc. prob=0.55]
sample: 100%|██████████████| 5/5 [00:06<00:00,  1.21s/it, 1 steps of size 5.89e-01. acc. prob=0.60]
sample: 100%|█████████████| 5/5 [00:00<00:00, 228.72it/s, 1 steps of size 5.89e-01. acc. prob=0.60]
PASSED
test/test_mcmc.py::test_chain_jit_args_smoke[False-parallel] PASSED
# vectorized
warmup: 100%|██████████████████████████████████████████████████| 2/2 [00:06<00:00,  3.29s/it, None]
sample: 100%|█████████████████████████████████████████████████| 5/5 [00:00<00:00, 977.56it/s, None]
sample: 100%|██████████████████████████████████████████████████| 5/5 [00:09<00:00,  1.83s/it, None]
PASSED
# sequential
warmup: 100%|██████████████| 2/2 [00:04<00:00,  2.43s/it, 3 steps of size 5.89e-01. acc. prob=0.00]
warmup: 100%|█████████████| 2/2 [00:00<00:00, 717.22it/s, 1 steps of size 5.89e-01. acc. prob=0.00]
sample: 100%|█████████████| 5/5 [00:00<00:00, 832.14it/s, 1 steps of size 5.89e-01. acc. prob=0.89]
sample: 100%|████████████| 5/5 [00:00<00:00, 1019.12it/s, 1 steps of size 5.89e-01. acc. prob=0.55]
sample: 100%|████████████| 5/5 [00:00<00:00, 1187.11it/s, 1 steps of size 5.89e-01. acc. prob=0.60]
sample: 100%|████████████| 5/5 [00:00<00:00, 1260.16it/s, 1 steps of size 5.89e-01. acc. prob=0.60]
PASSED
test/test_mcmc.py::test_chain_jit_args_smoke[True-parallel] PASSED
# vectorized
warmup: 100%|██████████████████████████████████████████████████| 2/2 [00:09<00:00,  4.65s/it, None]
sample: 100%|█████████████████████████████████████████████████| 5/5 [00:00<00:00, 816.74it/s, None]
sample: 100%|█████████████████████████████████████████████████| 5/5 [00:00<00:00, 704.69it/s, None]
PASSED
```
We can observe that `sequential` and `vectorized` methods take advantage of `jit_model_args=True`. For `parallel` method, it is not clear to me if `jit_model_args` works or `pmap` works out-of-the-box: I added some timing for the second run but got similar results for `True` and `False` and for both cases, the second runs are much faster than the first runs: 5s vs 20s).