### PR TITLE
Allow a callable to return an init value in param primitive

### DIFF
--- a/numpyro/infer/svi.py
+++ b/numpyro/infer/svi.py
@@ -60,7 +60,8 @@ class SVI(object):
 
         >>> def guide(data):
         ...     alpha_q = numpyro.param("alpha_q", 15., constraint=constraints.positive)
-        ...     beta_q = numpyro.param("beta_q", 15., constraint=constraints.positive)
+        ...     beta_q = numpyro.param("beta_q", lambda rng_key: random.exponential(rng_key),
+        ...                            constraint=constraints.positive)
         ...     numpyro.sample("latent_fairness", dist.Beta(alpha_q, beta_q))
 
         >>> data = jnp.concatenate([jnp.ones(6), jnp.zeros(4)])

--- a/numpyro/primitives.py
+++ b/numpyro/primitives.py
@@ -157,13 +157,11 @@ def param(name, init_value=None, **kwargs):
             "A callable init_value needs to be put inside a numpyro.handlers.seed handler."
         return init_value
 
-    default_fn = identity
     if callable(init_value):
-        def fn(*args, **kwargs):
-            init_fn = default_fn(*args, **kwargs)
+        def fn(init_fn, *args, **kwargs):
             return init_fn(prng_key())
     else:
-        fn = default_fn
+        fn = identity
 
     # Otherwise, we initialize a message...
     initial_msg = {

--- a/numpyro/primitives.py
+++ b/numpyro/primitives.py
@@ -30,12 +30,14 @@ def apply_stack(msg):
             msg['value'], msg['intermediates'] = msg['fn'](*msg['args'],
                                                            sample_intermediates=True,
                                                            **msg['kwargs'])
+        elif msg['type'] == 'param':
+            value = msg['fn'](*msg['args'], **msg['kwargs'])
+            if callable(value):
+                msg['value'] = value(prng_key())
+            else:
+                msg['value'] = value
         else:
             msg['value'] = msg['fn'](*msg['args'], **msg['kwargs'])
-
-        if msg['type'] == 'param' and callable(msg['value']):
-            rng_key = prng_key()
-            msg['value'] = msg['value'](rng_key)
 
     # A Messenger that sets msg["stop"] == True also prevents application
     # of postprocess_message by Messengers above it on the stack

--- a/test/test_svi.py
+++ b/test/test_svi.py
@@ -79,9 +79,9 @@ def test_run(progress_bar):
         numpyro.sample("obs", dist.Bernoulli(f), obs=data)
 
     def guide(data):
-        alpha_q = numpyro.param("alpha_q", 1.0,
+        alpha_q = numpyro.param("alpha_q", lambda key: random.normal(key),
                                 constraint=constraints.positive)
-        beta_q = numpyro.param("beta_q", 1.0,
+        beta_q = numpyro.param("beta_q", lambda key: random.exponential(key),
                                constraint=constraints.positive)
         numpyro.sample("beta", dist.Beta(alpha_q, beta_q))
 


### PR DESCRIPTION
This is useful if users want to set random initial values for the parameters. This can be helpful for SteinVI implementation, where it requires different initial parameter values for each particle. (we can use `lift` to lift param sites to sample sites, then run the model multiple times to get those param values but it might be a bit verbose)

Actually, many tests/examples in Pyro use callables init_tensor to return random values. So it would be nice to be able to do so in NumPyro. In addition, it will be a bit cheaper/less memory requirement for SVI if users use the pattern: `lambda rng_key: some_value` because we only need to run the callable to get the initial values (in later updates, the values are substituted by params from optimizer)

cc @OlaRonning 