### PR TITLE
Raise errors early if missing plates for models with discrete latent variable

### DIFF
--- a/numpyro/infer/util.py
+++ b/numpyro/infer/util.py
@@ -361,7 +361,7 @@ def _guess_max_plate_nesting(model_trace):
 def _validate_model(model_trace):
     # XXX: this validates plate statements under `enum`
     sites = [site for site in model_trace.values()
-             if site["type"] in ("sample", "control_flow")]
+             if site["type"] == "sample"]
 
     for site in sites:
         batch_dims = len(site["fn"].batch_shape)


### PR DESCRIPTION
Resolves #790 

This is a temporary fix for #790. If plates are missing, we will get the error
```
     56     def __exit__(self, *args, **kwargs):
---> 57         assert _PYRO_STACK[-1] is self
     58         _PYRO_STACK.pop()
```
I know about this issue while playing with some discrete models, but it is hard for users to guess where the error comes from. So this PR adds a validation code for that.