### PR TITLE
Relax summing up simplex constraint to align with Pyro.

### DIFF
--- a/numpyro/distributions/constraints.py
+++ b/numpyro/distributions/constraints.py
@@ -192,7 +192,7 @@ class _RealVector(Constraint):
 class _Simplex(Constraint):
     def __call__(self, x):
         x_sum = jnp.sum(x, axis=-1)
-        return jnp.all(x > 0, axis=-1) & (x_sum <= 1) & (x_sum > 1 - 1e-6)
+        return jnp.all(x > 0, axis=-1) & (x_sum < 1 + 1e-6) & (x_sum > 1 - 1e-6)
 
 
 # TODO: Make types consistent


### PR DESCRIPTION
Due to machine precision draws from Dirichlet are sometimes rejected as they fail the simplex constraint. Current Numpyro's implementation does not relax the summing up constraint on both sides.