### PR TITLE
Bernoulli distribution returns an int instead of a boolean

### DIFF
--- a/numpyro/distributions/discrete.py
+++ b/numpyro/distributions/discrete.py
@@ -83,7 +83,7 @@ class BernoulliProbs(Distribution):
 
     def sample(self, key, sample_shape=()):
         samples = random.bernoulli(key, self.probs, shape=sample_shape + self.batch_shape)
-        return samples.astype(canonicalize_dtype(jnp.int64))
+        return samples.astype(jnp.result_type(samples, int))
 
     @validate_sample
     def log_prob(self, value):
@@ -116,7 +116,7 @@ class BernoulliLogits(Distribution):
 
     def sample(self, key, sample_shape=()):
         samples = random.bernoulli(key, self.probs, shape=sample_shape + self.batch_shape)
-        return samples.astype(canonicalize_dtype(jnp.int64))
+        return samples.astype(jnp.result_type(samples, int))
 
     @validate_sample
     def log_prob(self, value):

--- a/numpyro/distributions/discrete.py
+++ b/numpyro/distributions/discrete.py
@@ -82,7 +82,8 @@ class BernoulliProbs(Distribution):
         super(BernoulliProbs, self).__init__(batch_shape=jnp.shape(self.probs), validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
-        return random.bernoulli(key, self.probs, shape=sample_shape + self.batch_shape)
+        samples = random.bernoulli(key, self.probs, shape=sample_shape + self.batch_shape)
+        return samples.astype(canonicalize_dtype(jnp.int64))
 
     @validate_sample
     def log_prob(self, value):
@@ -114,7 +115,8 @@ class BernoulliLogits(Distribution):
         super(BernoulliLogits, self).__init__(batch_shape=jnp.shape(self.logits), validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
-        return random.bernoulli(key, self.probs, shape=sample_shape + self.batch_shape)
+        samples = random.bernoulli(key, self.probs, shape=sample_shape + self.batch_shape)
+        return samples.astype(canonicalize_dtype(jnp.int64))
 
     @validate_sample
     def log_prob(self, value):

--- a/numpyro/distributions/distribution.py
+++ b/numpyro/distributions/distribution.py
@@ -27,6 +27,7 @@
 
 from collections import OrderedDict
 from contextlib import contextmanager
+import functools
 import warnings
 
 import numpy as np
@@ -83,6 +84,10 @@ class DistributionMeta(type):
             if result is not None:
                 return result
         return super().__call__(*args, **kwargs)
+
+    @property
+    def __wrapped__(cls):
+        return functools.partial(cls.__init__, None)
 
 
 class Distribution(metaclass=DistributionMeta):


### PR DESCRIPTION
Resolves #789.

This also makes `sample` return the same dtype (int) as `enumerate_support`.

Tests should pass because our `Bollean` constraint actually checks if `x == 1` or `x == 0`.