### PR TITLE
Add AutoNormal guide

### DIFF
--- a/docs/source/autoguide.rst
+++ b/docs/source/autoguide.rst
@@ -58,3 +58,11 @@ AutoLowRankMultivariateNormal
     :undoc-members:
     :show-inheritance:
     :member-order: bysource
+
+AutoNormal
+----------
+.. autoclass:: numpyro.infer.autoguide.AutoNormal
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :member-order: bysource

--- a/numpyro/distributions/util.py
+++ b/numpyro/distributions/util.py
@@ -428,6 +428,23 @@ def _von_mises_centered(key, concentration, shape, dtype):
     return jnp.sign(u) * jnp.arccos(w)
 
 
+# TODO: use funsor implementation
+def periodic_repeat(x, size, dim):
+    """
+    Repeat a ``period``-sized array up to given ``size``.
+    """
+    assert isinstance(size, int) and size >= 0
+    assert isinstance(dim, int)
+    if dim >= 0:
+        dim -= jnp.ndim(x)
+
+    period = jnp.shape(x)[dim]
+    repeats = (size + period - 1) // period
+    result = jnp.repeat(x, repeats, axis=dim)
+    result = result[(Ellipsis, slice(None, size)) + (slice(None),) * (-1 - dim)]
+    return result
+
+
 # The is sourced from: torch.distributions.util.py
 #
 # Copyright (c) 2016-     Facebook, Inc            (Adam Paszke)

--- a/numpyro/infer/autoguide.py
+++ b/numpyro/infer/autoguide.py
@@ -3,6 +3,7 @@
 
 # Adapted from pyro.infer.autoguide
 from abc import ABC, abstractmethod
+from contextlib import ExitStack
 import warnings
 
 from jax import hessian, lax, random, tree_map
