### PR TITLE
Pass tests for jax 0.2.1

### DIFF
--- a/test/contrib/test_funsor.py
+++ b/test/contrib/test_funsor.py
@@ -70,7 +70,7 @@ def test_bernoulli_latent_model():
 def test_change_point():
     def model(count_data):
         n_count_data = count_data.shape[0]
-        alpha = 1 / jnp.mean(count_data)
+        alpha = 1 / jnp.mean(count_data.astype(np.float32))
         lambda_1 = numpyro.sample('lambda_1', dist.Exponential(alpha))
         lambda_2 = numpyro.sample('lambda_2', dist.Exponential(alpha))
         # this is the same as DiscreteUniform(0, 69)

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -632,7 +632,7 @@ def test_mean_var(jax_dist, sp_dist, params):
     n = 20000 if jax_dist in [dist.LKJ, dist.LKJCholesky] else 200000
     d_jax = jax_dist(*params)
     k = random.PRNGKey(0)
-    samples = d_jax.sample(k, sample_shape=(n,))
+    samples = d_jax.sample(k, sample_shape=(n,)).astype(np.float32)
     # check with suitable scipy implementation if available
     if sp_dist and not _is_batched_multivariate(d_jax):
         d_sp = sp_dist(*params)

--- a/test/test_distributions_util.py
+++ b/test/test_distributions_util.py
@@ -144,6 +144,6 @@ def test_cholesky_update(chol_batch_shape, vec_batch_shape, dim, coef):
 @pytest.mark.parametrize("n", [10, 100, 1000])
 @pytest.mark.parametrize("p", [0., 0.01, 0.05, 0.3, 0.5, 0.7, 0.95, 1.])
 def test_binomial_mean(n, p):
-    samples = binomial(random.PRNGKey(1), p, n, shape=(100, 100))
+    samples = binomial(random.PRNGKey(1), p, n, shape=(100, 100)).astype(np.float32)
     expected_mean = n * p
     assert_allclose(jnp.mean(samples), expected_mean, rtol=0.05)

--- a/test/test_infer_util.py
+++ b/test/test_infer_util.py
@@ -67,7 +67,8 @@ def test_predictive(parallel):
     assert predictive_samples["beta_sq"].shape == (100,) + true_probs.shape
     assert predictive_samples["obs"].shape == (100,) + data.shape
     # check sample mean
-    assert_allclose(predictive_samples["obs"].reshape((-1,) + true_probs.shape).mean(0), true_probs, rtol=0.1)
+    obs = predictive_samples["obs"].reshape((-1,) + true_probs.shape).astype(np.float32)
+    assert_allclose(obs.mean(0), true_probs, rtol=0.1)
 
 
 def test_predictive_with_guide():
@@ -97,7 +98,7 @@ def test_predictive_with_guide():
     params = svi.get_params(svi_state)
     predictive = Predictive(model, guide=guide, params=params, num_samples=1000)(random.PRNGKey(2), data=None)
     assert predictive["beta_sq"].shape == (1000,)
-    obs_pred = predictive["obs"]
+    obs_pred = predictive["obs"].astype(np.float32)
     assert_allclose(jnp.mean(obs_pred), 0.8, atol=0.05)
 
 
@@ -208,7 +209,7 @@ def test_model_with_mask_false():
 ])
 def test_initialize_model_change_point(init_strategy):
     def model(data):
-        alpha = 1 / jnp.mean(data)
+        alpha = 1 / jnp.mean(data.astype(np.float32))
         lambda1 = numpyro.sample('lambda1', dist.Exponential(alpha))
         lambda2 = numpyro.sample('lambda2', dist.Exponential(alpha))
         tau = numpyro.sample('tau', dist.Uniform(0, 1))

--- a/test/test_mcmc.py
+++ b/test/test_mcmc.py
@@ -197,7 +197,7 @@ def test_change_point_x64():
     warmup_steps, num_samples = 500, 3000
 
     def model(data):
-        alpha = 1 / jnp.mean(data)
+        alpha = 1 / jnp.mean(data.astype(np.float32))
         lambda1 = numpyro.sample('lambda1', dist.Exponential(alpha))
         lambda2 = numpyro.sample('lambda2', dist.Exponential(alpha))
         tau = numpyro.sample('tau', dist.Uniform(0, 1))


### PR DESCRIPTION
There is an [issue](https://github.com/google/jax/issues/4490) at `np.mean` in jax 0.2.1 that makes our CI failed. Because the issue just raises some UserWarning and it only affects a few tests, I haven't pinned jax to 0.2.0. Instead, I made a few changes in our tests to make CI pass.