### PR TITLE
Add various discrete gibbs functions method

### DIFF
--- a/numpyro/infer/hmc_gibbs.py
+++ b/numpyro/infer/hmc_gibbs.py
@@ -156,12 +156,13 @@ class HMCGibbs(MCMCKernel):
         return HMCGibbsState(z, hmc_state, rng_key)
 
 
-def _discrete_step(rng_key, z_discrete, pe, potential_fn, idx, support_size):
+def _discrete_gibbs_step(rng_key, z_discrete, pe, potential_fn, idx, support_size):
     # idx: current index of `z_discrete_flat` to update
     # support_size: support size of z_discrete at the index idx
 
     # get z proposal
     z_discrete_flat, unravel_fn = ravel_pytree(z_discrete)
+    pe_0 = pe
 
     # XXX: we can't vmap potential_fn over all proposals and sample from the conditional
     # categorical distribution because support_size is a traced value, i.e. its value
@@ -169,29 +170,92 @@ def _discrete_step(rng_key, z_discrete, pe, potential_fn, idx, support_size):
     # so here we will loop over all proposals and use an online scheme to sample from
     # the conditional categorical distribution
     def body_fn(i, val):
-        rng_key, z, pe, weight_logsumexp = val
-        rng_key, rng_accept = random.split(rng_key)
+        rng_key, z, pe, log_weight_sum = val
+        rng_key, rng_transition = random.split(rng_key)
         proposal = jnp.where(i >= z_discrete_flat[idx], i + 1, i)
         z_new_flat = ops.index_update(z_discrete_flat, idx, proposal)
         z_new = unravel_fn(z_new_flat)
         pe_new = potential_fn(z_new)
-        weight_new = pe - pe_new
+        log_weight_new = pe_0 - pe_new
         # Handles the NaN case...
-        weight_new = jnp.where(jnp.isfinite(weight_new), weight_new, -jnp.inf)
+        log_weight_new = jnp.where(jnp.isfinite(log_weight_new), log_weight_new, -jnp.inf)
         # transition_prob = e^weight_new / (e^weight_logsumexp + e^weight_new)
