### PR TITLE
Add Distribution.infer_shapes() for static shape analysis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@ lint: FORCE
 format: FORCE
 	isort -rc .
 
+install: FORCE
+	pip install -e .[dev,doc,test,examples]
+
 doctest: FORCE
 	$(MAKE) -C docs doctest
 

--- a/numpyro/distributions/conjugate.py
+++ b/numpyro/distributions/conjugate.py
@@ -84,7 +84,7 @@ class DirichletMultinomial(Distribution):
         Dirichlet distribution.
     :param numpy.ndarray total_count: number of Categorical trials.
     """
-    arg_constraints = {'concentration': constraints.positive,
+    arg_constraints = {'concentration': constraints.independent(constraints.positive, 1),
                        'total_count': constraints.nonnegative_integer}
     is_discrete = True
 

--- a/numpyro/distributions/conjugate.py
+++ b/numpyro/distributions/conjugate.py
@@ -67,7 +67,7 @@ class BetaBinomial(Distribution):
     def variance(self):
         return self._beta.variance * self.total_count * (self.concentration0 + self.concentration1 + self.total_count)
 
-    @property
+    @constraints.dependent_property(is_discrete=True, event_dim=0)
     def support(self):
         return constraints.integer_interval(0, self.total_count)
 
@@ -125,9 +125,15 @@ class DirichletMultinomial(Distribution):
         alpha_ratio = alpha / alpha_sum
         return n * alpha_ratio * (1 - alpha_ratio) * (n + alpha_sum) / (1 + alpha_sum)
 
-    @property
+    @constraints.dependent_property(is_discrete=True, event_dim=1)
     def support(self):
         return constraints.multinomial(self.total_count)
+
+    @staticmethod
+    def infer_shapes(concentration, total_count=()):
+        batch_shape = lax.broadcast_shapes(concentration[:-1], total_count)
+        event_shape = concentration[-1:]
+        return batch_shape, event_shape
 
 
 class GammaPoisson(Distribution):

--- a/numpyro/distributions/constraints.py
+++ b/numpyro/distributions/constraints.py
@@ -123,8 +123,62 @@ class _CorrMatrix(Constraint):
 
 
 class _Dependent(Constraint):
+    """
+    Placeholder for variables whose support depends on other variables.
+    These variables obey no simple coordinate-wise constraints.
+
+    :param bool is_discrete: Optional value of ``.is_discrete`` in case this
+        can be computed statically. If not provided, access to the
+        ``.is_discrete`` attribute will raise a NotImplementedError.
+    :param int event_dim: Optional value of ``.event_dim`` in case this can be
+        computed statically. If not provided, access to the ``.event_dim``
+        attribute will raise a NotImplementedError.
+    """
+    def __init__(self, *, is_discrete=NotImplemented, event_dim=NotImplemented):
+        self._is_discrete = is_discrete
+        self._event_dim = event_dim
+        super().__init__()
+
+    @property
+    def is_discrete(self):
+        if self._is_discrete is NotImplemented:
+            raise NotImplementedError(".is_discrete cannot be determined statically")
+        return self._is_discrete
+
+    @property
+    def event_dim(self):
+        if self._event_dim is NotImplemented:
+            raise NotImplementedError(".event_dim cannot be determined statically")
+        return self._event_dim
+
+    def __call__(self, x=None, *, is_discrete=NotImplemented, event_dim=NotImplemented):
+        if x is not None:
+            raise ValueError('Cannot determine validity of dependent constraint')
+
+        # Support for syntax to customize static attributes::
+        #     constraints.dependent(is_discrete=True, event_dim=1)
+        if is_discrete is NotImplemented:
+            is_discrete = self._is_discrete
+        if event_dim is NotImplemented:
+            event_dim = self._event_dim
+        return _Dependent(is_discrete=is_discrete, event_dim=event_dim)
+
+
+class dependent_property(property, _Dependent):
+    def __init__(self, fn=None, *, is_discrete=NotImplemented, event_dim=NotImplemented):
+        super().__init__(fn)
+        self._is_discrete = is_discrete
+        self._event_dim = event_dim
+
     def __call__(self, x):
-        raise ValueError('Cannot determine validity of dependent constraint')
+        if not callable(x):
+            return super().__call__(x)
+
+        # Support for syntax to customize static attributes::
+        #     @constraints.dependent_property(is_discrete=True, event_dim=1)
+        #     def support(self):
+        #         ...
+        return dependent_property(x, is_discrete=self._is_discrete, event_dim=self._event_dim)
 
 
 def is_dependent(constraint):

--- a/numpyro/distributions/continuous.py
+++ b/numpyro/distributions/continuous.py
@@ -1245,6 +1245,12 @@ class Uniform(TransformedDistribution):
             d._support = constraints.interval(*aux_data)
         return d
 
+    @staticmethod
+    def infer_shapes(low=(), high=()):
+        batch_shape = lax.broadcast_shapes(low, high)
+        event_shape = ()
+        return batch_shape, event_shape
+
 
 class Logistic(Distribution):
     arg_constraints = {'loc': constraints.real, 'scale': constraints.positive}

--- a/numpyro/distributions/continuous.py
+++ b/numpyro/distributions/continuous.py
@@ -111,7 +111,7 @@ class Cauchy(Distribution):
 
 
 class Dirichlet(Distribution):
-    arg_constraints = {'concentration': constraints.positive}
+    arg_constraints = {'concentration': constraints.independent(constraints.positive, 1)}
     reparametrized_params = ['concentration']
     support = constraints.simplex
 

--- a/numpyro/distributions/continuous.py
+++ b/numpyro/distributions/continuous.py
@@ -639,7 +639,7 @@ class LKJCholesky(Distribution):
 
 class LogNormal(TransformedDistribution):
     arg_constraints = {'loc': constraints.real, 'scale': constraints.positive}
-    support = constraints.real
+    support = constraints.positive
     reparametrized_params = ['loc', 'scale']
 
     def __init__(self, loc=0., scale=1., validate_args=None):

--- a/numpyro/distributions/continuous.py
+++ b/numpyro/distributions/continuous.py
@@ -715,8 +715,6 @@ class MultivariateNormal(Distribution):
                  validate_args=None):
         if jnp.ndim(loc) == 0:
             loc, = promote_shapes(loc, shape=(1,))
-        # FIXME this expansion can lead to expensive gradient computation; for
-        # discussion see https://github.com/pytorch/pytorch/issues/43837
         # temporary append a new axis to loc
         loc = loc[..., jnp.newaxis]
         if covariance_matrix is not None:
@@ -854,8 +852,6 @@ class LowRankMultivariateNormal(Distribution):
         if jnp.shape(cov_diag)[-1:] != event_shape:
             raise ValueError("`cov_diag` must be a batch of vectors with shape {}".format(self.event_shape))
 
-        # FIXME this expansion can lead to expensive gradient computation; for
-        # discussion see https://github.com/pytorch/pytorch/issues/43837
         loc, cov_factor, cov_diag = promote_shapes(loc[..., jnp.newaxis], cov_factor, cov_diag[..., jnp.newaxis])
         batch_shape = lax.broadcast_shapes(jnp.shape(loc), jnp.shape(cov_factor), jnp.shape(cov_diag))[:-2]
         self.loc = loc[..., 0]

--- a/numpyro/distributions/discrete.py
+++ b/numpyro/distributions/discrete.py
@@ -387,8 +387,6 @@ class OrderedLogistic(CategoricalProbs):
             predictor, = promote_shapes(predictor, shape=(1,))
         else:
             predictor = predictor[..., None]
-        # FIXME this expansion can lead to expensive gradient computation; for
-        # discussion see https://github.com/pytorch/pytorch/issues/43837
         predictor, self.cutpoints = promote_shapes(predictor, cutpoints)
         self.predictor = predictor[..., 0]
         cumulative_probs = expit(cutpoints - predictor)

--- a/numpyro/distributions/discrete.py
+++ b/numpyro/distributions/discrete.py
@@ -396,6 +396,12 @@ class OrderedLogistic(CategoricalProbs):
         probs = cumulative_probs[..., 1:] - cumulative_probs[..., :-1]
         super(OrderedLogistic, self).__init__(probs, validate_args=validate_args)
 
+    @staticmethod
+    def infer_shapes(predictor, cutpoints):
+        batch_shape = lax.broadcast_shapes(predictor, cutpoints[:-1])
+        event_shape = ()
+        return batch_shape, event_shape
+
 
 class PRNGIdentity(Distribution):
     """

