### PR TITLE
Incorporate input_event_dim/output_event_dim to transforms

### DIFF
--- a/numpyro/contrib/funsor/enum_messenger.py
+++ b/numpyro/contrib/funsor/enum_messenger.py
@@ -526,7 +526,7 @@ class trace(OrigTraceMessenger):
         if msg["type"] == "sample":
             total_batch_shape = lax.broadcast_shapes(
                 tuple(msg["fn"].batch_shape),
-                msg["value"].shape[:len(msg["value"].shape)-len(msg["fn"].event_shape)]
+                msg["value"].shape[:len(msg["value"].shape) - msg["fn"].event_dim]
             )
             msg["infer"]["dim_to_name"] = NamedMessenger._get_dim_to_name(total_batch_shape)
         if msg["type"] in ("sample", "param"):

--- a/numpyro/distributions/distribution.py
+++ b/numpyro/distributions/distribution.py
@@ -36,7 +36,7 @@ from jax import lax, tree_util
 import jax.numpy as jnp
 
 from numpyro.distributions.constraints import is_dependent, real
-from numpyro.distributions.transforms import Transform
+from numpyro.distributions.transforms import ComposeTransform, Transform
 from numpyro.distributions.util import lazy_property, promote_shapes, sum_rightmost, validate_sample
 from numpyro.util import not_jax_tracer
 
@@ -725,9 +725,23 @@ class TransformedDistribution(Distribution):
         # to pay attention to any inference function that inspects
         # transformed distribution's shape.
         shape = base_distribution.batch_shape + base_distribution.event_shape
-        event_dim = max([len(base_distribution.event_shape)] + [t.event_dim for t in transforms])
-        batch_shape = shape[:len(shape) - event_dim]
-        event_shape = shape[len(shape) - event_dim:]
+        base_ndim = len(shape)
+        transform = ComposeTransform(self.transforms)
+        transform_input_event_dim = transform.input_event_dim
+        if base_ndim < transform_input_event_dim:
+            raise ValueError("Base distribution needs to have shape with size at least {}, but got {}."
+                             .format(transform_input_event_dim, base_ndim))
+        event_dim = transform.output_event_dim + max(self.base_dist.event_dim - transform_input_event_dim, 0)
+        # See the above note. Currently, there is no way to interpret the shape of output after
+        # transforming. To solve this issue, we need something like Bijector.forward_event_shape
+        # as in TFP. For now, we will prepend singleton dimensions to compromise, so that
+        # event_dim, len(batch_shape) are still correct.
+        if event_dim <= base_ndim:
+            batch_shape = shape[:base_ndim - event_dim]
+            event_shape = shape[base_ndim - event_dim:]
+        else:
+            event_shape = (1,) * (event_dim - base_ndim) + shape
+            batch_shape = ()
         super(TransformedDistribution, self).__init__(batch_shape, event_shape, validate_args=validate_args)
 
     @property
@@ -766,7 +780,9 @@ class TransformedDistribution(Distribution):
             x = transform.inv(y) if intermediates is None else intermediates[-i - 1][0]
             t_inter = None if intermediates is None else intermediates[-i - 1][1]
             t_log_det = transform.log_abs_det_jacobian(x, y, t_inter)
-            log_prob = log_prob - sum_rightmost(t_log_det, event_dim - transform.event_dim)
+            batch_ndim = event_dim - transform.output_event_dim
+            log_prob = log_prob - sum_rightmost(t_log_det, batch_ndim)
+            event_dim = transform.input_event_dim + batch_ndim
             y = x
 
         log_prob = log_prob + sum_rightmost(self.base_dist.log_prob(y),

--- a/numpyro/distributions/distribution.py
+++ b/numpyro/distributions/distribution.py
@@ -740,7 +740,7 @@ class TransformedDistribution(Distribution):
             batch_shape = shape[:base_ndim - event_dim]
             event_shape = shape[base_ndim - event_dim:]
         else:
-            event_shape = (1,) * (event_dim - base_ndim) + shape
+            event_shape = (-1,) * event_dim
             batch_shape = ()
         super(TransformedDistribution, self).__init__(batch_shape, event_shape, validate_args=validate_args)
 

--- a/numpyro/distributions/transforms.py
+++ b/numpyro/distributions/transforms.py
@@ -54,6 +54,14 @@ class Transform(object):
     codomain = constraints.real
     event_dim = 0
 
+    @property
+    def input_event_dim(self):
+        return self.event_dim
+
+    @property
+    def output_event_dim(self):
+        return self.event_dim
+
     def __call__(self, x):
         return NotImplementedError
 
@@ -147,7 +155,21 @@ class ComposeTransform(Transform):
 
     @property
     def event_dim(self):
-        return max(p.event_dim for p in self.parts)
+        raise ValueError("Please use `.input_event_dim` or `.output_event_dim` instead.")
+
+    @property
+    def input_event_dim(self):
+        input_event_dim = self.parts[-1].input_event_dim
+        for part in self.parts[len(self.parts) - 1::-1]:
+            input_event_dim = part.input_event_dim + max(input_event_dim - part.output_event_dim, 0)
+        return input_event_dim
+
+    @property
+    def output_event_dim(self):
+        output_event_dim = self.parts[0].output_event_dim
+        for part in self.parts[1:]:
+            output_event_dim = part.output_event_dim + max(output_event_dim - part.input_event_dim, 0)
+        return output_event_dim
 
     def __call__(self, x):
         for part in self.parts:
@@ -166,16 +188,20 @@ class ComposeTransform(Transform):
                                  .format(len(intermediates), len(self.parts)))
 
         result = 0.
