### PR TITLE
Move the warning of using the sequential chain method to the constructor

### DIFF
--- a/numpyro/infer/mcmc.py
+++ b/numpyro/infer/mcmc.py
@@ -255,9 +255,9 @@ class MCMC(object):
             chain_method = 'sequential'
             warnings.warn('There are not enough devices to run parallel chains: expected {} but got {}.'
                           ' Chains will be drawn sequentially. If you are running MCMC in CPU,'
-                          ' consider to use `numpyro.set_host_device_count({})` at the beginning'
-                          ' of your program. You can double-check how many devices available in your'
-                          ' system using `jax.local_device_count()`.'
+                          ' consider using `numpyro.set_host_device_count({})` at the beginning'
+                          ' of your program. You can double-check how many devices are available in'
+                          ' your system using `jax.local_device_count()`.'
                           .format(self.num_chains, local_device_count(), self.num_chains))
         self.chain_method = chain_method
         self.progress_bar = progress_bar

--- a/numpyro/infer/mcmc.py
+++ b/numpyro/infer/mcmc.py
@@ -7,10 +7,9 @@ from operator import attrgetter
 import os
 import warnings
 
-from jax import device_put, jit, lax, pmap, random, vmap
+from jax import device_put, jit, lax, local_device_count, pmap, random, vmap
 from jax.core import Tracer
 from jax.interpreters.xla import DeviceArray
-from jax.lib import xla_bridge
 import jax.numpy as jnp
 from jax.tree_util import tree_flatten, tree_map, tree_multimap
 
@@ -252,13 +251,13 @@ class MCMC(object):
         if chain_method not in ['parallel', 'vectorized', 'sequential']:
             raise ValueError('Only supporting the following methods to draw chains:'
                              ' "sequential", "parallel", or "vectorized"')
-        if chain_method == 'parallel' and xla_bridge.device_count() < self.num_chains:
+        if chain_method == 'parallel' and local_device_count() < self.num_chains:
             chain_method = 'sequential'
             warnings.warn('There are not enough devices to run parallel chains: expected {} but got {}.'
                           ' Chains will be drawn sequentially. If you are running MCMC in CPU,'
                           ' consider to use `numpyro.set_host_device_count({})` at the beginning'
                           ' of your program.'
-                          .format(self.num_chains, xla_bridge.device_count(), self.num_chains))
+                          .format(self.num_chains, local_device_count(), self.num_chains))
         self.chain_method = chain_method
         self.progress_bar = progress_bar
         # TODO: We should have progress bars (maybe without diagnostics) for num_chains > 1

--- a/numpyro/infer/mcmc.py
+++ b/numpyro/infer/mcmc.py
@@ -498,10 +498,7 @@ class MCMC(object):
             states = tree_map(lambda x: x[jnp.newaxis, ...], states_flat)
         else:
             if self.chain_method == 'sequential':
-                if self.progress_bar:
-                    states, last_state = _laxmap(partial_map_fn, map_args)
-                else:
-                    states, last_state = lax.map(partial_map_fn, map_args)
+                states, last_state = _laxmap(partial_map_fn, map_args)
             elif self.chain_method == 'parallel':
                 states, last_state = pmap(partial_map_fn)(map_args)
             else:

--- a/numpyro/infer/mcmc.py
+++ b/numpyro/infer/mcmc.py
@@ -7,7 +7,7 @@ from operator import attrgetter
 import os
 import warnings
 
-from jax import device_put, jit, lax, local_device_count, pmap, random, vmap
+from jax import jit, lax, local_device_count, pmap, random, vmap
 from jax.core import Tracer
 from jax.interpreters.xla import DeviceArray
 import jax.numpy as jnp
@@ -504,8 +504,6 @@ class MCMC(object):
                     states, last_state = lax.map(partial_map_fn, map_args)
             elif self.chain_method == 'parallel':
                 states, last_state = pmap(partial_map_fn)(map_args)
-                # TODO: remove when https://github.com/google/jax/issues/3597 is resolved
-                states = device_put(states)
             else:
                 assert self.chain_method == 'vectorized'
                 states, last_state = partial_map_fn(map_args)

--- a/numpyro/infer/mcmc.py
+++ b/numpyro/infer/mcmc.py
@@ -256,7 +256,8 @@ class MCMC(object):
             warnings.warn('There are not enough devices to run parallel chains: expected {} but got {}.'
                           ' Chains will be drawn sequentially. If you are running MCMC in CPU,'
                           ' consider to use `numpyro.set_host_device_count({})` at the beginning'
-                          ' of your program.'
+                          ' of your program. You can double-check how many devices available in your'
+                          ' system using `jax.local_device_count()`.'
                           .format(self.num_chains, local_device_count(), self.num_chains))
         self.chain_method = chain_method
         self.progress_bar = progress_bar

--- a/numpyro/infer/mcmc.py
+++ b/numpyro/infer/mcmc.py
@@ -210,9 +210,9 @@ class MCMC(object):
     :param int thinning: Positive integer that controls the fraction of post-warmup samples that are
         retained. For example if thinning is 2 then every other sample is retained.
         Defaults to 1, i.e. no thinning.
-    :param int num_chains: Number of Number of MCMC chains to run. By default,
-        chains will be run in parallel using :func:`jax.pmap`, failing which,
-        chains will be run in sequence.
+    :param int num_chains: Number of MCMC chains to run. By default, chains will be
+        run in parallel using :func:`jax.pmap`. If there are not enough devices
+        available, chains will be run in sequence.
     :param postprocess_fn: Post-processing callable - used to convert a collection of unconstrained
         sample values returned from the sampler to constrained values that lie within the support
         of the sample sites. Additionally, this is used to return values at deterministic sites in


### PR DESCRIPTION
Tried to address memory leak as reported by @PaoloRanzi81 in https://github.com/pyro-ppl/numpyro/issues/539 for `chain_method='sequential'` in 1 GPU but haven't found the root problem yet. But I think it would be nice to raise the warning about not enough devices to run parallel method as early as possible.

Also use `jax.local_device_count` instead of `jax.lib.xla_bridge.device_count` to calculate the number of available devices, as mentioned in docs of `pmap`.