-        transition_prob = expit(weight_new - weight_logsumexp)
-        z, pe = cond(random.bernoulli(rng_accept, transition_prob),
+        transition_prob = expit(log_weight_new - log_weight_sum)
+        z, pe = cond(random.bernoulli(rng_transition, transition_prob),
                      (z_new, pe_new), identity,
                      (z, pe), identity)
-        weight_logsumexp = jnp.logaddexp(weight_new, weight_logsumexp)
-        return rng_key, z, pe, weight_logsumexp
+        log_weight_sum = jnp.logaddexp(log_weight_new, log_weight_sum)
+        return rng_key, z, pe, log_weight_sum
 
     init_val = (rng_key, z_discrete, pe, jnp.array(0.))
-    rng_key, z, pe, _ = fori_loop(0, support_size - 1, body_fn, init_val)
-    return rng_key, z, pe
+    rng_key, z_new, pe_new, _ = fori_loop(0, support_size - 1, body_fn, init_val)
+    log_accept_ratio = jnp.array(0.)
+    return rng_key, z_new, pe_new, log_accept_ratio
 
 
-def discrete_gibbs_fn(model, *model_args, **model_kwargs):
+def _discrete_modified_gibbs_step(rng_key, z_discrete, pe, potential_fn, idx, support_size, stay_prob=0.):
+    z_discrete_flat, unravel_fn = ravel_pytree(z_discrete)
+    pe_0 = pe
+
+    def body_fn(i, val):
+        rng_key, z, pe, log_weight_sum = val
+        rng_key, rng_transition = random.split(rng_key)
+        proposal = jnp.where(i >= z_discrete_flat[idx], i + 1, i)
+        z_new_flat = ops.index_update(z_discrete_flat, idx, proposal)
+        z_new = unravel_fn(z_new_flat)
+        pe_new = potential_fn(z_new)
+        log_weight_new = pe_0 - pe_new
+        # Handles the NaN case...
+        log_weight_new = jnp.where(jnp.isfinite(log_weight_new), log_weight_new, -jnp.inf)
+        # transition_prob = e^weight_new / (e^weight_logsumexp + e^weight_new)
+        transition_prob = expit(log_weight_new - log_weight_sum)
+        z, pe = cond(random.bernoulli(rng_transition, transition_prob),
+                     (z_new, pe_new), identity,
+                     (z, pe), identity)
+        weight_logsumexp = jnp.logaddexp(log_weight_new, log_weight_sum)
+        return rng_key, z, pe, weight_logsumexp
+
+    # like gibbs_step but here, weight of the current value is 0
+    init_val = (rng_key, z_discrete, pe, jnp.array(-jnp.inf))
+    rng_key, z_new, pe_new, log_weight_sum = fori_loop(0, support_size - 1, body_fn, init_val)
+    rng_key, rng_stay = random.split(rng_key)
+    z_new, pe_new = cond(random.bernoulli(rng_stay, stay_prob),
+                         (z_discrete, pe), identity,
+                         (z_new, pe_new), identity)
+    # here we calculate the MH correction: (1 - P(z)) / (1 - P(z_new))
+    # where 1 - P(z) ~ weight_sum
+    # and 1 - P(z_new) ~ 1 + weight_sum - z_new_weight
+    log_accept_ratio = log_weight_sum - jnp.log(jnp.exp(log_weight_sum) - jnp.expm1(pe - pe_new))
+    return rng_key, z_new, pe_new, log_accept_ratio
+
+
+def _discrete_rw_step(rng_key, z_discrete, pe, potential_fn, idx, support_size):
+    rng_key, rng_proposal, rng_accept = random.split(rng_key, 3)
+    z_discrete_flat, unravel_fn = ravel_pytree(z_discrete)
+
+    proposal = random.randint(rng_proposal, (), minval=0, maxval=support_size)
+    z_new_flat = ops.index_update(z_discrete_flat, idx, proposal)
+    z_new = unravel_fn(z_new_flat)
+    pe_new = potential_fn(z_new)
+    log_accept_ratio = pe - pe_new
+    return rng_key, z_new, pe_new, log_accept_ratio
+
+
+def _discrete_modified_rw_step(rng_key, z_discrete, pe, potential_fn, idx, support_size, stay_prob=0.):
+    rng_key, rng_proposal, rng_stay = random.split(rng_key, 3)
+    z_discrete_flat, unravel_fn = ravel_pytree(z_discrete)
+
+    i = random.randint(rng_proposal, (), minval=0, maxval=support_size - 1)
+    proposal = jnp.where(i >= z_discrete_flat[idx], i + 1, i)
+    proposal = jnp.where(random.bernoulli(rng_stay, stay_prob), idx, proposal)
+    z_new_flat = ops.index_update(z_discrete_flat, idx, proposal)
+    z_new = unravel_fn(z_new_flat)
+    pe_new = potential_fn(z_new)
+    log_accept_ratio = pe - pe_new
+    return rng_key, z_new, pe_new, log_accept_ratio
+
+
+def discrete_gibbs_fn(model, model_args=(), model_kwargs={}, *, random_walk=False, stay_prob=None):
     """
     [EXPERIMENTAL INTERFACE]
 
@@ -200,6 +264,25 @@ def discrete_gibbs_fn(model, *model_args, **model_kwargs):
 
     Note that those discrete latent sites that are not specified in the constructor of
     :class:`HMCGibbs` will be marginalized out by default (if they have enumerate supports).
+
+    :param callable model: a callable with NumPyro primitives. This should be the same model
+        as the one used in the `inner_kernel` of :class:`HMCGibbs`.
+    :param tuple model_args: Arguments provided to the model.
+    :param dict model_kwargs: Keyword arguments provided to the model.
+    :param bool random_walk: If False, Gibbs sampling will be used to draw a sample from the
+        conditional `p(gibbs_site | remaining sites)`. Otherwise, a sample will be drawn uniformly
+        from the domain of `gibbs_site`.
+    :param float stay_prob: if not None, propose a new sample with
+        - probability to stay at the current value is `stay_prob`
+        - probability to move to a new value is scaled down by `(1 - stay_prob)`
+        The special case `stay_prob=0.`, which is suggested in reference [1], appears in literature
+        under the name "modified Gibbs sampler" or "Metropolised Gibbs sampler".
+    :return: a callable `gibbs_fn` to be used in :class:`HMCGibbs
+
+    **References:**
+
+    1. *Peskun's theorem and a modified discrete-state Gibbs sampler*,
+       Liu, J. S. (1996)
 
     **Example**
 
@@ -217,13 +300,11 @@ def discrete_gibbs_fn(model, *model_args, **model_kwargs):
         ...
         >>> probs = jnp.array([0.15, 0.3, 0.3, 0.25])
         >>> locs = jnp.array([-2, 0, 2, 4])
-        >>> gibbs_fn = discrete_gibbs_fn(model, probs, locs)
+        >>> gibbs_fn = discrete_gibbs_fn(model, (probs, locs))
         >>> kernel = HMCGibbs(NUTS(model), gibbs_fn, gibbs_sites=["c"])
         >>> mcmc = MCMC(kernel, 1000, 100000, progress_bar=False)
         >>> mcmc.run(random.PRNGKey(0), probs, locs)
-        >>> samples = mcmc.get_samples()["x"]
-        >>> assert abs(jnp.mean(samples) - 1.3) < 0.1
-        >>> assert abs(jnp.var(samples) - 4.36) < 0.5
+        >>> mcmc.print_summary()  # doctest: +SKIP
 
     """
     # NB: all of the information such as `model`, `model_args`, `model_kwargs`
@@ -236,6 +317,18 @@ def discrete_gibbs_fn(model, *model_args, **model_kwargs):
         if site["type"] == "sample" and site["fn"].has_enumerate_support and not site["is_observed"]
     }
     max_plate_nesting = _guess_max_plate_nesting(prototype_trace)
