### PR TITLE
Expose potential_fn_gen for composed kernels

### DIFF
--- a/numpyro/infer/hmc.py
+++ b/numpyro/infer/hmc.py
@@ -399,6 +399,7 @@ class HMC(MCMCKernel):
         self._find_heuristic_step_size = find_heuristic_step_size
         # Set on first call to init
         self._init_fn = None
+        self._potential_fn_gen = None
         self._postprocess_fn = None
         self._sample_fn = None
 
@@ -415,6 +416,7 @@ class HMC(MCMCKernel):
                 self._init_fn, self._sample_fn = hmc(potential_fn_gen=potential_fn,
                                                      kinetic_fn=self._kinetic_fn,
                                                      algo=self._algo)
+            self._potential_fn_gen = potential_fn
             self._postprocess_fn = postprocess_fn
         elif self._init_fn is None:
             self._init_fn, self._sample_fn = hmc(potential_fn=self._potential_fn,

--- a/numpyro/infer/sa.py
+++ b/numpyro/infer/sa.py
@@ -243,6 +243,7 @@ class SA(MCMCKernel):
         self._dense_mass = dense_mass
         self._init_strategy = init_strategy
         self._init_fn = None
+        self._potential_fn_gen = None
         self._postprocess_fn = None
         self._sample_fn = None
 
@@ -258,6 +259,7 @@ class SA(MCMCKernel):
             init_params = init_params[0]
             # NB: init args is different from HMC
             self._init_fn, sample_fn = _sa(potential_fn_gen=potential_fn)
+            self._potential_fn_gen = potential_fn
             if self._postprocess_fn is None:
                 self._postprocess_fn = postprocess_fn
         else:


### PR DESCRIPTION
Currently, if we use HMC/NUTS as an inner kernel, there is no way for the outer kernel to access the potential function that is created by the inner kernel. This PR exposes it through a hidden attribute. We might consider exposing it when the composing pattern becomes clearer.