### PR TITLE
Make omnistaging work with validate_args=True

### DIFF
--- a/numpyro/contrib/tfp/distributions.py
+++ b/numpyro/contrib/tfp/distributions.py
@@ -1,6 +1,8 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
+import numpy as np
+
 from jax.dtypes import canonicalize_dtype
 import jax.numpy as jnp
 from tensorflow_probability.substrates.jax import bijectors as tfb
@@ -22,7 +24,7 @@ def _get_codomain(bijector):
         return constraints.positive
     elif bijector.__class__.__name__ == "GeneralizedPareto":
         loc, scale, concentration = bijector.loc, bijector.scale, bijector.concentration
-        if not_jax_tracer(concentration) and jnp.all(concentration < 0):
+        if not_jax_tracer(concentration) and np.all(concentration < 0):
             return constraints.interval(loc, loc + scale / jnp.abs(concentration))
         # XXX: here we suppose concentration > 0
         # which is not true in general, but should cover enough usage cases

--- a/numpyro/distributions/constraints.py
+++ b/numpyro/distributions/constraints.py
@@ -50,7 +50,9 @@ __all__ = [
     'Constraint',
 ]
 
-import jax.numpy as jnp
+import numpy as np
+
+import jax.numpy
 
 
 class Constraint(object):
@@ -79,6 +81,7 @@ class _Boolean(Constraint):
 
 class _CorrCholesky(Constraint):
     def __call__(self, x):
+        jnp = np if isinstance(x, (np.ndarray, np.generic)) else jax.numpy
         tril = jnp.tril(x)
         lower_triangular = jnp.all(jnp.reshape(tril == x, x.shape[:-2] + (-1,)), axis=-1)
         positive_diagonal = jnp.all(jnp.diagonal(x, axis1=-2, axis2=-1) > 0, axis=-1)
@@ -89,6 +92,7 @@ class _CorrCholesky(Constraint):
 
 class _CorrMatrix(Constraint):
     def __call__(self, x):
+        jnp = np if isinstance(x, (np.ndarray, np.generic)) else jax.numpy
         # check for symmetric
         symmetric = jnp.all(jnp.all(x == jnp.swapaxes(x, -2, -1), axis=-1), axis=-1)
         # check for the smallest eigenvalue is positive
@@ -129,7 +133,7 @@ class _IntegerInterval(Constraint):
         self.upper_bound = upper_bound
 
     def __call__(self, x):
-        return (x >= self.lower_bound) & (x <= self.upper_bound) & (x == jnp.floor(x))
+        return (x >= self.lower_bound) & (x <= self.upper_bound) & (x % 1 == 0)
 
 
 class _IntegerGreaterThan(Constraint):
@@ -151,6 +155,7 @@ class _Interval(Constraint):
 
 class _LowerCholesky(Constraint):
     def __call__(self, x):
+        jnp = np if isinstance(x, (np.ndarray, np.generic)) else jax.numpy
         tril = jnp.tril(x)
         lower_triangular = jnp.all(jnp.reshape(tril == x, x.shape[:-2] + (-1,)), axis=-1)
         positive_diagonal = jnp.all(jnp.diagonal(x, axis1=-2, axis2=-1) > 0, axis=-1)
@@ -162,16 +167,17 @@ class _Multinomial(Constraint):
         self.upper_bound = upper_bound
 
     def __call__(self, x):
-        return jnp.all(x >= 0, axis=-1) & (jnp.sum(x, -1) == self.upper_bound)
+        return (x >= 0).all(axis=-1) & (x.sum(axis=-1) == self.upper_bound)
 
 
 class _OrderedVector(Constraint):
     def __call__(self, x):
-        return jnp.all(x[..., 1:] > x[..., :-1], axis=-1)
+        return (x[..., 1:] > x[..., :-1]).all(axis=-1)
 
 
 class _PositiveDefinite(Constraint):
     def __call__(self, x):
+        jnp = np if isinstance(x, (np.ndarray, np.generic)) else jax.numpy
         # check for symmetric
         symmetric = jnp.all(jnp.all(x == jnp.swapaxes(x, -2, -1), axis=-1), axis=-1)
         # check for the smallest eigenvalue is positive
@@ -182,18 +188,18 @@ class _PositiveDefinite(Constraint):
 class _Real(Constraint):
     def __call__(self, x):
         # XXX: consider to relax this condition to [-inf, inf] interval
-        return jnp.isfinite(x)
+        return (x == x) & (x != float('inf')) & (x != float('-inf'))
 
 
 class _RealVector(Constraint):
     def __call__(self, x):
-        return jnp.all(jnp.isfinite(x), axis=-1)
+        return ((x != x) & (x != float('inf')) & (x != float('-inf'))).all(axis=-1)
 
 
 class _Simplex(Constraint):
     def __call__(self, x):
