### PR TITLE
Support decorator syntax for handlers

### DIFF
--- a/numpyro/primitives.py
+++ b/numpyro/primitives.py
@@ -78,6 +78,11 @@ class Messenger(object):
         pass
 
     def __call__(self, *args, **kwargs):
+        if self.fn is None:
+            # Assume self is being used as a decorator.
+            assert len(args) == 1 and not kwargs
+            self.fn = args[0]
+            return self
         with self:
             return self.fn(*args, **kwargs)
 

--- a/test/infer/test_reparam.py
+++ b/test/infer/test_reparam.py
@@ -85,6 +85,7 @@ def test_syntax():
     def m():
         return model()
 
+    m()
     tr4 = trace.trace
 
     assert tr1.keys() == tr2.keys() == tr3.keys() == tr4.keys()


### PR DESCRIPTION
Aims to support the syntax that @jatentaki noticed was missing.
Replaces #1008 

This aims to support Pyro-style syntax like
```py
@handlers.reparam(config={"x": LocScaleReparam})
def model():
    ...
```

## Tested
- [x] added a test of all sorts of syntax