### PR TITLE
Add positive ordered vector constraint, deprecate InvCholeskyTransform

### DIFF
--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -526,6 +526,10 @@ positive_integer
 -----------------
 .. autodata:: numpyro.distributions.constraints.positive_integer
 
+positive_ordered_vector
+-----------------------
+.. autodata:: numpyro.distributions.constraints.positive_ordered_vector
+
 real
 ----
 .. autodata:: numpyro.distributions.constraints.real
@@ -574,6 +578,14 @@ AffineTransform
     :show-inheritance:
     :member-order: bysource
 
+CholeskyTransform
+-----------------
+.. autoclass:: numpyro.distributions.transforms.CholeskyTransform
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :member-order: bysource
+
 ComposeTransform
 ----------------
 .. autoclass:: numpyro.distributions.transforms.ComposeTransform
@@ -585,6 +597,14 @@ ComposeTransform
 CorrCholeskyTransform
 ---------------------
 .. autoclass:: numpyro.distributions.transforms.CorrCholeskyTransform
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :member-order: bysource
+
+CorrMatrixCholeskyTransform
+---------------------------
+.. autoclass:: numpyro.distributions.transforms.CorrMatrixCholeskyTransform
     :members:
     :undoc-members:
     :show-inheritance:

--- a/numpyro/distributions/constraints.py
+++ b/numpyro/distributions/constraints.py
@@ -333,6 +333,21 @@ class _PositiveDefinite(Constraint):
         return jax.numpy.broadcast_to(jax.numpy.eye(prototype.shape[-1]), prototype.shape)
 
 
+class _PositiveOrderedVector(Constraint):
+    """
+    Constrains to a positive real-valued tensor where the elements are monotonically
+    increasing along the `event_shape` dimension.
+    """
+    event_dim = 1
+
+    def __call__(self, x):
+        return ordered_vector.check(x) & independent(positive, 1).check(x)
+
+    def feasible_like(self, prototype):
+        return jax.numpy.broadcast_to(jax.numpy.exp(jax.numpy.arange(float(prototype.shape[-1]))),
+                                      prototype.shape)
+
+
 class _Real(Constraint):
     def __call__(self, x):
         # XXX: consider to relax this condition to [-inf, inf] interval
@@ -372,6 +387,7 @@ ordered_vector = _OrderedVector()
 positive = _GreaterThan(0.)
 positive_definite = _PositiveDefinite()
 positive_integer = _IntegerGreaterThan(1)
+positive_ordered_vector = _PositiveOrderedVector()
 real = _Real()
 real_vector = independent(real, 1)
 simplex = _Simplex()

--- a/numpyro/distributions/continuous.py
+++ b/numpyro/distributions/continuous.py
@@ -35,7 +35,7 @@ from jax.scipy.special import gammaln, log_ndtr, logsumexp, multigammaln, ndtr, 
 
 from numpyro.distributions import constraints
 from numpyro.distributions.distribution import Distribution, TransformedDistribution
