### PR TITLE
Make scan compatible with unconstrain reparam

### DIFF
--- a/docs/source/handlers.rst
+++ b/docs/source/handlers.rst
@@ -35,6 +35,14 @@ do
     :show-inheritance:
     :member-order: bysource
 
+infer_config
+------------
+.. autoclass:: numpyro.handlers.infer_config
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :member-order: bysource
+
 lift
 ----
 .. autoclass:: numpyro.handlers.lift

--- a/numpyro/contrib/control_flow/scan.py
+++ b/numpyro/contrib/control_flow/scan.py
@@ -29,14 +29,20 @@ class PytreeTrace:
                     # scanned sites have stop field because we trace them inside a block handler
                     elif key != 'stop':
                         aux_trace[name][key] = site[key]
-        return (trace,), aux_trace
+        # keep the site order information because in JAX, flatten and unflatten do not preserve
+        # the order of keys in a dict
+        site_names = list(trace.keys())
+        return (trace,), (aux_trace, site_names)
 
     @classmethod
     def tree_unflatten(cls, aux_data, children):
+        aux_trace, site_names = aux_data
         trace, = children
-        for name, site in trace.items():
-            site.update(aux_data[name])
-        return cls(trace)
+        trace_with_aux = {}
+        for name in site_names:
+            trace[name].update(aux_trace[name])
+            trace_with_aux[name] = trace[name]
+        return cls(trace_with_aux)
 
 
 def _subs_wrapper(subs_map, i, length, site):
@@ -100,7 +106,7 @@ class promote_shapes(Messenger):
 
 
 def scan_enum(f, init, xs, length, reverse, rng_key=None, substitute_stack=None):
-    from numpyro.contrib.funsor import config_enumerate, enum, markov
+    from numpyro.contrib.funsor import config_enumerate, enum, infer_config, markov
     from numpyro.contrib.funsor import trace as packed_trace
 
     # XXX: This implementation only works for history size=1 but can be
@@ -122,7 +128,11 @@ def scan_enum(f, init, xs, length, reverse, rng_key=None, substitute_stack=None)
         init = True if (not_jax_tracer(i) and i == 0) else False
         rng_key, subkey = random.split(rng_key) if rng_key is not None else (None, None)
 
-        seeded_fn = handlers.seed(f, subkey) if subkey is not None else f
+        # we need to tell unconstrained messenger in potential energy computation
+        # that only the item at time `i` is needed when transforming
+        fn = infer_config(f, config_fn=lambda msg: {'_scan_current_index': i})
+
+        seeded_fn = handlers.seed(fn, subkey) if subkey is not None else fn
         for subs_type, subs_map in substitute_stack:
             subs_fn = partial(_subs_wrapper, subs_map, i, length)
             if subs_type == 'condition':

--- a/numpyro/contrib/funsor/enum_messenger.py
+++ b/numpyro/contrib/funsor/enum_messenger.py
@@ -9,7 +9,7 @@ from jax import lax
 import jax.numpy as jnp
 
 import funsor
-from numpyro.handlers import trace as OrigTraceMessenger
+from numpyro.handlers import infer_config, trace as OrigTraceMessenger
 from numpyro.primitives import Messenger, apply_stack
 from numpyro.primitives import plate as OrigPlateMessenger
 
@@ -551,24 +551,6 @@ def markov(fn=None, history=1, keep=False):
     if fn is not None and not callable(fn):  # Used as a generator
         return LocalNamedMessenger(fn=None, history=history, keep=keep).generator(iterable=fn)
     return LocalNamedMessenger(fn, history=history, keep=keep)
-
-
-class infer_config(Messenger):
-    """
-    Given a callable `fn` that contains Pyro primitive calls
-    and a callable `config_fn` taking a trace site and returning a dictionary,
-    updates the value of the infer kwarg at a sample site to config_fn(site).
-
-    :param fn: a stochastic function (callable containing Pyro primitive calls)
-    :param config_fn: a callable taking a site and returning an infer dict
-    """
-    def __init__(self, fn, config_fn):
-        super().__init__(fn)
-        self.config_fn = config_fn
-
-    def process_message(self, msg):
-        if msg["type"] in ("sample", "param"):
-            msg["infer"].update(self.config_fn(msg))
 
 
 ####################

