### PR TITLE
soft_vmap: Don't reshape empty tensors.

### DIFF
--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -392,6 +392,6 @@ def soft_vmap(fn, xs, batch_ndims=1, chunk_size=None):
     ys = lax.map(fn, xs) if num_chunks > 1 else fn(xs)
     map_ndims = int(num_chunks > 1) + int(chunk_size > 1)
     ys = tree_map(
-        lambda y: jnp.reshape(y, (-1,) + jnp.shape(y)[map_ndims:])[:batch_size], ys
+        lambda y: jnp.reshape(y, (-1,) + jnp.shape(y)[map_ndims:])[:batch_size] if y.size else y, ys
     )
-    return tree_map(lambda y: jnp.reshape(y, batch_shape + jnp.shape(y)[1:]), ys)
+    return tree_map(lambda y: jnp.reshape(y, batch_shape + jnp.shape(y)[1:]) if y.size else y, ys)

--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -392,6 +392,11 @@ def soft_vmap(fn, xs, batch_ndims=1, chunk_size=None):
     ys = lax.map(fn, xs) if num_chunks > 1 else fn(xs)
     map_ndims = int(num_chunks > 1) + int(chunk_size > 1)
     ys = tree_map(
-        lambda y: jnp.reshape(y, (-1,) + jnp.shape(y)[map_ndims:])[:batch_size] if y.size else y, ys
+        lambda y: jnp.reshape(y, (-1,) + jnp.shape(y)[map_ndims:])[:batch_size]
+        if y.size
+        else y,
+        ys,
     )
-    return tree_map(lambda y: jnp.reshape(y, batch_shape + jnp.shape(y)[1:]) if y.size else y, ys)
+    return tree_map(
+        lambda y: jnp.reshape(y, batch_shape + jnp.shape(y)[1:]) if y.size else y, ys
+    )


### PR DESCRIPTION
# General description
Empty observed variables cause `soft_vmap` to fail with a `ZeroDivisionError` ultimately originating from an invalid reshape operation within Jax. This PR prevents resizing of empty tensors (tensors that have a zero in their shape) in `soft_vmap`.

# Minimal example
```python
from jax import random
import numpy as np
import numpyro
import numpyro.distributions as dist
from numpyro.infer import MCMC, NUTS, log_likelihood

y = np.array([-1.0, -1.5, 2.0, 2.5])
y1 = np.array([-1.0, -1.5])
y2 = np.array([2.0, 2.5])

def model(y):
    theta = numpyro.sample('theta', dist.Normal(0.0, 2.5))
    numpyro.sample('obs1', dist.Normal(theta, 0.25), obs=y[y > 1.0])
    numpyro.sample('obs2', dist.Normal(theta, 0.50), obs=y[y < 1.0])

nuts_kernel = NUTS(model)
mcmc = MCMC(nuts_kernel, num_warmup=500, num_samples=1000)
rng_key = random.PRNGKey(0)
mcmc.run(rng_key, y)
trace = mcmc.get_samples()

# works fine
print(log_likelihood(model, trace, y))

# fails as obs1 will be empty
print(log_likelihood(model, trace, y1))

# fails as obs2 will be empty
print(log_likelihood(model, trace, y2))
``` 

Both failures above are fixed after applying the fix.

Tested on master and 0.6.0 with identical behaviour.