### PR TITLE
Fix postprocess for MCMC vectorized chain method

### DIFF
--- a/numpyro/infer/mcmc.py
+++ b/numpyro/infer/mcmc.py
@@ -7,7 +7,7 @@ from operator import attrgetter
 import os
 import warnings
 
-from jax import device_put, jit, lax, pmap, random
+from jax import device_put, jit, lax, pmap, random, vmap
 from jax.core import Tracer
 from jax.interpreters.xla import DeviceArray
 from jax.lib import xla_bridge
@@ -342,6 +342,8 @@ class MCMC(object):
         # so we only need to filter out the case site_value.shape[0] == 0
         # (which happens when lower_idx==upper_idx)
         if len(site_values) > 0 and jnp.shape(site_values[0])[0] > 0:
+            if self.chain_method == "vectorized" and self.num_chains > 1:
+                postprocess_fn = vmap(postprocess_fn)
             states[self._sample_field] = lax.map(postprocess_fn, states[self._sample_field])
         return states, last_state
 

--- a/test/test_mcmc.py
+++ b/test/test_mcmc.py
@@ -366,6 +366,7 @@ def test_chain(use_init_params, chain_method):
     def model(labels):
         coefs = numpyro.sample('coefs', dist.Normal(jnp.zeros(dim), jnp.ones(dim)))
         logits = jnp.sum(coefs * data, axis=-1)
+        numpyro.deterministic("logits", logits)
         return numpyro.sample('obs', dist.Bernoulli(logits=logits), obs=labels)
 
     kernel = NUTS(model=model)


### PR DESCRIPTION
Resolves #786. Currently, for vectorized map, each hmc state is a batch (size `num_chains`) of samples but postprocess_fn only applies for 1 sample. So we need to wrap `postprocess_fn` inside a `vmap` to make it work.

I also added a deterministic site to `test_chain` to test for this change. Without this PR, the test will fail.