### PR TITLE
Support infer_discrete for Predictive

### DIFF
--- a/examples/annotation.py
+++ b/examples/annotation.py
@@ -313,7 +313,7 @@ def main(args):
     mcmc.print_summary()
 
     posterior_samples = mcmc.get_samples()
-    predictive = Predictive(model, posterior_samples, infer_discrete_temperature=1)
+    predictive = Predictive(model, posterior_samples, infer_discrete=True)
     discrete_samples = predictive(random.PRNGKey(1), *data)
 
     item_class = vmap(lambda x: jnp.bincount(x, length=4), in_axes=1)(

--- a/examples/annotation.py
+++ b/examples/annotation.py
@@ -313,7 +313,7 @@ def main(args):
     mcmc.print_summary()
 
     posterior_samples = mcmc.get_samples()
-    predictive = Predictive(model, posterior_samples, infer_discrete=True)
+    predictive = Predictive(model, posterior_samples, infer_discrete_temperature=1)
     discrete_samples = predictive(random.PRNGKey(1), *data)
 
     item_class = vmap(lambda x: jnp.bincount(x, length=4), in_axes=1)(

--- a/examples/annotation.py
+++ b/examples/annotation.py
@@ -42,7 +42,6 @@ import jax.numpy as jnp
 
 import numpyro
 from numpyro import handlers
-from numpyro.contrib.funsor import config_enumerate
 from numpyro.contrib.indexing import Vindex
 import numpyro.distributions as dist
 from numpyro.infer import MCMC, NUTS, Predictive
@@ -314,9 +313,7 @@ def main(args):
     mcmc.print_summary()
 
     posterior_samples = mcmc.get_samples()
-    predictive = Predictive(
-        config_enumerate(model), posterior_samples, infer_discrete=True
-    )
+    predictive = Predictive(model, posterior_samples, infer_discrete=True)
     discrete_samples = predictive(random.PRNGKey(1), *data)
 
     item_class = vmap(lambda x: jnp.bincount(x, length=4), in_axes=1)(

--- a/examples/annotation.py
+++ b/examples/annotation.py
@@ -42,10 +42,10 @@ import jax.numpy as jnp
 
 import numpyro
 from numpyro import handlers
-from numpyro.contrib.funsor import config_enumerate, infer_discrete
+from numpyro.contrib.funsor import config_enumerate
 from numpyro.contrib.indexing import Vindex
 import numpyro.distributions as dist
-from numpyro.infer import MCMC, NUTS
+from numpyro.infer import MCMC, NUTS, Predictive
 from numpyro.infer.reparam import LocScaleReparam
 
 
@@ -313,24 +313,11 @@ def main(args):
     mcmc.run(random.PRNGKey(0), *data)
     mcmc.print_summary()
 
-    def infer_discrete_model(rng_key, samples):
-        conditioned_model = handlers.condition(model, data=samples)
-        infer_discrete_model = infer_discrete(
-            config_enumerate(conditioned_model), rng_key=rng_key
-        )
-        with handlers.trace() as tr:
-            infer_discrete_model(*data)
-
-        return {
-            name: site["value"]
-            for name, site in tr.items()
-            if site["type"] == "sample" and site["infer"].get("enumerate") == "parallel"
-        }
-
     posterior_samples = mcmc.get_samples()
-    discrete_samples = vmap(infer_discrete_model)(
-        random.split(random.PRNGKey(1), args.num_samples), posterior_samples
+    predictive = Predictive(
+        config_enumerate(model), posterior_samples, infer_discrete=True
     )
+    discrete_samples = predictive(random.PRNGKey(1), *data)
 
     item_class = vmap(lambda x: jnp.bincount(x, length=4), in_axes=1)(
         discrete_samples["c"].squeeze(-1)

--- a/numpyro/infer/util.py
+++ b/numpyro/infer/util.py
@@ -674,14 +674,13 @@ def _predictive(
     posterior_samples,
     batch_shape,
     return_sites=None,
-    infer_discrete=False,
-    temperature=1,
+    infer_discrete_temperature=None,
     parallel=True,
     model_args=(),
     model_kwargs={},
 ):
     masked_model = numpyro.handlers.mask(model, mask=False)
-    if infer_discrete:
+    if infer_discrete_temperature is not None:
         # inspect the model to get some structure
         rng_key, subkey = random.split(rng_key)
         batch_ndim = len(batch_shape)
@@ -696,7 +695,7 @@ def _predictive(
 
     def single_prediction(val):
         rng_key, samples = val
-        if infer_discrete:
+        if infer_discrete_temperature is not None:
             from numpyro.contrib.funsor import config_enumerate
             from numpyro.contrib.funsor.discrete import _sample_posterior
 
@@ -704,7 +703,7 @@ def _predictive(
             pred_samples = _sample_posterior(
                 config_enumerate(condition(model, samples)),
                 first_available_dim,
-                temperature,
+                infer_discrete_temperature,
                 rng_key,
                 *model_args,
                 **model_kwargs,
@@ -758,15 +757,15 @@ class Predictive(object):
     :param int num_samples: number of samples
     :param list return_sites: sites to return; by default only sample sites not present
         in `posterior_samples` are returned.
-    :param bool infer_discrete: whether or not to sample discrete sites from the
+    :param infer_discrete_temperature: if not None, we'll sample discrete sites from the
         posterior, conditioned on observations and other latent values in
         ``posterior_samples``. Under the hood, those sites will be marked with
         ``site["infer"]["enumerate"] = "parallel"``. See how `infer_discrete` works at
         the `Pyro enumeration tutorial <https://pyro.ai/examples/enumeration.html>`_.
-        This feature requires ``funsor`` installation.
-    :param int temperature: Either 1 (sample via forward-filter backward-sample)
-        or 0 (optimize via Viterbi-like MAP inference). Defaults to 1 (sample).
-        This argument only takes effect when ``infer_discrete=True``.
+        The temperature value is either 1 (sample via forward-filter backward-sample)
+        or 0 (optimize via Viterbi-like MAP inference).
+        Note that this requires ``funsor`` installation.
+    :type infer_discrete_temperature: None or int
     :param bool parallel: whether to predict in parallel using JAX vectorized map :func:`jax.vmap`.
         Defaults to False.
     :param batch_ndims: the number of batch dimensions in posterior samples. Some usages:
@@ -792,8 +791,7 @@ class Predictive(object):
         params=None,
         num_samples=None,
         return_sites=None,
-        infer_discrete=False,
-        temperature=1,
+        infer_discrete_temperature=None,
         parallel=False,
         batch_ndims=1,
     ):
@@ -842,8 +840,7 @@ class Predictive(object):
         self.num_samples = num_samples
         self.guide = guide
         self.params = {} if params is None else params
-        self.infer_discrete = infer_discrete
-        self.temperature = temperature
+        self.infer_discrete_temperature = infer_discrete_temperature
         self.return_sites = return_sites
         self.parallel = parallel
         self.batch_ndims = batch_ndims
@@ -881,8 +878,7 @@ class Predictive(object):
             posterior_samples,
             self._batch_shape,
             return_sites=self.return_sites,
-            infer_discrete=self.infer_discrete,
-            temperature=self.temperature,
+            infer_discrete_temperature=self.infer_discrete_temperature,
             parallel=self.parallel,
             model_args=args,
             model_kwargs=kwargs,


### PR DESCRIPTION
Follow-up #1043, this PR adds arguments `infer_discrete` and `temperature` to `Predictive` to make it easier for users to get samples for discrete latent variables (illustrated in the annotation example).