-from numpyro.distributions.transforms import AffineTransform, ExpTransform, InvCholeskyTransform, PowerTransform
+from numpyro.distributions.transforms import AffineTransform, CorrMatrixCholeskyTransform, ExpTransform, PowerTransform
 from numpyro.distributions.util import (
     cholesky_of_inverse,
     is_prng_key,
@@ -446,7 +446,7 @@ class LKJ(TransformedDistribution):
         base_dist = LKJCholesky(dimension, concentration, sample_method)
         self.dimension, self.concentration = base_dist.dimension, base_dist.concentration
         self.sample_method = sample_method
-        super(LKJ, self).__init__(base_dist, InvCholeskyTransform(domain=constraints.corr_cholesky),
+        super(LKJ, self).__init__(base_dist, CorrMatrixCholeskyTransform().inv,
                                   validate_args=validate_args)
 
     @property

--- a/numpyro/distributions/transforms.py
+++ b/numpyro/distributions/transforms.py
@@ -29,8 +29,10 @@ __all__ = [
     'biject_to',
     'AbsTransform',
     'AffineTransform',
+    'CholeskyTransform',
     'ComposeTransform',
     'CorrCholeskyTransform',
+    'CorrMatrixCholeskyTransform',
     'ExpTransform',
     'IdentityTransform',
     'InvCholeskyTransform',
@@ -315,6 +317,27 @@ def _matrix_inverse_shape(shape, offset=0):
     return shape[:-2] + (N,)
 
 
+class CholeskyTransform(Transform):
+    r"""
+    Transform via the mapping :math:`y = cholesky(x)`, where `x` is a
+    positive definite matrix.
+    """
+    domain = constraints.positive_definite
+    codomain = constraints.lower_cholesky
+
+    def __call__(self, x):
+        return jnp.linalg.cholesky(x)
+
+    def _inverse(self, y):
+        return jnp.matmul(y, jnp.swapaxes(y, -2, -1))
+
+    def log_abs_det_jacobian(self, x, y, intermediates=None):
+        # Ref: http://web.mit.edu/18.325/www/handouts/handout2.pdf page 13
+        n = jnp.shape(x)[-1]
+        order = -jnp.arange(n, 0, -1)
+        return -n * jnp.log(2) + jnp.sum(order * jnp.log(jnp.diagonal(y, axis1=-2, axis2=-1)), axis=-1)
+
+
 class CorrCholeskyTransform(Transform):
     r"""
     Transforms a uncontrained real vector :math:`x` with length :math:`D*(D-1)/2` into the
@@ -382,6 +405,21 @@ class CorrCholeskyTransform(Transform):
 
     def inverse_shape(self, shape):
         return _matrix_inverse_shape(shape, offset=-1)
+
+
+class CorrMatrixCholeskyTransform(CholeskyTransform):
+    r"""
+    Transform via the mapping :math:`y = cholesky(x)`, where `x` is a
+    correlation matrix.
+    """
+    domain = constraints.corr_matrix
+    codomain = constraints.corr_cholesky
+
+    def log_abs_det_jacobian(self, x, y, intermediates=None):
+        # NB: see derivation in LKJCholesky implementation
+        n = jnp.shape(x)[-1]
+        order = -jnp.arange(n - 1, -1, -1)
+        return jnp.sum(order * jnp.log(jnp.diagonal(y, axis1=-2, axis2=-1)), axis=-1)
 
 
 class ExpTransform(Transform):
@@ -477,6 +515,8 @@ class InvCholeskyTransform(Transform):
     """
 
     def __init__(self, domain=constraints.lower_cholesky):
+        warnings.warn("InvCholeskyTransform is deprecated. Please use CholeskyTransform"
+                      " or CorrMatrixCholeskyTransform instead.", FutureWarning)
         assert domain in [constraints.lower_cholesky, constraints.corr_cholesky]
         self.domain = domain
 
@@ -779,7 +819,7 @@ def _transform_to_corr_cholesky(constraint):
 @biject_to.register(constraints.corr_matrix)
 def _transform_to_corr_matrix(constraint):
     return ComposeTransform([CorrCholeskyTransform(),
-                             InvCholeskyTransform(domain=constraints.corr_cholesky)])
+                             CorrMatrixCholeskyTransform().inv])
 
 
 @biject_to.register(constraints.greater_than)
@@ -826,7 +866,12 @@ def _transform_to_ordered_vector(constraint):
 
 @biject_to.register(constraints.positive_definite)
 def _transform_to_positive_definite(constraint):
-    return ComposeTransform([LowerCholeskyTransform(), InvCholeskyTransform()])
+    return ComposeTransform([LowerCholeskyTransform(), CholeskyTransform().inv])
+
+
+@biject_to.register(constraints.positive_ordered_vector)
+def _transform_to_positive_ordered_vector(constraint):
+    return ComposeTransform([OrderedTransform(), ExpTransform()])
 
 
 @biject_to.register(constraints.real)

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -953,6 +953,7 @@ def test_constraints(constraint, x, expected):
     constraints.ordered_vector,
     constraints.positive,
     constraints.positive_definite,
+    constraints.positive_ordered_vector,
     constraints.real,
     constraints.real_vector,
     constraints.simplex,
@@ -1001,7 +1002,8 @@ def test_biject_to(constraint, shape):
         if constraint is constraints.simplex:
             expected = np.linalg.slogdet(jax.jacobian(transform)(x)[:-1, :])[1]
             inv_expected = np.linalg.slogdet(jax.jacobian(transform.inv)(y)[:, :-1])[1]
-        elif constraint in [constraints.real_vector, constraints.ordered_vector]:
+        elif constraint in [constraints.real_vector, constraints.ordered_vector,
+                            constraints.positive_ordered_vector]:
             expected = np.linalg.slogdet(jax.jacobian(transform)(x))[1]
             inv_expected = np.linalg.slogdet(jax.jacobian(transform.inv)(y))[1]
         elif constraint in [constraints.corr_cholesky, constraints.corr_matrix]:


### PR DESCRIPTION
Addresses #906. This adds `positive_ordered_vector` constraint and refactor `InvCholeskyTransform` into `CholeskyTransform` and `CorrMatrixCholeskyTransform`.