+        input_event_dim = self.input_event_dim
         for i, part in enumerate(self.parts[:-1]):
             y_tmp = part(x) if intermediates is None else intermediates[i][0]
             inter = None if intermediates is None else intermediates[i][1]
             logdet = part.log_abs_det_jacobian(x, y_tmp, intermediates=inter)
-            result = result + sum_rightmost(logdet, self.event_dim - part.event_dim)
+            batch_ndim = input_event_dim - part.input_event_dim
+            result = result + sum_rightmost(logdet, batch_ndim)
+            input_event_dim = part.output_event_dim + batch_ndim
             x = y_tmp
         # account the the last transform, where y is available
         inter = None if intermediates is None else intermediates[-1]
-        logdet = self.parts[-1].log_abs_det_jacobian(x, y, intermediates=inter)
-        result = result + sum_rightmost(logdet, self.event_dim - self.parts[-1].event_dim)
+        part = self.parts[-1]
+        logdet = part.log_abs_det_jacobian(x, y, intermediates=inter)
+        result = result + sum_rightmost(logdet, input_event_dim - part.input_event_dim)
         return result
 
     def call_with_intermediates(self, x):
@@ -217,7 +243,12 @@ class CorrCholeskyTransform(Transform):
     """
     domain = constraints.real_vector
     codomain = constraints.corr_cholesky
-    event_dim = 2
+    input_event_dim = 1
+    output_event_dim = 2
+
+    @property
+    def event_dim(self):
+        raise ValueError("Please use `.input_event_dim` or `.output_event_dim` instead.")
 
     def __call__(self, x):
         # we interchange step 1 and step 2.a for a better performance
@@ -371,7 +402,12 @@ class LowerCholeskyAffine(Transform):
 class LowerCholeskyTransform(Transform):
     domain = constraints.real_vector
     codomain = constraints.lower_cholesky
-    event_dim = 2
+    input_event_dim = 1
+    output_event_dim = 2
+
+    @property
+    def event_dim(self):
+        raise ValueError("Please use `.input_event_dim` or `.output_event_dim` instead.")
 
     def __call__(self, x):
         n = round((math.sqrt(1 + 8 * x.shape[-1]) - 1) / 2)

--- a/numpyro/infer/autoguide.py
+++ b/numpyro/infer/autoguide.py
@@ -417,7 +417,7 @@ class AutoContinuous(AutoGuide):
             transform = biject_to(site['fn'].support)
             value = transform(unconstrained_value)
             log_density = - transform.log_abs_det_jacobian(unconstrained_value, value)
-            event_ndim = len(site['fn'].event_shape)
+            event_ndim = site['fn'].event_dim
             log_density = sum_rightmost(log_density,
                                         jnp.ndim(log_density) - jnp.ndim(value) + event_ndim)
             delta_dist = dist.Delta(value, log_density=log_density, event_dim=event_ndim)

--- a/numpyro/infer/util.py
+++ b/numpyro/infer/util.py
@@ -122,12 +122,7 @@ def _unconstrain_reparam(params, site):
         # in scan, we might only want to substitute an item at index i, rather than the whole sequence
         i = site['infer'].get('_scan_current_index', None)
         if i is not None:
-            # TODO: leverage t.input_event_dim, t.output_event_dim when they are available
-            if support in (constraints.corr_cholesky, constraints.corr_matrix,
-                           constraints.positive_definite, constraints.lower_cholesky):
-                event_dim_shift = 1
-            else:
-                event_dim_shift = 0
+            event_dim_shift = t.output_event_dim - t.input_event_dim
             expected_unconstrained_dim = len(site["fn"].shape()) - event_dim_shift
             # check if p has additional time dimension
             if jnp.ndim(p) > expected_unconstrained_dim:

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -874,10 +874,7 @@ def test_constraints(constraint, x, expected):
 @pytest.mark.parametrize('shape', [(), (1,), (3,), (6,), (3, 1), (1, 3), (5, 3)])
 def test_biject_to(constraint, shape):
     transform = biject_to(constraint)
-    if transform.event_dim == 2:
-        event_dim = 1  # actual dim of unconstrained domain
-    else:
-        event_dim = transform.event_dim
+    event_dim = transform.input_event_dim
     if isinstance(constraint, constraints._Interval):
         assert transform.codomain.upper_bound == constraint.upper_bound
         assert transform.codomain.lower_bound == constraint.lower_bound

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -988,6 +988,65 @@ def test_bijective_transforms(transform, event_shape, batch_shape):
         assert_allclose(actual, -inv_expected, atol=1e-6)
 
 
+@pytest.mark.parametrize('batch_shape', [(), (5,)])
+def test_composed_transform(batch_shape):
+    t1 = transforms.AffineTransform(0, 2)
+    t2 = transforms.LowerCholeskyTransform()
+    t = transforms.ComposeTransform([t1, t2, t1])
+    assert t.input_event_dim == 1
+    assert t.output_event_dim == 2
+
+    x = np.random.normal(size=batch_shape + (6,))
+    y = t(x)
+    log_det = t.log_abs_det_jacobian(x, y)
+    assert log_det.shape == batch_shape
+    expected_log_det = jnp.log(2) * 6 + t2.log_abs_det_jacobian(x * 2, y / 2) + jnp.log(2) * 9
+    assert_allclose(log_det, expected_log_det)
+
+
+@pytest.mark.parametrize('batch_shape', [(), (5,)])
+def test_composed_transform_1(batch_shape):
+    t1 = transforms.AffineTransform(0, 2)
+    t2 = transforms.LowerCholeskyTransform()
+    t = transforms.ComposeTransform([t1, t2, t2])
+    assert t.input_event_dim == 1
+    assert t.output_event_dim == 3
+
+    x = np.random.normal(size=batch_shape + (6,))
+    y = t(x)
+    log_det = t.log_abs_det_jacobian(x, y)
+    assert log_det.shape == batch_shape
+    z = t2(x * 2)
+    expected_log_det = jnp.log(2) * 6 + t2.log_abs_det_jacobian(x * 2, z) + \
+        t2.log_abs_det_jacobian(z, t2(z)).sum(-1)
+    assert_allclose(log_det, expected_log_det)
+
+
+@pytest.mark.parametrize('batch_shape', [(), (5,)])
+@pytest.mark.parametrize('prepend_event_shape', [(), (4,)])
+@pytest.mark.parametrize('sample_shape', [(), (7,)])
+def test_transformed_distribution(batch_shape, prepend_event_shape, sample_shape):
+    base_dist = dist.Normal(0, 1).expand(batch_shape + prepend_event_shape + (6,)).to_event(
+        1 + len(prepend_event_shape)
+    )
+    t1 = transforms.AffineTransform(0, 2)
+    t2 = transforms.LowerCholeskyTransform()
+    d = dist.TransformedDistribution(base_dist, [t1, t2, t1])
+    assert d.event_dim == 2 + len(prepend_event_shape)
+
+    y = d.sample(random.PRNGKey(0), sample_shape)
+    t = transforms.ComposeTransform([t1, t2, t1])
+    x = t.inv(y)
+    assert x.shape == sample_shape + base_dist.shape()
+    log_prob = d.log_prob(y)
+    assert log_prob.shape == sample_shape + batch_shape
+    t_log_det = t.log_abs_det_jacobian(x, y)
+    if prepend_event_shape:
+        t_log_det = t_log_det.sum(-1)
+    expected_log_prob = base_dist.log_prob(x) - t_log_det
+    assert_allclose(log_prob, expected_log_prob, atol=1e-5)
+
+
 @pytest.mark.parametrize('transformed_dist', [
     dist.TransformedDistribution(dist.Normal(jnp.array([2., 3.]), 1.), transforms.ExpTransform()),
     dist.TransformedDistribution(dist.Exponential(jnp.ones(2)), [


### PR DESCRIPTION
This feature is incorporated in PyTorch distributions recently. I found it useful for #835, where I need to know what is the ndim of a constrained sample, given an unconstrained sample.

I believe this change will cover more ComposedTransform transforms or TransformedDistribution distributions, but still not enough. We need something like [forward_event_shape](https://www.tensorflow.org/probability/api_docs/python/tfp/bijectors/Bijector#forward_event_shape) to provide correct batch_shape, event_shape for TransformedDistributions (currently, only len(batch_shape), len(event_shape) are correct)). But it can be deferred to the future if needed.

**Example** for a not supported case
```
import numpyro.distributions as dist
from jax import random
d = dist.TransformedDistribution(dist.Normal(0, 1).expand([6]), dist.transforms.LowerCholeskyTransform())
d.event_shape, d.sample(random.PRNGKey(0)).shape
```
returns `(1, 6)` and `(3, 3)`