### PR TITLE
Fix missing infer key in handlers.lift

### DIFF
--- a/numpyro/handlers.py
+++ b/numpyro/handlers.py
@@ -447,6 +447,7 @@ class lift(Messenger):
             msg["kwargs"] = {"rng_key": msg["kwargs"].get("rng_key", None),
                              "sample_shape": msg["kwargs"].get("sample_shape", ())}
             msg["intermediates"] = []
+            msg["infer"] = msg.get("infer", {})
         else:
             # otherwise leave as is
             return

--- a/test/test_mcmc.py
+++ b/test/test_mcmc.py
@@ -681,3 +681,14 @@ def test_forward_mode_differentiation():
     # this fails in reverse mode
     mcmc = MCMC(NUTS(model, forward_mode_differentiation=True), 10, 10)
     mcmc.run(random.PRNGKey(0))
+
+
+def test_model_with_lift_handler():
+    def model(data):
+        c = numpyro.param("c", jnp.array(1.), constraint=dist.constraints.positive)
+        x = numpyro.sample("x", dist.LogNormal(c, 1.), obs=data)
+        return x
+
+    nuts_kernel = NUTS(numpyro.handlers.lift(model, prior={"c": dist.Gamma(0.01, 0.01)}))
+    mcmc = MCMC(nuts_kernel, num_warmup=10, num_samples=10)
+    mcmc.run(random.PRNGKey(1), jnp.exp(random.normal(random.PRNGKey(0), (1000,))))


### PR DESCRIPTION
This PR addresses issue #891 and fixes `handlers.lift` in 0.5.0