+    if random_walk:
+        if stay_prob is not None:
+            assert isinstance(stay_prob, float) and (stay_prob >= 0) and (stay_prob < 1)
+            step_fn = partial(_discrete_modified_rw_step, stay_prob=stay_prob)
+        else:
+            step_fn = _discrete_rw_step
+    else:
+        if stay_prob is not None:
+            assert isinstance(stay_prob, float) and (stay_prob >= 0) and (stay_prob < 1)
+            step_fn = partial(_discrete_modified_gibbs_step, stay_prob=stay_prob)
+        else:
+            step_fn = _discrete_gibbs_step
 
     def gibbs_fn(rng_key, gibbs_sites, hmc_sites):
         # convert to unconstrained values
@@ -249,8 +342,9 @@ def discrete_gibbs_fn(model, *model_args, **model_kwargs):
             wrapped_model = enum(config_enumerate(wrapped_model), -max_plate_nesting - 1)
 
         def potential_fn(z_discrete):
-            model_kwargs["_gibbs_sites"] = z_discrete
-            return potential_energy(wrapped_model, model_args, model_kwargs, z_hmc, enum=use_enum)
+            model_kwargs_ = model_kwargs.copy()
+            model_kwargs_["_gibbs_sites"] = z_discrete
+            return potential_energy(wrapped_model, model_args, model_kwargs_, z_hmc, enum=use_enum)
 
         # get support_sizes of gibbs_sites
         support_sizes_flat, _ = ravel_pytree({k: support_sizes[k] for k in gibbs_sites})
@@ -262,7 +356,16 @@ def discrete_gibbs_fn(model, *model_args, **model_kwargs):
         def body_fn(i, val):
             idx = idxs[i]
             support_size = support_sizes_flat[idx]
-            return _discrete_step(*val, potential_fn=potential_fn, idx=idx, support_size=support_size)
+            rng_key, z, pe = val
+            rng_key, z_new, pe_new, log_accept_ratio = step_fn(
+                rng_key, z, pe, potential_fn=potential_fn, idx=idx, support_size=support_size)
+            rng_key, rng_accept = random.split(rng_key)
+            # u ~ Uniform(0, 1), u < accept_ratio => -log(u) > -log_accept_ratio
+            # and -log(u) ~ exponential(1)
+            z, pe = cond(random.exponential(rng_accept) > -log_accept_ratio,
+                         (z_new, pe_new), identity,
+                         (z, pe), identity)
+            return rng_key, z, pe
 
         init_val = (rng_key, gibbs_sites, potential_fn(gibbs_sites))
         _, gibbs_sites, _ = fori_loop(0, num_discretes, body_fn, init_val)
