### PR TITLE
Make TransformReparam compatible with .to_event()

### DIFF
--- a/numpyro/infer/reparam.py
+++ b/numpyro/infer/reparam.py
@@ -28,12 +28,13 @@ class Reparam(ABC):
 
     def _unwrap(self, fn):
         """
-        Unwrap Independent(...) distributions.
+        Unwrap Independent(...) and ExpandedDistribution(...) distributions.
         """
+        batch_shape = fn.batch_shape
         event_dim = fn.event_dim
-        while isinstance(fn, dist.Independent):
+        while isinstance(fn, (dist.Independent, dist.ExpandedDistribution)):
             fn = fn.base_dist
-        return fn, event_dim
+        return fn, batch_shape, event_dim
 
     def _wrap(self, fn, event_dim):
         """
@@ -43,15 +44,6 @@ class Reparam(ABC):
             fn = fn.to_event(event_dim - fn.event_dim)
         assert fn.event_dim == event_dim
         return fn
-
-    def _unexpand(self, fn):
-        """
-        Unexpand ExpandedDistribution(...) distributions.
-        """
-        batch_shape = fn.batch_shape
-        if isinstance(fn, dist.ExpandedDistribution):
-            fn = fn.base_dist
-        return fn, batch_shape
 
 
 class LocScaleReparam(Reparam):
@@ -89,8 +81,7 @@ class LocScaleReparam(Reparam):
         if is_identically_one(centered):
             return name, fn, obs
         event_shape = fn.event_shape
-        fn, event_dim = self._unwrap(fn)
-        fn, batch_shape = self._unexpand(fn)
+        fn, batch_shape, event_dim = self._unwrap(fn)
 
         # Apply a partial decentering transform.
         params = {key: getattr(fn, key) for key in self.shape_params}
@@ -100,11 +91,13 @@ class LocScaleReparam(Reparam):
                                      constraint=constraints.unit_interval)
         params["loc"] = fn.loc * centered
         params["scale"] = fn.scale ** centered
-        decentered_fn = type(fn)(**params).expand(batch_shape)
+        decentered_fn = type(fn)(**params)
+        decentered_fn = self._wrap(decentered_fn, event_dim)
+        decentered_fn = decentered_fn.expand(batch_shape)
 
         # Draw decentered noise.
         decentered_value = numpyro.sample("{}_decentered".format(name),
-                                          self._wrap(decentered_fn, event_dim))
+                                          decentered_fn)
 
         # Differentiably transform.
         delta = decentered_value - centered * fn.loc
@@ -127,14 +120,15 @@ class TransformReparam(Reparam):
     """
     def __call__(self, name, fn, obs):
         assert obs is None, "TransformReparam does not support observe statements"
-        fn, batch_shape = self._unexpand(fn)
+        fn, batch_shape, event_dim = self._unwrap(fn)
         assert isinstance(fn, dist.TransformedDistribution)
 
         # Draw noise from the base distribution.
-        # We need to make sure that we have the same batch_shape
-        reinterpreted_batch_ndims = fn.event_dim - fn.base_dist.event_dim
+        base_event_dim = event_dim
+        for t in reversed(fn.transforms):
+            base_event_dim += t.domain.event_dim - t.codomain.event_dim
         x = numpyro.sample("{}_base".format(name),
-                           fn.base_dist.to_event(reinterpreted_batch_ndims).expand(batch_shape))
+                           self._wrap(fn.base_dist, base_event_dim).expand(batch_shape))
 
         # Differentiably transform.
         for t in fn.transforms:

--- a/test/test_reparam.py
+++ b/test/test_reparam.py
@@ -43,7 +43,8 @@ def test_log_normal(batch_shape, event_shape):
         fn = dist.TransformedDistribution(
             dist.Normal(jnp.zeros_like(loc), jnp.ones_like(scale)),
             [AffineTransform(loc, scale), ExpTransform()])
-        fn = fn.to_event(len(event_shape)).expand_by([100000])
+        if event_shape:
+            fn = fn.to_event(len(event_shape)).expand_by([100000])
         with numpyro.plate_stack("plates", batch_shape):
             with numpyro.plate("particles", 100000):
                 return numpyro.sample("x", fn)


### PR DESCRIPTION
Port of https://github.com/pyro-ppl/pyro/pull/2746
Fixes a bug [on the forum](https://forum.pyro.ai/t/using-transformreparam-with-to-event/2553).

This PR:
- refactors `._unexpand()` into `._unwrap()` to handle arbitrary interleaved `Independent` and `ExpandedDistribution`;
- uses `._unwrap()` in `TransformedDistribution`
- updates `TransformDistribution` computation of `event_dim` to support batched transforms applied to scalar base distributions.

## Tested
- [x] added new test cases