### PR TITLE
Display correct error message and cleanup _PYRO_STACK when error happens

### DIFF
--- a/numpyro/contrib/funsor/infer_util.py
+++ b/numpyro/contrib/funsor/infer_util.py
@@ -175,4 +175,8 @@ def log_density(model, model_args, model_kwargs, params):
             funsor.ops.logaddexp, funsor.ops.add, log_factors,
             eliminate=sum_vars | prod_vars, plates=prod_vars)
     result = funsor.optimizer.apply_optimizer(lazy_result)
+    if len(result.inputs) > 0:
+        raise ValueError("Expected the joint log density is a scalar, but got {}. "
+                         "There seems to be something wrong at the following sites: {}."
+                         .format(result.data.shape, {k.split("__BOUND")[0] for k in result.inputs}))
     return result.data, model_trace

--- a/numpyro/distributions/distribution.py
+++ b/numpyro/distributions/distribution.py
@@ -269,13 +269,6 @@ class Distribution(metaclass=DistributionMeta):
 
     def __call__(self, *args, **kwargs):
         key = kwargs.pop('rng_key')
-        # FIXME: This also raises error for Delta site.
-        # Is there a better way to raise this error?
-        if key is None:
-            raise ValueError("Missing random key for {} distribution. Looking like you "
-                             "have not seeded your stochastic function. See "
-                             "`numpyro.handlers.seed` documentation for more information."
-                             .format(self.__class__.__name__))
         sample_intermediates = kwargs.pop('sample_intermediates', False)
         if sample_intermediates:
             return self.sample_with_intermediates(key, *args, **kwargs)

--- a/numpyro/distributions/distribution.py
+++ b/numpyro/distributions/distribution.py
@@ -269,6 +269,13 @@ class Distribution(metaclass=DistributionMeta):
 
     def __call__(self, *args, **kwargs):
         key = kwargs.pop('rng_key')
+        # FIXME: This also raises error for Delta site.
+        # Is there a better way to raise this error?
+        if key is None:
+            raise ValueError("Missing random key for {} distribution. Looking like you "
+                             "have not seeded your stochastic function. See "
+                             "`numpyro.handlers.seed` documentation for more information."
+                             .format(self.__class__.__name__))
         sample_intermediates = kwargs.pop('sample_intermediates', False)
         if sample_intermediates:
             return self.sample_with_intermediates(key, *args, **kwargs)

--- a/numpyro/handlers.py
+++ b/numpyro/handlers.py
@@ -278,18 +278,23 @@ class collapse(trace):
         COERCIONS.append(self._coerce)
         return super().__enter__()
 
-    def __exit__(self, *args, **kwargs):
+    def __exit__(self, exc_type, exc_value, traceback):
         import funsor
 
         _coerce = COERCIONS.pop()
         assert _coerce is self._coerce
-        super().__exit__(*args, **kwargs)
+        super().__exit__(exc_type, exc_value, traceback)
+
+        if exc_type is not None:
+            return
 
         # Convert delayed statements to pyro.factor()
         reduced_vars = []
         log_prob_terms = []
         plates = frozenset()
         for name, site in self.trace.items():
+            if site["type"] != "sample":
+                continue
             if not site["is_observed"]:
                 reduced_vars.append(name)
             dim_to_name = {f.dim: f.name for f in site["cond_indep_stack"]}

--- a/numpyro/primitives.py
+++ b/numpyro/primitives.py
@@ -52,9 +52,21 @@ class Messenger(object):
     def __enter__(self):
         _PYRO_STACK.append(self)
 
-    def __exit__(self, *args, **kwargs):
-        assert _PYRO_STACK[-1] is self
-        _PYRO_STACK.pop()
+    def __exit__(self, exc_type, exc_value, traceback):
+        if exc_type is None:
+            assert _PYRO_STACK[-1] is self
+            _PYRO_STACK.pop()
+        else:
+            # NB: this mimics Pyro exception handling
+            # the wrapped function or block raised an exception
+            # handler exception handling:
+            # when the callee or enclosed block raises an exception,
+            # find this handler's position in the stack,
+            # then remove it and everything below it in the stack.
+            if self in _PYRO_STACK:
+                loc = _PYRO_STACK.index(self)
+                for i in range(loc, len(_PYRO_STACK)):
+                    _PYRO_STACK.pop()
 
     def process_message(self, msg):
         pass


### PR DESCRIPTION
Fixes #815.

Currently, if an error happens inside an message handler, sometimes we got the error
```
~/miniconda3/lib/python3.7/site-packages/numpyro/primitives.py in __exit__(self, *args, **kwargs)
     56     def __exit__(self, *args, **kwargs):
---> 57         assert _PYRO_STACK[-1] is self
     58         _PYRO_STACK.pop()

FilteredStackTrace: AssertionError
```
which is not meaningful and `_PYRO_STACK` is not cleared when it happens. After incorporating Pyro's exit mechanism, the error becomes
```
~/numpyro/numpyro/contrib/funsor/enum_messenger.py in _pyro_post_to_data(self, msg)
    392         if msg["kwargs"]["dim_type"] in (DimType.GLOBAL, DimType.VISIBLE):
    393             for name in msg["args"][0].inputs:
--> 394                 self._saved_globals += ((name, _DIM_STACK.global_frame.name_to_dim[name]),)
    395 
    396 

KeyError: 'p'
```
which is more meaningful and `PYRO_STACK` is cleared after the error.