### PR TITLE
Refactor TFP wrappers to avoid new metadata logic

### DIFF
--- a/numpyro/contrib/tfp/distributions.py
+++ b/numpyro/contrib/tfp/distributions.py
@@ -130,8 +130,6 @@ class TFPDistribution(NumPyroDistribution, metaclass=_TFPDistributionMeta):
 
         d = TFPDistribution[tfd.Normal](0, 1)
 
-    .. note:: Some special distributions like TransformedDistribution is not yet supported.
-        You can use NumPyro's TransformedDistribution as an alternative.
     """
 
     tfd_class = None
@@ -140,7 +138,6 @@ class TFPDistribution(NumPyroDistribution, metaclass=_TFPDistributionMeta):
         # return parameters from the constructor
         if name in self.tfp_dist.parameters:
             return self.tfp_dist.parameters[name]
-        return super().__getattr__(name)
 
     @property
     def batch_shape(self):
@@ -231,7 +228,7 @@ for _name, _Dist in tfd.__dict__.items():
         continue
     if not issubclass(_Dist, tfd.Distribution):
         continue
-    if _Dist in [tfd.Distribution, tfd.TransformedDistribution]:
+    if _Dist is tfd.Distribution:
         continue
 
     try:
@@ -253,7 +250,7 @@ for _name, _Dist in tfd.__dict__.items():
 
     _PyroDist.__doc__ = """
     Wraps `{}.{} <https://www.tensorflow.org/probability/api_docs/python/tfp/substrates/jax/distributions/{}>`_
-    with :class:`~numpyro.contrib.tfp.distributions.TFPDistributionMixin`.
+    with :class:`~numpyro.contrib.tfp.distributions.TFPDistribution`.
     """.format(
         _Dist.__module__, _Dist.__name__, _Dist.__name__
     )

--- a/numpyro/contrib/tfp/distributions.py
+++ b/numpyro/contrib/tfp/distributions.py
@@ -138,6 +138,9 @@ class TFPDistribution(NumPyroDistribution, metaclass=_TFPDistributionMeta):
         # return parameters from the constructor
         if name in self.tfp_dist.parameters:
             return self.tfp_dist.parameters[name]
+        elif name in ["dtype", "reparameterization_type"]:
+            return getattr(self.tfp_dist, name)
+        raise AttributeError(name)
 
     @property
     def batch_shape(self):

--- a/test/contrib/test_tfp.py
+++ b/test/contrib/test_tfp.py
@@ -59,7 +59,9 @@ def test_transformed_distributions():
     from numpyro.contrib.tfp import distributions as tfd
 
     d = dist.TransformedDistribution(dist.Normal(0, 1), dist.transforms.ExpTransform())
-    d1 = tfd.TransformedDistribution(tfd.Normal(0, 1), tfb.Exp())
+    d1 = dist.TransformedDistribution(
+        tfd.Normal(0, 1), tfd.BijectorTransform(tfb.Exp())
+    )
     d2 = dist.TransformedDistribution(
         dist.Normal(0, 1), tfd.BijectorTransform(tfb.Exp())
     )

--- a/test/contrib/test_tfp.py
+++ b/test/contrib/test_tfp.py
@@ -55,13 +55,12 @@ def test_independent():
 @pytest.mark.filterwarnings("ignore:can't resolve package")
 def test_transformed_distributions():
     from tensorflow_probability.substrates.jax import bijectors as tfb
+    from tensorflow_probability.substrates.jax.distributions import Normal as TFPNormal
 
     from numpyro.contrib.tfp import distributions as tfd
 
     d = dist.TransformedDistribution(dist.Normal(0, 1), dist.transforms.ExpTransform())
-    d1 = dist.TransformedDistribution(
-        tfd.Normal(0, 1), tfd.BijectorTransform(tfb.Exp())
-    )
+    d1 = tfd.TransformedDistribution(TFPNormal(0, 1), tfb.Exp())
     d2 = dist.TransformedDistribution(
         dist.Normal(0, 1), tfd.BijectorTransform(tfb.Exp())
     )


### PR DESCRIPTION
Resolves #1062.

In a recent nightly release, TFP distributions are a subclass of so-called `AutoCompositeTensorDistribution`, which has a new meta type. It is pretty complicated to resolve relevant issues to make CI pass, so I revise the TFP wrappers so that they are more agnostic to the upstream changes. This way, we can resolve some conflicts like `mean` is a property in NumPyro while it is a method in TFP.