-        x_sum = jnp.sum(x, axis=-1)
-        return jnp.all(x >= 0, axis=-1) & (x_sum < 1 + 1e-6) & (x_sum > 1 - 1e-6)
+        x_sum = x.sum(axis=-1)
+        return (x >= 0).all(axis=-1) & (x_sum < 1 + 1e-6) & (x_sum > 1 - 1e-6)
 
 
 # TODO: Make types consistent

--- a/numpyro/distributions/constraints.py
+++ b/numpyro/distributions/constraints.py
@@ -193,7 +193,7 @@ class _Real(Constraint):
 
 class _RealVector(Constraint):
     def __call__(self, x):
-        return ((x != x) & (x != float('inf')) & (x != float('-inf'))).all(axis=-1)
+        return ((x == x) & (x != float('inf')) & (x != float('-inf'))).all(axis=-1)
 
 
 class _Simplex(Constraint):

--- a/numpyro/distributions/continuous.py
+++ b/numpyro/distributions/continuous.py
@@ -688,7 +688,7 @@ class MultivariateNormal(Distribution):
 
     def __init__(self, loc=0., covariance_matrix=None, precision_matrix=None, scale_tril=None,
                  validate_args=None):
-        if jnp.isscalar(loc):
+        if jnp.ndim(loc) == 0:
             loc, = promote_shapes(loc, shape=(1,))
         # temporary append a new axis to loc
         loc = loc[..., jnp.newaxis]
@@ -999,7 +999,7 @@ class StudentT(Distribution):
 
     @property
     def variance(self):
-        var = jnp.where(self.df > 2, self.scale ** 2 * self.df / (self.df - 2.0), jnp.inf)
+        var = jnp.where(self.df > 2, jnp.divide(self.scale ** 2 * self.df, self.df - 2.0), jnp.inf)
         var = jnp.where(self.df <= 1, jnp.nan, var)
         return jnp.broadcast_to(var, self.batch_shape)
 

--- a/numpyro/distributions/discrete.py
+++ b/numpyro/distributions/discrete.py
@@ -412,7 +412,10 @@ class OrderedLogistic(CategoricalProbs):
                        'cutpoints': constraints.ordered_vector}
 
     def __init__(self, predictor, cutpoints, validate_args=None):
-        predictor, = promote_shapes(predictor, shape=jnp.shape(predictor) + (1,))
+        if jnp.ndim(predictor) == 0:
+            predictor, = promote_shapes(predictor, shape=(1,))
+        else:
+            predictor = predictor[..., None]
         predictor, self.cutpoints = promote_shapes(predictor, cutpoints)
         self.predictor = predictor[..., 0]
         cumulative_probs = expit(cutpoints - predictor)

--- a/numpyro/distributions/discrete.py
+++ b/numpyro/distributions/discrete.py
@@ -412,7 +412,8 @@ class OrderedLogistic(CategoricalProbs):
                        'cutpoints': constraints.ordered_vector}
 
     def __init__(self, predictor, cutpoints, validate_args=None):
-        predictor, self.cutpoints = promote_shapes(jnp.expand_dims(predictor, -1), cutpoints)
+        predictor, = promote_shapes(predictor, shape=jnp.shape(predictor) + (1,))
+        predictor, self.cutpoints = promote_shapes(predictor, cutpoints)
         self.predictor = predictor[..., 0]
         cumulative_probs = expit(cutpoints - predictor)
         # add two boundary points 0 and 1

--- a/numpyro/distributions/distribution.py
+++ b/numpyro/distributions/distribution.py
@@ -29,6 +29,8 @@ from collections import OrderedDict
 from contextlib import contextmanager
 import warnings
 
+import numpy as np
+
 from jax import lax, tree_util
 import jax.numpy as jnp
 
@@ -138,9 +140,9 @@ class Distribution(object):
                     continue
                 if is_dependent(constraint):
                     continue  # skip constraints that cannot be checked
-                is_valid = jnp.all(constraint(getattr(self, param)))
+                is_valid = constraint(getattr(self, param))
                 if not_jax_tracer(is_valid):
-                    if not is_valid:
+                    if not np.all(is_valid):
                         raise ValueError("{} distribution got invalid {} parameter.".format(
                             self.__class__.__name__, param))
         super(Distribution, self).__init__()
@@ -243,7 +245,7 @@ class Distribution(object):
     def _validate_sample(self, value):
         mask = self.support(value)
         if not_jax_tracer(mask):
-            if not jnp.all(mask):
+            if not np.all(mask):
                 warnings.warn('Out-of-support values provided to log prob method. '
                               'The value argument should be within the support.')
         return mask

--- a/numpyro/distributions/transforms.py
+++ b/numpyro/distributions/transforms.py
@@ -4,6 +4,8 @@
 import math
 import warnings
 
