### PR TITLE
debug sampling of tfp distributions using numpyro.sample function

### DIFF
--- a/numpyro/contrib/tfp/distributions.py
+++ b/numpyro/contrib/tfp/distributions.py
@@ -119,7 +119,9 @@ class TFPDistributionMixin(NumPyroDistribution, metaclass=_TFPMixinMeta):
 
     def __call__(self, *args, **kwargs):
         key = kwargs.pop('rng_key')
-        kwargs.pop('sample_intermediates', False)
+        sample_intermediates = kwargs.pop('sample_intermediates', False)
+        if sample_intermediates:
+            return self.sample(*args, seed=key, **kwargs), []
         return self.sample(*args, seed=key, **kwargs)
 
     @property

--- a/test/contrib/test_tfp.py
+++ b/test/contrib/test_tfp.py
@@ -197,3 +197,19 @@ def test_unnormalized_normal_chain(kernel, kwargs, num_chains):
     hmc_states = mcmc.get_samples()
     assert_allclose(jnp.mean(hmc_states), true_mean, rtol=0.07)
     assert_allclose(jnp.std(hmc_states), true_std, rtol=0.07)
+
+
+# test if sampling from tfp distributions works as expected using
+# numpyro sample function: numpyro.sample("name", dist) (bug)
+@pytest.mark.filterwarnings("ignore:can't resolve package")
+def test_sample_tfp_distributions():
+    from numpyro.contrib.tfp import distributions as tfd
+
+    # test no error raised
+    d = tfd.Normal(0, 1)
+    with numpyro.handlers.seed(rng_seed=random.PRNGKey(0)):
+        numpyro.sample("normal", d)
+
+    # test intermediates are []
+    value, intermediates = d(sample_intermediates=True, rng_key=random.PRNGKey(0))
+    assert intermediates == []


### PR DESCRIPTION
debug sampling using `numpyro.sample` with tfp distributions by returning `[]` when `sample_intermediates` is `True`.