@@ -36,6 +37,7 @@ __all__ = [
     'AutoDiagonalNormal',
     'AutoLaplaceApproximation',
     'AutoLowRankMultivariateNormal',
+    'AutoNormal',
     'AutoMultivariateNormal',
     'AutoBNAFNormal',
     'AutoIAFNormal',
@@ -52,11 +54,29 @@ class AutoGuide(ABC):
     :param str prefix: a prefix that will be prefixed to all param internal sites
     """
 
-    def __init__(self, model, prefix='auto'):
-        assert isinstance(prefix, str)
+    def __init__(self, model, *, prefix="auto", init_strategy=init_to_uniform, create_plates=None):
         self.model = model
         self.prefix = prefix
+        self.init_strategy = init_strategy
+        self.create_plates = create_plates
         self.prototype_trace = None
+        self._prototype_frames = {}
+
+    def _create_plates(self, *args, **kwargs):
+        if self.create_plates is None:
+            self.plates = {}
+        else:
+            plates = self.create_plates(*args, **kwargs)
+            if isinstance(plates, numpyro.plate):
+                plates = [plates]
+            assert all(isinstance(p, numpyro.plate) for p in plates), \
+                "create_plates() returned a non-plate"
+            self.plates = {p.name: p for p in plates}
+        for name, frame in sorted(self._prototype_frames.items()):
+            if name not in self.plates:
+                size = self._prototype_plate_sizes[name]
+                self.plates[name] = numpyro.plate(name, size, dim=frame.dim, subsample_size=frame.size)
+        return self.plates
 
     @abstractmethod
     def __call__(self, *args, **kwargs):
@@ -81,19 +101,89 @@ class AutoGuide(ABC):
         """
         raise NotImplementedError
 
-    @abstractmethod
-    def _sample_latent(self, *args, **kwargs):
-        """
-        Samples an encoded latent given the same ``*args, **kwargs`` as the
-        base ``model``.
-        """
-        raise NotImplementedError
-
     def _setup_prototype(self, *args, **kwargs):
-        # run the model so we can inspect its structure
         rng_key = numpyro.sample("_{}_rng_key_setup".format(self.prefix), dist.PRNGIdentity())
-        model = handlers.seed(self.model, rng_key)
-        self.prototype_trace = handlers.block(handlers.trace(model).get_trace)(*args, **kwargs)
+        with handlers.block():
+            init_params, _, self._postprocess_fn, self.prototype_trace = initialize_model(
+                rng_key, self.model,
+                init_strategy=self.init_strategy,
+                dynamic_args=False,
+                model_args=args,
+                model_kwargs=kwargs)
+        self._init_values = init_params[0]
+
+        self._prototype_frames = {}
+        self._prototype_plate_sizes = {}
+        for name, site in self.prototype_trace.items():
+            if site["type"] == "sample":
+                for frame in site["cond_indep_stack"]:
+                    self._prototype_frames[frame.name] = frame
+            elif site["type"] == "plate":
+                self._prototype_plate_sizes[name] = site["args"][0]
+
+
+class AutoNormal(AutoGuide):
+    def __init__(self, model, *, prefix="auto", init_strategy=init_to_uniform, init_scale=0.1):
+        # TODO: support subsampling for `create_plates` arg
+        # TODO: rename `init_strategy` to `init_loc_fn` to be consistent with Pyro
+        self._init_scale = init_scale
+        super().__init__(model, prefix=prefix, init_strategy=init_strategy)
+
+    def __call__(self, *args, **kwargs):
+        """
+        An automatic guide with the same ``*args, **kwargs`` as the base ``model``.
+
+        :return: A dict mapping sample site name to sampled value.
+        :rtype: dict
+        """
+        if self.prototype_trace is None:
+            # run model to inspect the model structure
+            self._setup_prototype(*args, **kwargs)
+
+        plates = self._create_plates(*args, **kwargs)
+        result = {}
+        for name, site in self.prototype_trace.items():
+            if site["type"] != "sample" or isinstance(site["fn"], dist.PRNGIdentity) or site["is_observed"]:
+                continue
+
+            with ExitStack() as stack:
+                for frame in site["cond_indep_stack"]:
+                    print("aaaa", frame)
+                    stack.enter_context(plates[frame.name])
+
+                site_loc = numpyro.param("{}_{}_loc".format(name, self.prefix), self._init_values[name])
+                site_scale = numpyro.param("{}_{}_scale".format(name, self.prefix),
+                                           jnp.full(jnp.shape(site_loc), self._init_scale),
+                                           constraint=constraints.positive)
+                event_dim = site["fn"].event_dim + jnp.ndim(site_loc) - jnp.ndim(site["value"])
+                site_fn = dist.Normal(site_loc, site_scale).to_event(event_dim)
+                if site["fn"].support in [constraints.real, constraints.real_vector]:
+                    result[name] = numpyro.sample(name, site_fn)
+                else:
+                    unconstrained_value = numpyro.sample("{}_unconstrained".format(name), site_fn,
+                                                         infer={"is_auxiliary": True})
+
+                    transform = biject_to(site['fn'].support)
+                    value = transform(unconstrained_value)
+                    log_density = - transform.log_abs_det_jacobian(unconstrained_value, value)
+                    log_density = sum_rightmost(log_density,
+                                                jnp.ndim(log_density) - jnp.ndim(value) + site["fn"].event_dim)
+                    delta_dist = dist.Delta(value, log_density=log_density, event_dim=site["fn"].event_dim)
+                    result[name] = numpyro.sample(name, delta_dist)
+
+        return result
+
+    def sample_posterior(self, rng_key, params, sample_shape=()):
+        # TODO: implement
+        pass
+
+    def median(self, params):
+        # TODO: implement
+        pass
+
+    def quantiles(self, params):
+        # TODO: implement
+        pass
 
 
 class AutoContinuous(AutoGuide):
@@ -117,21 +207,9 @@ class AutoContinuous(AutoGuide):
     :param callable init_strategy: A per-site initialization function.
         See :ref:`init_strategy` section for available functions.
     """
-    def __init__(self, model, prefix="auto", init_strategy=init_to_uniform):
-        self.init_strategy = init_strategy
-        super(AutoContinuous, self).__init__(model, prefix=prefix)
-
     def _setup_prototype(self, *args, **kwargs):
-        rng_key = numpyro.sample("_{}_rng_key_setup".format(self.prefix), dist.PRNGIdentity())
-        with handlers.block():
-            init_params, _, self._postprocess_fn, self.prototype_trace = initialize_model(
-                rng_key, self.model,
-                init_strategy=self.init_strategy,
-                dynamic_args=False,
-                model_args=args,
-                model_kwargs=kwargs)
-
-        self._init_latent, unpack_latent = ravel_pytree(init_params[0])
+        super()._setup_prototype(*args, **kwargs)
+        self._init_latent, unpack_latent = ravel_pytree(self._init_values)
         # this is to match the behavior of Pyro, where we can apply
         # unpack_latent for a batch of samples
         self._unpack_latent = UnpackTransform(unpack_latent)
@@ -147,7 +225,8 @@ class AutoContinuous(AutoGuide):
     def _sample_latent(self, *args, **kwargs):
         sample_shape = kwargs.pop('sample_shape', ())
         posterior = self._get_posterior()
-        return numpyro.sample("_{}_latent".format(self.prefix), posterior, sample_shape=sample_shape)
+        return numpyro.sample("_{}_latent".format(self.prefix), posterior.expand_by(sample_shape),
+                              infer={"is_auxiliary": True})
 
     def __call__(self, *args, **kwargs):
         """
@@ -289,11 +368,11 @@ class AutoDiagonalNormal(AutoContinuous):
         guide = AutoDiagonalNormal(model, ...)
         svi = SVI(model, guide, ...)
     """
-    def __init__(self, model, prefix="auto", init_strategy=init_to_uniform, init_scale=0.1):
+    def __init__(self, model, *, prefix="auto", init_strategy=init_to_uniform, init_scale=0.1):
         if init_scale <= 0:
             raise ValueError("Expected init_scale > 0. but got {}".format(init_scale))
         self._init_scale = init_scale
-        super().__init__(model, prefix, init_strategy)
+        super().__init__(model, prefix=prefix, init_strategy=init_strategy)
 
     def _get_posterior(self):
         loc = numpyro.param('{}_loc'.format(self.prefix), self._init_latent)
@@ -338,11 +417,11 @@ class AutoMultivariateNormal(AutoContinuous):
         guide = AutoMultivariateNormal(model, ...)
         svi = SVI(model, guide, ...)
     """
-    def __init__(self, model, prefix="auto", init_strategy=init_to_uniform, init_scale=0.1):
+    def __init__(self, model, *, prefix="auto", init_strategy=init_to_uniform, init_scale=0.1):
         if init_scale <= 0:
             raise ValueError("Expected init_scale > 0. but got {}".format(init_scale))
         self._init_scale = init_scale
-        super().__init__(model, prefix, init_strategy)
+        super().__init__(model, prefix=prefix, init_strategy=init_strategy)
 
     def _get_posterior(self):
         loc = numpyro.param('{}_loc'.format(self.prefix), self._init_latent)
@@ -388,7 +467,7 @@ class AutoLowRankMultivariateNormal(AutoContinuous):
         guide = AutoLowRankMultivariateNormal(model, rank=2, ...)
         svi = SVI(model, guide, ...)
     """
-    def __init__(self, model, prefix="auto", init_strategy=init_to_uniform, init_scale=0.1, rank=None):
+    def __init__(self, model, *, prefix="auto", init_strategy=init_to_uniform, init_scale=0.1, rank=None):
         if init_scale <= 0:
             raise ValueError("Expected init_scale > 0. but got {}".format(init_scale))
         self._init_scale = init_scale
@@ -530,7 +609,7 @@ class AutoIAFNormal(AutoContinuous):
     :param callable nonlinearity: the nonlinearity to use in the feedforward network.
         Defaults to :func:`jax.experimental.stax.Elu`.
     """
-    def __init__(self, model, prefix="auto", init_strategy=init_to_uniform,
+    def __init__(self, model, *, prefix="auto", init_strategy=init_to_uniform,
                  num_flows=3, hidden_dims=None, skip_connections=False, nonlinearity=stax.Elu):
         self.num_flows = num_flows
         # 2-layer, stax.Elu, skip_connections=False by default following the experiments in
@@ -587,7 +666,7 @@ class AutoBNAFNormal(AutoContinuous):
         input dimension. This corresponds to both :math:`a` and :math:`b` in reference [1].
         The elements of hidden_factors must be integers.
     """
-    def __init__(self, model, prefix="auto", init_strategy=init_to_uniform, num_flows=1,
+    def __init__(self, model, *, prefix="auto", init_strategy=init_to_uniform, num_flows=1,
                  hidden_factors=[8, 8]):
         self.num_flows = num_flows
         self._hidden_factors = hidden_factors

--- a/test/test_autoguide.py
+++ b/test/test_autoguide.py
@@ -6,12 +6,13 @@ from functools import partial
 from numpy.testing import assert_allclose
 import pytest
 
-from jax import lax, random
+from jax import jit, lax, random
 import jax.numpy as jnp
 from jax.test_util import check_eq
 
 import numpyro
-from numpyro import optim
+from numpyro import handlers, optim
+from numpyro.contrib.control_flow import scan
 import numpyro.distributions as dist
 from numpyro.distributions import constraints, transforms
 from numpyro.distributions.flows import InverseAutoregressiveTransform
@@ -23,7 +24,8 @@ from numpyro.infer.autoguide import (
     AutoIAFNormal,
     AutoLaplaceApproximation,
     AutoLowRankMultivariateNormal,
-    AutoMultivariateNormal
+    AutoMultivariateNormal,
+    AutoNormal
 )
 from numpyro.infer.initialization import init_to_median
 from numpyro.infer.reparam import TransformReparam
@@ -40,6 +42,7 @@ init_strategy = init_to_median(num_samples=2)
     AutoMultivariateNormal,
     AutoLaplaceApproximation,
     AutoLowRankMultivariateNormal,
+    AutoNormal,
 ])
 def test_beta_bernoulli(auto_class):
     data = jnp.array([[1.0] * 8 + [0.0] * 2,
@@ -73,6 +76,7 @@ def test_beta_bernoulli(auto_class):
     AutoMultivariateNormal,
     AutoLaplaceApproximation,
     AutoLowRankMultivariateNormal,
+    AutoNormal,
 ])
 def test_logistic_regression(auto_class):
     N, dim = 3000, 3
@@ -300,3 +304,49 @@ def test_improper():
     svi = SVI(model, guide, optim.Adam(0.003), ELBO(), y=y)
     svi_state = svi.init(random.PRNGKey(2))
     lax.scan(lambda state, i: svi.update(state), svi_state, jnp.zeros(10000))
+
+
+@pytest.mark.parametrize("auto_class", [AutoNormal])
+def test_subsample_guide(auto_class):
+
+    # The model adapted from tutorial/source/easyguide.ipynb
+    def model(batch, subsample, full_size):
+        drift = numpyro.sample("drift", dist.LogNormal(-1, 0.5))
+        with handlers.substitute(data={"data": subsample}):
+            plate = numpyro.plate("data", full_size, subsample_size=len(subsample))
+        assert plate.size == 50
+
+        def transition_fn(z_prev, y_curr):
+            with plate:
+                z_curr = numpyro.sample("state", dist.Normal(z_prev, drift))
+                y_curr = numpyro.sample("obs", dist.Bernoulli(logits=z_curr), obs=y_curr)
+            return z_curr, y_curr
+
+        _, result = scan(transition_fn, jnp.zeros(len(subsample)), batch, length=num_time_steps)
+        return result
+
+    def create_plates(batch, subsample, full_size):
+        with handlers.substitute(data={"data": subsample}):
+            return numpyro.plate("data", full_size, subsample_size=subsample.shape[0])
+
+    guide = auto_class(model, create_plates=create_plates)
+
+    full_size = 50
+    batch_size = 20
+    num_time_steps = 8
+    with handlers.seed(rng_seed=0):
+        data = model(None, jnp.arange(full_size), full_size)
+    assert data.shape == (num_time_steps, full_size)
+
+    svi = SVI(model, guide, optim.Adam(0.02), ELBO())
+    svi_state = svi.init(random.PRNGKey(0), data[:, :batch_size],
+                         jnp.arange(batch_size), full_size=full_size)
+    update_fn = jit(svi.update, static_argnums=(3,))
+    for epoch in range(2):
+        beg = 0
+        while beg < full_size:
+            end = min(full_size, beg + batch_size)
+            subsample = jnp.arange(beg, end)
+            batch = data[:, beg:end]
+            beg = end
+            svi_state, loss = update_fn(svi_state, batch, subsample, full_size)


### PR DESCRIPTION
Resolves #746.

With this guide, we can leverage MeanFieldELBO to make SVI converge faster.

There are several differences from Pyro:
- `cond_indep_stack` is a class in Pyro but it is a namedtuple in NumPyro. This makes it not possible to set the attribute `full_size` to `CondIndepStackFrame`. I made a workaround by storing an additional attribute `_prototype_frame_full_sizes` along with `_prototype_frames`.
- `locs` and `scales` are PyroModule in Pyro, but they do not have similar alternatives in NumPyro. So I stored `_init_locs` values and used `numpyro.param` for them instead.
- Because there are no `locs` and `scales`, I used the following names for those parameters: `f"{site_name}_{self.prefix}_loc"` and `f"{site_name}_{self.prefix}_scale"`. There are other alternatives in naming, but I have no preference among them. Suggestions are very welcome!
- When `support` of latent sites are real/real_vector, I skip the transform logic and use a single `Normal` guide (instead of Normal + Delta). With this, I can leverage MeanFieldELBO to improve SVI results.

#### TODO

- [x] Add test