@@ -271,7 +374,7 @@ def discrete_gibbs_fn(model, *model_args, **model_kwargs):
     return gibbs_fn
 
 
-def subsample_gibbs_fn(model, *model_args, **model_kwargs):
+def subsample_gibbs_fn(model, model_args=(), model_kwargs={}):
     """
     [EXPERIMENTAL INTERFACE]
 
@@ -286,6 +389,12 @@ def subsample_gibbs_fn(model, *model_args, **model_kwargs):
        Dang, K. D., Quiroz, M., Kohn, R., Minh-Ngoc, T., & Villani, M. (2019)
     2. *Speeding Up MCMC by Efficient Data Subsampling*,
        Quiroz, M., Kohn, R., Villani, M., & Tran, M. N. (2018)
+
+    :param callable model: a callable with NumPyro primitives. This should be the same model
+        as the one used in the `inner_kernel` of :class:`HMCGibbs`.
+    :param tuple model_args: Arguments provided to the model.
+    :param dict model_kwargs: Keyword arguments provided to the model.
+    :return: a callable `gibbs_fn` to be used in :class:`HMCGibbs
 
     **Example**
 
@@ -304,7 +413,7 @@ def subsample_gibbs_fn(model, *model_args, **model_kwargs):
         ...         numpyro.sample("obs", dist.Normal(x, 1), obs=batch)
         ...
         >>> data = random.normal(random.PRNGKey(0), (10000,)) + 1
-        >>> gibbs_fn = subsample_gibbs_fn(model, data)
+        >>> gibbs_fn = subsample_gibbs_fn(model, (data,))
         >>> kernel = HMCGibbs(NUTS(model), gibbs_fn, gibbs_sites=["N"])
         >>> mcmc = MCMC(kernel, 1000, 1000)
         >>> mcmc.run(random.PRNGKey(0), data)

--- a/test/test_hmc_gibbs.py
+++ b/test/test_hmc_gibbs.py
@@ -176,13 +176,13 @@ def test_discrete_gibbs_enum():
 
 
 @pytest.mark.parametrize("random_walk", [False, True])
-@pytest.mark.parametrize("stay_prob", [None, 0., 0.2])
-def test_discrete_gibbs_bernoulli(random_walk, stay_prob):
+@pytest.mark.parametrize("modified", [False, True])
+def test_discrete_gibbs_bernoulli(random_walk, modified):
 
     def model():
         numpyro.sample("c", dist.Bernoulli(0.8))
 
-    gibbs_fn = discrete_gibbs_fn(model, random_walk=random_walk, stay_prob=stay_prob)
+    gibbs_fn = discrete_gibbs_fn(model, random_walk=random_walk, modified=modified)
     kernel = HMCGibbs(NUTS(model), gibbs_fn, gibbs_sites=["c"])
     mcmc = MCMC(kernel, 1000, 200000, progress_bar=False)
     mcmc.run(random.PRNGKey(0))
@@ -190,8 +190,8 @@ def test_discrete_gibbs_bernoulli(random_walk, stay_prob):
     assert_allclose(jnp.mean(samples), 0.8, atol=0.05)
 
 
-@pytest.mark.parametrize("stay_prob", [None, 0., 0.2])
-def test_discrete_gibbs_gmm_1d(stay_prob):
+@pytest.mark.parametrize("modified", [False, True])
+def test_discrete_gibbs_gmm_1d(modified):
 
     def model(probs, locs):
         c = numpyro.sample("c", dist.Categorical(probs))
@@ -199,7 +199,7 @@ def test_discrete_gibbs_gmm_1d(stay_prob):
 
     probs = jnp.array([0.15, 0.3, 0.3, 0.25])
     locs = jnp.array([-2, 0, 2, 4])
-    gibbs_fn = discrete_gibbs_fn(model, (probs, locs), stay_prob=stay_prob)
+    gibbs_fn = discrete_gibbs_fn(model, (probs, locs), modified=modified)
     kernel = HMCGibbs(NUTS(model), gibbs_fn, gibbs_sites=["c"])
     mcmc = MCMC(kernel, 1000, 200000, progress_bar=False)
     mcmc.run(random.PRNGKey(0), probs, locs)

--- a/test/test_hmc_gibbs.py
+++ b/test/test_hmc_gibbs.py
@@ -173,3 +173,38 @@ def test_discrete_gibbs_enum():
     mcmc.run(random.PRNGKey(0))
     samples = mcmc.get_samples()
     assert_allclose(jnp.mean(samples["y"], 0), 0.3 * 10, atol=0.1)
+
+
+@pytest.mark.parametrize("random_walk", [False, True])
+@pytest.mark.parametrize("stay_prob", [None, 0., 0.2])
+def test_discrete_gibbs_bernoulli(random_walk, stay_prob):
+
+    def model():
+        numpyro.sample("c", dist.Bernoulli(0.8))
+
+    gibbs_fn = discrete_gibbs_fn(model, random_walk=random_walk, stay_prob=stay_prob)
+    kernel = HMCGibbs(NUTS(model), gibbs_fn, gibbs_sites=["c"])
+    mcmc = MCMC(kernel, 1000, 200000, progress_bar=False)
+    mcmc.run(random.PRNGKey(0))
+    samples = mcmc.get_samples()["c"]
+    assert_allclose(jnp.mean(samples), 0.8, atol=0.05)
+
+
+@pytest.mark.parametrize("stay_prob", [None, 0., 0.2])
+def test_discrete_gibbs_gmm_1d(stay_prob):
+
+    def model(probs, locs):
+        c = numpyro.sample("c", dist.Categorical(probs))
+        numpyro.sample("x", dist.Normal(locs[c], 0.5))
+
+    probs = jnp.array([0.15, 0.3, 0.3, 0.25])
+    locs = jnp.array([-2, 0, 2, 4])
+    gibbs_fn = discrete_gibbs_fn(model, (probs, locs), stay_prob=stay_prob)
+    kernel = HMCGibbs(NUTS(model), gibbs_fn, gibbs_sites=["c"])
+    mcmc = MCMC(kernel, 1000, 200000, progress_bar=False)
+    mcmc.run(random.PRNGKey(0), probs, locs)
+    samples = mcmc.get_samples()
+    assert_allclose(jnp.mean(samples["x"]), 1.3, atol=0.1)
+    assert_allclose(jnp.var(samples["x"]), 4.36, atol=0.1)
+    assert_allclose(jnp.mean(samples["c"]), 1.65, atol=0.1)
+    assert_allclose(jnp.var(samples["c"]), 1.03, atol=0.1)


### PR DESCRIPTION
### Motivation

+ PyMC3 supports [2 methods](https://docs.pymc.io/api/inference.html#pymc3.step_methods.metropolis.CategoricalGibbsMetropolis): `random_walk=True or False` (corresponding to uniform proposal and proportional proposal there) with `modified=True` (i.e. modified Gibbs)
+ In Mixed-HMC, [various proposals](https://github.com/StannisZhou/mixed_hmc/blob/master/momentum/hmc/mixed_hmc_jax.py#L166) are used: besides the above 2 methods, the original Gibbs is also used (i.e. `random_walk=False, modified=False`).

To benchmark against those frameworks, I added options to switch between them.

### API changes

+ new keyword `random_walk` and `modified` are introduced
+ model_args and model_kwargs are arguments of `discrete_gibbs_fn` and `subsample_gibbs_fn`. This allows us more flexibility to add options for future enhancements (e.g. there are various subsample methods) without having to introduce a new `foo_gibbs_fn`.

### Implementation changes

+ The hidden method `_discrete_foo_proposal` is revised to return only the proposal and its corresponding `log_accept_ratio`, and not perform MH acceptance/rejection. The reason is in a sequential scheme of mixed-hmc, that accept_ratio information is needed to adjust the current kinetic energy and I would like to reuse those functions instead of reimplementing them in mixed hmc.