### PR TITLE
Warn instead of raising ValueError when substituting a different size subsample indices

### DIFF
--- a/numpyro/primitives.py
+++ b/numpyro/primitives.py
@@ -4,6 +4,7 @@
 from collections import namedtuple
 from contextlib import ExitStack, contextmanager
 import functools
+import warnings
 
 from jax import lax, random
 import jax.numpy as jnp
@@ -289,7 +290,7 @@ class plate(Messenger):
         apply_stack(msg)
         subsample = msg['value']
         if subsample_size is not None and subsample_size != subsample.shape[0]:
-            raise ValueError("subsample_size does not match len(subsample), {} vs {}.".format(
+            warnings.warn("subsample_size does not match len(subsample), {} vs {}.".format(
                 subsample_size, len(subsample)) +
                 " Did you accidentally use different subsample_size in the model and guide?")
         cond_indep_stack = msg['cond_indep_stack']


### PR DESCRIPTION
The motivation is to allow us evaluating log density of the full data, given a model with [subsample](https://github.com/pyro-ppl/numpyro/blob/master/numpyro/infer/hmc_gibbs.py#L395) statement:
```python
def model(data):
     x = numpyro.sample("x", dist.Normal(0, 1))
     with numpyro.plate("N", data.shape[0], subsample_size=100):
         batch = numpyro.subsample(data, event_dim=0)
         numpyro.sample("obs", dist.Normal(x, 1), obs=batch)
```
Currently, I couldn't find a simpler way to achieve that. :(