### PR TITLE
Fix DiscreteHMCGibbs to work with multiple chains

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,7 @@ jobs:
       run: |
         XLA_FLAGS="--xla_force_host_platform_device_count=2" pytest -vs test/test_mcmc.py -k "chain or pmap or vmap"
         XLA_FLAGS="--xla_force_host_platform_device_count=2" pytest -vs test/contrib/test_tfp.py -k "chain"
+        XLA_FLAGS="--xla_force_host_platform_device_count=2" pytest -vs test/test_hmc_gibbs.py -k "chain"
 
 
   examples:

--- a/numpyro/infer/hmc_gibbs.py
+++ b/numpyro/infer/hmc_gibbs.py
@@ -325,7 +325,7 @@ class DiscreteHMCGibbs(HMCGibbs):
         >>> kernel = DiscreteHMCGibbs(NUTS(model), modified=True)
         >>> mcmc = MCMC(kernel, 1000, 100000, progress_bar=False)
         >>> mcmc.run(random.PRNGKey(0), probs, locs)
-        >>> mcmc.print_summary()
+        >>> mcmc.print_summary()  # doctest: +SKIP
         >>> samples = mcmc.get_samples()["x"]
         >>> assert abs(jnp.mean(samples) - 1.3) < 0.1
         >>> assert abs(jnp.var(samples) - 4.36) < 0.5

--- a/numpyro/infer/hmc_gibbs.py
+++ b/numpyro/infer/hmc_gibbs.py
@@ -293,13 +293,11 @@ class DiscreteHMCGibbs(HMCGibbs):
         corresponding :func:`~numpyro.primitives.sample` statement.
 
     :param inner_kernel: One of :class:`~numpyro.infer.hmc.HMC` or :class:`~numpyro.infer.hmc.NUTS`.
-    :param list discrete_sites: a list of site names for the discrete latent variables
-        that are covered by the Gibbs sampler.
     :param bool random_walk: If False, Gibbs sampling will be used to draw a sample from the
         conditional `p(gibbs_site | remaining sites)`. Otherwise, a sample will be drawn uniformly
-        from the domain of `gibbs_site`.
+        from the domain of `gibbs_site`. Defaults to False.
     :param bool modified: whether to use a modified proposal, as suggested in reference [1], which
-        always proposes a new state for the current Gibbs site.
+        always proposes a new state for the current Gibbs site. Defaults to False.
         The modified scheme appears in the literature under the name "modified Gibbs sampler" or
         "Metropolised Gibbs sampler".
 
@@ -364,6 +362,7 @@ class DiscreteHMCGibbs(HMCGibbs):
                              and site["fn"].has_enumerate_support
                              and not site["is_observed"]
                              and site["infer"].get("enumerate", "") != "parallel"]
+        assert self._gibbs_sites, "Cannot detect any discrete latent variables in the model."
         return super().init(rng_key, num_warmup, init_params, model_args, model_kwargs)
 
     def sample(self, state, model_args, model_kwargs):
@@ -492,6 +491,7 @@ class HMCECS(HMCGibbs):
             if site["type"] == "plate" and site["args"][0] > site["args"][1]  # i.e. size > subsample_size
         }
         self._gibbs_sites = list(self._plate_sizes.keys())
+        assert self._gibbs_sites, "Cannot detect any subsample statements in the model."
         return super().init(rng_key, num_warmup, init_params, model_args, model_kwargs)
 
     def sample(self, state, model_args, model_kwargs):

--- a/numpyro/infer/hmc_gibbs.py
+++ b/numpyro/infer/hmc_gibbs.py
@@ -5,6 +5,8 @@ from collections import namedtuple
 import copy
 from functools import partial
 
+import numpy as np
+
 from jax import device_put, grad, jacfwd, ops, random, value_and_grad
 import jax.numpy as jnp
 from jax.scipy.special import expit
@@ -353,7 +355,7 @@ class DiscreteHMCGibbs(HMCGibbs):
         self._prototype_trace = trace(seed(self.model, key_u)).get_trace(*model_args, **model_kwargs)
 
         self._support_sizes = {
-            name: jnp.broadcast_to(site["fn"].enumerate_support(False).shape[0], jnp.shape(site["value"]))
+            name: np.broadcast_to(site["fn"].enumerate_support(False).shape[0], jnp.shape(site["value"]))
             for name, site in self._prototype_trace.items()
             if site["type"] == "sample" and site["fn"].has_enumerate_support and not site["is_observed"]
         }

