### PR TITLE
Fix initial params affected by enumeration with init_to_median strategy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,8 @@ jobs:
         pip freeze
     - name: Test with pytest
       run: |
-        pytest -vs --durations=100 test/infer
+        pytest -vs --durations=20 test/infer/test_mcmc.py
+        pytest -vs --durations=20 test/infer --ignore=test/infer/test_mcmc.py
     - name: Test x64
       run: |
         JAX_ENABLE_X64=1 pytest -vs test/infer/test_mcmc.py -k x64

--- a/test/contrib/test_funsor.py
+++ b/test/contrib/test_funsor.py
@@ -19,7 +19,7 @@ from numpyro.contrib.funsor.enum_messenger import NamedMessenger, plate as enum_
 from numpyro.contrib.funsor.infer_util import log_density
 from numpyro.contrib.indexing import Vindex
 import numpyro.distributions as dist
-from numpyro.infer import MCMC, NUTS
+from numpyro.infer import MCMC, NUTS, init_to_median
 from numpyro.primitives import _PYRO_STACK
 
 
@@ -49,7 +49,7 @@ def test_gaussian_mixture_model():
         random.PRNGKey(1)
     )
 
-    nuts_kernel = NUTS(gmm)
+    nuts_kernel = NUTS(gmm, init_strategy=init_to_median)
     mcmc = MCMC(nuts_kernel, num_warmup=500, num_samples=500)
     mcmc.run(random.PRNGKey(2), data)
     samples = mcmc.get_samples()


### PR DESCRIPTION
Fixes #1015. The issue happens because we tried to get initial latent values for an enumerated model. I fix that by adding some extra logic (not a good solution but should be enough for the purpose of `initialize_model`) to skip the `enum` mechanism.