### PR TITLE
Make cond test more robust

### DIFF
--- a/test/contrib/test_control_flow.py
+++ b/test/contrib/test_control_flow.py
@@ -190,14 +190,8 @@ def test_cond():
     x = mcmc.get_samples()["x"]
     assert x.shape == (10_000,)
     assert_allclose(
-        [
-            x.mean(),
-            x.std(),
-            x[x > 2.0].mean(),
-            x[x > 2.0].std(),
-            x[x < 2.0].mean(),
-            x[x < 2.0].std(),
-        ],
-        [2.0, jnp.sqrt(5.0), 4.0, 1.0, 0.0, 1.0],
+        [x[x > 2.0].mean(), x[x > 2.0].std(), x[x < 2.0].mean(), x[x < 2.0].std()],
+        [4.01, 0.965, -0.01, 0.965],
         atol=0.1,
     )
+    assert_allclose([x.mean(), x.std()], [2.0, jnp.sqrt(5.0)], atol=0.5)


### PR DESCRIPTION
The target distribution is bimodal which means MCMC chains sometimes get stuck in a particular mode and bias the mean. This PR increases the tolerance to reduce the chance of the test failing.
