### PR TITLE
Fix von mises log prob and sample

### DIFF
--- a/numpyro/distributions/directional.py
+++ b/numpyro/distributions/directional.py
@@ -4,6 +4,7 @@ import math
 
 from jax import lax
 import jax.numpy as jnp
+from jax.scipy.special import i0e, i1e
 
 from numpyro.distributions import constraints
 from numpyro.distributions.distribution import Distribution
@@ -43,8 +44,8 @@ class VonMises(Distribution):
 
     @validate_sample
     def log_prob(self, value):
-        return -(jnp.log(2 * jnp.pi) + lax.bessel_i0e(self.concentration)) + (
-                self.concentration * jnp.cos(value - self.loc))
+        return -(jnp.log(2 * jnp.pi) + jnp.log(i0e(self.concentration))) + \
+            self.concentration * (jnp.cos((value - self.loc) % (2 * jnp.pi)) - 1)
 
     @property
     def mean(self):
@@ -54,5 +55,5 @@ class VonMises(Distribution):
     @property
     def variance(self):
         """ Computes circular variance of distribution """
-        return jnp.broadcast_to(1. - lax.bessel_i1e(self.concentration) / lax.bessel_i0e(self.concentration),
+        return jnp.broadcast_to(1. - i1e(self.concentration) / i0e(self.concentration),
                                 self.batch_shape)

--- a/numpyro/distributions/util.py
+++ b/numpyro/distributions/util.py
@@ -420,7 +420,7 @@ def _von_mises_centered(key, concentration, shape, dtype):
         w = jnp.where(done, w, (1. + s * z) / (s + z))  # Update where not done
 
         y = concentration * (s - w)
-        v = random.uniform(key=uni_vkey, shape=shape, dtype=concentration.dtype, minval=-1., maxval=1.)
+        v = random.uniform(key=uni_vkey, shape=shape, dtype=concentration.dtype)
 
         accept = (y * (2. - y) >= v) | (jnp.log(y / v) + 1. >= y)
 

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -93,7 +93,9 @@ _DIST_MAP = {
     dist.Poisson: lambda rate: osp.poisson(rate),
     dist.StudentT: lambda df, loc, scale: osp.t(df=df, loc=loc, scale=scale),
     dist.Uniform: lambda a, b: osp.uniform(a, b - a),
-    dist.Logistic: lambda loc, scale: osp.logistic(loc=loc, scale=scale)
+    dist.Logistic: lambda loc, scale: osp.logistic(loc=loc, scale=scale),
+    dist.VonMises: lambda loc, conc: osp.vonmises(loc=np.array(loc, dtype=np.float64),
+                                                  kappa=np.array(conc, dtype=np.float64))
 }
 
 CONTINUOUS = [
@@ -634,7 +636,8 @@ def test_mean_var(jax_dist, sp_dist, params):
     k = random.PRNGKey(0)
     samples = d_jax.sample(k, sample_shape=(n,))
     # check with suitable scipy implementation if available
-    if sp_dist and not _is_batched_multivariate(d_jax):
+    # XXX: VonMises is already tested below
+    if sp_dist and not _is_batched_multivariate(d_jax) and jax_dist not in [dist.VonMises]:
         d_sp = sp_dist(*params)
         try:
             sp_mean = d_sp.mean()

--- a/test/test_distributions_util.py
+++ b/test/test_distributions_util.py
@@ -6,6 +6,7 @@ from numbers import Number
 import numpy as np
 from numpy.testing import assert_allclose
 import pytest
+import scipy
 
 from jax import lax, random, vmap
 import jax.numpy as jnp
@@ -17,7 +18,8 @@ from numpyro.distributions.util import (
     categorical,
     cholesky_update,
     multinomial,
-    vec_to_tril_matrix
+    vec_to_tril_matrix,
+    von_mises_centered
 )
 
 
@@ -147,3 +149,10 @@ def test_binomial_mean(n, p):
     samples = binomial(random.PRNGKey(1), p, n, shape=(100, 100))
     expected_mean = n * p
     assert_allclose(jnp.mean(samples), expected_mean, rtol=0.05)
+
+
+@pytest.mark.parametrize("concentration", [1, 10, 100])
+def test_von_mises_centered(concentration):
+    samples = von_mises_centered(random.PRNGKey(0), concentration, shape=(10000,))
+    cdf = scipy.stats.vonmises(kappa=concentration).cdf
+    assert scipy.stats.kstest(samples, cdf).pvalue > 0.01


### PR DESCRIPTION
Hopefully, this will be helpful for #774.

This fixes VonMises.log_prob and `von_mises_centered` sampler. They are tested against scipy. In the master branch, we missed taking `log` after applying Bessel function on concentration parameter. In addition, because `bessel_i0e` is exponentially scaled Bessel function, we need to plus `concentration` after taking the log. In addition, I made some enhancements:
+ using `jax.scipy.special.i1e` instead of `lax.bessel_i1e` because the latter can't be applied on int scalar/arrays.
+ scale `value - loc` to [0, 2pi] before taking `cos`. This is helpful when `value - loc` is very large, which causes discontinuity as in the picture below
![image](https://user-images.githubusercontent.com/4736342/95283916-76cd2c00-0822-11eb-9d13-c40fd68873f7.png)

Blocked by #777


cc @Nikolin4 @OlaRonning 