### PR TITLE
Add constraint event_dim

### DIFF
--- a/numpyro/contrib/tfp/distributions.py
+++ b/numpyro/contrib/tfp/distributions.py
@@ -47,6 +47,10 @@ class BijectorConstraint(constraints.Constraint):
     def __init__(self, bijector):
         self.bijector = bijector
 
+    @property
+    def event_dim(self):
+        return self.bijector.forward_min_event_ndims
+
     def __call__(self, x):
         return self.codomain(x)
 
@@ -64,10 +68,6 @@ class BijectorTransform(Transform):
     """
     def __init__(self, bijector):
         self.bijector = bijector
-
-    @property
-    def event_dim(self):
-        return self.bijector.forward_min_event_ndims
 
     @property
     def domain(self):

--- a/numpyro/contrib/tfp/distributions.py
+++ b/numpyro/contrib/tfp/distributions.py
@@ -84,7 +84,7 @@ class BijectorTransform(Transform):
         return self.bijector.inverse(y)
 
     def log_abs_det_jacobian(self, x, y, intermediates=None):
-        return self.bijector.forward_log_det_jacobian(x, self.event_dim)
+        return self.bijector.forward_log_det_jacobian(x, self.domain.event_dim)
 
 
 @biject_to.register(BijectorConstraint)

--- a/numpyro/contrib/tfp/distributions.py
+++ b/numpyro/contrib/tfp/distributions.py
@@ -80,7 +80,7 @@ class BijectorTransform(Transform):
     def __call__(self, x):
         return self.bijector.forward(x)
 
-    def inv(self, y):
+    def _inverse(self, y):
         return self.bijector.inverse(y)
 
     def log_abs_det_jacobian(self, x, y, intermediates=None):

--- a/numpyro/distributions/constraints.py
+++ b/numpyro/distributions/constraints.py
@@ -62,6 +62,7 @@ class Constraint(object):
     A constraint object represents a region over which a variable is valid,
     e.g. within which a variable can be optimized.
     """
+    event_dim = 0
 
     def __call__(self, x):
         raise NotImplementedError
@@ -89,6 +90,8 @@ class _Boolean(Constraint):
 
 
 class _CorrCholesky(Constraint):
+    event_dim = 2
+
     def __call__(self, x):
         jnp = np if isinstance(x, (np.ndarray, np.generic)) else jax.numpy
         tril = jnp.tril(x)
@@ -103,6 +106,8 @@ class _CorrCholesky(Constraint):
 
 
 class _CorrMatrix(Constraint):
+    event_dim = 2
+
     def __call__(self, x):
         jnp = np if isinstance(x, (np.ndarray, np.generic)) else jax.numpy
         # check for symmetric
@@ -135,6 +140,40 @@ class _GreaterThan(Constraint):
 
     def feasible_like(self, prototype):
         return jax.numpy.broadcast_to(self.lower_bound + 1, jax.numpy.shape(prototype))
+
+
+class _IndependentConstraint(Constraint):
+    """
+    Wraps a constraint by aggregating over ``reinterpreted_batch_ndims``-many
+    dims in :meth:`check`, so that an event is valid only if all its
+    independent entries are valid.
+    """
+    def __init__(self, base_constraint, reinterpreted_batch_ndims):
+        assert isinstance(base_constraint, Constraint)
+        assert isinstance(reinterpreted_batch_ndims, int)
+        assert reinterpreted_batch_ndims >= 0
+        self.base_constraint = base_constraint
+        self.reinterpreted_batch_ndims = reinterpreted_batch_ndims
+        super().__init__()
+
+    @property
+    def event_dim(self):
+        return self.base_constraint.event_dim + self.reinterpreted_batch_ndims
+
+    def __call__(self, value):
+        result = self.base_constraint(value)
+        if self.reinterpreted_batch_ndims == 0:
+            return result
+        elif jax.numpy.ndim(result) < self.reinterpreted_batch_ndims:
+            expected = self.event_dim
+            raise ValueError(f"Expected value.dim() >= {expected} but got {jax.numpy.ndim(value)}")
+        result = result.reshape(
+            jax.numpy.shape(result)[:jax.numpy.ndim(result) - self.reinterpreted_batch_ndims] + (-1,))
+        result = result.all(-1)
+        return result
+
+    def feasible_like(self, prototype):
+        return self.base_constraint.feasible_like(prototype)
 
 
 class _LessThan(Constraint):
@@ -184,6 +223,8 @@ class _Interval(Constraint):
 
 
 class _LowerCholesky(Constraint):
+    event_dim = 2
+
     def __call__(self, x):
         jnp = np if isinstance(x, (np.ndarray, np.generic)) else jax.numpy
         tril = jnp.tril(x)
@@ -196,6 +237,8 @@ class _LowerCholesky(Constraint):
 
 
 class _Multinomial(Constraint):
+    event_dim = 1
+
     def __init__(self, upper_bound):
         self.upper_bound = upper_bound
 
@@ -209,6 +252,8 @@ class _Multinomial(Constraint):
 
 
 class _OrderedVector(Constraint):
+    event_dim = 1
+
     def __call__(self, x):
         return (x[..., 1:] > x[..., :-1]).all(axis=-1)
 
