### PR TITLE
Add a flag to control regularize mass matrix behavior

### DIFF
--- a/numpyro/handlers.py
+++ b/numpyro/handlers.py
@@ -597,16 +597,16 @@ class scope(Messenger):
 
     .. doctest::
 
-       >>> import numpyro
-       >>> import numpyro.distributions as dist
-       >>> from numpyro.handlers import scope, seed, trace
-       >>>
-       >>> def model():
-       ...     with scope(prefix="a"):
-       ...         with scope(prefix="b", divider="."):
-       ...             return numpyro.sample("x", dist.Bernoulli(0.5))
-       ...
-       >>> assert "a/b.x" in trace(seed(model, 0)).get_trace()
+        >>> import numpyro
+        >>> import numpyro.distributions as dist
+        >>> from numpyro.handlers import scope, seed, trace
+        >>>
+        >>> def model():
+        ...     with scope(prefix="a"):
+        ...         with scope(prefix="b", divider="."):
+        ...             return numpyro.sample("x", dist.Bernoulli(0.5))
+        ...
+        >>> assert "a/b.x" in trace(seed(model, 0)).get_trace()
 
     :param fn: Python callable with NumPyro primitives.
     :param str prefix: a string to prepend to sample names

--- a/numpyro/infer/barker.py
+++ b/numpyro/infer/barker.py
@@ -285,3 +285,9 @@ class BarkerMH(MCMCKernel):
         return BarkerMHState(
             itr, x, pe, x_grad, accept_prob, mean_accept_prob, adapt_state, rng_key
         )
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        state["_postprocess_fn"] = None
+        state["_wa_update"] = None
+        return state

--- a/numpyro/infer/hmc.py
+++ b/numpyro/infer/hmc.py
@@ -194,6 +194,7 @@ def hmc(potential_fn=None, potential_fn_gen=None, kinetic_fn=None, algo="NUTS"):
         max_tree_depth=10,
         find_heuristic_step_size=False,
         forward_mode_differentiation=False,
+        regularize_mass_matrix=True,
         model_args=(),
         model_kwargs=None,
         rng_key=random.PRNGKey(0),
@@ -252,6 +253,9 @@ def hmc(potential_fn=None, potential_fn_gen=None, kinetic_fn=None, algo="NUTS"):
             `d2` is the max tree depth during post warmup phase.
         :param bool find_heuristic_step_size: whether to a heuristic function to adjust the
             step size at the beginning of each adaptation window. Defaults to False.
+        :param bool regularize_mass_matrix: whether or not to regularize the estimated mass
+            matrix for numerical stability during warmup phase. Default to True. This flag
+            does not take effect if ``adapt_mass_matrix == False``.
         :param tuple model_args: Model arguments if `potential_fn_gen` is specified.
         :param dict model_kwargs: Model keyword arguments if `potential_fn_gen` is specified.
         :param jax.random.PRNGKey rng_key: random key to be used as the source of
@@ -298,6 +302,7 @@ def hmc(potential_fn=None, potential_fn_gen=None, kinetic_fn=None, algo="NUTS"):
             dense_mass=dense_mass,
             target_accept_prob=target_accept_prob,
             find_reasonable_step_size=find_reasonable_ss,
+            regularize_mass_matrix=regularize_mass_matrix,
         )
 
         rng_key_hmc, rng_key_wa, rng_key_momentum = random.split(rng_key, 3)
@@ -562,8 +567,9 @@ class HMC(MCMCKernel):
         value is :math:`2\\pi`.
     :param callable init_strategy: a per-site initialization function.
         See :ref:`init_strategy` section for available functions.
-    :param bool find_heuristic_step_size: whether to a heuristic function to adjust the
-        step size at the beginning of each adaptation window. Defaults to False.
+    :param bool find_heuristic_step_size: whether or not to use a heuristic function
+        to adjust the step size at the beginning of each adaptation window. Defaults
+        to False.
     :param bool forward_mode_differentiation: whether to use forward-mode differentiation
         or reverse-mode differentiation. By default, we use reverse mode but the forward
         mode can be useful in some cases to improve the performance. In addition, some
