### PR TITLE
Reduce memory requirement for AutoLowRankMultivariateNormal.quantiles

### DIFF
--- a/numpyro/infer/autoguide.py
+++ b/numpyro/infer/autoguide.py
@@ -691,8 +691,10 @@ class AutoLowRankMultivariateNormal(AutoContinuous):
         return self._unpack_and_constrain(loc, params)
 
     def quantiles(self, params, quantiles):
-        posterior = self.get_posterior(params)
-        loc, scale = posterior.loc, jnp.sqrt(posterior.variance)
+        loc = params[f'{self.prefix}_loc']
+        cov_factor = params[f'{self.prefix}_cov_factor']
+        scale = params[f'{self.prefix}_scale']
+        scale = scale * jnp.sqrt(jnp.square(cov_factor).sum(-1) + 1)
         quantiles = jnp.array(quantiles)[..., None]
         latent = dist.Normal(loc, scale).icdf(quantiles)
         return self._unpack_and_constrain(latent, params)

--- a/numpyro/infer/autoguide.py
+++ b/numpyro/infer/autoguide.py
@@ -691,9 +691,10 @@ class AutoLowRankMultivariateNormal(AutoContinuous):
         return self._unpack_and_constrain(loc, params)
 
     def quantiles(self, params, quantiles):
-        transform = self.get_transform(params)
+        posterior = self.get_posterior(params)
+        loc, scale = posterior.loc, jnp.sqrt(posterior.variance)
         quantiles = jnp.array(quantiles)[..., None]
-        latent = dist.Normal(transform.loc, jnp.diagonal(transform.scale_tril)).icdf(quantiles)
+        latent = dist.Normal(loc, scale).icdf(quantiles)
         return self._unpack_and_constrain(latent, params)
 
 


### PR DESCRIPTION
Fixes #920. Currently, computing `quantiles` in AutoLowRankMVN requires computing an `N x N` scale_tril matrix. It is expensive.

Testing: current tests for AutoLowRankMVN.quantiles pass.