### PR TITLE
Fix a bug at MCMC.print_summary

### DIFF
--- a/numpyro/contrib/tfp/distributions.py
+++ b/numpyro/contrib/tfp/distributions.py
@@ -24,7 +24,7 @@ def _get_codomain(bijector):
         return constraints.positive
     elif bijector.__class__.__name__ == "GeneralizedPareto":
         loc, scale, concentration = bijector.loc, bijector.scale, bijector.concentration
-        if not_jax_tracer(concentration) and np.all(concentration < 0):
+        if not_jax_tracer(concentration) and np.all(np.less(concentration, 0)):
             return constraints.interval(loc, loc + scale / jnp.abs(concentration))
         # XXX: here we suppose concentration > 0
         # which is not true in general, but should cover enough usage cases

--- a/numpyro/distributions/transforms.py
+++ b/numpyro/distributions/transforms.py
@@ -98,19 +98,19 @@ class AffineTransform(Transform):
         elif self.domain is constraints.real_vector:
             return constraints.real_vector
         elif isinstance(self.domain, constraints.greater_than):
-            if not_jax_tracer(self.scale) and np.all(self.scale < 0):
+            if not_jax_tracer(self.scale) and np.all(np.less(self.scale, 0)):
                 return constraints.less_than(self(self.domain.lower_bound))
             # we suppose scale > 0 for any tracer
             else:
                 return constraints.greater_than(self(self.domain.lower_bound))
         elif isinstance(self.domain, constraints.less_than):
-            if not_jax_tracer(self.scale) and np.all(self.scale < 0):
+            if not_jax_tracer(self.scale) and np.all(np.less(self.scale, 0)):
                 return constraints.greater_than(self(self.domain.upper_bound))
             # we suppose scale > 0 for any tracer
             else:
                 return constraints.less_than(self(self.domain.upper_bound))
         elif isinstance(self.domain, constraints.interval):
-            if not_jax_tracer(self.scale) and np.all(self.scale < 0):
+            if not_jax_tracer(self.scale) and np.all(np.less(self.scale, 0)):
                 return constraints.interval(self(self.domain.upper_bound),
                                             self(self.domain.lower_bound))
             else:

--- a/numpyro/distributions/util.py
+++ b/numpyro/distributions/util.py
@@ -329,8 +329,7 @@ def signed_stick_breaking_tril(t):
     # we omit the step of computing s = z * z_cumprod by using the fact:
     #     y = sign(r) * s = sign(r) * sqrt(z * z_cumprod) = r * sqrt(z_cumprod)
     z = r ** 2
-    z1m_cumprod = jnp.cumprod(1 - z, axis=-1)
-    z1m_cumprod_sqrt = jnp.sqrt(z1m_cumprod)
+    z1m_cumprod_sqrt = jnp.cumprod(jnp.sqrt(1 - z), axis=-1)
 
     pad_width = [(0, 0)] * z.ndim
     pad_width[-1] = (1, 0)
@@ -477,6 +476,14 @@ def periodic_repeat(x, size, dim):
     result = jnp.repeat(x, repeats, axis=dim)
     result = result[(Ellipsis, slice(None, size)) + (slice(None),) * (-1 - dim)]
     return result
+
+
+# src: https://github.com/google/jax/blob/5a41779fbe12ba7213cd3aa1169d3b0ffb02a094/jax/_src/random.py#L95
+def is_prng_key(key):
+    try:
+        return key.shape == (2,) and key.dtype == np.uint32
+    except AttributeError:
+        return False
 
 
 # The is sourced from: torch.distributions.util.py

--- a/numpyro/handlers.py
+++ b/numpyro/handlers.py
@@ -532,7 +532,7 @@ class scale(Messenger):
     """
     def __init__(self, fn=None, scale=1.):
         if not_jax_tracer(scale):
-            if np.any(scale <= 0):
+            if np.any(np.less_equal(scale, 0)):
                 raise ValueError("'scale' argument should be positive.")
         self.scale = scale
         super().__init__(fn)

--- a/numpyro/handlers.py
+++ b/numpyro/handlers.py
@@ -79,6 +79,8 @@ results for all the data points, but does so by using JAX's auto-vectorize trans
 from collections import OrderedDict
 import warnings
 
+import numpy as np
+
 from jax import lax, random
 import jax.numpy as jnp
 
@@ -524,12 +526,13 @@ class scale(Messenger):
     This is typically used for data subsampling or for stratified sampling of data
     (e.g. in fraud detection where negatives vastly outnumber positives).
 
-    :param float scale: a positive scaling factor
+    :param scale: a positive scaling factor
+    :type scale: float or numpy.ndarray
     """
     def __init__(self, fn=None, scale=1.):
         if not_jax_tracer(scale):
-            if scale <= 0:
-                raise ValueError("'scale' argument should be a positive number.")
+            if np.any(scale <= 0):
+                raise ValueError("'scale' argument should be positive.")
         self.scale = scale
         super().__init__(fn)
 

--- a/numpyro/handlers.py
+++ b/numpyro/handlers.py
@@ -526,7 +526,8 @@ class scale(Messenger):
     This is typically used for data subsampling or for stratified sampling of data
     (e.g. in fraud detection where negatives vastly outnumber positives).
 
-    :param scale: a positive scaling factor
+    :param scale: a positive scaling factor that is broadcastable to the shape
+        of log probability.
     :type scale: float or numpy.ndarray
     """
     def __init__(self, fn=None, scale=1.):


### PR DESCRIPTION
There, we assume `sample_field` is `z`, which might not be true for other MCMC kernels.

Tested on MH example, where I changed `sample_field` to `u`.

I also revise `scale` handler docstring to mention that `scale` can be a ndarray. cc @xidulu 