### PR TITLE
Experimental Dockerfiles

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,39 @@
+Docker Images for NumPyro
+=========================
+
+Experimental Dockerfiles for CUDA-accelerated NumPyro. There are two Dockerfiles included:
+
+- `release`: intended for users of NumPyro. Includes the jax and jaxlib versions needed to run NumPyro only. (Right now, that is 0.2.10, 0.1.62, and 0.6.0 respectively).
+- `dev`: intended for NumPyro developers. It includes the jax and jaxlib versions needed to run the latest release of NumPyro (same as above, for now), plus an installation of NumPyro from source.
+
+## Pre-Requisites
+
+The Docker host that the image is being deployed on will need to have the proprietary Nvidia driver as well as [the Nvidia Container Toolkit](https://github.com/NVIDIA/nvidia-docker) installed. OS support is constrained by what Nvidia supports on their toolkit. Right now, that means Linux only, although there is [experimental WSL2 support](https://docs.nvidia.com/cuda/wsl-user-guide/index.html#installing-wip), with an estimated ~30% hit to performance.
+
+## Using the Dockerfiles
+
+At the moment, these images are not distributed on Dockerhub or any similar Docker registry. Users must build the Docker images themselves. This can be done (from the root of the git repository) with the command
+
+```
+docker build -t <name_for_image:tag> docker/[dev or release]/.
+```
+
+The Docker image will then be available locally. For example, to open a shell in the Docker image, one would run
+
+```
+docker run -ti <name_for_image>
+```
+
+## Current State & Future Work
+
+Design Choices:
+
+- The Docker images do not include any users other than root, and do not include any other packages (such as Tensorflow or PyTorch). Users of the Docker image should layer their own requirements on top of these images.
+- To avoid long build-times, the images use Google's provided CUDA wheels rather than building jaxlib from source.
+
+Future Work:
+
+- Right now the jax, jaxlib, and numpyro versions are manually specified, so they have to be updated every NumPyro release. There are two ways forward for this:
+    1. If there is a CI/CD in place to build and push images to a repository like Dockerhub, then the jax, jaxlib, and numpyro versions can be passed in as environment variables (for example, if something like [Drone CI](http://plugins.drone.io/drone-plugins/drone-docker/). If implemented this way, the jax/jaxlib/numpyro versions will be ephemereal (not stored in source code).
+    2. Alternative, one can create a Python script that will modify the Dockerfiles upon release accordingly (using a hook of some sort). 
+- For development work, it would be nice to be able to pull the latest versions of jax and jaxlib into the `dev` image. This would be made a lot easier if jax upstream published Docker images for CUDA-accelerated jaxlibs. There is [currently an issue for it](https://github.com/google/jax/issues/6340).

--- a/docker/README.md
+++ b/docker/README.md
@@ -34,6 +34,6 @@ Design Choices:
 Future Work:
 
 - Right now the jax, jaxlib, and numpyro versions are manually specified, so they have to be updated every NumPyro release. There are two ways forward for this:
-    1. If there is a CI/CD in place to build and push images to a repository like Dockerhub, then the jax, jaxlib, and numpyro versions can be passed in as environment variables (for example, if something like [Drone CI](http://plugins.drone.io/drone-plugins/drone-docker/). If implemented this way, the jax/jaxlib/numpyro versions will be ephemereal (not stored in source code).
+    1. If there is a CI/CD in place to build and push images to a repository like Dockerhub, then the jax, jaxlib, and numpyro versions can be passed in as environment variables (for example, if something like [Drone CI](http://plugins.drone.io/drone-plugins/drone-docker/) is used). If implemented this way, the jax/jaxlib/numpyro versions will be ephemereal (not stored in source code).
     2. Alternative, one can create a Python script that will modify the Dockerfiles upon release accordingly (using a hook of some sort). 
 - For development work, it would be nice to be able to pull the latest versions of jax and jaxlib into the `dev` image. This would be made a lot easier if jax upstream published Docker images for CUDA-accelerated jaxlibs. There is [currently an issue for it](https://github.com/google/jax/issues/6340).

--- a/docker/README.md
+++ b/docker/README.md
@@ -35,5 +35,4 @@ Future Work:
 
 - Right now the jax, jaxlib, and numpyro versions are manually specified, so they have to be updated every NumPyro release. There are two ways forward for this:
     1. If there is a CI/CD in place to build and push images to a repository like Dockerhub, then the jax, jaxlib, and numpyro versions can be passed in as environment variables (for example, if something like [Drone CI](http://plugins.drone.io/drone-plugins/drone-docker/) is used). If implemented this way, the jax/jaxlib/numpyro versions will be ephemereal (not stored in source code).
-    2. Alternative, one can create a Python script that will modify the Dockerfiles upon release accordingly (using a hook of some sort). 
-- For development work, it would be nice to be able to pull the latest versions of jax and jaxlib into the `dev` image. This would be made a lot easier if jax upstream published Docker images for CUDA-accelerated jaxlibs. There is [currently an issue for it](https://github.com/google/jax/issues/6340).
+    2. Alternative, one can create a Python script that will modify the Dockerfiles upon release accordingly (using a hook of some sort).

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -24,6 +24,9 @@ ENV IMG_NAME=11.2.2-cudnn8-devel-ubuntu20.04 \
 RUN apt update && \
     apt install python3-dev python3-pip git build-essential -y
 
+# add .local/bin to PATH for tqdm and f2py
+ENV PATH=/root/.local/bin:$PATH
+
 # install python packages via pip
 RUN pip3 install --user \
     jax==${JAX_VERSION} \

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -1,0 +1,37 @@
+# Experimental Dockerfile for CUDA-enabled numpyro
+# This image should be suitable for numpyro developers
+# it installs the latest version of numpyro from git
+# and includes [dev] for libraries needed for development
+# Author/Maintainer: AndrewCSQ (web_enquiry at andrewchia dot tech)
+
+FROM nvidia/cuda:11.2.2-cudnn8-devel-ubuntu20.04
+
+# declare the image name
+# note that this image uses Python 3.8
+ENV IMG_NAME=11.2.2-cudnn8-devel-ubuntu20.04 \
+    # declare what jaxlib, jax, and numpyro versions to use
+    # right now this is a manual process - in the future it should be automated
+    # if a CI/CD system is expected to pass in these arguments
+    # the dockerfile should be modified accordingly
+    JAXLIB_CUDA=112 \
+    JAXLIB_VERSION=0.1.62 \
+    JAX_VERSION=0.2.10 \
+    NUMPYRO_VERSION=0.6.0
+
+# install python3 and pip on top of the base Ubuntu image
+# unlike for release, we need to install git and setuptools too
+# one would probably want build-essential (gcc and friends) as well
+RUN apt update && \
+    apt install python3-dev python3-pip git build-essential -y
+
+# install python packages via pip
+RUN pip3 install --user \
+    jax==${JAX_VERSION} \
+    # we pull wheels from google's api as per https://github.com/google/jax#installation
+    # the pre-compiled wheels that google provides work for now. This may change in the future (and necessitate building from source)
+    jaxlib==${JAXLIB_VERSION}+cuda${JAXLIB_CUDA} -f https://storage.googleapis.com/jax-releases/jax_releases.html
+
+# clone the numpyro git repository and run pip install
+RUN git clone https://github.com/pyro-ppl/numpyro.git && \
+    cd numpyro && \
+    pip3 install -e .[dev]  # contains additional dependencies for NumPyro development

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -28,12 +28,6 @@ RUN pip3 install pip-versions
 RUN pip-versions latest jaxlib | xargs -I{} pip3 install jaxlib=={}+cuda${JAXLIB_CUDA} -f https://storage.googleapis.com/jax-releases/jax_releases.html \
     jax
 
-RUN pip3 install --user \
-    jax==${JAX_VERSION} \
-    # we pull wheels from google's api as per https://github.com/google/jax#installation
-    # the pre-compiled wheels that google provides work for now. This may change in the future (and necessitate building from source)
-    jaxlib==${JAXLIB_VERSION}+cuda${JAXLIB_CUDA} -f https://storage.googleapis.com/jax-releases/jax_releases.html
-
 # clone the numpyro git repository and run pip install
 RUN git clone https://github.com/pyro-ppl/numpyro.git && \
     cd numpyro && \

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -9,14 +9,8 @@ FROM nvidia/cuda:11.2.2-cudnn8-devel-ubuntu20.04
 # declare the image name
 # note that this image uses Python 3.8
 ENV IMG_NAME=11.2.2-cudnn8-devel-ubuntu20.04 \
-    # declare what jaxlib, jax, and numpyro versions to use
-    # right now this is a manual process - in the future it should be automated
-    # if a CI/CD system is expected to pass in these arguments
-    # the dockerfile should be modified accordingly
-    JAXLIB_CUDA=112 \
-    JAXLIB_VERSION=0.1.62 \
-    JAX_VERSION=0.2.10 \
-    NUMPYRO_VERSION=0.6.0
+    # declare the cuda version for pulling appropriate jaxlib wheel
+    JAXLIB_CUDA=112
 
 # install python3 and pip on top of the base Ubuntu image
 # unlike for release, we need to install git and setuptools too
@@ -28,6 +22,12 @@ RUN apt update && \
 ENV PATH=/root/.local/bin:$PATH
 
 # install python packages via pip
+# install pip-versions to detect the latest version of jax and jaxlib
+RUN pip3 install pip-versions
+# this uses latest version of jax and jaxlib available from pypi
+RUN pip-versions latest jaxlib | xargs -I{} pip3 install jaxlib=={}+cuda${JAXLIB_CUDA} -f https://storage.googleapis.com/jax-releases/jax_releases.html \
+    jax
+
 RUN pip3 install --user \
     jax==${JAX_VERSION} \
     # we pull wheels from google's api as per https://github.com/google/jax#installation
@@ -37,4 +37,4 @@ RUN pip3 install --user \
 # clone the numpyro git repository and run pip install
 RUN git clone https://github.com/pyro-ppl/numpyro.git && \
     cd numpyro && \
-    pip3 install -e .[dev]  # contains additional dependencies for NumPyro development
+    pip3 install -e .[dev, test]  # contains additional dependencies for NumPyro development

--- a/docker/release/Dockerfile
+++ b/docker/release/Dockerfile
@@ -21,6 +21,9 @@ ENV IMG_NAME=11.2.2-cudnn8-devel-ubuntu20.04 \
 RUN apt update && \
     apt install python3-dev python3-pip -y
 
+# add .local/bin to PATH for tqdm and f2py
+ENV PATH=/root/.local/bin:$PATH
+
 # install python packages via pip
 RUN pip3 install --user \
     numpyro==${NUMPYRO_VERSION} \

--- a/docker/release/Dockerfile
+++ b/docker/release/Dockerfile
@@ -1,0 +1,30 @@
+# Experimental Dockerfile for CUDA-enabled numpyro
+# This image should be suitable for developers on top of numpyro, or for end-users
+# who wish to hit the ground running with CUDA+numpyro.
+# Author/Maintainer: AndrewCSQ (web_enquiry at andrewchia dot tech)
+
+FROM nvidia/cuda:11.2.2-cudnn8-devel-ubuntu20.04
+
+# declare the image name
+# note that this image uses Python 3.8
+ENV IMG_NAME=11.2.2-cudnn8-devel-ubuntu20.04 \
+    # declare what jaxlib, jax, and numpyro versions to use
+    # right now this is a manual process - in the future it should be automated
+    # if a CI/CD system is expected to pass in these arguments
+    # the dockerfile should be modified accordingly
+    JAXLIB_CUDA=112 \
+    JAXLIB_VERSION=0.1.62 \
+    JAX_VERSION=0.2.10 \
+    NUMPYRO_VERSION=0.6.0
+
+# install python3 and pip on top of the base Ubuntu image
+RUN apt update && \
+    apt install python3-dev python3-pip -y
+
+# install python packages via pip
+RUN pip3 install --user \
+    numpyro==${NUMPYRO_VERSION} \
+    jax==${JAX_VERSION} \
+    # we pull wheels from google's api as per https://github.com/google/jax#installation
+    # the pre-compiled wheels that google provides work for now. This may change in the future (and necessitate building from source)
+    jaxlib==${JAXLIB_VERSION}+cuda${JAXLIB_CUDA} -f https://storage.googleapis.com/jax-releases/jax_releases.html


### PR DESCRIPTION
#992 Follow-up. Pull request comprising two Dockerfiles:
1. A `release` Dockerfile suitable for NumPyro users.
2. A `dev` Dockerfile suitable for developers.

If the NumPyro team does not want to publish images to Dockerhub at this time, I can do so in an unofficial capacity (to gauge interest), in a separate repository.