### PR TITLE
Make infer_discrete work with scan

### DIFF
--- a/numpyro/contrib/funsor/discrete.py
+++ b/numpyro/contrib/funsor/discrete.py
@@ -7,10 +7,9 @@ import functools
 from jax import random
 
 import funsor
-from numpyro.contrib.funsor.enum_messenger import enum, trace as packed_trace
-from numpyro.contrib.funsor.infer_util import plate_to_enum_plate
-from numpyro.distributions.util import is_identically_one
-from numpyro.handlers import block, replay, seed, trace
+from numpyro.contrib.funsor.enum_messenger import enum
+from numpyro.contrib.funsor.infer_util import _enum_log_density
+from numpyro.handlers import block, seed, substitute, trace
 from numpyro.infer.util import _guess_max_plate_nesting
 
 
@@ -38,46 +37,6 @@ def _get_support_value_delta(funsor_dist, name, **kwargs):
     return OrderedDict(funsor_dist.terms)[name][0]
 
 
-def terms_from_trace(tr):
-    """Helper function to extract elbo components from execution traces."""
-    log_factors = {}
-    log_measures = {}
-    sum_vars, prod_vars = frozenset(), frozenset()
-    for site in tr.values():
-        if site["type"] == "sample":
-            value = site["value"]
-            intermediates = site["intermediates"]
-            scale = site["scale"]
-            if intermediates:
-                log_prob = site["fn"].log_prob(value, intermediates)
-            else:
-                log_prob = site["fn"].log_prob(value)
-
-            if (scale is not None) and (not is_identically_one(scale)):
-                log_prob = scale * log_prob
-
-            dim_to_name = site["infer"]["dim_to_name"]
-            log_prob_factor = funsor.to_funsor(
-                log_prob, output=funsor.Real, dim_to_name=dim_to_name
-            )
-
-            if site["is_observed"]:
-                log_factors[site["name"]] = log_prob_factor
-            else:
-                log_measures[site["name"]] = log_prob_factor
-                sum_vars |= frozenset({site["name"]})
-            prod_vars |= frozenset(
-                f.name for f in site["cond_indep_stack"] if f.dim is not None
-            )
-
-    return {
-        "log_factors": log_factors,
-        "log_measures": log_measures,
-        "measure_vars": sum_vars,
-        "plate_vars": prod_vars,
-    }
-
-
 def _sample_posterior(
     model, first_available_dim, temperature, rng_key, *args, **kwargs
 ):
@@ -97,27 +56,14 @@ def _sample_posterior(
             model_trace = trace(seed(model, rng_key)).get_trace(*args, **kwargs)
         first_available_dim = -_guess_max_plate_nesting(model_trace) - 1
 
-    with block(), enum(first_available_dim=first_available_dim):
-        with plate_to_enum_plate():
-            model_tr = packed_trace(model).get_trace(*args, **kwargs)
-
-    terms = terms_from_trace(model_tr)
-    # terms["log_factors"] = [log p(x) for each observed or latent sample site x]
-    # terms["log_measures"] = [log p(z) or other Dice factor
-    #                          for each latent sample site z]
-
-    with funsor.interpretations.lazy:
-        log_prob = funsor.sum_product.sum_product(
-            sum_op,
-            prod_op,
-            list(terms["log_factors"].values()) + list(terms["log_measures"].values()),
-            eliminate=terms["measure_vars"] | terms["plate_vars"],
-            plates=terms["plate_vars"],
-        )
-        log_prob = funsor.optimizer.apply_optimizer(log_prob)
+    with funsor.adjoint.AdjointTape() as tape:
+        with block(), enum(first_available_dim=first_available_dim):
+            log_prob, model_tr, log_measures = _enum_log_density(
+                model, args, kwargs, {}, sum_op, prod_op
+            )
 
     with approx:
-        approx_factors = funsor.adjoint.adjoint(sum_op, prod_op, log_prob)
+        approx_factors = tape.adjoint(sum_op, prod_op, log_prob)
 
     # construct a result trace to replay against the model
     sample_tr = model_tr.copy()
@@ -138,13 +84,19 @@ def _sample_posterior(
                 value, name_to_dim=node["infer"]["name_to_dim"]
             )
         else:
-            log_measure = approx_factors[terms["log_measures"][name]]
+            log_measure = approx_factors[log_measures[name]]
             sample_subs[name] = _get_support_value(log_measure, name)
             node["value"] = funsor.to_data(
                 sample_subs[name], name_to_dim=node["infer"]["name_to_dim"]
             )
 
-    with replay(guide_trace=sample_tr):
+    data = {
+        name: site["value"]
+        for name, site in sample_tr.items()
+        if site["type"] == "sample"
+    }
+    print(data)
+    with substitute(data=data):
         return model(*args, **kwargs)
 
 

--- a/test/contrib/test_infer_discrete.py
+++ b/test/contrib/test_infer_discrete.py
@@ -12,6 +12,7 @@ import jax.numpy as jnp
 
 import numpyro
 from numpyro import handlers, infer
+from numpyro.contrib.control_flow import scan
 import numpyro.distributions as dist
 from numpyro.distributions.util import is_identically_one
 
@@ -68,6 +69,38 @@ def test_hmm_smoke(length, temperature):
         return states, data
 
     true_states, data = handlers.seed(hmm, 0)([None] * length)
+    assert len(data) == length
+    assert len(true_states) == 1 + len(data)
+
+    decoder = infer_discrete(
+        config_enumerate(hmm), temperature=temperature, rng_key=random.PRNGKey(1)
+    )
+    inferred_states, _ = decoder(data)
+    assert len(inferred_states) == len(true_states)
+
+    logger.info("true states: {}".format(list(map(int, true_states))))
+    logger.info("inferred states: {}".format(list(map(int, inferred_states))))
+
+
+@pytest.mark.parametrize("length", [1, 2, 10])
+@pytest.mark.parametrize("temperature", [0, 1])
+def test_scan_hmm_smoke(length, temperature):
+
+    # This should match the example in the infer_discrete docstring.
+    def hmm(data, hidden_dim=10):
+        transition = 0.3 / hidden_dim + 0.7 * jnp.eye(hidden_dim)
+        means = jnp.arange(float(hidden_dim))
+
+        def transition_fn(state, y):
+            state = numpyro.sample("states", dist.Categorical(transition[state]))
+            y = numpyro.sample("obs", dist.Normal(means[state], 1.0), obs=y)
+            return state, (state, y)
+
+        _, (states, data) = scan(transition_fn, 0, data, length=length)
+
+        return [0] + [s for s in states], data
+
+    true_states, data = handlers.seed(hmm, 0)(None)
     assert len(data) == length
     assert len(true_states) == 1 + len(data)
 


### PR DESCRIPTION
Continue of #977. Pair-coded with @eb8680 @fritzo @ordabayevy 

### TODO

- [ ] fix substituting issues of `enum_scan`: under `enum`, latent variable names will be `_PREV_z` and `z` while without it, there is only one latent variable names `z`. One solution is to merge `_PREV_z` and `z` in `infer_discrete`
- [ ] fix adjoint issue with length=10

Follow-up PR: add test for history > 1

Blocked by https://github.com/pyro-ppl/funsor/pull/517