### PR TITLE
Expose some mcmc states for sequential sampling strategy

### DIFF
--- a/numpyro/distributions/discrete.py
+++ b/numpyro/distributions/discrete.py
@@ -53,7 +53,7 @@ from numpyro.util import not_jax_tracer
 
 
 def _to_probs_bernoulli(logits):
-    return 1 / (1 + jnp.exp(-logits))
+    return expit(logits)
 
 
 def _to_logits_bernoulli(probs):

--- a/numpyro/infer/hmc.py
+++ b/numpyro/infer/hmc.py
@@ -121,12 +121,10 @@ def hmc(potential_fn=None, potential_fn_gen=None, kinetic_fn=None, algo='NUTS'):
 
         >>> true_coefs = jnp.array([1., 2., 3.])
         >>> data = random.normal(random.PRNGKey(2), (2000, 3))
-        >>> dim = 3
         >>> labels = dist.Bernoulli(logits=(true_coefs * data).sum(-1)).sample(random.PRNGKey(3))
         >>>
         >>> def model(data, labels):
-        ...     coefs_mean = jnp.zeros(dim)
-        ...     coefs = numpyro.sample('beta', dist.Normal(coefs_mean, jnp.ones(3)))
+        ...     coefs = numpyro.sample('coefs', dist.Normal(jnp.zeros(3), jnp.ones(3)))
         ...     intercept = numpyro.sample('intercept', dist.Normal(0., 10.))
         ...     return numpyro.sample('y', dist.Bernoulli(logits=(coefs * data + intercept).sum(-1)), obs=labels)
         >>>
@@ -137,7 +135,7 @@ def hmc(potential_fn=None, potential_fn_gen=None, kinetic_fn=None, algo='NUTS'):
         ...                         num_warmup=300)
         >>> samples = fori_collect(0, 500, sample_kernel, hmc_state,
         ...                        transform=lambda state: model_info.postprocess_fn(state.z))
-        >>> print(jnp.mean(samples['beta'], axis=0))  # doctest: +SKIP
+        >>> print(jnp.mean(samples['coefs'], axis=0))  # doctest: +SKIP
         [0.9153987 2.0754058 2.9621222]
     """
     if kinetic_fn is None:

--- a/numpyro/infer/mcmc.py
+++ b/numpyro/infer/mcmc.py
@@ -386,19 +386,17 @@ class MCMC(object):
     @property
     def init_state(self):
         """
-        The initial state to run MCMC. If this attribute is not None,
-        :meth:`run` will skip calling `self.sampler.init(...)` method to
-        obtain the initial state.
+        The initial state of the MCMC chain. If this attribute is None,
+        :meth:`run` will call `self.sampler.init(...)` method for initialization.
 
-        .. warning:: If you want to set a value for this attribute, then making sure
-            that some fields such as `HMCState.i`, `HMCState.mean_accept_prob` are
-            reseted to 0. In addition, if the initial state has invalid fields such as
-            `HMCState.potential_energy` (because e.g. `data` of the new `run` has been
-            changed), the sampler might get trouble during some initial MCMC steps.
-            To resolve that, we can set `potential_energy` to a high value (says `1e38`),
-            so that it is more likely to accept a new proposal (which will have a correct
-            `potential_energy` field) in the first MCMC step.
-            For example
+        .. warning:: If you want to set a value for this attribute, then you will need to make sure
+            that certain fields such as `HMCState.i` and `HMCState.mean_accept_prob` are
+            reset to 0. In addition, if any of the fields of the initial state have invalid values
+            (e.g. `HMCState.potential_energy` may be invalid if `data` of the new `run` has been
+            changed), the sampler might get stuck or otherwise perform suboptimally.
+            To resolve this issue, you can set `potential_energy` to a large value (say `1e38`),
+            so that the sampler is more likely to accept a new proposal in the first MCMC step
+            (and which will have a correct `potential_energy`). For example
 
             .. code-block:: python
 
@@ -420,8 +418,8 @@ class MCMC(object):
     @property
     def warmup_state(self):
         """
-        The state before sampling phase. If this attribute is not None,
-        :meth:`run` will skip warmup phase and start with the state
+        The state before the sampling phase. If this attribute is not None,
+        :meth:`run` will skip the warmup phase and start with the state
         specified in this attribute.
 
         .. note:: This attribute can be used to sequentially draw MCMC samples. For example,
@@ -444,7 +442,7 @@ class MCMC(object):
     @property
     def last_state(self):
         """
