### PR TITLE
Add one-sided/two-sided truncated distribution and cdf/icdf method for univariate symmetric distributions

### DIFF
--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -245,6 +245,14 @@ TruncatedCauchy
     :show-inheritance:
     :member-order: bysource
 
+TruncatedDistribution
+---------------------
+.. autoclass:: numpyro.distributions.continuous.TruncatedDistribution
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :member-order: bysource
+
 TruncatedNormal
 ---------------
 .. autoclass:: numpyro.distributions.continuous.TruncatedNormal

--- a/numpyro/distributions/__init__.py
+++ b/numpyro/distributions/__init__.py
@@ -26,6 +26,7 @@ from numpyro.distributions.continuous import (
     Pareto,
     StudentT,
     TruncatedCauchy,
+    TruncatedDistribution,
     TruncatedNormal,
     TruncatedPolyaGamma,
     Uniform
@@ -121,6 +122,7 @@ __all__ = [
     'StudentT',
     'TransformedDistribution',
     'TruncatedCauchy',
+    'TruncatedDistribution',
     'TruncatedNormal',
     'TruncatedPolyaGamma',
     'Uniform',

--- a/numpyro/distributions/distribution.py
+++ b/numpyro/distributions/distribution.py
@@ -391,6 +391,24 @@ class Distribution(metaclass=DistributionMeta):
         event_shape = ()
         return batch_shape, event_shape
 
+    def cdf(self, value):
+        """
+        The cummulative distribution function of this distribution.
+
+        :param value: samples from this distribution.
+        :return: output of the cummulative distribution function evaluated at `value`.
+        """
+        raise NotImplementedError
+
+    def icdf(self, q):
+        """
+        The inverse cumulative distribution function of this distribution.
+
+        :param q: quantile values, should belong to [0, 1].
+        :return: the samples whose cdf values equals to `q`.
+        """
+        raise NotImplementedError
+
 
 class ExpandedDistribution(Distribution):
     arg_constraints = {}


### PR DESCRIPTION
Resolves #895, #894, #914. The implementation only supports symmetric distributions because we can leverage the symmetry to address numerical issues that are discussed at [probtorch](https://github.com/probtorch/pytorch/pull/121) for the lower bound > 5. The issue is cdf/icdf suffers from precision errors at the right tail (e.g. `Normal().cdf(6.) = 1.`). Thanks to the symmetry, we can transform the right tail to the left tail, which has better precision (e.g. `Normal().cdf(-6.) = 9.865896e-10`).

### TODO
- [x] Add student T cdf/icdf
- [x] Support truncated from above
- [x] Add tests for cdf/icdf
- [x] Add tests for TruncatedDistribution
- [x] Make pytree test pass