### PR TITLE
Port get_mask to NumPyro

### DIFF
--- a/docs/source/primitives.rst
+++ b/docs/source/primitives.rst
@@ -35,6 +35,10 @@ factor
 ------
 .. autofunction:: numpyro.primitives.factor
 
+get_mask
+--------
+.. autofunction:: numpyro.primitives.get_mask
+
 module
 ------
 .. autofunction:: numpyro.primitives.module

--- a/numpyro/__init__.py
+++ b/numpyro/__init__.py
@@ -4,7 +4,7 @@
 from numpyro import compat, diagnostics, distributions, handlers, infer, optim
 from numpyro.distributions.distribution import enable_validation, validation_enabled
 import numpyro.patch  # noqa: F401
-from numpyro.primitives import deterministic, factor, module, param, plate, plate_stack, prng_key, sample, subsample
+from numpyro.primitives import deterministic, factor, get_mask, module, param, plate, plate_stack, prng_key, sample, subsample
 from numpyro.util import enable_x64, set_host_device_count, set_platform
 from numpyro.version import __version__
 
@@ -20,6 +20,7 @@ __all__ = [
     'enable_x64',
     'enable_validation',
     'factor',
+    'get_mask',
     'handlers',
     'infer',
     'module',

--- a/numpyro/__init__.py
+++ b/numpyro/__init__.py
@@ -4,34 +4,45 @@
 from numpyro import compat, diagnostics, distributions, handlers, infer, optim
 from numpyro.distributions.distribution import enable_validation, validation_enabled
 import numpyro.patch  # noqa: F401
-from numpyro.primitives import deterministic, factor, get_mask, module, param, plate, plate_stack, prng_key, sample, subsample
+from numpyro.primitives import (
+    deterministic,
+    factor,
+    get_mask,
+    module,
+    param,
+    plate,
+    plate_stack,
+    prng_key,
+    sample,
+    subsample,
+)
 from numpyro.util import enable_x64, set_host_device_count, set_platform
 from numpyro.version import __version__
 
-set_platform('cpu')
+set_platform("cpu")
 
 
 __all__ = [
-    '__version__',
-    'compat',
-    'deterministic',
-    'diagnostics',
-    'distributions',
-    'enable_x64',
-    'enable_validation',
-    'factor',
-    'get_mask',
-    'handlers',
-    'infer',
-    'module',
-    'optim',
-    'param',
-    'plate',
-    'plate_stack',
-    'prng_key',
-    'sample',
-    'subsample',
-    'set_host_device_count',
-    'set_platform',
-    'validation_enabled',
+    "__version__",
+    "compat",
+    "deterministic",
+    "diagnostics",
+    "distributions",
+    "enable_x64",
+    "enable_validation",
+    "factor",
+    "get_mask",
+    "handlers",
+    "infer",
+    "module",
+    "optim",
+    "param",
+    "plate",
+    "plate_stack",
+    "prng_key",
+    "sample",
+    "subsample",
+    "set_host_device_count",
+    "set_platform",
+    "validation_enabled",
 ]

--- a/numpyro/handlers.py
+++ b/numpyro/handlers.py
@@ -484,6 +484,8 @@ class mask(Messenger):
 
     def process_message(self, msg):
         if msg['type'] != 'sample':
+            if msg["type"] == "inspect":
+                msg["mask"] = self.mask if msg["mask"] is None else (self.mask & msg["mask"])
             return
 
         msg['fn'] = msg['fn'].mask(self.mask)

--- a/numpyro/infer/autoguide.py
+++ b/numpyro/infer/autoguide.py
@@ -416,10 +416,13 @@ class AutoContinuous(AutoGuide):
             site = self.prototype_trace[name]
             transform = biject_to(site['fn'].support)
             value = transform(unconstrained_value)
-            log_density = - transform.log_abs_det_jacobian(unconstrained_value, value)
-            event_ndim = site['fn'].event_dim
-            log_density = sum_rightmost(log_density,
-                                        jnp.ndim(log_density) - jnp.ndim(value) + event_ndim)
+            if numpyro.get_mask() is False:
+                log_density = 0.
+            else:
+                log_density = - transform.log_abs_det_jacobian(unconstrained_value, value)
+                event_ndim = site['fn'].event_dim
+                log_density = sum_rightmost(log_density,
+                                            jnp.ndim(log_density) - jnp.ndim(value) + event_ndim)
             delta_dist = dist.Delta(value, log_density=log_density, event_dim=event_ndim)
             result[name] = numpyro.sample(name, delta_dist)
 

--- a/numpyro/infer/hmc_gibbs.py
+++ b/numpyro/infer/hmc_gibbs.py
@@ -760,10 +760,9 @@ class estimate_likelihood(numpyro.primitives.Messenger):
         if self.params is None:
             return
 
-        # add numpyro.factor; ideally, we will want to skip this computation when making prediction
-        # see: https://github.com/pyro-ppl/pyro/issues/2744
-        numpyro.factor("_biased_corrected_log_likelihood",
-                       self.method(self.likelihoods, self.params, self.gibbs_state))
+        if numpyro.get_mask() is not False:
+            numpyro.factor("_biased_corrected_log_likelihood",
+                           self.method(self.likelihoods, self.params, self.gibbs_state))
 
         # clean up
         self.params = None

--- a/numpyro/infer/reparam.py
+++ b/numpyro/infer/reparam.py
@@ -226,6 +226,7 @@ class NeuTraReparam(Reparam):
         assert obs is None, "NeuTraReparam does not support observe statements"
 
         log_density = 0.
+        compute_density = (numpyro.get_mask() is not False)
         if not self._x_unconstrained:  # On first sample site.
             # Sample a shared latent.
             z_unconstrained = numpyro.sample("{}_shared_latent".format(self.guide.prefix),
@@ -233,17 +234,18 @@ class NeuTraReparam(Reparam):
 
             # Differentiably transform.
             x_unconstrained = self.transform(z_unconstrained)
-            # TODO: find a way to only compute those log_prob terms when needed
-            log_density = self.transform.log_abs_det_jacobian(z_unconstrained, x_unconstrained)
+            if compute_density:
+                log_density = self.transform.log_abs_det_jacobian(z_unconstrained, x_unconstrained)
             self._x_unconstrained = self.guide._unpack_latent(x_unconstrained)
 
         # Extract a single site's value from the shared latent.
         unconstrained_value = self._x_unconstrained.pop(name)
         transform = biject_to(fn.support)
         value = transform(unconstrained_value)
-        logdet = transform.log_abs_det_jacobian(unconstrained_value, value)
-        logdet = sum_rightmost(logdet, jnp.ndim(logdet) - jnp.ndim(value) + len(fn.event_shape))
-        log_density = log_density + fn.log_prob(value) + logdet
+        if compute_density:
+            logdet = transform.log_abs_det_jacobian(unconstrained_value, value)
+            logdet = sum_rightmost(logdet, jnp.ndim(logdet) - jnp.ndim(value) + len(fn.event_shape))
+            log_density = log_density + fn.log_prob(value) + logdet
         numpyro.factor("_{}_log_prob".format(name), log_density)
         return None, value
 

--- a/numpyro/infer/util.py
+++ b/numpyro/infer/util.py
@@ -490,6 +490,8 @@ def initialize_model(rng_key, model,
 
 def _predictive(rng_key, model, posterior_samples, batch_shape, return_sites=None,
                 parallel=True, model_args=(), model_kwargs={}):
+    model = numpyro.handlers.mask(model, mask=False)
+
     def single_prediction(val):
         rng_key, samples = val
         model_trace = trace(seed(substitute(model, samples), rng_key)).get_trace(

--- a/numpyro/primitives.py
+++ b/numpyro/primitives.py
@@ -206,6 +206,49 @@ def deterministic(name, value):
     return msg['value']
 
 
+def _inspect():
+    """
+    EXPERIMENTAL Inspect the Pyro stack.
+
+    .. warning:: The format of the returned message may change at any time and
+        does not guarantee backwards compatibility.
+
+    :returns: A message with mask effects applied.
+    :rtype: dict
+    """
+    # NB: this is different from Pyro that in Pyro, all effects applied.
+    # Here, we only apply mask effect handler.
+    msg = {
+        "type": "inspect",
+        "fn": lambda: True,
+        "args": (),
+        "kwargs": {},
+        "value": None,
+        "mask": None,
+    }
+    apply_stack(msg)
+    return msg
+
+
+def get_mask():
+    """
+    Records the effects of enclosing ``handlers.mask`` handlers.
+    This is useful for avoiding expensive ``numpyro.factor()`` computations during
+    prediction, when the log density need not be computed, e.g.::
+
+        def model():
+            # ...
+            if numpyro.get_mask() is not False:
+                log_density = my_expensive_computation()
+                numpyro.factor("foo", log_density)
+            # ...
+
+    :returns: The mask.
+    :rtype: None, bool, or numpy.ndarray
+    """
+    return _inspect()["mask"]
+
+
 def module(name, nn, input_shape=None):
     """
     Declare a :mod:`~jax.experimental.stax` style neural network inside a


### PR DESCRIPTION
Port https://github.com/pyro-ppl/pyro/pull/2751 to NumPyro to skip log density computation in NeuTra, AutoContinuous, and HMCECS (cc @OlaRonning).