-        The state obtained at the end of sampling phase.
+        The final MCMC state at the end of the sampling phase.
         """
         return self._last_state
 

--- a/numpyro/infer/mcmc.py
+++ b/numpyro/infer/mcmc.py
@@ -392,23 +392,24 @@ class MCMC(object):
 
         .. warning:: If you want to set a value for this attribute, then making sure
             that some fields such as `HMCState.i`, `HMCState.mean_accept_prob` are
-            reseted to 0. For example
+            reseted to 0. In addition, if the initial state has invalid fields such as
+            `HMCState.potential_energy` (because e.g. `data` of the new `run` has been
+            changed), the sampler might get trouble during some initial MCMC steps.
+            To resolve that, we can set `potential_energy` to a high value (says `1e38`),
+            so that it is more likely to accept a new proposal (which will have a correct
+            `potential_energy` field) in the first MCMC step.
+            For example
 
             .. code-block:: python
 
                 mcmc = MCMC(NUTS(model), 100, 100)
                 mcmc.run(random.PRNGKey(0), data0)
                 samples_for_data0 = mcmc.get_samples()
-                mcmc.init_state = mcmc.last_state._replace(i=0, mean_accept_prob=0.)
+                mcmc.init_state = mcmc.last_state._replace(
+                    i=0, potential_energy=1e38, mean_accept_prob=0.)
                 mcmc.run(random.PRNGKey(1), data1)
                 samples_for_data1 = mcmc.get_samples()
 
-            In addition, if the initial state has invalid fields such as
-            `HMCState.potential_energy` (because e.g. `data` of the new `run` has been changed),
-            the sampler might get trouble during some initial MCMC steps.
-            To resolve that, we can set `potential_energy` to a high value (says `1e38`),
-            so that it is more likely to accept a new proposal in the
-            first MCMC step.
         """
         return self._init_state
 

--- a/numpyro/infer/mcmc.py
+++ b/numpyro/infer/mcmc.py
@@ -266,7 +266,6 @@ class MCMC(object):
         # HMCState returned by last warmup
         self._warmup_state = None
         # HMCState returned by hmc.init_kernel
-        self._init_state = None
         self._init_state_cache = {}
         self._cache = {}
         self._collection_params = {}
@@ -384,39 +383,7 @@ class MCMC(object):
             pass
 
     @property
-    def init_state(self):
-        """
-        The initial state of the MCMC chain. If this attribute is None,
-        :meth:`run` will call `self.sampler.init(...)` method for initialization.
-
-        .. warning:: If you want to set a value for this attribute, then you will need to make sure
-            that certain fields such as `HMCState.i` and `HMCState.mean_accept_prob` are
-            reset to 0. In addition, if any of the fields of the initial state have invalid values
-            (e.g. `HMCState.potential_energy` may be invalid if `data` of the new `run` has been
-            changed), the sampler might get stuck or otherwise perform suboptimally.
-            To resolve this issue, you can set `potential_energy` to a large value (say `1e38`),
-            so that the sampler is more likely to accept a new proposal in the first MCMC step
-            (and which will have a correct `potential_energy`). For example
-
-            .. code-block:: python
-
-                mcmc = MCMC(NUTS(model), 100, 100)
-                mcmc.run(random.PRNGKey(0), data0)
-                samples_for_data0 = mcmc.get_samples()
-                mcmc.init_state = mcmc.last_state._replace(
-                    i=0, potential_energy=1e38, mean_accept_prob=0.)
-                mcmc.run(random.PRNGKey(1), data1)
-                samples_for_data1 = mcmc.get_samples()
-
-        """
-        return self._init_state
-
-    @init_state.setter
-    def init_state(self, state):
-        self._init_state = state
-
-    @property
-    def warmup_state(self):
+    def post_warmup_state(self):
         """
         The state before the sampling phase. If this attribute is not None,
         :meth:`run` will skip the warmup phase and start with the state
@@ -429,14 +396,14 @@ class MCMC(object):
                 mcmc = MCMC(NUTS(model), 100, 100)
                 mcmc.run(random.PRNGKey(0))
                 first_100_samples = mcmc.get_samples()
-                mcmc.warmup_state = mcmc.last_state
-                mcmc.run(mcmc.warmup_state.rng_key)  # or mcmc.run(random.PRNGKey(1))
+                mcmc.post_warmup_state = mcmc.last_state
+                mcmc.run(mcmc.post_warmup_state.rng_key)  # or mcmc.run(random.PRNGKey(1))
                 second_100_samples = mcmc.get_samples()
         """
         return self._warmup_state
 
-    @warmup_state.setter
-    def warmup_state(self, state):
+    @post_warmup_state.setter
+    def post_warmup_state(self, state):
         self._warmup_state = state
 
     @property
@@ -505,8 +472,6 @@ class MCMC(object):
         if self._warmup_state is not None:
             self._set_collection_params(0, self.num_samples, self.num_samples, "sample")
             init_state = self._warmup_state._replace(rng_key=rng_key)
-        elif self._init_state is not None:
-            init_state = self._init_state._replace(rng_key=rng_key)
 
         chain_method = self.chain_method
         if chain_method == 'parallel' and xla_bridge.device_count() < self.num_chains:


### PR DESCRIPTION
Resolves #534. This is also requested by @rexdouglass in https://github.com/pyro-ppl/numpyro/issues/539 

This is just a solution, mainly for discussion. I'm not sure if this is a good API so if reviewers have other ideas, please let me know.