--- a/numpyro/distributions/discrete.py
+++ b/numpyro/distributions/discrete.py
@@ -190,7 +190,7 @@ class BinomialProbs(Distribution):
     def variance(self):
         return jnp.broadcast_to(self.total_count * self.probs * (1 - self.probs), self.batch_shape)
 
-    @property
+    @constraints.dependent_property(is_discrete=True, event_dim=0)
     def support(self):
         return constraints.integer_interval(0, self.total_count)
 
@@ -247,7 +247,7 @@ class BinomialLogits(Distribution):
     def variance(self):
         return jnp.broadcast_to(self.total_count * self.probs * (1 - self.probs), self.batch_shape)
 
-    @property
+    @constraints.dependent_property(is_discrete=True, event_dim=0)
     def support(self):
         return constraints.integer_interval(0, self.total_count)
 
@@ -298,7 +298,7 @@ class CategoricalProbs(Distribution):
     def variance(self):
         return jnp.full(self.batch_shape, jnp.nan, dtype=get_dtype(self.probs))
 
-    @property
+    @constraints.dependent_property(is_discrete=True, event_dim=0)
     def support(self):
         return constraints.integer_interval(0, jnp.shape(self.probs)[-1] - 1)
 
@@ -346,7 +346,7 @@ class CategoricalLogits(Distribution):
     def variance(self):
         return jnp.full(self.batch_shape, jnp.nan, dtype=get_dtype(self.logits))
 
