### PR TITLE
[breaking change] not setting platform to CPU by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ To use NumPyro on the GPU, you will need to first [install](https://github.com/g
 
 To run NumPyro on Cloud TPUs, you can use pip to install NumPyro as above and setup the TPU backend as detailed [here](https://github.com/google/jax/tree/master/cloud_tpu_colabs).
 
-> **Default Platform:** In contrast to JAX, which uses GPU as the default platform, we use CPU as the default platform. You can use [set_platform](http://num.pyro.ai/en/stable/utilities.html#set-platform) utility to switch to other platforms such as GPU or TPU at the beginning of your program.
+> **Default Platform:** JAX will use GPU by default if CUDA-supported `jaxlib` package is installed. You can use [set_platform](http://num.pyro.ai/en/stable/utilities.html#set-platform) utility `numpyro.set_platform("cpu")` to switch to CPU at the beginning of your program.
 
 You can also install NumPyro from source:
 

--- a/numpyro/__init__.py
+++ b/numpyro/__init__.py
@@ -20,9 +20,6 @@ from numpyro.primitives import (
 from numpyro.util import enable_x64, set_host_device_count, set_platform
 from numpyro.version import __version__
 
-set_platform("cpu")
-
-
 __all__ = [
     "__version__",
     "compat",

--- a/numpyro/__init__.py
+++ b/numpyro/__init__.py
@@ -1,6 +1,8 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
+
 from numpyro import compat, diagnostics, distributions, handlers, infer, optim
 from numpyro.contrib.render import render_model
 from numpyro.distributions.distribution import enable_validation, validation_enabled
@@ -19,6 +21,15 @@ from numpyro.primitives import (
 )
 from numpyro.util import enable_x64, set_host_device_count, set_platform
 from numpyro.version import __version__
+
+
+# filter out this annoying warning, which raises even when we install CPU-only jaxlib
+def _filter_absl_cpu_warning(record):
+    return not record.getMessage().startswith("No GPU/TPU found, falling back to CPU.")
+
+
+logging.getLogger("absl").addFilter(_filter_absl_cpu_warning)
+
 
 __all__ = [
     "__version__",

--- a/numpyro/infer/hmc.py
+++ b/numpyro/infer/hmc.py
@@ -257,9 +257,10 @@ def hmc(potential_fn=None, potential_fn_gen=None, kinetic_fn=None, algo="NUTS"):
 
         """
         step_size = lax.convert_element_type(step_size, jnp.result_type(float))
-        trajectory_length = lax.convert_element_type(
-            trajectory_length, jnp.result_type(float)
-        )
+        if trajectory_length is not None:
+            trajectory_length = lax.convert_element_type(
+                trajectory_length, jnp.result_type(float)
+            )
         nonlocal wa_update, max_treedepth, vv_update, wa_steps, forward_mode_ad
         forward_mode_ad = forward_mode_differentiation
         wa_steps = num_warmup

--- a/numpyro/infer/hmc_gibbs.py
+++ b/numpyro/infer/hmc_gibbs.py
@@ -19,6 +19,7 @@ from jax import (
     random,
     value_and_grad,
 )
+from jax.flatten_util import ravel_pytree
 import jax.numpy as jnp
 from jax.scipy.special import expit
 
@@ -28,7 +29,7 @@ from numpyro.handlers import block, condition, seed, substitute, trace
 from numpyro.infer.hmc import HMC
 from numpyro.infer.mcmc import MCMCKernel
 from numpyro.infer.util import _unconstrain_reparam
-from numpyro.util import cond, fori_loop, identity, ravel_pytree
+from numpyro.util import cond, fori_loop, identity
 
 HMCGibbsState = namedtuple("HMCGibbsState", "z, hmc_state, rng_key")
 """

--- a/numpyro/infer/mixed_hmc.py
+++ b/numpyro/infer/mixed_hmc.py
@@ -5,12 +5,13 @@ from collections import namedtuple
 from functools import partial
 
 from jax import grad, jacfwd, lax, ops, random
+from jax.flatten_util import ravel_pytree
 import jax.numpy as jnp
 
 from numpyro.infer.hmc import momentum_generator
 from numpyro.infer.hmc_gibbs import DiscreteHMCGibbs
 from numpyro.infer.hmc_util import euclidean_kinetic_energy, warmup_adapter
-from numpyro.util import cond, fori_loop, identity, ravel_pytree
+from numpyro.util import cond, fori_loop, identity
 
 MixedHMCState = namedtuple("MixedHMCState", "z, hmc_state, rng_key, accept_prob")
 

--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -1,7 +1,7 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
-from collections import OrderedDict, namedtuple
+from collections import OrderedDict
 from contextlib import contextmanager
 import os
 import random
@@ -15,8 +15,9 @@ import jax
 from jax import device_put, jit, lax, ops, vmap
 from jax.core import Tracer
 from jax.experimental import host_callback
+from jax.flatten_util import ravel_pytree
 import jax.numpy as jnp
-from jax.tree_util import tree_flatten, tree_map, tree_unflatten
+from jax.tree_util import tree_flatten, tree_map
 
 _DISABLE_CONTROL_FLOW_PRIM = False
 
@@ -345,44 +346,6 @@ def fori_collect(
 
     unravel_collection = vmap(unravel_fn)(collection)
     return (unravel_collection, last_val) if return_last_val else unravel_collection
-
-
-pytree_metadata = namedtuple("pytree_metadata", ["flat", "shape", "size", "dtype"])
-
-
-def _ravel_list(*leaves):
-    leaves_metadata = tree_map(
-        lambda l: pytree_metadata(
-            jnp.ravel(l), jnp.shape(l), jnp.size(l), jnp.result_type(l)
-        ),
-        leaves,
-    )
-    leaves_idx = jnp.cumsum(jnp.array((0,) + tuple(d.size for d in leaves_metadata)))
-
-    def unravel_list(arr):
-        return [
-            jnp.reshape(
-                lax.dynamic_slice_in_dim(arr, leaves_idx[i], m.size), m.shape
-            ).astype(m.dtype)
-            for i, m in enumerate(leaves_metadata)
-        ]
-
-    flat = (
-        jnp.concatenate([m.flat for m in leaves_metadata])
-        if leaves_metadata
-        else jnp.array([])
-    )
-    return flat, unravel_list
-
-
-def ravel_pytree(pytree):
-    leaves, treedef = tree_flatten(pytree)
-    flat, unravel_list = _ravel_list(*leaves)
-
-    def unravel_pytree(arr):
-        return tree_unflatten(treedef, unravel_list(arr))
-
-    return flat, unravel_pytree
 
 
 def soft_vmap(fn, xs, batch_ndims=1, chunk_size=None):

--- a/setup.py
+++ b/setup.py
@@ -32,10 +32,8 @@ setup(
     url="https://github.com/pyro-ppl/numpyro",
     author="Uber AI Labs",
     install_requires=[
-        # TODO: pin to a specific version for the release (until JAX's API becomes stable)
-        "jax==0.2.10",
-        # check min version here: https://github.com/google/jax/blob/master/jax/lib/__init__.py#L26
-        "jaxlib==0.1.62",
+        "jax>=0.2.11",
+        "jaxlib>=0.1.62",
         "tqdm",
     ],
     extras_require={

--- a/test/infer/test_autoguide.py
+++ b/test/infer/test_autoguide.py
@@ -244,7 +244,7 @@ def test_param():
     class _AutoGuide(AutoDiagonalNormal):
         def __call__(self, *args, **kwargs):
             return substitute(
-                super(_AutoGuide, self).__call__, {"_auto_latent": x_init}
+                super(_AutoGuide, self).__call__, {"_auto_latent": x_init[None]}
             )(*args, **kwargs)
 
     adam = optim.Adam(0.01)

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -4,11 +4,12 @@
 from numpy.testing import assert_allclose
 import pytest
 
+from jax.flatten_util import ravel_pytree
 import jax.numpy as jnp
 from jax.test_util import check_eq
 from jax.tree_util import tree_flatten, tree_multimap
 
-from numpyro.util import fori_collect, ravel_pytree, soft_vmap
+from numpyro.util import fori_collect, soft_vmap
 
 
 def test_fori_collect_thinning():


### PR DESCRIPTION
Resolves #727.

I think for those who don't use GPU/TPU, CPU is still the default device (because there are no other devices and most of those people will install jaxlib through `pip install jaxlib`). For those who install GPU-supported jaxlib version
```
pip install --upgrade jaxlib==0.1.64+cuda110 -f https://storage.googleapis.com/jax-releases/jax_releases.html
```
they will want to use GPU for some reason and they will know that JAX uses GPU device by default. So it might be a better idea to not change the default behavior of JAX.

This PR also relaxes jax/jaxlib versions and cleans up `ravel_pytree` utility, which is available on jax 0.2.11.