### PR TITLE
Address memory leak of postprocess_fn and lax.map

### DIFF
--- a/numpyro/infer/mcmc.py
+++ b/numpyro/infer/mcmc.py
@@ -288,10 +288,7 @@ class MCMC(object):
 
             def laxmap_postprocess_fn(states, args, kwargs):
                 if self.postprocess_fn is None:
-                    if self._jit_model_args:
-                        body_fn = self.sampler.postprocess_fn(args, kwargs)
-                    else:
-                        body_fn = sampler_postprocess_fn
+                    body_fn = self.sampler.postprocess_fn(args, kwargs)
                 else:
                     body_fn = self.postprocess_fn
                 if self.chain_method == "vectorized" and self.num_chains > 1:
@@ -305,7 +302,6 @@ class MCMC(object):
             else:
                 sample_fn = partial(_sample_fn_nojit_args, sampler=self.sampler,
                                     args=self._args, kwargs=self._kwargs)
-                sampler_postprocess_fn = self.sampler.postprocess_fn(self._args, self._kwargs)
                 postprocess_fn = jit(partial(laxmap_postprocess_fn,
                                              args=self._args, kwargs=self._kwargs))
 


### PR DESCRIPTION
Resolves #448 and #539.

```python
import gc
from collections import Counter

import numpy as np

from numpyro import sample
import numpyro.distributions as dist
from jax import random, vmap
from numpyro.infer import MCMC, NUTS


def model(y_obs):
    mu = sample('mu', dist.Normal(0., 1.))
    sigma = sample("sigma", dist.HalfCauchy(3.))
    y = sample("y", dist.Normal(mu, sigma), obs=y_obs)

kernel = NUTS(model)
mcmc = MCMC(kernel, 1, 2)
for i in range(10):
    mcmc.run(random.PRNGKey(i), np.zeros((1,)))
    print("\nGC OBJECTS:")
    cnt = Counter()
    # force collection; it is expected that count of different types
    # should not increase per iteration
    gc.collect()
    for x in gc.get_objects():
        if isinstance(x, list):
            if len(x) > 1:
                cnt[type(x[0])] += 1
    print(cnt.most_common(10))
```
returns
```
GC OBJECTS:
[(<class 'str'>, 1555), (<class 'jax.core.Var'>, 1502), (<class 'tuple'>, 263), (<class 'jax.core.JaxprEqn'>, 252), (<class 'int'>, 85), (<class 'jax.core.ShapedArray'>, 64), (<class 'jax.core.Literal'>, 52), (<class 'set'>, 29), (<class 'argparse._ArgumentGroup'>, 19), (<class 'IPython.core.magic_arguments.argument'>, 18)]

GC OBJECTS:
[(<class 'str'>, 1555), (<class 'jax.core.Var'>, 1502), (<class 'tuple'>, 263), (<class 'jax.core.JaxprEqn'>, 252), (<class 'int'>, 85), (<class 'jax.core.ShapedArray'>, 64), (<class 'jax.core.Literal'>, 52), (<class 'set'>, 29), (<class 'argparse._ArgumentGroup'>, 19), (<class 'IPython.core.magic_arguments.argument'>, 18)]
```
consistently.

The reason for the leak is: a new `postprocess_fn` is created each time `.run` is called, so `lax.map(postprocess_fn,...)` involves a new JAX cache each time it is run.

@rexdouglass Could you help me verify this change in a large model that you have? I'm not sure if we leave some things behind the change.