-    @property
+    @constraints.dependent_property(is_discrete=True, event_dim=0)
     def support(self):
         return constraints.integer_interval(0, jnp.shape(self.logits)[-1] - 1)
 
@@ -387,6 +387,8 @@ class OrderedLogistic(CategoricalProbs):
             predictor, = promote_shapes(predictor, shape=(1,))
         else:
             predictor = predictor[..., None]
+        # FIXME this expansion can lead to expensive gradient computation; for
+        # discussion see https://github.com/pytorch/pytorch/issues/43837
         predictor, self.cutpoints = promote_shapes(predictor, cutpoints)
         self.predictor = predictor[..., 0]
         cumulative_probs = expit(cutpoints - predictor)
@@ -424,11 +426,11 @@ class MultinomialProbs(Distribution):
     def __init__(self, probs, total_count=1, validate_args=None):
         if jnp.ndim(probs) < 1:
             raise ValueError("`probs` parameter must be at least one-dimensional.")
-        batch_shape = lax.broadcast_shapes(jnp.shape(probs)[:-1], jnp.shape(total_count))
+        batch_shape, event_shape = self.infer_shapes(jnp.shape(probs), jnp.shape(total_count))
         self.probs = promote_shapes(probs, shape=batch_shape + jnp.shape(probs)[-1:])[0]
         self.total_count = promote_shapes(total_count, shape=batch_shape)[0]
         super(MultinomialProbs, self).__init__(batch_shape=batch_shape,
-                                               event_shape=jnp.shape(self.probs)[-1:],
+                                               event_shape=event_shape,
                                                validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
@@ -454,9 +456,15 @@ class MultinomialProbs(Distribution):
     def variance(self):
         return jnp.expand_dims(self.total_count, -1) * self.probs * (1 - self.probs)
 
-    @property
+    @constraints.dependent_property(is_discrete=True, event_dim=1)
     def support(self):
         return constraints.multinomial(self.total_count)
+
+    @staticmethod
+    def infer_shapes(probs, total_count):
+        batch_shape = lax.broadcast_shapes(probs[:-1], total_count)
+        event_shape = probs[-1:]
+        return batch_shape, event_shape
 
 
 class MultinomialLogits(Distribution):
@@ -467,11 +475,11 @@ class MultinomialLogits(Distribution):
     def __init__(self, logits, total_count=1, validate_args=None):
         if jnp.ndim(logits) < 1:
             raise ValueError("`logits` parameter must be at least one-dimensional.")
-        batch_shape = lax.broadcast_shapes(jnp.shape(logits)[:-1], jnp.shape(total_count))
+        batch_shape, event_shape = self.infer_shapes(jnp.shape(logits), jnp.shape(total_count))
         self.logits = promote_shapes(logits, shape=batch_shape + jnp.shape(logits)[-1:])[0]
         self.total_count = promote_shapes(total_count, shape=batch_shape)[0]
         super(MultinomialLogits, self).__init__(batch_shape=batch_shape,
-                                                event_shape=jnp.shape(self.logits)[-1:],
+                                                event_shape=event_shape,
                                                 validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
@@ -498,9 +506,15 @@ class MultinomialLogits(Distribution):
     def variance(self):
         return jnp.expand_dims(self.total_count, -1) * self.probs * (1 - self.probs)
 
-    @property
+    @constraints.dependent_property(is_discrete=True, event_dim=1)
     def support(self):
         return constraints.multinomial(self.total_count)
+
+    @staticmethod
+    def infer_shapes(logits, total_count):
+        batch_shape = lax.broadcast_shapes(logits[:-1], total_count)
+        event_shape = logits[-1:]
+        return batch_shape, event_shape
 
 
 def Multinomial(total_count=1, probs=None, logits=None, validate_args=None):

--- a/numpyro/distributions/distribution.py
+++ b/numpyro/distributions/distribution.py
@@ -36,10 +36,11 @@ import numpy as np
 from jax import lax, tree_util
 import jax.numpy as jnp
 
-import numpyro.distributions.constraints as constraints
 from numpyro.distributions.transforms import ComposeTransform, Transform
 from numpyro.distributions.util import lazy_property, promote_shapes, sum_rightmost, validate_sample
 from numpyro.util import not_jax_tracer
+
+from . import constraints
 
 _VALIDATION_ENABLED = False
 

--- a/numpyro/distributions/distribution.py
+++ b/numpyro/distributions/distribution.py
@@ -378,7 +378,8 @@ class Distribution(metaclass=DistributionMeta):
         try:
             arg_names = cls._arg_names
         except AttributeError:
-            arg_names = cls._arg_names = inspect.getargspec(cls.__init__)[0][1:]
+            sig = inspect.signature(cls.__init__)
+            arg_names = cls._arg_names = tuple(sig.parameters)[1:]
         kwargs.update(zip(arg_names, args))
 
         # Assumes distribution is univariate.

--- a/numpyro/distributions/distribution.py
+++ b/numpyro/distributions/distribution.py
@@ -28,6 +28,7 @@
 from collections import OrderedDict
 from contextlib import contextmanager
 import functools
+import inspect
 import warnings
 
 import numpy as np
@@ -35,7 +36,7 @@ import numpy as np
 from jax import lax, tree_util
 import jax.numpy as jnp
 
-from numpyro.distributions.constraints import independent, is_dependent, real
+import numpyro.distributions.constraints as constraints
 from numpyro.distributions.transforms import ComposeTransform, Transform
 from numpyro.distributions.util import lazy_property, promote_shapes, sum_rightmost, validate_sample
 from numpyro.util import not_jax_tracer
@@ -155,7 +156,7 @@ class Distribution(metaclass=DistributionMeta):
             for param, constraint in self.arg_constraints.items():
                 if param not in self.__dict__ and isinstance(getattr(type(self), param), lazy_property):
                     continue
-                if is_dependent(constraint):
+                if constraints.is_dependent(constraint):
                     continue  # skip constraints that cannot be checked
                 is_valid = constraint(getattr(self, param))
                 if not_jax_tracer(is_valid):
@@ -351,6 +352,43 @@ class Distribution(metaclass=DistributionMeta):
             return self
         return MaskedDistribution(self, mask)
 
+    @classmethod
+    def infer_shapes(cls, *args, **kwargs):
+        r"""
+        Infers ``batch_shape`` and ``event_shape`` given shapes of args to
+        :meth:`__init__`.
+
+        .. note:: This assumes distribution shape depends only on the shapes
+            of tensor inputs, not in the data contained in those inputs.
+
+        :param \*args: Positional args replacing each input arg with a
+            tuple representing the sizes of each tensor input.
+        :param \*\*kwargs: Keywords mapping name of input arg to tuple
+            representing the sizes of each tensor input.
+        :returns: A pair ``(batch_shape, event_shape)`` of the shapes of a
+            distribution that would be created with input args of the given
+            shapes.
+        :rtype: tuple
+        """
+        if cls.support.event_dim > 0:
+            raise NotImplementedError
+
+        # Convert args to kwargs.
+        try:
+            arg_names = cls._arg_names
+        except AttributeError:
+            arg_names = cls._arg_names = inspect.getargspec(cls.__init__)[0][1:]
+        kwargs.update(zip(arg_names, args))
+
+        # Assumes distribution is univariate.
+        batch_shapes = []
+        for name, shape in kwargs.items():
+            event_dim = cls.arg_constraints.get(name, constraints.real).event_dim
+            batch_shapes.append(shape[:len(shape) - event_dim])
+        batch_shape = lax.broadcast_shapes(*batch_shapes) if batch_shapes else ()
+        event_shape = ()
+        return batch_shape, event_shape
+
 
 class ExpandedDistribution(Distribution):
     arg_constraints = {}
@@ -516,9 +554,10 @@ class ImproperUniform(Distribution):
     :param tuple event_shape: event shape of this distribution.
     """
     arg_constraints = {}
+    support = constraints.dependent
 
     def __init__(self, support, batch_shape, event_shape, validate_args=None):
-        self.support = independent(support, len(event_shape) - support.event_dim)
+        self.support = constraints.independent(support, len(event_shape) - support.event_dim)
         super().__init__(batch_shape, event_shape, validate_args=validate_args)
 
     @validate_sample
@@ -582,7 +621,7 @@ class Independent(Distribution):
 
     @property
     def support(self):
-        return independent(self.base_dist.support, self.reinterpreted_batch_ndims)
+        return constraints.independent(self.base_dist.support, self.reinterpreted_batch_ndims)
 
     @property
     def has_enumerate_support(self):
@@ -797,7 +836,7 @@ class TransformedDistribution(Distribution):
         if self.event_dim == codomain_event_dim:
             return codomain
         else:
-            return independent(codomain, self.event_dim - codomain_event_dim)
+            return constraints.independent(codomain, self.event_dim - codomain_event_dim)
 
     def sample(self, key, sample_shape=()):
         x = self.base_dist(rng_key=key, sample_shape=sample_shape)
@@ -853,7 +892,8 @@ class TransformedDistribution(Distribution):
 
 
 class Delta(Distribution):
-    arg_constraints = {'v': real, 'log_density': real}
+    # FIXME v and log_density should be constraints.independent(constraints.real, ???)
+    arg_constraints = {'v': constraints.real, 'log_density': constraints.real}
     reparameterized_params = ['v', 'log_density']
     is_discrete = True
 
@@ -869,9 +909,9 @@ class Delta(Distribution):
         self.log_density = promote_shapes(log_density, shape=batch_shape)[0]
         super(Delta, self).__init__(batch_shape, event_shape, validate_args=validate_args)
 
-    @property
+    @constraints.dependent_property(is_discrete=True)
     def support(self):
-        return independent(real, self.event_dim)
+        return constraints.independent(constraints.real, self.event_dim)
 
     def sample(self, key, sample_shape=()):
         shape = sample_shape + self.batch_shape + self.event_shape
@@ -907,8 +947,8 @@ class Unit(Distribution):
 
     This is used for :func:`numpyro.factor` statements.
     """
-    arg_constraints = {'log_factor': real}
-    support = real
+    arg_constraints = {'log_factor': constraints.real}
+    support = constraints.real
 
     def __init__(self, log_factor, validate_args=None):
         batch_shape = jnp.shape(log_factor)

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -335,12 +335,12 @@ def test_dist_shape(jax_dist, sp_dist, params, prepend_shape):
         assert_allclose(jax_dist.precision_matrix, jnp.linalg.inv(jax_dist.covariance_matrix), rtol=1e-6)
 
 
-@pytest.mark.parametrize('jax_dist, sp_dist, params', CONTINUOUS + DISCRETE + DIRECTIONAL)
 @pytest.mark.parametrize('prepend_shape', [
     (),
     (2,),
     (2, 3),
-])
+], ids=str)
+@pytest.mark.parametrize('jax_dist, sp_dist, params', CONTINUOUS + DISCRETE + DIRECTIONAL)
 def test_infer_shapes(jax_dist, sp_dist, params, prepend_shape):
     shapes = tuple(getattr(p, "shape", ()) for p in params)
     try:

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -334,15 +334,22 @@ def test_dist_shape(jax_dist, sp_dist, params, prepend_shape):
         assert jax_dist.covariance_matrix.ndim == len(jax_dist.batch_shape) + 2
         assert_allclose(jax_dist.precision_matrix, jnp.linalg.inv(jax_dist.covariance_matrix), rtol=1e-6)
 
