### PR TITLE
Raise a better error message when rng_key is missing

### DIFF
--- a/numpyro/distributions/conjugate.py
+++ b/numpyro/distributions/conjugate.py
@@ -9,7 +9,7 @@ from numpyro.distributions import constraints
 from numpyro.distributions.continuous import Beta, Dirichlet, Gamma
 from numpyro.distributions.discrete import BinomialProbs, MultinomialProbs, Poisson
 from numpyro.distributions.distribution import Distribution
-from numpyro.distributions.util import promote_shapes, validate_sample
+from numpyro.distributions.util import is_prng_key, promote_shapes, validate_sample
 
 
 def _log_beta_1(alpha, value):
@@ -48,6 +48,7 @@ class BetaBinomial(Distribution):
         super(BetaBinomial, self).__init__(batch_shape, validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
+        assert is_prng_key(key)
         key_beta, key_binom = random.split(key)
         probs = self._beta.sample(key_beta, sample_shape)
         return BinomialProbs(total_count=self.total_count, probs=probs).sample(key_binom)
@@ -101,6 +102,7 @@ class DirichletMultinomial(Distribution):
             self._dirichlet.batch_shape, self._dirichlet.event_shape, validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
+        assert is_prng_key(key)
         key_dirichlet, key_multinom = random.split(key)
         probs = self._dirichlet.sample(key_dirichlet, sample_shape)
         return MultinomialProbs(total_count=self.total_count, probs=probs).sample(key_multinom)
@@ -148,6 +150,7 @@ class GammaPoisson(Distribution):
         super(GammaPoisson, self).__init__(self._gamma.batch_shape, validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
+        assert is_prng_key(key)
         key_gamma, key_poisson = random.split(key)
         rate = self._gamma.sample(key_gamma, sample_shape)
         return Poisson(rate).sample(key_poisson)

--- a/numpyro/distributions/continuous.py
+++ b/numpyro/distributions/continuous.py
@@ -38,6 +38,7 @@ from numpyro.distributions.distribution import Distribution, TransformedDistribu
 from numpyro.distributions.transforms import AffineTransform, ExpTransform, InvCholeskyTransform, PowerTransform
 from numpyro.distributions.util import (
     cholesky_of_inverse,
+    is_prng_key,
     lazy_property,
     matrix_to_tril_vec,
     promote_shapes,
@@ -63,7 +64,7 @@ class Beta(Distribution):
         super(Beta, self).__init__(batch_shape=batch_shape, validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
-        assert key is not None
+        assert is_prng_key(key)
         return self._dirichlet.sample(key, sample_shape)[..., 0]
 
     @validate_sample
@@ -91,7 +92,7 @@ class Cauchy(Distribution):
         super(Cauchy, self).__init__(batch_shape=batch_shape, validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
-        assert key is not None
+        assert is_prng_key(key)
         eps = random.cauchy(key, shape=sample_shape + self.batch_shape)
         return self.loc + eps * self.scale
 
@@ -122,7 +123,7 @@ class Dirichlet(Distribution):
                                         validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
-        assert key is not None
+        assert is_prng_key(key)
         shape = sample_shape + self.batch_shape + self.event_shape
         gamma_samples = random.gamma(key, self.concentration, shape=shape)
         samples = gamma_samples / jnp.sum(gamma_samples, axis=-1, keepdims=True)
@@ -154,7 +155,7 @@ class Exponential(Distribution):
         super(Exponential, self).__init__(batch_shape=jnp.shape(rate), validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
-        assert key is not None
+        assert is_prng_key(key)
         return random.exponential(key, shape=sample_shape + self.batch_shape) / self.rate
 
     @validate_sample
@@ -183,7 +184,7 @@ class Gamma(Distribution):
                                     validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
-        assert key is not None
+        assert is_prng_key(key)
         shape = sample_shape + self.batch_shape + self.event_shape
         return random.gamma(key, self.concentration, shape=shape) / self.rate
 
@@ -223,7 +224,7 @@ class GaussianRandomWalk(Distribution):
         super(GaussianRandomWalk, self).__init__(batch_shape, event_shape, validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
-        assert key is not None
+        assert is_prng_key(key)
         shape = sample_shape + self.batch_shape + self.event_shape
         walks = random.normal(key, shape=shape)
         return jnp.cumsum(walks, axis=-1) * jnp.expand_dims(self.scale, axis=-1)
@@ -263,7 +264,7 @@ class HalfCauchy(Distribution):
         super(HalfCauchy, self).__init__(batch_shape=jnp.shape(scale), validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
-        assert key is not None
+        assert is_prng_key(key)
         return jnp.abs(self._cauchy.sample(key, sample_shape))
 
     @validate_sample
@@ -290,7 +291,7 @@ class HalfNormal(Distribution):
         super(HalfNormal, self).__init__(batch_shape=jnp.shape(scale), validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
-        assert key is not None
+        assert is_prng_key(key)
         return jnp.abs(self._normal.sample(key, sample_shape))
 
     @validate_sample
@@ -352,7 +353,7 @@ class Gumbel(Distribution):
                                      validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
-        assert key is not None
+        assert is_prng_key(key)
         standard_gumbel_sample = random.gumbel(key, shape=sample_shape + self.batch_shape + self.event_shape)
         return self.loc + self.scale * standard_gumbel_sample
 
@@ -383,7 +384,7 @@ class Laplace(Distribution):
         super(Laplace, self).__init__(batch_shape=batch_shape, validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
-        assert key is not None
+        assert is_prng_key(key)
         eps = random.laplace(key, shape=sample_shape + self.batch_shape + self.event_shape)
         return self.loc + eps * self.scale
 
@@ -564,7 +565,7 @@ class LKJCholesky(Distribution):
         return cholesky
 
     def sample(self, key, sample_shape=()):
-        assert key is not None
+        assert is_prng_key(key)
         if self.sample_method == "onion":
             return self._onion(key, sample_shape)
         else:
@@ -722,7 +723,7 @@ class MultivariateNormal(Distribution):
                                                  validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
-        assert key is not None
+        assert is_prng_key(key)
         eps = random.normal(key, shape=sample_shape + self.batch_shape + self.event_shape)
         return self.loc + jnp.squeeze(jnp.matmul(self.scale_tril, eps[..., jnp.newaxis]), axis=-1)
 
@@ -885,7 +886,7 @@ class LowRankMultivariateNormal(Distribution):
         return diag_embed - jnp.matmul(jnp.swapaxes(A, -1, -2), A)
 
     def sample(self, key, sample_shape=()):
-        assert key is not None
+        assert is_prng_key(key)
         key_W, key_D = random.split(key)
         batch_shape = sample_shape + self.batch_shape
         W_shape = batch_shape + self.cov_factor.shape[-1:]
@@ -926,7 +927,7 @@ class Normal(Distribution):
         super(Normal, self).__init__(batch_shape=batch_shape, validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
-        assert key is not None
+        assert is_prng_key(key)
         eps = random.normal(key, shape=sample_shape + self.batch_shape + self.event_shape)
         return self.loc + eps * self.scale
 
@@ -993,7 +994,7 @@ class StudentT(Distribution):
         super(StudentT, self).__init__(batch_shape, validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
-        assert key is not None
+        assert is_prng_key(key)
         key_normal, key_chi2 = random.split(key)
         std_normal = random.normal(key_normal, shape=sample_shape + self.batch_shape)
         z = self._chi2.sample(key_chi2, sample_shape)
@@ -1028,7 +1029,7 @@ class _BaseTruncatedCauchy(Distribution):
         super(_BaseTruncatedCauchy, self).__init__(batch_shape=jnp.shape(base_loc))
 
     def sample(self, key, sample_shape=()):
-        assert key is not None
+        assert is_prng_key(key)
         # We use inverse transform method:
         # z ~ inv_cdf(U), where U ~ Uniform(cdf(low), cdf(high)).
         #                         ~ Uniform(arctan(low), arctan(high)) / pi + 1/2
@@ -1096,7 +1097,7 @@ class _BaseTruncatedNormal(Distribution):
         super(_BaseTruncatedNormal, self).__init__(batch_shape=jnp.shape(base_loc))
 
     def sample(self, key, sample_shape=()):
-        assert key is not None
+        assert is_prng_key(key)
         size = sample_shape + self.batch_shape
         # We use inverse transform method:
         # z ~ icdf(U), where U ~ Uniform(0, 1).
@@ -1162,7 +1163,7 @@ class _BaseUniform(Distribution):
         super(_BaseUniform, self).__init__(batch_shape=batch_shape)
 
     def sample(self, key, sample_shape=()):
-        assert key is not None
+        assert is_prng_key(key)
         size = sample_shape + self.batch_shape
         return random.uniform(key, shape=size)
 
@@ -1222,7 +1223,7 @@ class Logistic(Distribution):
         super(Logistic, self).__init__(batch_shape, validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
-        assert key is not None
+        assert is_prng_key(key)
         z = random.logistic(key, shape=sample_shape + self.batch_shape + self.event_shape)
         return self.loc + z * self.scale
 
@@ -1255,7 +1256,7 @@ class TruncatedPolyaGamma(Distribution):
         super(TruncatedPolyaGamma, self).__init__(batch_shape, validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
-        assert key is not None
+        assert is_prng_key(key)
         denom = jnp.square(jnp.arange(0.5, self.num_gamma_variates))
         x = random.gamma(key, jnp.ones(self.batch_shape + sample_shape + (self.num_gamma_variates,)))
         x = jnp.sum(x / denom, axis=-1)

--- a/numpyro/distributions/continuous.py
+++ b/numpyro/distributions/continuous.py
@@ -63,6 +63,7 @@ class Beta(Distribution):
         super(Beta, self).__init__(batch_shape=batch_shape, validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
+        assert key is not None
         return self._dirichlet.sample(key, sample_shape)[..., 0]
 
     @validate_sample
@@ -90,6 +91,7 @@ class Cauchy(Distribution):
         super(Cauchy, self).__init__(batch_shape=batch_shape, validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
+        assert key is not None
         eps = random.cauchy(key, shape=sample_shape + self.batch_shape)
         return self.loc + eps * self.scale
 
@@ -120,6 +122,7 @@ class Dirichlet(Distribution):
                                         validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
+        assert key is not None
         shape = sample_shape + self.batch_shape + self.event_shape
         gamma_samples = random.gamma(key, self.concentration, shape=shape)
         samples = gamma_samples / jnp.sum(gamma_samples, axis=-1, keepdims=True)
@@ -151,6 +154,7 @@ class Exponential(Distribution):
         super(Exponential, self).__init__(batch_shape=jnp.shape(rate), validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
+        assert key is not None
         return random.exponential(key, shape=sample_shape + self.batch_shape) / self.rate
 
     @validate_sample
@@ -179,6 +183,7 @@ class Gamma(Distribution):
                                     validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
+        assert key is not None
         shape = sample_shape + self.batch_shape + self.event_shape
         return random.gamma(key, self.concentration, shape=shape) / self.rate
 
@@ -218,6 +223,7 @@ class GaussianRandomWalk(Distribution):
         super(GaussianRandomWalk, self).__init__(batch_shape, event_shape, validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
+        assert key is not None
         shape = sample_shape + self.batch_shape + self.event_shape
         walks = random.normal(key, shape=shape)
         return jnp.cumsum(walks, axis=-1) * jnp.expand_dims(self.scale, axis=-1)
@@ -257,6 +263,7 @@ class HalfCauchy(Distribution):
         super(HalfCauchy, self).__init__(batch_shape=jnp.shape(scale), validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
+        assert key is not None
         return jnp.abs(self._cauchy.sample(key, sample_shape))
 
     @validate_sample
@@ -283,6 +290,7 @@ class HalfNormal(Distribution):
         super(HalfNormal, self).__init__(batch_shape=jnp.shape(scale), validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
+        assert key is not None
         return jnp.abs(self._normal.sample(key, sample_shape))
 
     @validate_sample
@@ -344,6 +352,7 @@ class Gumbel(Distribution):
                                      validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
+        assert key is not None
         standard_gumbel_sample = random.gumbel(key, shape=sample_shape + self.batch_shape + self.event_shape)
         return self.loc + self.scale * standard_gumbel_sample
 
@@ -374,6 +383,7 @@ class Laplace(Distribution):
         super(Laplace, self).__init__(batch_shape=batch_shape, validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
+        assert key is not None
         eps = random.laplace(key, shape=sample_shape + self.batch_shape + self.event_shape)
         return self.loc + eps * self.scale
 
@@ -554,6 +564,7 @@ class LKJCholesky(Distribution):
         return cholesky
 
     def sample(self, key, sample_shape=()):
+        assert key is not None
         if self.sample_method == "onion":
             return self._onion(key, sample_shape)
         else:
@@ -711,6 +722,7 @@ class MultivariateNormal(Distribution):
                                                  validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
+        assert key is not None
         eps = random.normal(key, shape=sample_shape + self.batch_shape + self.event_shape)
         return self.loc + jnp.squeeze(jnp.matmul(self.scale_tril, eps[..., jnp.newaxis]), axis=-1)
 
@@ -873,6 +885,7 @@ class LowRankMultivariateNormal(Distribution):
         return diag_embed - jnp.matmul(jnp.swapaxes(A, -1, -2), A)
 
     def sample(self, key, sample_shape=()):
+        assert key is not None
         key_W, key_D = random.split(key)
         batch_shape = sample_shape + self.batch_shape
         W_shape = batch_shape + self.cov_factor.shape[-1:]
@@ -913,6 +926,7 @@ class Normal(Distribution):
         super(Normal, self).__init__(batch_shape=batch_shape, validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
+        assert key is not None
         eps = random.normal(key, shape=sample_shape + self.batch_shape + self.event_shape)
         return self.loc + eps * self.scale
 
@@ -979,6 +993,7 @@ class StudentT(Distribution):
         super(StudentT, self).__init__(batch_shape, validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
+        assert key is not None
         key_normal, key_chi2 = random.split(key)
         std_normal = random.normal(key_normal, shape=sample_shape + self.batch_shape)
         z = self._chi2.sample(key_chi2, sample_shape)
@@ -1013,6 +1028,7 @@ class _BaseTruncatedCauchy(Distribution):
         super(_BaseTruncatedCauchy, self).__init__(batch_shape=jnp.shape(base_loc))
 
     def sample(self, key, sample_shape=()):
+        assert key is not None
         # We use inverse transform method:
         # z ~ inv_cdf(U), where U ~ Uniform(cdf(low), cdf(high)).
         #                         ~ Uniform(arctan(low), arctan(high)) / pi + 1/2
@@ -1080,6 +1096,7 @@ class _BaseTruncatedNormal(Distribution):
         super(_BaseTruncatedNormal, self).__init__(batch_shape=jnp.shape(base_loc))
 
     def sample(self, key, sample_shape=()):
+        assert key is not None
         size = sample_shape + self.batch_shape
         # We use inverse transform method:
         # z ~ icdf(U), where U ~ Uniform(0, 1).
@@ -1145,6 +1162,7 @@ class _BaseUniform(Distribution):
         super(_BaseUniform, self).__init__(batch_shape=batch_shape)
 
     def sample(self, key, sample_shape=()):
+        assert key is not None
         size = sample_shape + self.batch_shape
         return random.uniform(key, shape=size)
 
@@ -1204,6 +1222,7 @@ class Logistic(Distribution):
         super(Logistic, self).__init__(batch_shape, validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
+        assert key is not None
         z = random.logistic(key, shape=sample_shape + self.batch_shape + self.event_shape)
         return self.loc + z * self.scale
 
@@ -1236,6 +1255,7 @@ class TruncatedPolyaGamma(Distribution):
         super(TruncatedPolyaGamma, self).__init__(batch_shape, validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
+        assert key is not None
         denom = jnp.square(jnp.arange(0.5, self.num_gamma_variates))
         x = random.gamma(key, jnp.ones(self.batch_shape + sample_shape + (self.num_gamma_variates,)))
         x = jnp.sum(x / denom, axis=-1)

--- a/numpyro/distributions/directional.py
+++ b/numpyro/distributions/directional.py
@@ -36,6 +36,7 @@ class VonMises(Distribution):
             :param key: random number generator key
             :return: samples from von Mises
         """
+        assert key is not None
         samples = von_mises_centered(key, self.concentration, sample_shape + self.shape())
         samples = samples + self.loc  # VM(0, concentration) -> VM(loc,concentration)
         samples = (samples + jnp.pi) % (2. * jnp.pi) - jnp.pi

--- a/numpyro/distributions/directional.py
+++ b/numpyro/distributions/directional.py
@@ -8,7 +8,7 @@ from jax.scipy.special import i0e, i1e
 
 from numpyro.distributions import constraints
 from numpyro.distributions.distribution import Distribution
-from numpyro.distributions.util import promote_shapes, validate_sample, von_mises_centered
+from numpyro.distributions.util import is_prng_key, promote_shapes, validate_sample, von_mises_centered
 
 
 class VonMises(Distribution):
@@ -36,7 +36,7 @@ class VonMises(Distribution):
             :param key: random number generator key
             :return: samples from von Mises
         """
-        assert key is not None
+        assert is_prng_key(key)
         samples = von_mises_centered(key, self.concentration, sample_shape + self.shape())
         samples = samples + self.loc  # VM(0, concentration) -> VM(loc,concentration)
         samples = (samples + jnp.pi) % (2. * jnp.pi) - jnp.pi

--- a/numpyro/distributions/discrete.py
+++ b/numpyro/distributions/discrete.py
@@ -82,6 +82,7 @@ class BernoulliProbs(Distribution):
         super(BernoulliProbs, self).__init__(batch_shape=jnp.shape(self.probs), validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
+        assert key is not None
         samples = random.bernoulli(key, self.probs, shape=sample_shape + self.batch_shape)
         return samples.astype(jnp.result_type(samples, int))
 
@@ -115,6 +116,7 @@ class BernoulliLogits(Distribution):
         super(BernoulliLogits, self).__init__(batch_shape=jnp.shape(self.logits), validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
+        assert key is not None
         samples = random.bernoulli(key, self.probs, shape=sample_shape + self.batch_shape)
         return samples.astype(jnp.result_type(samples, int))
 
@@ -162,6 +164,7 @@ class BinomialProbs(Distribution):
         super(BinomialProbs, self).__init__(batch_shape=batch_shape, validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
+        assert key is not None
         return binomial(key, self.probs, n=self.total_count, shape=sample_shape + self.batch_shape)
 
     @validate_sample
@@ -212,6 +215,7 @@ class BinomialLogits(Distribution):
         super(BinomialLogits, self).__init__(batch_shape=batch_shape, validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
+        assert key is not None
         return binomial(key, self.probs, n=self.total_count, shape=sample_shape + self.batch_shape)
 
     @validate_sample
@@ -263,6 +267,7 @@ class CategoricalProbs(Distribution):
                                                validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
+        assert key is not None
         return categorical(key, self.probs, shape=sample_shape + self.batch_shape)
 
     @validate_sample
@@ -306,6 +311,7 @@ class CategoricalLogits(Distribution):
                                                 validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
+        assert key is not None
         return random.categorical(key, self.logits, shape=sample_shape + self.batch_shape)
 
     @validate_sample
@@ -463,6 +469,7 @@ class MultinomialProbs(Distribution):
                                                validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
+        assert key is not None
         return multinomial(key, self.probs, self.total_count, shape=sample_shape + self.batch_shape)
 
     @validate_sample
@@ -501,6 +508,7 @@ class MultinomialLogits(Distribution):
                                                 validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
+        assert key is not None
         return multinomial(key, self.probs, self.total_count, shape=sample_shape + self.batch_shape)
 
     @validate_sample
@@ -547,6 +555,7 @@ class Poisson(Distribution):
         super(Poisson, self).__init__(jnp.shape(rate), validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
+        assert key is not None
         return random.poisson(key, self.rate, shape=sample_shape + self.batch_shape)
 
     @validate_sample
@@ -581,6 +590,7 @@ class ZeroInflatedPoisson(Distribution):
         super(ZeroInflatedPoisson, self).__init__(batch_shape, validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
+        assert key is not None
         key_bern, key_poisson = random.split(key)
         shape = sample_shape + self.batch_shape
         mask = random.bernoulli(key_bern, self.gate, shape)
@@ -612,6 +622,7 @@ class GeometricProbs(Distribution):
                                              validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
+        assert key is not None
         probs = self.probs
         dtype = get_dtype(probs)
         shape = sample_shape + self.batch_shape
@@ -647,6 +658,7 @@ class GeometricLogits(Distribution):
         return _to_probs_bernoulli(self.logits)
 
     def sample(self, key, sample_shape=()):
+        assert key is not None
         logits = self.logits
         dtype = get_dtype(logits)
         shape = sample_shape + self.batch_shape

--- a/numpyro/distributions/discrete.py
+++ b/numpyro/distributions/discrete.py
@@ -44,6 +44,7 @@ from numpyro.distributions.util import (
     categorical,
     clamp_probs,
     get_dtype,
+    is_prng_key,
     lazy_property,
     multinomial,
     promote_shapes,
@@ -82,7 +83,7 @@ class BernoulliProbs(Distribution):
         super(BernoulliProbs, self).__init__(batch_shape=jnp.shape(self.probs), validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
-        assert key is not None
+        assert is_prng_key(key)
         samples = random.bernoulli(key, self.probs, shape=sample_shape + self.batch_shape)
         return samples.astype(jnp.result_type(samples, int))
 
@@ -116,7 +117,7 @@ class BernoulliLogits(Distribution):
         super(BernoulliLogits, self).__init__(batch_shape=jnp.shape(self.logits), validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
-        assert key is not None
+        assert is_prng_key(key)
         samples = random.bernoulli(key, self.probs, shape=sample_shape + self.batch_shape)
         return samples.astype(jnp.result_type(samples, int))
 
@@ -164,7 +165,7 @@ class BinomialProbs(Distribution):
         super(BinomialProbs, self).__init__(batch_shape=batch_shape, validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
-        assert key is not None
+        assert is_prng_key(key)
         return binomial(key, self.probs, n=self.total_count, shape=sample_shape + self.batch_shape)
 
     @validate_sample
@@ -215,7 +216,7 @@ class BinomialLogits(Distribution):
         super(BinomialLogits, self).__init__(batch_shape=batch_shape, validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
-        assert key is not None
+        assert is_prng_key(key)
         return binomial(key, self.probs, n=self.total_count, shape=sample_shape + self.batch_shape)
 
     @validate_sample
@@ -267,7 +268,7 @@ class CategoricalProbs(Distribution):
                                                validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
-        assert key is not None
+        assert is_prng_key(key)
         return categorical(key, self.probs, shape=sample_shape + self.batch_shape)
 
     @validate_sample
@@ -311,7 +312,7 @@ class CategoricalLogits(Distribution):
                                                 validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
-        assert key is not None
+        assert is_prng_key(key)
         return random.categorical(key, self.logits, shape=sample_shape + self.batch_shape)
 
     @validate_sample
@@ -469,7 +470,7 @@ class MultinomialProbs(Distribution):
                                                validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
-        assert key is not None
+        assert is_prng_key(key)
         return multinomial(key, self.probs, self.total_count, shape=sample_shape + self.batch_shape)
 
     @validate_sample
@@ -508,7 +509,7 @@ class MultinomialLogits(Distribution):
                                                 validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
-        assert key is not None
+        assert is_prng_key(key)
         return multinomial(key, self.probs, self.total_count, shape=sample_shape + self.batch_shape)
 
     @validate_sample
@@ -555,7 +556,7 @@ class Poisson(Distribution):
         super(Poisson, self).__init__(jnp.shape(rate), validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
-        assert key is not None
+        assert is_prng_key(key)
         return random.poisson(key, self.rate, shape=sample_shape + self.batch_shape)
 
     @validate_sample
@@ -590,7 +591,7 @@ class ZeroInflatedPoisson(Distribution):
         super(ZeroInflatedPoisson, self).__init__(batch_shape, validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
-        assert key is not None
+        assert is_prng_key(key)
         key_bern, key_poisson = random.split(key)
         shape = sample_shape + self.batch_shape
         mask = random.bernoulli(key_bern, self.gate, shape)
@@ -622,7 +623,7 @@ class GeometricProbs(Distribution):
                                              validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
-        assert key is not None
+        assert is_prng_key(key)
         probs = self.probs
         dtype = get_dtype(probs)
         shape = sample_shape + self.batch_shape
@@ -658,7 +659,7 @@ class GeometricLogits(Distribution):
         return _to_probs_bernoulli(self.logits)
 
     def sample(self, key, sample_shape=()):
-        assert key is not None
+        assert is_prng_key(key)
         logits = self.logits
         dtype = get_dtype(logits)
         shape = sample_shape + self.batch_shape

--- a/numpyro/distributions/distribution.py
+++ b/numpyro/distributions/distribution.py
@@ -269,13 +269,6 @@ class Distribution(metaclass=DistributionMeta):
 
     def __call__(self, *args, **kwargs):
         key = kwargs.pop('rng_key')
-        # FIXME: This also raises error for Delta site.
-        # Is there a better way to raise this error?
-        if key is None:
-            raise ValueError("Missing random key for {} distribution. Looking like you "
-                             "have not seeded your stochastic function. See "
-                             "`numpyro.handlers.seed` documentation for more information."
-                             .format(self.__class__.__name__))
         sample_intermediates = kwargs.pop('sample_intermediates', False)
         if sample_intermediates:
             return self.sample_with_intermediates(key, *args, **kwargs)

--- a/numpyro/distributions/distribution.py
+++ b/numpyro/distributions/distribution.py
@@ -269,6 +269,13 @@ class Distribution(metaclass=DistributionMeta):
 
     def __call__(self, *args, **kwargs):
         key = kwargs.pop('rng_key')
+        # FIXME: This also raises error for Delta site.
+        # Is there a better way to raise this error?
+        if key is None:
+            raise ValueError("Missing random key for {} distribution. Looking like you "
+                             "have not seeded your stochastic function. See "
+                             "`numpyro.handlers.seed` documentation for more information."
+                             .format(self.__class__.__name__))
         sample_intermediates = kwargs.pop('sample_intermediates', False)
         if sample_intermediates:
             return self.sample_with_intermediates(key, *args, **kwargs)

--- a/numpyro/distributions/util.py
+++ b/numpyro/distributions/util.py
@@ -479,6 +479,14 @@ def periodic_repeat(x, size, dim):
     return result
 
 
+# src: https://github.com/google/jax/blob/5a41779fbe12ba7213cd3aa1169d3b0ffb02a094/jax/_src/random.py#L95
+def is_prng_key(key):
+    try:
+        return key.shape == (2,) and key.dtype == np.uint32
+    except AttributeError:
+        return False
+
+
 # The is sourced from: torch.distributions.util.py
 #
 # Copyright (c) 2016-     Facebook, Inc            (Adam Paszke)

--- a/test/contrib/test_module.py
+++ b/test/contrib/test_module.py
@@ -65,7 +65,8 @@ def test_update_params():
     params = {'a': {'b': {'c': {'d': 1}, 'e': np.array(2)}, 'f': np.ones(4)}}
     prior = {'a.b.c.d': dist.Delta(4), 'a.f': dist.Delta(5)}
     new_params = deepcopy(params)
-    _update_params(params, new_params, prior)
+    with handlers.seed(rng_seed=0):
+        _update_params(params, new_params, prior)
     assert params == {'a': {'b': {'c': {'d': ParamShape(())}, 'e': 2}, 'f': ParamShape((4,))}}
     test_util.check_eq(new_params, {'a': {'b': {'c': {'d': np.array(4.)}, 'e': np.array(2)},
                                           'f': np.full((4,), 5.)}})


### PR DESCRIPTION
Currently, when `rng_key` is missing. Users will get a very long error message
```
...
...
~/jax/jax/interpreters/partial_eval.py in trace_to_subjaxpr_dynamic(fun, main, in_avals)
   1172     trace = DynamicJaxprTrace(main, core.cur_sublevel())
   1173     in_tracers = map(trace.new_arg, in_avals)
-> 1174     ans = fun.call_wrapped(*in_tracers)
   1175     out_tracers = map(trace.full_raise, ans)
   1176   jaxpr, out_avals, consts = frame.to_jaxpr(in_tracers, out_tracers)

~/jax/jax/linear_util.py in call_wrapped(self, *args, **kwargs)
    158 
    159     try:
--> 160       ans = self.f(*args, **dict(self.params, **kwargs))
    161     except:
    162       # Some transformations yield from inside context managers, so we have to

~/jax/jax/random.py in _random_bits(key, bit_width, shape)
    309   """Sample uniform random bits of given width and shape using PRNG key."""
    310   if not _is_prng_key(key):
--> 311     raise TypeError("_random_bits got invalid prng key.")
    312   if bit_width not in (8, 16, 32, 64):
    313     raise TypeError("requires 8-, 16-, 32- or 64-bit field width.")

TypeError: _random_bits got invalid prng key.
```
But it is not meaningful. This PR adds a better error message when it happens.