@@ -571,6 +577,9 @@ class HMC(MCMCKernel):
         only supports forward-mode differentiation. See
         `JAX's The Autodiff Cookbook <https://jax.readthedocs.io/en/latest/notebooks/autodiff_cookbook.html>`_
         for more information.
+    :param bool regularize_mass_matrix: whether or not to regularize the estimated mass
+        matrix for numerical stability during warmup phase. Default to True. This flag
+        does not take effect if ``adapt_mass_matrix == False``.
     """
 
     def __init__(
@@ -588,6 +597,7 @@ class HMC(MCMCKernel):
         init_strategy=init_to_uniform,
         find_heuristic_step_size=False,
         forward_mode_differentiation=False,
+        regularize_mass_matrix=True,
     ):
         if not (model is None) ^ (potential_fn is None):
             raise ValueError("Only one of `model` or `potential_fn` must be specified.")
@@ -612,6 +622,7 @@ class HMC(MCMCKernel):
         self._init_strategy = init_strategy
         self._find_heuristic_step_size = find_heuristic_step_size
         self._forward_mode_differentiation = forward_mode_differentiation
+        self._regularize_mass_matrix = regularize_mass_matrix
         # Set on first call to init
         self._init_fn = None
         self._potential_fn_gen = None
@@ -707,6 +718,7 @@ class HMC(MCMCKernel):
             max_tree_depth=self._max_tree_depth,
             find_heuristic_step_size=self._find_heuristic_step_size,
             forward_mode_differentiation=self._forward_mode_differentiation,
+            regularize_mass_matrix=self._regularize_mass_matrix,
             model_args=model_args,
             model_kwargs=model_kwargs,
             rng_key=rng_key,
@@ -818,8 +830,9 @@ class NUTS(HMC):
         `d2` is the max tree depth during post warmup phase.
     :param callable init_strategy: a per-site initialization function.
         See :ref:`init_strategy` section for available functions.
-    :param bool find_heuristic_step_size: whether to a heuristic function to adjust the
-        step size at the beginning of each adaptation window. Defaults to False.
+    :param bool find_heuristic_step_size: whether or not to use a heuristic function
+        to adjust the step size at the beginning of each adaptation window. Defaults
+        to False.
     :param bool forward_mode_differentiation: whether to use forward-mode differentiation
         or reverse-mode differentiation. By default, we use reverse mode but the forward
         mode can be useful in some cases to improve the performance. In addition, some
@@ -845,6 +858,7 @@ class NUTS(HMC):
         init_strategy=init_to_uniform,
         find_heuristic_step_size=False,
         forward_mode_differentiation=False,
+        regularize_mass_matrix=True,
     ):
         super(NUTS, self).__init__(
             potential_fn=potential_fn,
@@ -860,6 +874,7 @@ class NUTS(HMC):
             init_strategy=init_strategy,
             find_heuristic_step_size=find_heuristic_step_size,
             forward_mode_differentiation=forward_mode_differentiation,
+            regularize_mass_matrix=regularize_mass_matrix,
         )
         self._max_tree_depth = max_tree_depth
         self._algo = "NUTS"

--- a/numpyro/infer/hmc.py
+++ b/numpyro/infer/hmc.py
@@ -184,6 +184,7 @@ def hmc(potential_fn=None, potential_fn_gen=None, kinetic_fn=None, algo="NUTS"):
     def init_kernel(
         init_params,
         num_warmup,
+        *,
         step_size=1.0,
         inverse_mass_matrix=None,
         adapt_step_size=True,
@@ -244,7 +245,7 @@ def hmc(potential_fn=None, potential_fn_gen=None, kinetic_fn=None, algo="NUTS"):
         :type dense_mass: bool or list
         :param float target_accept_prob: Target acceptance probability for step size
             adaptation using Dual Averaging. Increasing this value will lead to a smaller
-            step size, hence the sampling will be slower but more robust. Default to 0.8.
+            step size, hence the sampling will be slower but more robust. Defaults to 0.8.
         :param float trajectory_length: Length of a MCMC trajectory for HMC. Default
             value is :math:`2\\pi`.
         :param int max_tree_depth: Max depth of the binary tree created during the doubling
@@ -254,7 +255,7 @@ def hmc(potential_fn=None, potential_fn_gen=None, kinetic_fn=None, algo="NUTS"):
         :param bool find_heuristic_step_size: whether to a heuristic function to adjust the
             step size at the beginning of each adaptation window. Defaults to False.
         :param bool regularize_mass_matrix: whether or not to regularize the estimated mass
-            matrix for numerical stability during warmup phase. Default to True. This flag
+            matrix for numerical stability during warmup phase. Defaults to True. This flag
             does not take effect if ``adapt_mass_matrix == False``.
         :param tuple model_args: Model arguments if `potential_fn_gen` is specified.
         :param dict model_kwargs: Model keyword arguments if `potential_fn_gen` is specified.
@@ -562,7 +563,7 @@ class HMC(MCMCKernel):
     :type dense_mass: bool or list
     :param float target_accept_prob: Target acceptance probability for step size
         adaptation using Dual Averaging. Increasing this value will lead to a smaller
-        step size, hence the sampling will be slower but more robust. Default to 0.8.
+        step size, hence the sampling will be slower but more robust. Defaults to 0.8.
     :param float trajectory_length: Length of a MCMC trajectory for HMC. Default
         value is :math:`2\\pi`.
     :param callable init_strategy: a per-site initialization function.
@@ -578,7 +579,7 @@ class HMC(MCMCKernel):
         `JAX's The Autodiff Cookbook <https://jax.readthedocs.io/en/latest/notebooks/autodiff_cookbook.html>`_
         for more information.
     :param bool regularize_mass_matrix: whether or not to regularize the estimated mass
-        matrix for numerical stability during warmup phase. Default to True. This flag
+        matrix for numerical stability during warmup phase. Defaults to True. This flag
         does not take effect if ``adapt_mass_matrix == False``.
     """
 
