### PR TITLE
Bump version to 0.7.1

### DIFF
--- a/examples/annotation.py
+++ b/examples/annotation.py
@@ -327,7 +327,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert numpyro.__version__.startswith("0.7.0")
+    assert numpyro.__version__.startswith("0.7.1")
     parser = argparse.ArgumentParser(description="Bayesian Models of Annotation")
     parser.add_argument("-n", "--num-samples", nargs="?", default=1000, type=int)
     parser.add_argument("--num-warmup", nargs="?", default=1000, type=int)

--- a/examples/baseball.py
+++ b/examples/baseball.py
@@ -210,7 +210,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert numpyro.__version__.startswith("0.7.0")
+    assert numpyro.__version__.startswith("0.7.1")
     parser = argparse.ArgumentParser(description="Baseball batting average using MCMC")
     parser.add_argument("-n", "--num-samples", nargs="?", default=3000, type=int)
     parser.add_argument("--num-warmup", nargs="?", default=1500, type=int)

--- a/examples/bnn.py
+++ b/examples/bnn.py
@@ -156,7 +156,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert numpyro.__version__.startswith("0.7.0")
+    assert numpyro.__version__.startswith("0.7.1")
     parser = argparse.ArgumentParser(description="Bayesian neural network example")
     parser.add_argument("-n", "--num-samples", nargs="?", default=2000, type=int)
     parser.add_argument("--num-warmup", nargs="?", default=1000, type=int)

--- a/examples/covtype.py
+++ b/examples/covtype.py
@@ -206,7 +206,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert numpyro.__version__.startswith("0.7.0")
+    assert numpyro.__version__.startswith("0.7.1")
     parser = argparse.ArgumentParser(description="parse args")
     parser.add_argument(
         "-n", "--num-samples", default=1000, type=int, help="number of samples"

--- a/examples/funnel.py
+++ b/examples/funnel.py
@@ -108,7 +108,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert numpyro.__version__.startswith("0.7.0")
+    assert numpyro.__version__.startswith("0.7.1")
     parser = argparse.ArgumentParser(
         description="Non-centered reparameterization example"
     )

--- a/examples/gaussian_shells.py
+++ b/examples/gaussian_shells.py
@@ -120,7 +120,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert numpyro.__version__.startswith("0.7.0")
+    assert numpyro.__version__.startswith("0.7.1")
     parser = argparse.ArgumentParser(description="Nested sampler for Gaussian shells")
     parser.add_argument("-n", "--num-samples", nargs="?", default=10000, type=int)
     parser.add_argument("--num-warmup", nargs="?", default=1000, type=int)

--- a/examples/gp.py
+++ b/examples/gp.py
@@ -170,7 +170,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert numpyro.__version__.startswith("0.7.0")
+    assert numpyro.__version__.startswith("0.7.1")
     parser = argparse.ArgumentParser(description="Gaussian Process example")
     parser.add_argument("-n", "--num-samples", nargs="?", default=1000, type=int)
     parser.add_argument("--num-warmup", nargs="?", default=1000, type=int)

--- a/examples/hmm.py
+++ b/examples/hmm.py
@@ -263,7 +263,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert numpyro.__version__.startswith("0.7.0")
+    assert numpyro.__version__.startswith("0.7.1")
     parser = argparse.ArgumentParser(description="Semi-supervised Hidden Markov Model")
     parser.add_argument("--num-categories", default=3, type=int)
     parser.add_argument("--num-words", default=10, type=int)

--- a/examples/minipyro.py
+++ b/examples/minipyro.py
@@ -58,7 +58,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert numpyro.__version__.startswith("0.7.0")
+    assert numpyro.__version__.startswith("0.7.1")
     parser = argparse.ArgumentParser(description="Mini Pyro demo")
     parser.add_argument("-f", "--full-pyro", action="store_true", default=False)
     parser.add_argument("-n", "--num-steps", default=1001, type=int)

--- a/examples/neutra.py
+++ b/examples/neutra.py
@@ -197,7 +197,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert numpyro.__version__.startswith("0.7.0")
+    assert numpyro.__version__.startswith("0.7.1")
     parser = argparse.ArgumentParser(description="NeuTra HMC")
     parser.add_argument("-n", "--num-samples", nargs="?", default=4000, type=int)
     parser.add_argument("--num-warmup", nargs="?", default=1000, type=int)

--- a/examples/ode.py
+++ b/examples/ode.py
@@ -116,7 +116,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert numpyro.__version__.startswith("0.7.0")
+    assert numpyro.__version__.startswith("0.7.1")
     parser = argparse.ArgumentParser(description="Predator-Prey Model")
     parser.add_argument("-n", "--num-samples", nargs="?", default=1000, type=int)
     parser.add_argument("--num-warmup", nargs="?", default=1000, type=int)

--- a/examples/prodlda.py
+++ b/examples/prodlda.py
@@ -314,7 +314,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert numpyro.__version__.startswith("0.7.0")
+    assert numpyro.__version__.startswith("0.7.1")
     parser = argparse.ArgumentParser(
         description="Probabilistic topic modelling with Flax and Haiku"
     )

--- a/examples/proportion_test.py
+++ b/examples/proportion_test.py
@@ -160,7 +160,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert numpyro.__version__.startswith("0.7.0")
+    assert numpyro.__version__.startswith("0.7.1")
     parser = argparse.ArgumentParser(description="Testing whether  ")
     parser.add_argument("-n", "--num-samples", nargs="?", default=500, type=int)
     parser.add_argument("--num-warmup", nargs="?", default=1500, type=int)

--- a/examples/sparse_regression.py
+++ b/examples/sparse_regression.py
@@ -401,7 +401,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert numpyro.__version__.startswith("0.7.0")
+    assert numpyro.__version__.startswith("0.7.1")
     parser = argparse.ArgumentParser(description="Gaussian Process example")
     parser.add_argument("-n", "--num-samples", nargs="?", default=1000, type=int)
     parser.add_argument("--num-warmup", nargs="?", default=500, type=int)

--- a/examples/stochastic_volatility.py
+++ b/examples/stochastic_volatility.py
@@ -122,7 +122,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert numpyro.__version__.startswith("0.7.0")
+    assert numpyro.__version__.startswith("0.7.1")
     parser = argparse.ArgumentParser(description="Stochastic Volatility Model")
     parser.add_argument("-n", "--num-samples", nargs="?", default=600, type=int)
     parser.add_argument("--num-warmup", nargs="?", default=600, type=int)

--- a/examples/thompson_sampling.py
+++ b/examples/thompson_sampling.py
@@ -294,7 +294,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert numpyro.__version__.startswith("0.7.0")
+    assert numpyro.__version__.startswith("0.7.1")
     parser = argparse.ArgumentParser(description="Thompson sampling example")
     parser.add_argument(
         "--num-random", nargs="?", default=2, type=int, help="number of random draws"

--- a/examples/ucbadmit.py
+++ b/examples/ucbadmit.py
@@ -151,7 +151,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert numpyro.__version__.startswith("0.7.0")
+    assert numpyro.__version__.startswith("0.7.1")
     parser = argparse.ArgumentParser(
         description="UCBadmit gender discrimination using HMC"
     )

--- a/examples/vae.py
+++ b/examples/vae.py
@@ -159,7 +159,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert numpyro.__version__.startswith("0.7.0")
+    assert numpyro.__version__.startswith("0.7.1")
     parser = argparse.ArgumentParser(description="parse args")
     parser.add_argument(
         "-n", "--num-epochs", default=15, type=int, help="number of training epochs"

--- a/notebooks/source/bayesian_hierarchical_linear_regression.ipynb
+++ b/notebooks/source/bayesian_hierarchical_linear_regression.ipynb
@@ -242,7 +242,7 @@
     "import numpyro.distributions as dist\n",
     "from jax import random\n",
     "\n",
-    "assert numpyro.__version__.startswith('0.7.0')"
+    "assert numpyro.__version__.startswith('0.7.1')"
    ]
   },
   {

--- a/notebooks/source/bayesian_imputation.ipynb
+++ b/notebooks/source/bayesian_imputation.ipynb
@@ -55,7 +55,7 @@
     "if \"NUMPYRO_SPHINXBUILD\" in os.environ:\n",
     "    set_matplotlib_formats(\"svg\")\n",
     "\n",
-    "assert numpyro.__version__.startswith('0.7.0')"
+    "assert numpyro.__version__.startswith('0.7.1')"
    ]
   },
   {

--- a/notebooks/source/bayesian_regression.ipynb
+++ b/notebooks/source/bayesian_regression.ipynb
@@ -95,7 +95,7 @@
         "if \"NUMPYRO_SPHINXBUILD\" in os.environ:\n",
         "    set_matplotlib_formats('svg')\n",
         "\n",
-        "assert numpyro.__version__.startswith('0.7.0')"
+        "assert numpyro.__version__.startswith('0.7.1')"
       ],
       "execution_count": 2,
       "outputs": []