@@ -217,6 +262,8 @@ class _OrderedVector(Constraint):
 
 
 class _PositiveDefinite(Constraint):
+    event_dim = 2
+
     def __call__(self, x):
         jnp = np if isinstance(x, (np.ndarray, np.generic)) else jax.numpy
         # check for symmetric
@@ -239,6 +286,8 @@ class _Real(Constraint):
 
 
 class _RealVector(Constraint):
+    event_dim = 1
+
     def __call__(self, x):
         return ((x == x) & (x != float('inf')) & (x != float('-inf'))).all(axis=-1)
 
@@ -247,6 +296,8 @@ class _RealVector(Constraint):
 
 
 class _Simplex(Constraint):
+    event_dim = 1
+
     def __call__(self, x):
         x_sum = x.sum(axis=-1)
         return (x >= 0).all(axis=-1) & (x_sum < 1 + 1e-6) & (x_sum > 1 - 1e-6)
@@ -263,6 +314,7 @@ corr_matrix = _CorrMatrix()
 dependent = _Dependent()
 greater_than = _GreaterThan
 less_than = _LessThan
+independent = _IndependentConstraint
 integer_interval = _IntegerInterval
 integer_greater_than = _IntegerGreaterThan
 interval = _Interval

--- a/numpyro/distributions/continuous.py
+++ b/numpyro/distributions/continuous.py
@@ -817,8 +817,8 @@ def _batch_lowrank_mahalanobis(W, D, x, capacitance_tril):
 class LowRankMultivariateNormal(Distribution):
     arg_constraints = {
         "loc": constraints.real_vector,
-        "cov_factor": constraints.real,
-        "cov_diag": constraints.positive
+        "cov_factor": constraints.independent(constraints.real, 2),
+        "cov_diag": constraints.independent(constraints.positive, 1)
     }
     support = constraints.real_vector
     reparametrized_params = ['loc', 'cov_factor', 'cov_diag']

--- a/numpyro/distributions/flows.py
+++ b/numpyro/distributions/flows.py
@@ -53,7 +53,7 @@ class InverseAutoregressiveTransform(Transform):
         scale = jnp.exp(log_scale)
         return scale * x + mean, log_scale
 
-    def inv(self, y):
+    def _inverse(self, y):
         """
         :param numpy.ndarray y: the output of the transform to be inverted
         """
@@ -108,7 +108,7 @@ class BlockNeuralAutoregressiveTransform(Transform):
         y, logdet = self.bn_arn(x)
         return y, logdet
 
-    def inv(self, y):
+    def _inverse(self, y):
         raise NotImplementedError("Block neural autoregressive transform does not have an analytic"
                                   " inverse implemented.")
 

--- a/numpyro/distributions/transforms.py
+++ b/numpyro/distributions/transforms.py
@@ -381,10 +381,7 @@ class IndependentTransform(Transform):
         if jnp.ndim(result) < self.reinterpreted_batch_ndims:
             expected = self.domain.event_dim
             raise ValueError(f"Expected x.dim() >= {expected} but got {jnp.ndim(x)}")
-        result = result.reshape(
-            jnp.shape(result)[:jnp.ndim(result) - self.reinterpreted_batch_ndims] + (-1,))
-        result = result.sum(-1)
-        return result
+        return sum_rightmost(result, jnp.ndim(result) - self.reinterpreted_batch_ndims)
 
     def call_with_intermediates(self, x):
         return self.base_transform.call_with_intermediates(x)

--- a/numpyro/distributions/transforms.py
+++ b/numpyro/distributions/transforms.py
@@ -58,6 +58,7 @@ class Transform(object):
         warnings.warn("transform.event_dim is deprecated. Please use Transform.domain.event_dim to "
                       "get input event dim or Transform.codomain.event_dim to get output event dim.",
                       DeprecationWarning)
+        return self.domain.event_dim
 
     @property
     def inv(self):

--- a/numpyro/distributions/transforms.py
+++ b/numpyro/distributions/transforms.py
@@ -115,9 +115,6 @@ class _InverseTransform(Transform):
         # NB: we don't use intermediates for inverse transform
         return -self._inv.log_abs_det_jacobian(y, x, None)
 
-    def call_with_intermediates(self, x):
-        return self(x), None
-
 
 class AbsTransform(Transform):
     domain = constraints.real

--- a/numpyro/distributions/transforms.py
+++ b/numpyro/distributions/transforms.py
@@ -57,7 +57,7 @@ class Transform(object):
     def event_dim(self):
         warnings.warn("transform.event_dim is deprecated. Please use Transform.domain.event_dim to "
                       "get input event dim or Transform.codomain.event_dim to get output event dim.",
-                      DeprecationWarning)
+                      FutureWarning)
         return self.domain.event_dim
 
     @property

--- a/numpyro/distributions/transforms.py
+++ b/numpyro/distributions/transforms.py
@@ -52,15 +52,12 @@ def _clipped_expit(x):
 class Transform(object):
     domain = constraints.real
     codomain = constraints.real
-    event_dim = 0
 
     @property
