### PR TITLE
Mention about the default platform in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ To use NumPyro on the GPU, you will need to first [install](https://github.com/g
 
 To run NumPyro on Cloud TPUs, you can use pip to install NumPyro as above and setup the TPU backend as detailed [here](https://github.com/google/jax/tree/master/cloud_tpu_colabs).
 
-> **Default Platform:** Different from JAX, which uses GPU as the default platform, we use CPU as the default platform. You can use [set_platform](http://num.pyro.ai/en/stable/utilities.html#set-platform) utility to switch to other platforms such as GPU or TPU at the begin of your program.
+> **Default Platform:** In contrast to JAX, which uses GPU as the default platform, we use CPU as the default platform. You can use [set_platform](http://num.pyro.ai/en/stable/utilities.html#set-platform) utility to switch to other platforms such as GPU or TPU at the beginning of your program.
 
 You can also install NumPyro from source:
 

--- a/README.md
+++ b/README.md
@@ -194,6 +194,8 @@ To use NumPyro on the GPU, you will need to first [install](https://github.com/g
 
 To run NumPyro on Cloud TPUs, you can use pip to install NumPyro as above and setup the TPU backend as detailed [here](https://github.com/google/jax/tree/master/cloud_tpu_colabs).
 
+> **Default Platform:** Different from JAX, which uses GPU as the default platform, we use CPU as the default platform. You can use [set_platform](http://num.pyro.ai/en/stable/utilities.html#set-platform) utility to switch to other platforms such as GPU or TPU at the begin of your program.
+
 You can also install NumPyro from source:
 
 ```


### PR DESCRIPTION
Resolves #727. This PR adds a note to README to mention that we use CPU by default, which is different from JAX default behavior. Is there a better idea?