+import numpy as np
+
 from jax import ops, tree_flatten, tree_map, vmap
 from jax.dtypes import canonicalize_dtype
 from jax.flatten_util import ravel_pytree
@@ -96,19 +98,19 @@ class AffineTransform(Transform):
         elif self.domain is constraints.real_vector:
             return constraints.real_vector
         elif isinstance(self.domain, constraints.greater_than):
-            if not_jax_tracer(self.scale) and jnp.all(self.scale < 0):
+            if not_jax_tracer(self.scale) and np.all(self.scale < 0):
                 return constraints.less_than(self(self.domain.lower_bound))
             # we suppose scale > 0 for any tracer
             else:
                 return constraints.greater_than(self(self.domain.lower_bound))
         elif isinstance(self.domain, constraints.less_than):
-            if not_jax_tracer(self.scale) and jnp.all(self.scale < 0):
+            if not_jax_tracer(self.scale) and np.all(self.scale < 0):
                 return constraints.greater_than(self(self.domain.upper_bound))
             # we suppose scale > 0 for any tracer
             else:
                 return constraints.less_than(self(self.domain.upper_bound))
         elif isinstance(self.domain, constraints.interval):
-            if not_jax_tracer(self.scale) and jnp.all(self.scale < 0):
+            if not_jax_tracer(self.scale) and np.all(self.scale < 0):
                 return constraints.interval(self(self.domain.upper_bound),
                                             self(self.domain.lower_bound))
             else:

--- a/numpyro/distributions/util.py
+++ b/numpyro/distributions/util.py
@@ -4,6 +4,8 @@ from collections import namedtuple
 from functools import update_wrapper
 import math
 
+import numpy as np
+
 from jax import jit, lax, random, vmap
 from jax.dtypes import canonicalize_dtype
 from jax.lib import xla_bridge
@@ -232,6 +234,13 @@ def binary_cross_entropy_with_logits(x, y):
     return jnp.clip(x, 0) + jnp.log1p(jnp.exp(-jnp.abs(x))) - x * y
 
 
+def _reshape(x, shape):
+    if isinstance(x, (int, float, np.ndarray, np.generic)):
+        return np.reshape(x, shape)
+    else:
+        return jnp.reshape(x, shape)
+
+
 def promote_shapes(*args, shape=()):
     # adapted from lax.lax_numpy
     if len(args) < 2 and not shape:
@@ -239,7 +248,7 @@ def promote_shapes(*args, shape=()):
     else:
         shapes = [jnp.shape(arg) for arg in args]
         num_dims = len(lax.broadcast_shapes(shape, *shapes))
-        return [lax.reshape(arg, (1,) * (num_dims - len(s)) + s)
+        return [_reshape(arg, (1,) * (num_dims - len(s)) + s)
                 if len(s) < num_dims else arg for arg, s in zip(args, shapes)]
 
 

--- a/numpyro/infer/autoguide.py
+++ b/numpyro/infer/autoguide.py
@@ -6,6 +6,8 @@ from abc import ABC, abstractmethod
 from contextlib import ExitStack
 import warnings
 
+import numpy as np
+
 from jax import hessian, lax, random, tree_map
 from jax.experimental import stax
 from jax.flatten_util import ravel_pytree
@@ -647,7 +649,7 @@ class AutoLaplaceApproximation(AutoContinuous):
         precision = hessian(loss_fn)(loc)
         scale_tril = cholesky_of_inverse(precision)
         if not_jax_tracer(scale_tril):
-            if jnp.any(jnp.isnan(scale_tril)):
+            if np.any(np.isnan(scale_tril)):
                 warnings.warn("Hessian of log posterior at the MAP point is singular. Posterior"
                               " samples from AutoLaplaceApproxmiation will be constant (equal to"
                               " the MAP point).")

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -748,6 +748,22 @@ def test_distribution_constraints(jax_dist, sp_dist, params, prepend_shape):
         d.log_prob(oob_samples)
 
 
+def test_omnistaging_invalid_param():
+    def f(x):
+        return dist.LogNormal(x, -np.ones(2), validate_args=True).log_prob(0)
+
+    with pytest.raises(ValueError, match="got invalid"):
+        jax.jit(f)(0)
+
+
+def test_omnistaging_invalid_sample():
+    def f(x):
+        return dist.LogNormal(x, np.ones(2), validate_args=True).log_prob(-1)
+
+    with pytest.warns(UserWarning, match="Out-of-support"):
+        jax.jit(f)(0)
+
+
 def test_categorical_log_prob_grad():
     data = jnp.repeat(jnp.arange(3), 10)
 


### PR DESCRIPTION
Fixes #771. The issue is with omnistaging, under jit, operators such as `jnp.all(concrete_array)` will return a TracedArray, which cannot be converted to a Python bool object. I think "omnistaging" is a bit annoying but given that it is the default behavior in JAX 0.2, we have to live with it. :(