-    def input_event_dim(self):
-        return self.event_dim
-
-    @property
-    def output_event_dim(self):
-        return self.event_dim
+    def event_dim(self):
+        warnings.warn("transform.event_dim is deprecated. Please use Transform.domain.event_dim to "
+                      "get input event dim or Transform.codomain.event_dim to get output event dim.",
+                      DeprecationWarning)
 
     @property
     def inv(self):
@@ -93,18 +90,6 @@ class _InverseTransform(Transform):
         return self._inv.domain
 
     @property
-    def input_event_dim(self):
-        return self._inv.output_event_dim
-
-    @property
-    def output_event_dim(self):
-        return self._inv.input_event_dim
-
-    @property
-    def event_dim(self):
-        return self._inv.event_dim
-
-    @property
     def inv(self):
         return self._inv
 
@@ -114,6 +99,48 @@ class _InverseTransform(Transform):
     def log_abs_det_jacobian(self, x, y, intermediates=None):
         # NB: we don't use intermediates for inverse transform
         return -self._inv.log_abs_det_jacobian(y, x, None)
+
+
+class IndependentTransform(Transform):
+    """
+    Wraps a transform by aggregating over ``reinterpreted_batch_ndims``-many
+    dims in :meth:`check`, so that an event is valid only if all its
+    independent entries are valid.
+    """
+    def __init__(self, base_transform, reinterpreted_batch_ndims):
+        assert isinstance(base_transform, Transform)
+        assert isinstance(reinterpreted_batch_ndims, int)
+        assert reinterpreted_batch_ndims >= 0
+        self.base_transform = base_transform
+        self.reinterpreted_batch_ndims = reinterpreted_batch_ndims
+        super().__init__()
+
+    @property
+    def domain(self):
+        return constraints.independent(self.base_transform.domain, self.reinterpreted_batch_ndims)
+
+    @property
+    def codomain(self):
+        return constraints.independent(self.base_transform.codomain, self.reinterpreted_batch_ndims)
+
+    def __call__(self, x):
+        return self.base_transform(x)
+
+    def _inverse(self, y):
+        raise self.base_transform._inverse(y)
+
+    def log_abs_det_jacobian(self, x, y, intermediates=None):
+        result = self.base_transform.log_abs_det_jacobian(x, y, intermediates=intermediates)
+        if jnp.ndim(result) < self.reinterpreted_batch_ndims:
+            expected = self.domain.event_dim
+            raise ValueError(f"Expected x.dim() >= {expected} but got {jnp.ndim(x)}")
+        result = result.reshape(
+            jnp.shape(result)[:jnp.ndim(result) - self.reinterpreted_batch_ndims] + (-1,))
+        result = result.sum(-1)
+        return result
+
+    def call_with_intermediates(self, x):
+        return self.base_transform.call_with_intermediates(x)
 
 
 class AbsTransform(Transform):
@@ -168,10 +195,6 @@ class AffineTransform(Transform):
         else:
             raise NotImplementedError
 
-    @property
-    def event_dim(self):
-        return 1 if self.domain is constraints.real_vector else 0
-
     def __call__(self, x):
         return self.loc + self.scale * x
 
@@ -179,7 +202,22 @@ class AffineTransform(Transform):
         return (y - self.loc) / self.scale
 
     def log_abs_det_jacobian(self, x, y, intermediates=None):
-        return sum_rightmost(jnp.broadcast_to(jnp.log(jnp.abs(self.scale)), jnp.shape(x)), self.event_dim)
+        return sum_rightmost(jnp.broadcast_to(jnp.log(jnp.abs(self.scale)), jnp.shape(x)),
+                             self.domain.event_dim)
+
+
+def _get_compose_transform_input_event_dim(parts):
+    input_event_dim = parts[-1].domain.event_dim
+    for part in parts[len(parts) - 1::-1]:
+        input_event_dim = part.domain.event_dim + max(input_event_dim - part.domain.event_dim, 0)
+    return input_event_dim
+
+
+def _get_compose_transform_output_event_dim(parts):
+    output_event_dim = parts[0].codomain.event_dim
+    for part in parts[1:]:
+        output_event_dim = part.codomain.event_dim + max(output_event_dim - part.domain.event_dim, 0)
+    return output_event_dim
 
 
 class ComposeTransform(Transform):
@@ -188,29 +226,23 @@ class ComposeTransform(Transform):
 
     @property
     def domain(self):
-        return self.parts[0].domain
+        input_event_dim = _get_compose_transform_input_event_dim(self.parts)
+        first_input_event_dim = self.parts[0].domain.event_dim
+        assert input_event_dim >= first_input_event_dim
+        if input_event_dim == first_input_event_dim:
+            return self.parts[0].domain
+        else:
+            return constraints.independent(self.parts[0].domain, input_event_dim - first_input_event_dim)
 
     @property
     def codomain(self):
