### PR TITLE
Support forward-mode differentiation

### DIFF
--- a/numpyro/infer/hmc.py
+++ b/numpyro/infer/hmc.py
@@ -147,6 +147,7 @@ def hmc(potential_fn=None, potential_fn_gen=None, kinetic_fn=None, algo='NUTS'):
     max_treedepth = None
     wa_update = None
     wa_steps = None
+    forward_mode_ad = False
     max_delta_energy = 1000.
     if algo not in {'HMC', 'NUTS'}:
         raise ValueError('`algo` must be one of `HMC` or `NUTS`.')
@@ -162,6 +163,7 @@ def hmc(potential_fn=None, potential_fn_gen=None, kinetic_fn=None, algo='NUTS'):
                     trajectory_length=2*math.pi,
                     max_tree_depth=10,
                     find_heuristic_step_size=False,
+                    forward_mode_differentiation=False,
                     model_args=(),
                     model_kwargs=None,
                     rng_key=random.PRNGKey(0)):
@@ -200,7 +202,8 @@ def hmc(potential_fn=None, potential_fn_gen=None, kinetic_fn=None, algo='NUTS'):
 
         """
         step_size = lax.convert_element_type(step_size, canonicalize_dtype(jnp.float64))
-        nonlocal wa_update, trajectory_len, max_treedepth, vv_update, wa_steps
+        nonlocal wa_update, trajectory_len, max_treedepth, vv_update, wa_steps, forward_mode_ad
+        forward_mode_ad = forward_mode_differentiation
         wa_steps = num_warmup
         trajectory_len = trajectory_length
         max_treedepth = max_tree_depth
@@ -236,7 +239,7 @@ def hmc(potential_fn=None, potential_fn_gen=None, kinetic_fn=None, algo='NUTS'):
                            inverse_mass_matrix=inverse_mass_matrix,
                            mass_matrix_size=jnp.size(ravel_pytree(z)[0]))
         r = momentum_generator(z, wa_state.mass_matrix_sqrt, rng_key_momentum)
-        vv_init, vv_update = velocity_verlet(pe_fn, kinetic_fn)
+        vv_init, vv_update = velocity_verlet(pe_fn, kinetic_fn, forward_mode_ad)
         vv_state = vv_init(z, r, potential_energy=pe, z_grad=z_grad)
         energy = kinetic_fn(wa_state.inverse_mass_matrix, vv_state.r)
         hmc_state = HMCState(0, vv_state.z, vv_state.z_grad, vv_state.potential_energy, energy,
@@ -246,9 +249,9 @@ def hmc(potential_fn=None, potential_fn_gen=None, kinetic_fn=None, algo='NUTS'):
     def _hmc_next(step_size, inverse_mass_matrix, vv_state,
                   model_args, model_kwargs, rng_key):
         if potential_fn_gen:
-            nonlocal vv_update
+            nonlocal vv_update, forward_mode_ad
             pe_fn = potential_fn_gen(*model_args, **model_kwargs)
-            _, vv_update = velocity_verlet(pe_fn, kinetic_fn)
+            _, vv_update = velocity_verlet(pe_fn, kinetic_fn, forward_mode_ad)
 
         num_steps = _get_num_steps(step_size, trajectory_len)
         vv_state_new = fori_loop(0, num_steps,
@@ -269,9 +272,9 @@ def hmc(potential_fn=None, potential_fn_gen=None, kinetic_fn=None, algo='NUTS'):
     def _nuts_next(step_size, inverse_mass_matrix, vv_state,
                    model_args, model_kwargs, rng_key):
         if potential_fn_gen:
-            nonlocal vv_update
+            nonlocal vv_update, forward_mode_ad
             pe_fn = potential_fn_gen(*model_args, **model_kwargs)
-            _, vv_update = velocity_verlet(pe_fn, kinetic_fn)
+            _, vv_update = velocity_verlet(pe_fn, kinetic_fn, forward_mode_ad)
 
         binary_tree = build_tree(vv_update, kinetic_fn, vv_state,
                                  inverse_mass_matrix, step_size, rng_key,
@@ -369,6 +372,13 @@ class HMC(MCMCKernel):
         See :ref:`init_strategy` section for available functions.
     :param bool find_heuristic_step_size: whether to a heuristic function to adjust the
         step size at the beginning of each adaptation window. Defaults to False.
+    :param bool forward_mode_differentiation: whether to use forward-mode differentiation
+        or reverse-mode differentiation. By default, we use reverse mode but the forward
+        mode can be useful in some cases to improve the performance. In addition, some
+        control flow utility on JAX such as `jax.lax.while_loop` or `jax.lax.fori_loop`
+        only supports forward-mode differentiation. See
+        `JAX's The Autodiff Cookbook <https://jax.readthedocs.io/en/latest/notebooks/autodiff_cookbook.html>`_
+        for more information.
     """
     def __init__(self,
                  model=None,
@@ -381,7 +391,8 @@ class HMC(MCMCKernel):
                  target_accept_prob=0.8,
                  trajectory_length=2 * math.pi,
                  init_strategy=init_to_uniform,
-                 find_heuristic_step_size=False):
+                 find_heuristic_step_size=False,
+                 forward_mode_differentiation=False):
         if not (model is None) ^ (potential_fn is None):
             raise ValueError('Only one of `model` or `potential_fn` must be specified.')
         self._model = model
@@ -397,6 +408,7 @@ class HMC(MCMCKernel):
         self._max_tree_depth = 10
         self._init_strategy = init_strategy
         self._find_heuristic_step_size = find_heuristic_step_size