-    # Test static .infer_shapes() method.
+
+@pytest.mark.parametrize('jax_dist, sp_dist, params', CONTINUOUS + DISCRETE + DIRECTIONAL)
+@pytest.mark.parametrize('prepend_shape', [
+    (),
+    (2,),
+    (2, 3),
+])
+def test_infer_shapes(jax_dist, sp_dist, params, prepend_shape):
     shapes = tuple(getattr(p, "shape", ()) for p in params)
     try:
-        expected_batch_shape, expected_event_shape = type(jax_dist).infer_shapes(*shapes)
+        expected_batch_shape, expected_event_shape = jax_dist.infer_shapes(*shapes)
     except NotImplementedError:
-        pass
-    else:
-        assert jax_dist.batch_shape == expected_batch_shape
-        assert jax_dist.event_shape == expected_event_shape
+        pytest.skip(f'{jax_dist.__name__}.infer_shapes() is not implemented')
+    jax_dist = jax_dist(*params)
+    assert jax_dist.batch_shape == expected_batch_shape
+    assert jax_dist.event_shape == expected_event_shape
 
 
 @pytest.mark.parametrize('jax_dist, sp_dist, params', CONTINUOUS + DISCRETE + DIRECTIONAL)

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -334,6 +334,16 @@ def test_dist_shape(jax_dist, sp_dist, params, prepend_shape):
         assert jax_dist.covariance_matrix.ndim == len(jax_dist.batch_shape) + 2
         assert_allclose(jax_dist.precision_matrix, jnp.linalg.inv(jax_dist.covariance_matrix), rtol=1e-6)
 