--- a/numpyro/distributions/util.py
+++ b/numpyro/distributions/util.py
@@ -261,7 +261,7 @@ def sum_rightmost(x, dim):
     Sum out ``dim`` many rightmost dimensions of a given tensor.
     """
     out_dim = jnp.ndim(x) - dim
-    x = jnp.reshape(x[..., jnp.newaxis], jnp.shape(x)[:out_dim] + (-1,))
+    x = jnp.reshape(jnp.expand_dims(x, -1), jnp.shape(x)[:out_dim] + (-1,))
     return jnp.sum(x, axis=-1)
 
 

--- a/numpyro/handlers.py
+++ b/numpyro/handlers.py
@@ -93,6 +93,7 @@ __all__ = [
     'block',
     'collapse',
     'condition',
+    'infer_config',
     'lift',
     'mask',
     'reparam',
@@ -374,6 +375,24 @@ class condition(Messenger):
         if value is not None:
             msg['value'] = value
             msg['is_observed'] = True
+
+
+class infer_config(Messenger):
+    """
+    Given a callable `fn` that contains Pyro primitive calls
+    and a callable `config_fn` taking a trace site and returning a dictionary,
+    updates the value of the infer kwarg at a sample site to config_fn(site).
+
+    :param fn: a stochastic function (callable containing NumPyro primitive calls)
+    :param config_fn: a callable taking a site and returning an infer dict
+    """
+    def __init__(self, fn=None, config_fn=None):
+        super().__init__(fn)
+        self.config_fn = config_fn
+
+    def process_message(self, msg):
+        if msg["type"] in ("sample", "param"):
+            msg["infer"].update(self.config_fn(msg))
 
 
 class lift(Messenger):

--- a/numpyro/infer/util.py
+++ b/numpyro/infer/util.py
@@ -12,7 +12,7 @@ from jax.flatten_util import ravel_pytree
 import jax.numpy as jnp
 
 import numpyro
-from numpyro.distributions.constraints import _GreaterThan, _Interval, real, real_vector
+from numpyro.distributions import constraints
 from numpyro.distributions.transforms import biject_to
 from numpyro.distributions.util import is_identically_one, sum_rightmost
 from numpyro.handlers import seed, substitute, trace
@@ -118,9 +118,23 @@ def _unconstrain_reparam(params, site):
     if name in params:
         p = params[name]
         support = site['fn'].support
-        if support in [real, real_vector]:
-            return p
         t = biject_to(support)
+        # in scan, we might only want to substitute an item at index i, rather than the whole sequence
+        i = site['infer'].get('_scan_current_index', None)
+        if i is not None:
+            # TODO: leverage t.input_event_dim, t.output_event_dim when they are available
+            if support in (constraints.corr_cholesky, constraints.corr_matrix,
+                           constraints.positive_definite, constraints.lower_cholesky):
+                event_dim_shift = 1
+            else:
+                event_dim_shift = 0
+            expected_unconstrained_dim = len(site["fn"].shape()) - event_dim_shift
+            # check if p has additional time dimension
+            if jnp.ndim(p) > expected_unconstrained_dim:
+                p = p[i]
+
+        if support in [constraints.real, constraints.real_vector]:
+            return p
         value = t(p)
 
         log_det = t.log_abs_det_jacobian(p, value)
@@ -278,9 +292,9 @@ def _get_model_transforms(model, model_args=(), model_kwargs=None):
                 inv_transforms[k] = biject_to(support)
                 # XXX: the following code filters out most situations with dynamic supports
                 args = ()
-                if isinstance(support, _GreaterThan):
+                if isinstance(support, constraints._GreaterThan):
                     args = ('lower_bound',)
-                elif isinstance(support, _Interval):
+                elif isinstance(support, constraints._Interval):
                     args = ('lower_bound', 'upper_bound')
                 for arg in args:
                     if not isinstance(getattr(support, arg), (int, float)):

--- a/test/contrib/test_control_flow.py
+++ b/test/contrib/test_control_flow.py
@@ -103,9 +103,9 @@ def test_scan_constrain_reparam_compatible():
     T = 10
     params = {}
     for i in range(T):
-        params[f'x_{i}'] = i + 1.
-        params[f'y_{i}'] = -i
-    fun_params = {'x': jnp.arange(1, T + 1), 'y': -jnp.arange(T)}
+        params[f'x_{i}'] = (i + 1.) / 10
+        params[f'y_{i}'] = -i / 5
+    fun_params = {'x': jnp.arange(1, T + 1) / 10, 'y': -jnp.arange(T) / 5}
     actual_log_joint = potential_energy(fun_model, (T,), {}, fun_params)
     expected_log_joint = potential_energy(model, (T,), {}, params)
-    assert_allclose(actual_log_joint, expected_log_joint, rtol=1e-5)
+    assert_allclose(actual_log_joint, expected_log_joint)

--- a/test/contrib/test_control_flow.py
+++ b/test/contrib/test_control_flow.py
@@ -4,7 +4,7 @@
 from numpy.testing import assert_allclose
 import pytest
 
-import jax
+from jax import random
 import jax.numpy as jnp
 
 import numpyro
@@ -12,6 +12,7 @@ from numpyro.contrib.control_flow.scan import scan
 import numpyro.distributions as dist
 from numpyro.handlers import seed, substitute, trace
 from numpyro.infer import MCMC, NUTS, Predictive
+from numpyro.infer.util import potential_energy
 
 
 def test_scan():
@@ -37,7 +38,7 @@ def test_scan():
     num_samples = 100
     kernel = NUTS(model)
     mcmc = MCMC(kernel, 100, num_samples)
-    mcmc.run(jax.random.PRNGKey(0), T=T)
+    mcmc.run(random.PRNGKey(0), T=T)
     assert set(mcmc.get_samples()) == {'x', 'y', 'y2', 'x_0', 'y_0'}
     mcmc.print_summary()
 
@@ -48,7 +49,7 @@ def test_scan():
     future = 5
     predictive = Predictive(numpyro.handlers.condition(model, {'x': x}),
                             samples, return_sites=['x', 'y', 'y2'], parallel=True)
-    result = predictive(jax.random.PRNGKey(1), T=T + future)
+    result = predictive(random.PRNGKey(1), T=T + future)
     expected_shape = (num_samples, T + future)
     assert result['x'].shape == expected_shape
     assert result['y'].shape == expected_shape
@@ -78,3 +79,33 @@ def test_nested_scan_smoke():
     with trace(), seed(rng_seed=0), substitute(data={"z": data}):
         zs = model()
     assert_allclose(zs, data)
+
+
+def test_scan_constrain_reparam_compatible():
+    def model(T, q=1, r=1, phi=0., beta=0.):
+        x = 0.
+        mu = 0.
+        for i in range(T):
+            x = numpyro.sample(f'x_{i}', dist.LogNormal(phi * x, q))
+            mu = beta * mu + x
+            numpyro.sample(f'y_{i}', dist.Normal(mu, r))
+
+    def fun_model(T, q=1, r=1, phi=0., beta=0.):
+        def transition(state, i):
+            x, mu = state
+            x = numpyro.sample('x', dist.LogNormal(phi * x, q))
+            mu = beta * mu + x
+            numpyro.sample('y', dist.Normal(mu, r))
+            return (x, mu), None
+
+        scan(transition, (0., 0.), jnp.arange(T))
+
+    T = 10
+    params = {}
+    for i in range(T):
+        params[f'x_{i}'] = i + 1.
+        params[f'y_{i}'] = -i
+    fun_params = {'x': jnp.arange(1, T + 1), 'y': -jnp.arange(T)}
+    actual_log_joint = potential_energy(fun_model, (T,), {}, fun_params)
+    expected_log_joint = potential_energy(model, (T,), {}, params)
+    assert_allclose(actual_log_joint, expected_log_joint, rtol=1e-5)


### PR DESCRIPTION
Currently, at each scan step, we transform and compute logdet of the whole unconstrained values. This both wastes computation resources because we only need to transform a particular value at the current time step and gives wrong results because logdet is counted multiple times. This PR addresses that issue and adds a regression test.

I also move `infer_config` out of `contrib` to avoid depending on `funsor`. In addition, it seems that this handler is also useful outside of funsor context. (note that we also have `poutine.infer_config` in Pyro).