### PR TITLE
Fix for `AutoContinuous` guides with deterministic sites

### DIFF
--- a/numpyro/infer/util.py
+++ b/numpyro/infer/util.py
@@ -106,7 +106,10 @@ def constrain_fn(model, model_args, model_kwargs, params, return_deterministic=F
 
     def substitute_fn(site):
         if site["name"] in params:
-            return biject_to(site["fn"].support)(params[site["name"]])
+            if site["type"] == "sample":
+                return biject_to(site["fn"].support)(params[site["name"]])
+            else:
+                return params[site["name"]]
 
     substituted_model = substitute(model, substitute_fn=substitute_fn)
     model_trace = trace(substituted_model).get_trace(*model_args, **model_kwargs)


### PR DESCRIPTION
Fixes #1020.

Test case has been modified from toy example in linked issue to use a deterministic site that combines parameters, samples and model arguments just to check everything is collected / combined correctly.

@fehiepsi I am not testing `AutoIAFNormal` or `AutoBNAFNormal` in the tests because the example has a 1D latent. What do you think, should I make the test case more complex to increase the coverage or leave as it is?