+    # Test static .infer_shapes() method.
+    shapes = tuple(getattr(p, "shape", ()) for p in params)
+    try:
+        expected_batch_shape, expected_event_shape = type(jax_dist).infer_shapes(*shapes)
+    except NotImplementedError:
+        pass
+    else:
+        assert jax_dist.batch_shape == expected_batch_shape
+        assert jax_dist.event_shape == expected_event_shape
+
 
 @pytest.mark.parametrize('jax_dist, sp_dist, params', CONTINUOUS + DISCRETE + DIRECTIONAL)
 def test_has_rsample(jax_dist, sp_dist, params):


### PR DESCRIPTION
Addresses https://github.com/pyro-ppl/funsor/issues/412
Ports `.infer_shape()` from https://github.com/pyro-ppl/pyro/pull/2739
Ports `dependent_property` from https://github.com/pytorch/pytorch/pull/50581

This adds a static method `Disribution.infer_shapes()` to statically infer `(batch_shape, event_shape)` from the shapes of distribution parameters. This should speed up funsor computations as described in https://github.com/pyro-ppl/funsor/issues/412. Note this works for only a subset of distributions; shapes cannot currently be statically inferred for distributions with non-tensor inputs such as `TransformedDistribution` which takes a distribution, or `Delta` which takes an `event_dim: int`.

This generic logic requires static `.event_dim` attributes on dependent supports. Because NumPyro uses `Constraint.__call__()` rather than `Constraint.check()` I've added a type check to determine behavior in `_Dependent.__call__()`.

## Tested
- [x] added a unit test to test_distributions.py