--- a/notebooks/source/logistic_regression.ipynb
+++ b/notebooks/source/logistic_regression.ipynb
@@ -40,7 +40,7 @@
     "import numpyro.distributions as dist\n",
     "from numpyro.examples.datasets import COVTYPE, load_dataset\n",
     "from numpyro.infer import HMC, MCMC, NUTS\n",
-    "assert numpyro.__version__.startswith('0.7.0')\n",
+    "assert numpyro.__version__.startswith('0.7.1')\n",
     "\n",
     "# NB: replace gpu by cpu to run this notebook in cpu\n",
     "numpyro.set_platform(\"gpu\")"

--- a/notebooks/source/model_rendering.ipynb
+++ b/notebooks/source/model_rendering.ipynb
@@ -33,7 +33,7 @@
     "import numpyro\n",
     "import numpyro.distributions as dist\n",
     "\n",
-    "assert numpyro.__version__.startswith('0.7.0')"
+    "assert numpyro.__version__.startswith('0.7.1')"
    ]
   },
   {

--- a/notebooks/source/ordinal_regression.ipynb
+++ b/notebooks/source/ordinal_regression.ipynb
@@ -39,7 +39,7 @@
     "from numpyro.infer import MCMC, NUTS\n",
     "import pandas as pd\n",
     "import seaborn as sns\n",
-    "assert numpyro.__version__.startswith('0.7.0')"
+    "assert numpyro.__version__.startswith('0.7.1')"
    ]
   },
   {

--- a/numpyro/version.py
+++ b/numpyro/version.py
@@ -1,4 +1,4 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"


### PR DESCRIPTION
Resolves #1092

For some reason, when creating the wheel file with `python setup.py sdist bdist_wheel` in the last release, `.whl` file has content different from `.tar.gz` file (some scripts in `.whl` are from one of the old versions). I'm not sure what happens. :( I'll check two files for consistency this time.

List of old scripts in `numpyro-0.7.0-py3-none-any.whl` file:
+ __init__.py
+ contrib/funsor/__init__.py
+ contrib/funsor/infer_util.py
+ distributions/__init__.py
+ distributions/directional.py
+ distributions/discrete.py

I think I haven't deleted the old `build` folder and got the same issue as this https://stackoverflow.com/questions/66017277/bdist-using-old-files-to-create-built-distribution