@@ -821,7 +822,7 @@ class NUTS(HMC):
     :type dense_mass: bool or list
     :param float target_accept_prob: Target acceptance probability for step size
         adaptation using Dual Averaging. Increasing this value will lead to a smaller
-        step size, hence the sampling will be slower but more robust. Default to 0.8.
+        step size, hence the sampling will be slower but more robust. Defaults to 0.8.
     :param float trajectory_length: Length of a MCMC trajectory for HMC. This arg has
         no effect in NUTS sampler.
     :param int max_tree_depth: Max depth of the binary tree created during the doubling

--- a/numpyro/infer/hmc_util.py
+++ b/numpyro/infer/hmc_util.py
@@ -517,6 +517,7 @@ def warmup_adapter(
     adapt_mass_matrix=True,
     dense_mass=False,
     target_accept_prob=0.8,
+    regularize_mass_matrix=True,
 ):
     """
     A scheme to adapt tunable parameters, namely step size and mass matrix, during
@@ -601,7 +602,7 @@ def warmup_adapter(
 
         if adapt_mass_matrix:
             inverse_mass_matrix, mass_matrix_sqrt, mass_matrix_sqrt_inv = mm_final(
-                mm_state, regularize=True
+                mm_state, regularize=regularize_mass_matrix
             )
             if isinstance(inverse_mass_matrix, dict):
                 size = {k: v.shape for k, v in inverse_mass_matrix.items()}

--- a/numpyro/infer/sa.py
+++ b/numpyro/infer/sa.py
@@ -311,6 +311,7 @@ class SA(MCMCKernel):
                 init_strategy=self._init_strategy,
                 model_args=model_args,
                 model_kwargs=model_kwargs,
+                validate_grad=False,
             )
             init_params = init_params[0]
             # NB: init args is different from HMC

--- a/numpyro/infer/util.py
+++ b/numpyro/infer/util.py
@@ -182,6 +182,7 @@ def _init_to_unconstrained_value(site=None, values={}):
 def find_valid_initial_params(
     rng_key,
     model,
+    *,
     init_strategy=init_to_uniform,
     enum=False,
     model_args=(),
@@ -347,6 +348,7 @@ def _get_model_transforms(model, model_args=(), model_kwargs=None):
 def get_potential_fn(
     model,
     inv_transforms,
+    *,
     enum=False,
     replay_model=False,
     dynamic_args=False,
@@ -449,6 +451,7 @@ def _validate_model(model_trace):
 def initialize_model(
     rng_key,
     model,
+    *,
     init_strategy=init_to_uniform,
     dynamic_args=False,
     model_args=(),

--- a/numpyro/infer/util.py
+++ b/numpyro/infer/util.py
@@ -188,6 +188,7 @@ def find_valid_initial_params(
     model_kwargs=None,
     prototype_params=None,
     forward_mode_differentiation=False,
+    validate_grad=True,
 ):
     """
     (EXPERIMENTAL INTERFACE) Given a model with Pyro primitives, returns an initial