-        return self.parts[-1].codomain
-
-    @property
-    def event_dim(self):
-        raise ValueError("Please use `.input_event_dim` or `.output_event_dim` instead.")
-
-    @property
-    def input_event_dim(self):
-        input_event_dim = self.parts[-1].input_event_dim
-        for part in self.parts[len(self.parts) - 1::-1]:
-            input_event_dim = part.input_event_dim + max(input_event_dim - part.output_event_dim, 0)
-        return input_event_dim
-
-    @property
-    def output_event_dim(self):
-        output_event_dim = self.parts[0].output_event_dim
-        for part in self.parts[1:]:
-            output_event_dim = part.output_event_dim + max(output_event_dim - part.input_event_dim, 0)
-        return output_event_dim
+        output_event_dim = _get_compose_transform_output_event_dim(self.parts)
+        last_output_event_dim = self.parts[-1].codomain.event_dim
+        assert output_event_dim >= last_output_event_dim
+        if output_event_dim == last_output_event_dim:
+            return self.parts[-1].codomain
+        else:
+            return constraints.independent(self.parts[-1].codomain, output_event_dim - last_output_event_dim)
 
     def __call__(self, x):
         for part in self.parts:
@@ -229,20 +261,20 @@ class ComposeTransform(Transform):
                                  .format(len(intermediates), len(self.parts)))
 
         result = 0.
-        input_event_dim = self.input_event_dim
+        input_event_dim = self.domain.event_dim
         for i, part in enumerate(self.parts[:-1]):
             y_tmp = part(x) if intermediates is None else intermediates[i][0]
             inter = None if intermediates is None else intermediates[i][1]
             logdet = part.log_abs_det_jacobian(x, y_tmp, intermediates=inter)
-            batch_ndim = input_event_dim - part.input_event_dim
+            batch_ndim = input_event_dim - part.domain.event_dim
             result = result + sum_rightmost(logdet, batch_ndim)
-            input_event_dim = part.output_event_dim + batch_ndim
+            input_event_dim = part.codomain.event_dim + batch_ndim
             x = y_tmp
         # account the the last transform, where y is available
         inter = None if intermediates is None else intermediates[-1]
         part = self.parts[-1]
         logdet = part.log_abs_det_jacobian(x, y, intermediates=inter)
-        result = result + sum_rightmost(logdet, input_event_dim - part.input_event_dim)
+        result = result + sum_rightmost(logdet, input_event_dim - part.domain.event_dim)
         return result
 
     def call_with_intermediates(self, x):
@@ -284,12 +316,6 @@ class CorrCholeskyTransform(Transform):
     """
     domain = constraints.real_vector
     codomain = constraints.corr_cholesky
-    input_event_dim = 1
-    output_event_dim = 2
-
-    @property
-    def event_dim(self):
-        raise ValueError("Please use `.input_event_dim` or `.output_event_dim` instead.")
 
     def __call__(self, x):
         # we interchange step 1 and step 2.a for a better performance
@@ -356,8 +382,12 @@ class ExpTransform(Transform):
 
 class IdentityTransform(Transform):
 
-    def __init__(self, event_dim=0):
-        self.event_dim = event_dim
+    def __init__(self, domain=constraints.real):
+        self.domain = domain
+
+    @property
+    def codomain(self):
+        return self.domain
 
     def __call__(self, x):
         return x
@@ -374,7 +404,6 @@ class InvCholeskyTransform(Transform):
     Transform via the mapping :math:`y = x @ x.T`, where `x` is a lower
     triangular matrix with positive diagonal.
     """
-    event_dim = 2
 
     def __init__(self, domain=constraints.lower_cholesky):
         assert domain in [constraints.lower_cholesky, constraints.corr_cholesky]
@@ -415,7 +444,6 @@ class LowerCholeskyAffine(Transform):
     """
     domain = constraints.real_vector
     codomain = constraints.real_vector
-    event_dim = 1
 
     def __init__(self, loc, scale_tril):
         if jnp.ndim(scale_tril) != 2:
@@ -443,12 +471,6 @@ class LowerCholeskyAffine(Transform):
 class LowerCholeskyTransform(Transform):
     domain = constraints.real_vector
     codomain = constraints.lower_cholesky
-    input_event_dim = 1
-    output_event_dim = 2
-
-    @property
-    def event_dim(self):
-        raise ValueError("Please use `.input_event_dim` or `.output_event_dim` instead.")
 
     def __call__(self, x):
         n = round((math.sqrt(1 + 8 * x.shape[-1]) - 1) / 2)
@@ -477,7 +499,6 @@ class OrderedTransform(Transform):
     """
     domain = constraints.real_vector
     codomain = constraints.ordered_vector
-    event_dim = 1
 
     def __call__(self, x):
         z = jnp.concatenate([x[..., :1], jnp.exp(x[..., 1:])], axis=-1)
@@ -494,7 +515,6 @@ class OrderedTransform(Transform):
 class PermuteTransform(Transform):
     domain = constraints.real_vector
     codomain = constraints.real_vector
-    event_dim = 1
 
     def __init__(self, permutation):
         self.permutation = permutation
@@ -547,7 +567,6 @@ class SigmoidTransform(Transform):
 class StickBreakingTransform(Transform):
     domain = constraints.real_vector
     codomain = constraints.simplex
-    event_dim = 1
 
     def __call__(self, x):
         # we shift x to obtain a balanced mapping (0, 0, ..., 0) -> (1/K, 1/K, ..., 1/K)