--- a/numpyro/infer/hmc_util.py
+++ b/numpyro/infer/hmc_util.py
@@ -415,7 +415,9 @@ def warmup_adapter(num_adapt_steps, find_reasonable_step_size=None,
 
         if adapt_step_size:
             step_size = find_reasonable_step_size(step_size, inverse_mass_matrix, z_info, rng_key_ss)
-            ss_state = ss_init(jnp.log(10 * step_size))
+            # NB: when step_size is large, say 1e38, jnp.log(10 * step_size) will be inf
+            # and jnp.log(10) + jnp.log(step_size) will be finite
+            ss_state = ss_init(jnp.log(10) + jnp.log(step_size))
 
         return HMCAdaptState(step_size, inverse_mass_matrix, mass_matrix_sqrt,
                              ss_state, mm_state, window_idx, rng_key)
@@ -475,6 +477,8 @@ def _is_turning(inverse_mass_matrix, r_left, r_right, r_sum):
     elif inverse_mass_matrix.ndim == 1:
         v_left = jnp.multiply(inverse_mass_matrix, r_left)
         v_right = jnp.multiply(inverse_mass_matrix, r_right)
+    else:
+        raise ValueError("invese_mass_matrix should have 1 or 2 dimensions.")
 
     # This implements dynamic termination criterion (ref [2], section A.4.2).
     r_sum = r_sum - (r_left + r_right) / 2
@@ -737,6 +741,8 @@ def euclidean_kinetic_energy(inverse_mass_matrix, r):
         v = jnp.matmul(inverse_mass_matrix, r)
     elif inverse_mass_matrix.ndim == 1:
         v = jnp.multiply(inverse_mass_matrix, r)
+    else:
+        raise ValueError("invese_mass_matrix should have 1 or 2 dimensions.")
 
     return 0.5 * jnp.dot(v, r)
 
@@ -748,6 +754,8 @@ def _euclidean_kinetic_energy_grad(inverse_mass_matrix, r):
         v = jnp.matmul(inverse_mass_matrix, r)
     elif inverse_mass_matrix.ndim == 1:
         v = jnp.multiply(inverse_mass_matrix, r)
+    else:
+        raise ValueError("invese_mass_matrix should have 1 or 2 dimensions.")
 
     return unravel_fn(v)
 

--- a/test/test_hmc_gibbs.py
+++ b/test/test_hmc_gibbs.py
@@ -203,7 +203,7 @@ def test_discrete_gibbs_gmm_1d(modified):
     mcmc.run(random.PRNGKey(0), probs, locs)
     samples = mcmc.get_samples()
     assert_allclose(jnp.mean(samples["x"]), 1.3, atol=0.1)
-    assert_allclose(jnp.var(samples["x"]), 4.36, atol=0.1)
+    assert_allclose(jnp.var(samples["x"]), 4.36, atol=0.2)
     assert_allclose(jnp.mean(samples["c"]), 1.65, atol=0.1)
     assert_allclose(jnp.var(samples["c"]), 1.03, atol=0.1)
 

--- a/test/test_hmc_util.py
+++ b/test/test_hmc_util.py
@@ -322,7 +322,7 @@ def test_warmup_adapter(jitted):
     assert window_idx == 3
     # during the last window, because target_accept_prob=0.8,
     # log_step_size will be equal to the constant prox_center=log(10*last_step_size)
-    assert_allclose(step_size, last_step_size * 10)
+    assert_allclose(step_size, last_step_size * 10, atol=1e-6)
     # Verifies that inverse_mass_matrix does not change during the last window
     # despite z_flat changes w.r.t time t,
     assert_allclose(final_inverse_mass_matrix, inverse_mass_matrix)


### PR DESCRIPTION
Fixes #907. The issue is when we `pmap` the `DiscreteHMCGibbs.init` method, with `jnp.broadcast_to`, the `support_sizes` will be a tracer, rather than a concrete array. It raises some errors as reported in #907.

Also fixes #897 to raise errors when there are no gibbs sites.