### PR TITLE
Fix an erroneous incantation in documentation

### DIFF
--- a/numpyro/distributions/directional.py
+++ b/numpyro/distributions/directional.py
@@ -87,7 +87,7 @@ class ProjectedNormal(Distribution):
     with a :class:`~numpyro.infer.reparam.ProjectedNormalReparam`
     reparametrizer in the model, e.g.::
 
-        @handlers.reparam(config={"direction": ProjectedNormalReparam()})
+        @partial(reparam, config={"direction": ProjectedNormalReparam()})
         def model():
             direction = numpyro.sample("direction",
                                        ProjectedNormal(zeros(3)))


### PR DESCRIPTION
As in title: the [docs](http://num.pyro.ai/en/0.6.0/distributions.html#numpyro.distributions.directional.ProjectedNormal) suggest to use
```
@handlers.reparam(args...)
def f():
   ...
```

which doesn't work since `@handlers.reparam` is a decorator, rather than return a decorator (which would support partial initialization), resulting in `f == None` which gives rather cryptic error messages. I updated the documentation to the working incantation

```
@partial(reparam, args...)
def f():
    ...
```

Note the change from `handlers.reparam` to just `reparam` in order to fit in PEP80. I assume the reader can infer from the context what namespace `reparam` is in (it's mentioned above).

If that interpretation violates your intents, feel free to reject.