### PR TITLE
Fix chain detection in progress bar

### DIFF
--- a/numpyro/infer/mcmc.py
+++ b/numpyro/infer/mcmc.py
@@ -204,6 +204,11 @@ class MCMC(object):
     .. note:: Setting `progress_bar=False` will improve the speed for many cases. But it might
         require more memory than the other option.
 
+    .. note:: If setting `num_chains` greater than `1` in a Jupyter Notebook, then you will need to
+        have installed `ipywidgets <https://ipywidgets.readthedocs.io/en/latest/user_install.html>`_
+        in the environment from which you launced Jupyter in order for the progress bars to render
+        correctly.
+
     :param MCMCKernel sampler: an instance of :class:`~numpyro.infer.mcmc.MCMCKernel` that
         determines the sampler for running MCMC. Currently, only :class:`~numpyro.infer.hmc.HMC`
         and :class:`~numpyro.infer.hmc.NUTS` are available.

--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -21,7 +21,7 @@ import jax.numpy as jnp
 from jax.tree_util import tree_flatten, tree_map
 
 _DISABLE_CONTROL_FLOW_PRIM = False
-CHAIN_RE = re.compile(r"\d+$")
+CHAIN_RE = re.compile(r"(?<=_)\d+$")  # e.g. get '3' from 'TFRT_CPU_3'
 
 
 def set_rng_seed(rng_seed):

--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -21,7 +21,7 @@ import jax.numpy as jnp
 from jax.tree_util import tree_flatten, tree_map
 
 _DISABLE_CONTROL_FLOW_PRIM = False
-CHAIN_RE = re.compile(r"(?<=_)\d+$")  # e.g. get '3' from 'TFRT_CPU_3'
+_CHAIN_RE = re.compile(r"(?<=_)\d+$")  # e.g. get '3' from 'TFRT_CPU_3'
 
 
 def set_rng_seed(rng_seed):
@@ -190,14 +190,14 @@ def progress_bar_factory(num_samples, num_chains):
         tqdm_bars[chain].set_description("Compiling.. ", refresh=True)
 
     def _update_tqdm(arg, transform, device):
-        chain_match = CHAIN_RE.search(str(device))
+        chain_match = _CHAIN_RE.search(str(device))
         assert chain_match
         chain = int(chain_match.group())
         tqdm_bars[chain].set_description(f"Running chain {chain}", refresh=False)
         tqdm_bars[chain].update(arg)
 
     def _close_tqdm(arg, transform, device):
-        chain_match = CHAIN_RE.search(str(device))
+        chain_match = _CHAIN_RE.search(str(device))
         assert chain_match
         chain = int(chain_match.group())
         tqdm_bars[chain].update(arg)

--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -21,6 +21,7 @@ import jax.numpy as jnp
 from jax.tree_util import tree_flatten, tree_map
 
 _DISABLE_CONTROL_FLOW_PRIM = False
+CHAIN_RE = re.compile(r"\d+$")
 
 
 def set_rng_seed(rng_seed):
@@ -189,12 +190,16 @@ def progress_bar_factory(num_samples, num_chains):
         tqdm_bars[chain].set_description("Compiling.. ", refresh=True)
 
     def _update_tqdm(arg, transform, device):
-        chain = int(str(device)[4:])
+        chain_match = CHAIN_RE.search(str(device))
+        assert chain_match
+        chain = int(chain_match.group())
         tqdm_bars[chain].set_description(f"Running chain {chain}", refresh=False)
         tqdm_bars[chain].update(arg)
 
     def _close_tqdm(arg, transform, device):
-        chain = int(str(device)[4:])
+        chain_match = CHAIN_RE.search(str(device))
+        assert chain_match
+        chain = int(chain_match.group())
         tqdm_bars[chain].update(arg)
         finished_chains.append(chain)
         if len(finished_chains) == num_chains:


### PR DESCRIPTION
closes #1075 

Without ipywidgets installed, I get:
```python-traceback
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
<ipython-input-5-0c678769c1ff> in <module>
      8 kernel = NUTS(model)
      9 mcmc = MCMC(kernel, num_warmup=num_warmup, num_samples=num_samples, num_chains=4)
---> 10 mcmc.run(rng_key_, marriage=dset.MarriageScaled.values, divorce=dset.DivorceScaled.values)
     11 mcmc.print_summary()
     12 samples_1 = mcmc.get_samples()

~/numpyro-dev/numpyro/infer/mcmc.py in run(self, rng_key, extra_fields, init_params, *args, **kwargs)
    565                 states, last_state = _laxmap(partial_map_fn, map_args)
    566             elif self.chain_method == "parallel":
--> 567                 states, last_state = pmap(partial_map_fn)(map_args)
    568             else:
    569                 assert self.chain_method == "vectorized"

    [... skipping hidden 12 frame]

~/numpyro-dev/numpyro/infer/mcmc.py in _single_chain_mcmc(self, init, args, kwargs, collect_fields)
    371             else collection_size // self.thinning
    372         )
--> 373         collect_vals = fori_collect(
    374             lower_idx,
    375             upper_idx,

~/numpyro-dev/numpyro/util.py in fori_collect(lower, upper, body_fun, init_val, transform, progbar, return_last_val, collection_size, thinning, **progbar_opts)
    334         )
    335     elif num_chains > 1:
--> 336         progress_bar_fori_loop = progress_bar_factory(upper, num_chains)
    337         _body_fn_pbar = progress_bar_fori_loop(_body_fn)
    338         last_val, collection, _, _ = fori_loop(

~/numpyro-dev/numpyro/util.py in progress_bar_factory(num_samples, num_chains)
    186     finished_chains = []
    187     for chain in range(num_chains):
--> 188         tqdm_bars[chain] = tqdm_auto(range(num_samples), position=chain)
    189         tqdm_bars[chain].set_description("Compiling.. ", refresh=True)
    190 

~/numpyro-dev/venv/lib/python3.8/site-packages/tqdm/notebook.py in __init__(self, *args, **kwargs)
    237         unit_scale = 1 if self.unit_scale is True else self.unit_scale or 1
    238         total = self.total * unit_scale if self.total else self.total
--> 239         self.container = self.status_printer(self.fp, total, self.desc, self.ncols)
    240         self.container.pbar = self
    241         self.displayed = False

~/numpyro-dev/venv/lib/python3.8/site-packages/tqdm/notebook.py in status_printer(_, total, desc, ncols)
    110         # Prepare IPython progress bar
    111         if IProgress is None:  # #187 #451 #558 #872
--> 112             raise ImportError(
    113                 "IProgress not found. Please update jupyter and ipywidgets."
    114                 " See https://ipywidgets.readthedocs.io/en/stable"

ImportError: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html
```

With ipywidgets installed, it now works fine:

![4 chains fixed](https://user-images.githubusercontent.com/33491632/123548815-42a5ec80-d75e-11eb-8a6e-1b6cc3ed276e.gif)

Any tips on how to write a test for this? Should `device` be mocked out somehow?
