### PR TITLE
Validate the model when cannot find valid initial params.

### DIFF
--- a/numpyro/distributions/distribution.py
+++ b/numpyro/distributions/distribution.py
@@ -141,7 +141,8 @@ class Distribution(object):
                 is_valid = jnp.all(constraint(getattr(self, param)))
                 if not_jax_tracer(is_valid):
                     if not is_valid:
-                        raise ValueError("The parameter {} has invalid values".format(param))
+                        raise ValueError("{} distribution got invalid {} parameter.".format(
+                            self.__class__.__name__, param))
         super(Distribution, self).__init__()
 
     @property

--- a/numpyro/infer/util.py
+++ b/numpyro/infer/util.py
@@ -427,6 +427,9 @@ def initialize_model(rng_key, model,
 
     if not_jax_tracer(is_valid):
         if device_get(~jnp.all(is_valid)):
+            with numpyro.validation_enabled(), \
+                    seed(rng_seed=rng_key if jnp.ndim(rng_key) == 1 else rng_key[0]):
+                model(*model_args, **model_kwargs)
             raise RuntimeError("Cannot find valid initial parameters. Please check your model again.")
     return ModelInfo(ParamInfo(init_params, pe, grad), potential_fn, postprocess_fn, model_trace)
 

--- a/numpyro/infer/util.py
+++ b/numpyro/infer/util.py
@@ -427,7 +427,9 @@ def initialize_model(rng_key, model,
 
     if not_jax_tracer(is_valid):
         if device_get(~jnp.all(is_valid)):
-            with numpyro.validation_enabled(), trace() as tr, \
+            with numpyro.validation_enabled(), \
+                    trace() as tr, \
+                    substitute(substitute_fn=init_strategy), \
                     seed(rng_seed=rng_key if jnp.ndim(rng_key) == 1 else rng_key[0]):
                 # validate parameters
                 model(*model_args, **model_kwargs)

--- a/numpyro/infer/util.py
+++ b/numpyro/infer/util.py
@@ -427,12 +427,9 @@ def initialize_model(rng_key, model,
 
     if not_jax_tracer(is_valid):
         if device_get(~jnp.all(is_valid)):
-            with numpyro.validation_enabled(), \
-                    trace() as tr, \
-                    substitute(substitute_fn=init_strategy), \
-                    seed(rng_seed=rng_key if jnp.ndim(rng_key) == 1 else rng_key[0]):
+            with numpyro.validation_enabled(), trace() as tr:
                 # validate parameters
-                model(*model_args, **model_kwargs)
+                substituted_model(*model_args, **model_kwargs)
                 # validate values
                 for site in tr.values():
                     if site['type'] == 'sample':


### PR DESCRIPTION
Resolves #731. As explained there, it might be tricky to find bugs when the inference cannot find valid initial parameters. With this PR, when that happens, we can recognize at which site, things go wrong.

@rim30 could you run your code with this branch to see where causes the problem?

TODO

- [x] incorporate init_strategy because some distributions such Improper does not have `sample` method.