### PR TITLE
Fix model rendering tutorial headers

### DIFF
--- a/notebooks/source/model_rendering.ipynb
+++ b/notebooks/source/model_rendering.ipynb
@@ -149,7 +149,7 @@
    "id": "hungarian-indianapolis",
    "metadata": {},
    "source": [
-    "# Tweaking the visualization\n",
+    "## Tweaking the visualization\n",
     "\n",
     "As `numpyro.render_model` returns an object of type `graphviz.dot.Digraph`, you can further improve the visualization of this graph.\n",
     "For example, you could use the [unflatten preprocessor](https://graphviz.readthedocs.io/en/stable/api.html#graphviz.unflatten) to improve the layout aspect ratio for more complex models."
@@ -431,7 +431,7 @@
    "id": "industrial-customs",
    "metadata": {},
    "source": [
-    "# Distribution annotations\n",
+    "## Distribution annotations\n",
     "\n",
     "It is possible to display the distribution of each RV in the generated plot by providing `render_distributions=True` when calling `numpyro.render_model`."
    ]


### PR DESCRIPTION
The model rendering notebook uses `#` for sub-headings which makes the ToC confusing:
![image](https://user-images.githubusercontent.com/645279/112447139-425a1780-8d51-11eb-873f-b4ea5665c1ff.png)

This PR makes it use `##` instead.