@@ -587,7 +606,7 @@ class UnpackTransform(Transform):
     :param unpack_fn: callable used to unpack a contiguous array.
     """
     domain = constraints.real_vector
-    event_dim = 1
+    codomain = constraints.dependent
 
     def __init__(self, unpack_fn):
         self.unpack_fn = unpack_fn
@@ -669,6 +688,12 @@ def _transform_to_less_than(constraint):
                                              domain=constraints.positive)])
 
 
+@biject_to.register(constraints.independent)
+def _biject_to_independent(constraint):
+    return IndependentTransform(biject_to(constraint.base_transform),
+                                constraint.reinterpreted_batch_ndims)
+
+
 @biject_to.register(constraints.interval)
 def _transform_to_interval(constraint):
     if constraint is constraints.unit_interval:
@@ -695,13 +720,9 @@ def _transform_to_positive_definite(constraint):
 
 
 @biject_to.register(constraints.real)
-def _transform_to_real(constraint):
-    return IdentityTransform()
-
-
 @biject_to.register(constraints.real_vector)
-def _transform_to_real_vector(constraint):
-    return IdentityTransform(event_dim=1)
+def _transform_to_real(constraint):
+    return IdentityTransform(domain=constraint)
 
 
 @biject_to.register(constraints.simplex)

--- a/numpyro/distributions/transforms.py
+++ b/numpyro/distributions/transforms.py
@@ -62,14 +62,58 @@ class Transform(object):
     def output_event_dim(self):
         return self.event_dim
 
+    @property
+    def inv(self):
+        return _InverseTransform(self)
+
     def __call__(self, x):
         return NotImplementedError
 
-    def inv(self, y):
+    def _inverse(self, y):
         raise NotImplementedError
 
     def log_abs_det_jacobian(self, x, y, intermediates=None):
         raise NotImplementedError
+
+    def call_with_intermediates(self, x):
+        return self(x), None
+
+
+class _InverseTransform(Transform):
+    def __init__(self, transform):
+        super().__init__()
+        self._inv = transform
+
+    @property
+    def domain(self):
+        return self._inv.codomain
+
+    @property
+    def codomain(self):
+        return self._inv.domain
+
+    @property
+    def input_event_dim(self):
+        return self._inv.output_event_dim
+
+    @property
+    def output_event_dim(self):
+        return self._inv.input_event_dim
+
+    @property
+    def event_dim(self):
+        return self._inv.event_dim
+
+    @property
+    def inv(self):
+        return self._inv
+
+    def __call__(self, x):
+        return self._inv._inverse(x)
+
+    def log_abs_det_jacobian(self, x, y, intermediates=None):
+        # NB: we don't use intermediates for inverse transform
+        return -self._inv.log_abs_det_jacobian(y, x, None)
 
     def call_with_intermediates(self, x):
         return self(x), None
@@ -85,7 +129,7 @@ class AbsTransform(Transform):
     def __call__(self, x):
         return jnp.abs(x)
 
-    def inv(self, y):
+    def _inverse(self, y):
         return y
 
 
@@ -134,7 +178,7 @@ class AffineTransform(Transform):
     def __call__(self, x):
         return self.loc + self.scale * x
 
-    def inv(self, y):
+    def _inverse(self, y):
         return (y - self.loc) / self.scale
 
     def log_abs_det_jacobian(self, x, y, intermediates=None):
@@ -176,7 +220,7 @@ class ComposeTransform(Transform):
             x = part(x)
         return x
 
-    def inv(self, y):
+    def _inverse(self, y):
         for part in self.parts[::-1]:
             y = part.inv(y)
         return y
@@ -255,7 +299,7 @@ class CorrCholeskyTransform(Transform):
         t = jnp.tanh(x)
         return signed_stick_breaking_tril(t)
 
-    def inv(self, y):
+    def _inverse(self, y):
         # inverse stick-breaking
         z1m_cumprod = 1 - jnp.cumsum(y * y, axis=-1)
         pad_width = [(0, 0)] * y.ndim
@@ -306,7 +350,7 @@ class ExpTransform(Transform):
         # XXX consider to clamp from below for stability if necessary
         return jnp.exp(x)
 
-    def inv(self, y):
+    def _inverse(self, y):
         return jnp.log(y)
 
     def log_abs_det_jacobian(self, x, y, intermediates=None):
@@ -321,7 +365,7 @@ class IdentityTransform(Transform):
     def __call__(self, x):
         return x
 
-    def inv(self, y):
+    def _inverse(self, y):
         return y
 
     def log_abs_det_jacobian(self, x, y, intermediates=None):
@@ -349,7 +393,7 @@ class InvCholeskyTransform(Transform):
     def __call__(self, x):
         return jnp.matmul(x, jnp.swapaxes(x, -2, -1))
 
-    def inv(self, y):
+    def _inverse(self, y):
         return jnp.linalg.cholesky(y)
 
     def log_abs_det_jacobian(self, x, y, intermediates=None):
@@ -387,7 +431,7 @@ class LowerCholeskyAffine(Transform):
     def __call__(self, x):
         return self.loc + jnp.squeeze(jnp.matmul(self.scale_tril, x[..., jnp.newaxis]), axis=-1)
 
-    def inv(self, y):
+    def _inverse(self, y):
         y = y - self.loc
         original_shape = jnp.shape(y)
         yt = jnp.reshape(y, (-1, original_shape[-1])).T
@@ -415,7 +459,7 @@ class LowerCholeskyTransform(Transform):
         diag = jnp.exp(x[..., -n:])
         return z + jnp.expand_dims(diag, axis=-1) * jnp.identity(n)
 
-    def inv(self, y):
+    def _inverse(self, y):
         z = matrix_to_tril_vec(y, diagonal=-1)
         return jnp.concatenate([z, jnp.log(jnp.diagonal(y, axis1=-2, axis2=-1))], axis=-1)
 
@@ -442,7 +486,7 @@ class OrderedTransform(Transform):
         z = jnp.concatenate([x[..., :1], jnp.exp(x[..., 1:])], axis=-1)
         return jnp.cumsum(z, axis=-1)
 
-    def inv(self, y):
+    def _inverse(self, y):
         x = jnp.log(y[..., 1:] - y[..., :-1])
         return jnp.concatenate([y[..., :1], x], axis=-1)
 
@@ -461,7 +505,7 @@ class PermuteTransform(Transform):
     def __call__(self, x):
         return x[..., self.permutation]
 
-    def inv(self, y):
+    def _inverse(self, y):
         size = self.permutation.size
         permutation_inv = ops.index_update(jnp.zeros(size, dtype=canonicalize_dtype(jnp.int64)),
                                            self.permutation,
@@ -482,7 +526,7 @@ class PowerTransform(Transform):
     def __call__(self, x):
         return jnp.power(x, self.exponent)
 
-    def inv(self, y):
+    def _inverse(self, y):
         return jnp.power(y, 1 / self.exponent)
 
     def log_abs_det_jacobian(self, x, y, intermediates=None):
@@ -495,7 +539,7 @@ class SigmoidTransform(Transform):
     def __call__(self, x):
         return _clipped_expit(x)
 
-    def inv(self, y):
+    def _inverse(self, y):
         return logit(y)
 
     def log_abs_det_jacobian(self, x, y, intermediates=None):
@@ -522,7 +566,7 @@ class StickBreakingTransform(Transform):
         z1m_cumprod_shifted = jnp.pad(z1m_cumprod, pad_width, mode="constant", constant_values=1.)
         return z_padded * z1m_cumprod_shifted
 
-    def inv(self, y):
+    def _inverse(self, y):
         y_crop = y[..., :-1]
         z1m_cumprod = jnp.clip(1 - jnp.cumsum(y_crop, axis=-1), a_min=jnp.finfo(y.dtype).tiny)
         # hence x = logit(z) = log(z / (1 - z)) = y[::-1] / z1m_cumprod
@@ -559,7 +603,7 @@ class UnpackTransform(Transform):
         else:
             return self.unpack_fn(x)
 
-    def inv(self, y):
+    def _inverse(self, y):
         leading_dims = [v.shape[0] if jnp.ndim(v) > 0 else 0
                         for v in tree_flatten(y)[0]]
         d0 = leading_dims[0]

--- a/numpyro/distributions/transforms.py
+++ b/numpyro/distributions/transforms.py
@@ -381,7 +381,7 @@ class IndependentTransform(Transform):
         if jnp.ndim(result) < self.reinterpreted_batch_ndims:
             expected = self.domain.event_dim
             raise ValueError(f"Expected x.dim() >= {expected} but got {jnp.ndim(x)}")
-        return sum_rightmost(result, jnp.ndim(result) - self.reinterpreted_batch_ndims)
+        return sum_rightmost(result, self.reinterpreted_batch_ndims)
 
     def call_with_intermediates(self, x):
         return self.base_transform.call_with_intermediates(x)

--- a/numpyro/infer/autoguide.py
+++ b/numpyro/infer/autoguide.py
@@ -564,13 +564,13 @@ class AutoDiagonalNormal(AutoContinuous):
     def get_transform(self, params):
         loc = params['{}_loc'.format(self.prefix)]
         scale = params['{}_scale'.format(self.prefix)]
-        return IndependentTransform(AffineTransform(loc, scale))
+        return IndependentTransform(AffineTransform(loc, scale), 1)
 
     def get_posterior(self, params):
         """
         Returns a diagonal Normal posterior distribution.
         """
-        transform = self.get_transform(params)
+        transform = self.get_transform(params).base_transform
         return dist.Normal(transform.loc, transform.scale)
 
     def median(self, params):

--- a/numpyro/infer/initialization.py
+++ b/numpyro/infer/initialization.py
@@ -61,6 +61,7 @@ def init_to_uniform(site=None, radius=2):
             # we can't use this logic for general priors
             # because some distributions such as TransformedDistribution might
             # have wrong event_shape.
+            # TODO: address this when infer_shapes is available
             prototype_value = jnp.full(site['fn'].shape(), jnp.nan)
 
         transform = biject_to(site['fn'].support)

--- a/numpyro/infer/util.py
+++ b/numpyro/infer/util.py
@@ -122,7 +122,7 @@ def _unconstrain_reparam(params, site):
         # in scan, we might only want to substitute an item at index i, rather than the whole sequence
         i = site['infer'].get('_scan_current_index', None)
         if i is not None:
-            event_dim_shift = t.output_event_dim - t.input_event_dim
+            event_dim_shift = t.codomain.event_dim - t.domain.event_dim
             expected_unconstrained_dim = len(site["fn"].shape()) - event_dim_shift
             # check if p has additional time dimension
             if jnp.ndim(p) > expected_unconstrained_dim:

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -230,81 +230,85 @@ def _is_batched_multivariate(jax_dist):
 def gen_values_within_bounds(constraint, size, key=random.PRNGKey(11)):
     eps = 1e-6
 
-    if isinstance(constraint, constraints._Boolean):
+    if constraint is constraints.boolean:
         return random.bernoulli(key, shape=size)
-    elif isinstance(constraint, constraints._GreaterThan):
+    elif isinstance(constraint, constraints.greater_than):
         return jnp.exp(random.normal(key, size)) + constraint.lower_bound + eps
-    elif isinstance(constraint, constraints._IntegerInterval):
+    elif isinstance(constraint, constraints.integer_interval):
         lower_bound = jnp.broadcast_to(constraint.lower_bound, size)
         upper_bound = jnp.broadcast_to(constraint.upper_bound, size)
         return random.randint(key, size, lower_bound, upper_bound + 1)
-    elif isinstance(constraint, constraints._IntegerGreaterThan):
+    elif isinstance(constraint, constraints.integer_greater_than):
         return constraint.lower_bound + random.poisson(key, np.array(5), shape=size)
-    elif isinstance(constraint, constraints._Interval):
+    elif isinstance(constraint, constraints.interval):
         lower_bound = jnp.broadcast_to(constraint.lower_bound, size)
         upper_bound = jnp.broadcast_to(constraint.upper_bound, size)
         return random.uniform(key, size, minval=lower_bound, maxval=upper_bound)
-    elif isinstance(constraint, (constraints._Real, constraints._RealVector)):
+    elif constraint in (constraints.real, constraints.real_vector):
         return random.normal(key, size)
-    elif isinstance(constraint, constraints._Simplex):
+    elif constraint is constraints.simplex:
         return osp.dirichlet.rvs(alpha=jnp.ones((size[-1],)), size=size[:-1])
-    elif isinstance(constraint, constraints._Multinomial):
+    elif isinstance(constraint, constraints.multinomial):
         n = size[-1]
         return multinomial(key, p=jnp.ones((n,)) / n, n=constraint.upper_bound, shape=size[:-1])
-    elif isinstance(constraint, constraints._CorrCholesky):
+    elif constraint is constraints.corr_cholesky:
         return signed_stick_breaking_tril(
             random.uniform(key, size[:-2] + (size[-1] * (size[-1] - 1) // 2,), minval=-1, maxval=1))
-    elif isinstance(constraint, constraints._CorrMatrix):
+    elif constraint is constraints.corr_matrix:
         cholesky = signed_stick_breaking_tril(
             random.uniform(key, size[:-2] + (size[-1] * (size[-1] - 1) // 2,), minval=-1, maxval=1))
         return jnp.matmul(cholesky, jnp.swapaxes(cholesky, -2, -1))
-    elif isinstance(constraint, constraints._LowerCholesky):
+    elif constraint is constraints.lower_cholesky:
         return jnp.tril(random.uniform(key, size))
-    elif isinstance(constraint, constraints._PositiveDefinite):
+    elif constraint is constraints.positive_definite:
         x = random.normal(key, size)
         return jnp.matmul(x, jnp.swapaxes(x, -2, -1))
-    elif isinstance(constraint, constraints._OrderedVector):
+    elif constraint is constraints.ordered_vector:
         x = jnp.cumsum(random.exponential(key, size), -1)
         return x - random.normal(key, size[:-1])
+    elif isinstance(constraint, constraints.independent):
+        return gen_values_within_bounds(constraint.base_constraint, size, key)
     else:
         raise NotImplementedError('{} not implemented.'.format(constraint))
 
 
 def gen_values_outside_bounds(constraint, size, key=random.PRNGKey(11)):
-    if isinstance(constraint, constraints._Boolean):
+    if constraint is constraints.boolean:
         return random.bernoulli(key, shape=size) - 2
-    elif isinstance(constraint, constraints._GreaterThan):
+    elif isinstance(constraint, constraints.greater_than):
         return constraint.lower_bound - jnp.exp(random.normal(key, size))
-    elif isinstance(constraint, constraints._IntegerInterval):
+    elif isinstance(constraint, constraints.integer_interval):
         lower_bound = jnp.broadcast_to(constraint.lower_bound, size)
         return random.randint(key, size, lower_bound - 1, lower_bound)
-    elif isinstance(constraint, constraints._IntegerGreaterThan):
+    elif isinstance(constraint, constraints.integer_greater_than):
         return constraint.lower_bound - random.poisson(key, np.array(5), shape=size)
-    elif isinstance(constraint, constraints._Interval):
+    elif isinstance(constraint, constraints.interval):
         upper_bound = jnp.broadcast_to(constraint.upper_bound, size)
         return random.uniform(key, size, minval=upper_bound, maxval=upper_bound + 1.)
-    elif isinstance(constraint, (constraints._Real, constraints._RealVector)):
+    elif constraint in [constraints.real, constraints.real_vector]:
         return lax.full(size, jnp.nan)
-    elif isinstance(constraint, constraints._Simplex):
+    elif constraint is constraints.simplex:
         return osp.dirichlet.rvs(alpha=jnp.ones((size[-1],)), size=size[:-1]) + 1e-2
-    elif isinstance(constraint, constraints._Multinomial):
+    elif isinstance(constraint, constraints.multinomial):
         n = size[-1]
         return multinomial(key, p=jnp.ones((n,)) / n, n=constraint.upper_bound, shape=size[:-1]) + 1
-    elif isinstance(constraint, constraints._CorrCholesky):
+    elif constraint is constraints.corr_cholesky:
         return signed_stick_breaking_tril(
             random.uniform(key, size[:-2] + (size[-1] * (size[-1] - 1) // 2,),
                            minval=-1, maxval=1)) + 1e-2
-    elif isinstance(constraint, constraints._CorrMatrix):
+    elif constraint is constraints.corr_matrix:
         cholesky = 1e-2 + signed_stick_breaking_tril(
             random.uniform(key, size[:-2] + (size[-1] * (size[-1] - 1) // 2,), minval=-1, maxval=1))
         return jnp.matmul(cholesky, jnp.swapaxes(cholesky, -2, -1))
-    elif isinstance(constraint, constraints._LowerCholesky):
+    elif constraint is constraints.lower_cholesky:
         return random.uniform(key, size)
-    elif isinstance(constraint, constraints._PositiveDefinite):
+    elif constraint is constraints.positive_definite:
         return random.normal(key, size)
-    elif isinstance(constraint, constraints._OrderedVector):
+    elif constraint is constraints.ordered_vector:
         x = jnp.cumsum(random.exponential(key, size), -1)
         return x[..., ::-1]
+    elif isinstance(constraint, constraints.independent):
+        return gen_values_outside_bounds(constraint.base_constraint, size, key)
     else:
         raise NotImplementedError('{} not implemented.'.format(constraint))
 
@@ -1044,7 +1048,7 @@ def test_bijective_transforms(transform, event_shape, batch_shape):
     actual = transform.log_abs_det_jacobian(x, y)
     assert_allclose(actual, -transform.inv.log_abs_det_jacobian(y, x))
     assert jnp.shape(actual) == batch_shape
-    if len(shape) == transform.event_dim:
+    if len(shape) == transform.domain.event_dim:
         if len(event_shape) == 1:
             expected = np.linalg.slogdet(jax.jacobian(transform)(x))[1]
             inv_expected = np.linalg.slogdet(jax.jacobian(transform.inv)(y))[1]

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -1031,12 +1031,16 @@ def test_bijective_transforms(transform, event_shape, batch_shape):
     # test inv
     z = transform.inv(y)
     assert_allclose(x, z, atol=1e-6, rtol=1e-6)
+    assert transform.inv.inv is transform
+    assert transform.domain is transform.inv.codomain
+    assert transform.codomain is transform.inv.domain
 
     # test domain
     assert_array_equal(transform.domain(z), jnp.ones(batch_shape))
 
     # test log_abs_det_jacobian
     actual = transform.log_abs_det_jacobian(x, y)
+    assert_allclose(actual, -transform.inv.log_abs_det_jacobian(y, x))
     assert jnp.shape(actual) == batch_shape
     if len(shape) == transform.event_dim:
         if len(event_shape) == 1:

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -935,11 +935,13 @@ def test_constraints(constraint, x, expected):
     constraints.real,
     constraints.simplex,
     constraints.unit_interval,
+    constraints.independent(constraints.real, 1),
 ], ids=lambda x: x.__class__)
 @pytest.mark.parametrize('shape', [(), (1,), (3,), (6,), (3, 1), (1, 3), (5, 3)])
 def test_biject_to(constraint, shape):
+
     transform = biject_to(constraint)
-    event_dim = transform.input_event_dim
+    event_dim = transform.domain.event_dim
     if isinstance(constraint, constraints._Interval):
         assert transform.codomain.upper_bound == constraint.upper_bound
         assert transform.codomain.lower_bound == constraint.lower_bound
@@ -1059,8 +1061,8 @@ def test_composed_transform(batch_shape):
     t1 = transforms.AffineTransform(0, 2)
     t2 = transforms.LowerCholeskyTransform()
     t = transforms.ComposeTransform([t1, t2, t1])
-    assert t.input_event_dim == 1
-    assert t.output_event_dim == 2
+    assert t.domain.event_dim == 1
+    assert t.codomain.event_dim == 2
 
     x = np.random.normal(size=batch_shape + (6,))
     y = t(x)
@@ -1075,8 +1077,8 @@ def test_composed_transform_1(batch_shape):
     t1 = transforms.AffineTransform(0, 2)
     t2 = transforms.LowerCholeskyTransform()
     t = transforms.ComposeTransform([t1, t2, t2])
-    assert t.input_event_dim == 1
-    assert t.output_event_dim == 3
+    assert t.domain.event_dim == 1
+    assert t.codomain.event_dim == 3
 
     x = np.random.normal(size=batch_shape + (6,))
     y = t(x)


### PR DESCRIPTION
Addresses #874.

In this PR, I copied @fritzo's effort at https://github.com/pytorch/pytorch/pull/50547 and added his suggestion for IndependentTransform. Also removing `input_event_dim/output_event_dim` and deprecating `Transform.event_dim`.