@@ -207,6 +208,10 @@ def find_valid_initial_params(
     :param dict model_kwargs: kwargs provided to the model.
     :param dict prototype_params: an optional prototype parameters, which is used
         to define the shape for initial parameters.
+    :param bool forward_mode_differentiation: whether to use forward-mode differentiation
+        or reverse-mode differentiation. Defaults to False.
+    :param bool validate_grad: whether to validate gradient of the initial params.
+        Defaults to True.
     :return: tuple of `init_params_info` and `is_valid`, where `init_params_info` is the tuple
         containing the initial params, their potential energy, and their gradients.
     """
@@ -264,13 +269,19 @@ def find_valid_initial_params(
         potential_fn = partial(
             potential_energy, model, model_args, model_kwargs, enum=enum
         )
-        if forward_mode_differentiation:
-            pe = potential_fn(params)
-            z_grad = jacfwd(potential_fn)(params)
+        if validate_grad:
+            if forward_mode_differentiation:
+                pe = potential_fn(params)
+                z_grad = jacfwd(potential_fn)(params)
+            else:
+                pe, z_grad = value_and_grad(potential_fn)(params)
+            z_grad_flat = ravel_pytree(z_grad)[0]
+            is_valid = jnp.isfinite(pe) & jnp.all(jnp.isfinite(z_grad_flat))
         else:
-            pe, z_grad = value_and_grad(potential_fn)(params)
-        z_grad_flat = ravel_pytree(z_grad)[0]
-        is_valid = jnp.isfinite(pe) & jnp.all(jnp.isfinite(z_grad_flat))
+            pe = potential_fn(params)
+            is_valid = jnp.isfinite(pe)
+            z_grad = None
+
         return i + 1, key, (params, pe, z_grad), is_valid
 
     def _find_valid_params(rng_key, exit_early=False):
@@ -443,6 +454,7 @@ def initialize_model(
     model_args=(),
     model_kwargs=None,
     forward_mode_differentiation=False,
+    validate_grad=True,
 ):
     """
     (EXPERIMENTAL INTERFACE) Helper function that calls :func:`~numpyro.infer.util.get_potential_fn`
@@ -468,6 +480,8 @@ def initialize_model(
         only supports forward-mode differentiation. See
         `JAX's The Autodiff Cookbook <https://jax.readthedocs.io/en/latest/notebooks/autodiff_cookbook.html>`_
         for more information.
+    :param bool validate_grad: whether to validate gradient of the initial params.
+        Defaults to True.
     :return: a namedtupe `ModelInfo` which contains the fields
         (`param_info`, `potential_fn`, `postprocess_fn`, `model_trace`), where
         `param_info` is a namedtuple `ParamInfo` containing values from the prior
@@ -546,6 +560,7 @@ def initialize_model(
         model_kwargs=model_kwargs,
         prototype_params=prototype_params,
         forward_mode_differentiation=forward_mode_differentiation,
+        validate_grad=validate_grad,
     )
 
     if not_jax_tracer(is_valid):

--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -75,9 +75,9 @@ def set_host_device_count(n):
 
     :param int n: number of CPU devices to use.
     """
-    xla_flags = os.getenv("XLA_FLAGS", "").lstrip("--")
+    xla_flags = os.getenv("XLA_FLAGS", "")
     xla_flags = re.sub(
-        r"xla_force_host_platform_device_count=.+\s", "", xla_flags
+        r"--xla_force_host_platform_device_count=\S.", "", xla_flags
     ).split()
     os.environ["XLA_FLAGS"] = " ".join(
         ["--xla_force_host_platform_device_count={}".format(n)] + xla_flags

--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -77,7 +77,7 @@ def set_host_device_count(n):
     """
     xla_flags = os.getenv("XLA_FLAGS", "")
     xla_flags = re.sub(
-        r"--xla_force_host_platform_device_count=\S.", "", xla_flags
+        r"--xla_force_host_platform_device_count=\S+", "", xla_flags
     ).split()
     os.environ["XLA_FLAGS"] = " ".join(
         ["--xla_force_host_platform_device_count={}".format(n)] + xla_flags

--- a/test/infer/test_mcmc.py
+++ b/test/infer/test_mcmc.py
@@ -900,6 +900,16 @@ def test_forward_mode_differentiation():
     mcmc.run(random.PRNGKey(0))
 
 
+def test_SA_gradient_free():
+    def model():
+        x = numpyro.sample("x", dist.Normal(0, 1))
+        y = lax.while_loop(lambda x: x < 10, lambda x: x + 1, x)
+        numpyro.sample("obs", dist.Normal(y, 1), obs=1.0)
+
+    mcmc = MCMC(SA(model), 10, 10)
+    mcmc.run(random.PRNGKey(0))
+
+
 def test_model_with_lift_handler():
     def model(data):
         c = numpyro.param("c", jnp.array(1.0), constraint=dist.constraints.positive)

--- a/test/infer/test_mcmc.py
+++ b/test/infer/test_mcmc.py
@@ -53,7 +53,8 @@ def test_unnormalized_normal_x64(kernel_cls, dense_mass):
         assert hmc_states.dtype == jnp.float64
 
 
-def test_correlated_mvn():
+@pytest.mark.parametrize("regularize", [True, False])
+def test_correlated_mvn(regularize):
     # This requires dense mass matrix estimation.
     D = 5
 
@@ -71,7 +72,9 @@ def test_correlated_mvn():
         return 0.5 * jnp.dot(z.T, jnp.dot(true_prec, z))
 
     init_params = jnp.zeros(D)
-    kernel = NUTS(potential_fn=potential_fn, dense_mass=True)
+    kernel = NUTS(
+        potential_fn=potential_fn, dense_mass=True, regularize_mass_matrix=regularize
+    )
     mcmc = MCMC(kernel, warmup_steps, num_samples)
     mcmc.run(random.PRNGKey(0), init_params=init_params)
     samples = mcmc.get_samples()

--- a/test/test_pickle.py
+++ b/test/test_pickle.py
@@ -10,7 +10,16 @@ import jax.numpy as jnp
 
 import numpyro
 import numpyro.distributions as dist
-from numpyro.infer import BarkerMH, HMC, HMCECS, MCMC, NUTS, SA, DiscreteHMCGibbs, MixedHMC
+from numpyro.infer import (
+    HMC,
+    HMCECS,
+    MCMC,
+    NUTS,
+    SA,
+    BarkerMH,
+    DiscreteHMCGibbs,
+    MixedHMC,
+)
 
 
 def normal_model():

--- a/test/test_pickle.py
+++ b/test/test_pickle.py
@@ -10,7 +10,7 @@ import jax.numpy as jnp
 
 import numpyro
 import numpyro.distributions as dist
-from numpyro.infer import HMC, HMCECS, MCMC, NUTS, SA, DiscreteHMCGibbs, MixedHMC
+from numpyro.infer import BarkerMH, HMC, HMCECS, MCMC, NUTS, SA, DiscreteHMCGibbs, MixedHMC
 
 
 def normal_model():
@@ -29,7 +29,7 @@ def logistic_regression():
         numpyro.sample("obs", dist.Bernoulli(logits=x), obs=batch)
 
 
-@pytest.mark.parametrize("kernel", [HMC, NUTS, SA])
+@pytest.mark.parametrize("kernel", [BarkerMH, HMC, NUTS, SA])
 def test_pickle_hmc(kernel):
     mcmc = MCMC(kernel(normal_model), 10, 10)
     mcmc.run(random.PRNGKey(0))


### PR DESCRIPTION
Resolves #997.

I also fix #994 to make BarkerMH pickable. And add a flag `validate_grad` to `initialize_model` to make SA an actual gradient-free kernel.