+        self._forward_mode_differentiation = forward_mode_differentiation
         # Set on first call to init
         self._init_fn = None
         self._potential_fn_gen = None
@@ -411,7 +423,8 @@ class HMC(MCMCKernel):
                 dynamic_args=True,
                 init_strategy=self._init_strategy,
                 model_args=model_args,
-                model_kwargs=model_kwargs)
+                model_kwargs=model_kwargs,
+                forward_mode_differentiation=self._forward_mode_differentiation)
             if self._init_fn is None:
                 self._init_fn, self._sample_fn = hmc(potential_fn_gen=potential_fn,
                                                      kinetic_fn=self._kinetic_fn,
@@ -465,6 +478,7 @@ class HMC(MCMCKernel):
             trajectory_length=self._trajectory_length,
             max_tree_depth=self._max_tree_depth,
             find_heuristic_step_size=self._find_heuristic_step_size,
+            forward_mode_differentiation=self._forward_mode_differentiation,
             model_args=model_args,
             model_kwargs=model_kwargs,
             rng_key=rng_key,
@@ -541,6 +555,13 @@ class NUTS(HMC):
         See :ref:`init_strategy` section for available functions.
     :param bool find_heuristic_step_size: whether to a heuristic function to adjust the
         step size at the beginning of each adaptation window. Defaults to False.
+    :param bool forward_mode_differentiation: whether to use forward-mode differentiation
+        or reverse-mode differentiation. By default, we use reverse mode but the forward
+        mode can be useful in some cases to improve the performance. In addition, some
+        control flow utility on JAX such as `jax.lax.while_loop` or `jax.lax.fori_loop`
+        only supports forward-mode differentiation. See
+        `JAX's The Autodiff Cookbook <https://jax.readthedocs.io/en/latest/notebooks/autodiff_cookbook.html>`_
+        for more information.
     """
     def __init__(self,
                  model=None,
@@ -554,13 +575,15 @@ class NUTS(HMC):
                  trajectory_length=None,
                  max_tree_depth=10,
                  init_strategy=init_to_uniform,
-                 find_heuristic_step_size=False):
+                 find_heuristic_step_size=False,
+                 forward_mode_differentiation=False):
         super(NUTS, self).__init__(potential_fn=potential_fn, model=model, kinetic_fn=kinetic_fn,
                                    step_size=step_size, adapt_step_size=adapt_step_size,
                                    adapt_mass_matrix=adapt_mass_matrix, dense_mass=dense_mass,
                                    target_accept_prob=target_accept_prob,
                                    trajectory_length=trajectory_length,
                                    init_strategy=init_strategy,
-                                   find_heuristic_step_size=find_heuristic_step_size)
+                                   find_heuristic_step_size=find_heuristic_step_size,
+                                   forward_mode_differentiation=forward_mode_differentiation)
         self._max_tree_depth = max_tree_depth
         self._algo = 'NUTS'

--- a/test/test_mcmc.py
+++ b/test/test_mcmc.py
@@ -7,7 +7,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 import pytest
 
-from jax import device_get, jit, pmap, random, vmap
+from jax import device_get, jit, lax, pmap, random, vmap
 from jax.lib import xla_bridge
 import jax.numpy as jnp
 from jax.scipy.special import logit
@@ -101,7 +101,8 @@ def test_logistic_regression_x64(kernel_cls):
         assert samples['coefs'].dtype == jnp.float64
 
 
-def test_uniform_normal():
+@pytest.mark.parametrize("forward_mode_differentiation", [True, False])
+def test_uniform_normal(forward_mode_differentiation):
     true_coef = 0.9
     num_warmup, num_samples = 1000, 1000
 
@@ -112,7 +113,7 @@ def test_uniform_normal():
         numpyro.sample('obs', dist.Normal(loc, 0.1), obs=data)
 
     data = true_coef + random.normal(random.PRNGKey(0), (1000,))
-    kernel = NUTS(model=model)
+    kernel = NUTS(model=model, forward_mode_differentiation=forward_mode_differentiation)
     mcmc = MCMC(kernel, num_warmup=num_warmup, num_samples=num_samples)
     mcmc.warmup(random.PRNGKey(2), data, collect_warmup=True)
     assert mcmc.post_warmup_state is not None
@@ -669,3 +670,14 @@ def test_trivial_dirichlet(batch_shape):
     mcmc.run(random.PRNGKey(0))
     # because event_shape of x is (1,), x should only take value 1
     assert_allclose(mcmc.get_samples()["x"], jnp.ones((num_samples,) + batch_shape + (1,)))
+
+
+def test_forward_mode_differentiation():
+    def model():
+        x = numpyro.sample("x", dist.Normal(0, 1))
+        y = lax.while_loop(lambda x: x < 10, lambda x: x + 1, x)
+        numpyro.sample("obs", dist.Normal(y, 1), obs=1.)
+
+    # this fails in reverse mode
+    mcmc = MCMC(NUTS(model, forward_mode_differentiation=True), 10, 10)
+    mcmc.run(random.PRNGKey(0))


### PR DESCRIPTION
Fixes #877.

This adds support for forward-mode differentiation, hence users can use `fori_loop` or `while_loop` in their models.

@eb8680 With this, it is pretty straightforward to support nested loops with only observed variable (it might be more complicated to have latent variables in body_fn but might be doable) in `contrib.control_flow.fori_loop/while_loop`. :)

@OlaRonning I think after this, we can implement block poisson hmcecs.