### PR TITLE
Pin tfp nightly version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
             'ipython',
             'isort',
             'flax',
-            'dm-haiku @ https://github.com/deepmind/dm-haiku/archive/v0.0.2.zip',
+            'dm-haiku',
             'tfp-nightly==0.12.0.dev20200911',  # TODO: change this to stable release or a specific nightly release
         ],
         'examples': ['matplotlib', 'seaborn', 'graphviz'],

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
             'isort',
             'flax',
             'dm-haiku @ https://github.com/deepmind/dm-haiku/archive/v0.0.2.zip',
-            'tfp-nightly',  # TODO: change this to stable release or a specific nightly release
+            'tfp-nightly==0.12.0.dev20200911',  # TODO: change this to stable release or a specific nightly release
         ],
         'examples': ['matplotlib', 'seaborn', 'graphviz'],
     },


### PR DESCRIPTION
because the latest version is causing tests to fail (e.g. #738 does not pass Actions). There is a new flattening logic in the constructor of tfp distributions that prevents us from creating a thin wrapper. I think it will be fixed in the future.