### PR TITLE
Clarify `epoch_train` and `eval_test` in VAE example

### DIFF
--- a/examples/vae.py
+++ b/examples/vae.py
@@ -82,7 +82,7 @@ def main(args):
     svi_state = svi.init(rng_key_init, sample_batch)
 
     @jit
-    def epoch_train(svi_state, rng_key):
+    def epoch_train(svi_state, rng_key, train_idx):
         def body_fn(i, val):
             loss_sum, svi_state = val
             rng_key_binarize = random.fold_in(rng_key, i)
@@ -94,7 +94,7 @@ def main(args):
         return lax.fori_loop(0, num_train, body_fn, (0., svi_state))
 
     @jit
-    def eval_test(svi_state, rng_key):
+    def eval_test(svi_state, rng_key, test_idx):
         def body_fun(i, loss_sum):
             rng_key_binarize = random.fold_in(rng_key, i)
             batch = binarize(rng_key_binarize, test_fetch(i, test_idx)[0])
@@ -122,10 +122,10 @@ def main(args):
         rng_key, rng_key_train, rng_key_test, rng_key_reconstruct = random.split(rng_key, 4)
         t_start = time.time()
         num_train, train_idx = train_init()
-        _, svi_state = epoch_train(svi_state, rng_key_train)
+        _, svi_state = epoch_train(svi_state, rng_key_train, train_idx)
         rng_key, rng_key_test, rng_key_reconstruct = random.split(rng_key, 3)
         num_test, test_idx = test_init()
-        test_loss = eval_test(svi_state, rng_key_test)
+        test_loss = eval_test(svi_state, rng_key_test, test_idx)
         reconstruct_img(i, rng_key_reconstruct)
         print("Epoch {}: loss = {} ({:.2f} s.)".format(i, test_loss, time.time() - t_start))
 

--- a/test/test_handlers.py
+++ b/test/test_handlers.py
@@ -584,7 +584,7 @@ def test_lift_memoize():
         with handlers.lift(prior=dist.Normal(0, 1)):
             model()
 
-
+@pytest.mark.xfail(reason="Issue: https://github.com/pyro-ppl/numpyro/issues/964")
 def test_collapse_beta_binomial():
     total_count = 10
     data = 3.

--- a/test/test_handlers.py
+++ b/test/test_handlers.py
@@ -584,6 +584,7 @@ def test_lift_memoize():
         with handlers.lift(prior=dist.Normal(0, 1)):
             model()
 
+
 @pytest.mark.xfail(reason="Issue: https://github.com/pyro-ppl/numpyro/issues/964")
 def test_collapse_beta_binomial():
     total_count = 10


### PR DESCRIPTION
In `examples/vae.py`, I think the implicit use of the outer scope when referencing `train_idx` and `test_idx` from inside `epoch_train` and `eval_test`, respectively, is rather confusing. Explicitly passing them as arguments adds clarity.