### PR TITLE
Fixed bandwidth for RBF kernel and test cases

### DIFF
--- a/numpyro/infer/einstein/kernels.py
+++ b/numpyro/infer/einstein/kernels.py
@@ -313,10 +313,7 @@ class PrecondMatrixKernel(SteinKernel):
             qs = jnp.expand_dims(jnp.mean(qs, axis=0), axis=0)
         qs_inv = jnp.linalg.inv(qs)
         qs_sqrt = sqrth(qs)
-
         qs_inv_sqrt = sqrth(qs_inv)
-
-        # qs_sqrt, qs_inv, qs_inv_sqrt = sqrth_and_inv_sqrth(qs)
         inner_kernel = self.inner_kernel_fn.compute(particles, particle_info, loss_fn)
 
         def kernel(x, y):

--- a/numpyro/infer/einstein/kernels.py
+++ b/numpyro/infer/einstein/kernels.py
@@ -85,10 +85,7 @@ class RBFKernel(SteinKernel):
             diff_norms = safe_norm(diffs, ord=2, axis=-1)
         else:
             diff_norms = diffs
-        median = jnp.argsort(diff_norms)[int(diffs.shape[0] / 2)]
-        bandwidth = jnp.abs(diffs)[median] ** 2 * factor + 1e-5
-        if self._normed():
-            bandwidth = bandwidth[0]
+        bandwidth = jnp.median(diff_norms) ** 2 * factor + 1e-5
 
         def kernel(x, y):
             diff = safe_norm(x - y, ord=2) if self._normed() and x.ndim >= 1 else x - y
@@ -316,7 +313,10 @@ class PrecondMatrixKernel(SteinKernel):
             qs = jnp.expand_dims(jnp.mean(qs, axis=0), axis=0)
         qs_inv = jnp.linalg.inv(qs)
         qs_sqrt = sqrth(qs)
+
         qs_inv_sqrt = sqrth(qs_inv)
+
+        # qs_sqrt, qs_inv, qs_inv_sqrt = sqrth_and_inv_sqrth(qs)
         inner_kernel = self.inner_kernel_fn.compute(particles, particle_info, loss_fn)
 
         def kernel(x, y):

--- a/test/test_einstein_kernels.py
+++ b/test/test_einstein_kernels.py
@@ -15,9 +15,10 @@ from numpyro.infer.einstein.kernels import (
     PrecondMatrixKernel
 )
 
+jnp.set_printoptions(precision=100)
 T = namedtuple('TestSteinKernel', ['kernel', 'particle_info', 'loss_fn', 'kval'])
 
-PARTICLES_2D = jnp.array([[1., 2.], [-10., 10.], [0., 0.], [2., -1]])
+PARTICLES_2D = jnp.array([[1., 2.], [-10., 10.], [7., 3.], [2., -1]])
 
 TPARTICLES_2D = (jnp.array([1., 2.]), jnp.array([10., 5.]))  # transformed particles
 
@@ -25,15 +26,15 @@ TEST_CASES = [
     T(RBFKernel,
       lambda d: {},
       lambda x: x,
-      {'norm': 3.8147664e-06,
-       'vector': jnp.array([0., 0.2500005]),
-       'matrix': jnp.array([[3.8147664e-06, 0.],
-                            [0., 3.8147664e-06]])}
+      {'norm': 0.040711474,
+       'vector': jnp.array([0.056071877, 0.7260586]),
+       'matrix': jnp.array([[0.040711474, 0.],
+                            [0., 0.040711474]])}
       ),
     T(RandomFeatureKernel,
       lambda d: {},
       lambda x: x,
-      {'norm': -4.566867}),
+      {'norm': 12.190277}),
     T(IMQKernel,
       lambda d: {},
       lambda x: x,
@@ -48,20 +49,20 @@ TEST_CASES = [
     T(lambda mode: MixtureKernel(mode=mode, ws=jnp.array([.2, .8]), kernel_fns=[RBFKernel(mode), RBFKernel(mode)]),
       lambda d: {},
       lambda x: x,
-      {'matrix': jnp.array([[3.8147664e-06, 0.],
-                            [0., 3.8147664e-06]])}
+      {'matrix': jnp.array([[0.040711474, 0.],
+                            [0., 0.040711474]])}
       ),
     T(lambda mode: GraphicalKernel(mode=mode, local_kernel_fns={'p1': RBFKernel('norm')}),
       lambda d: {'p1': (0, d)},
       lambda x: x,
-      {'matrix': jnp.array([[3.8147664e-06, 0.],
-                            [0., 3.8147664e-06]])}
+      {'matrix': jnp.array([[0.040711474, 0.],
+                            [0., 0.040711474]])}
       ),
-    T(lambda mode: PrecondMatrixKernel(HessianPrecondMatrix(), RBFKernel(mode='matrix')),
+    T(lambda mode: PrecondMatrixKernel(HessianPrecondMatrix(), RBFKernel(mode='matrix'), precond_mode='const'),
       lambda d: {},
-      lambda x: x[0] ** 4 - x[1] ** 3 / 2,
-      {'matrix': jnp.array([[5.608312e-09, 0.],
-                            [0., 9.347186e-05]])}
+      lambda x: -.02 / 12 * x[0] ** 4 - .5 / 12 * x[1] ** 4 - x[0] * x[1],  # -hess = [[.02x_0^2 1] [1 .5x_1^2]]
+      {'matrix': jnp.array([[2.3780507e-04, - 1.6688075e-05],
+                            [-1.6688075e-05, 1.2849815e-05]])}
       )
 ]
 
@@ -79,5 +80,6 @@ def test_kernel_forward(kernel, particles, particle_info, loss_fn, tparticles, m
     d, = tparticles[0].shape
     kernel_fn = kernel(mode=mode).compute(particles, particle_info(d), loss_fn)
     value = kernel_fn(*tparticles)
+    print(value)
 
     assert_allclose(value, kval[mode])

--- a/test/test_einstein_kernels.py
+++ b/test/test_einstein_kernels.py
@@ -80,6 +80,5 @@ def test_kernel_forward(kernel, particles, particle_info, loss_fn, tparticles, m
     d, = tparticles[0].shape
     kernel_fn = kernel(mode=mode).compute(particles, particle_info(d), loss_fn)
     value = kernel_fn(*tparticles)
-    print(value)
 
     assert_allclose(value, kval[mode])


### PR DESCRIPTION
This PR fixes the test cases to be consistent with the assumptions for Stein kernels. The Precondition Kernel is now tested for the constant case as it is simpler to verify the computation manually.

@fehiepsi checked with #842 and this now works as expected.