### PR TITLE
add fix and test for model rendering of only discrete variables

### DIFF
--- a/numpyro/contrib/render.py
+++ b/numpyro/contrib/render.py
@@ -117,7 +117,10 @@ def get_model_relations(model, model_args=None, model_kwargs=None, num_tries=10)
         and not site["is_observed"]
         and not site["fn"].is_discrete
     }
-    log_prob_grads = jax.jacobian(get_log_probs)(samples)
+    if samples:
+        log_prob_grads = jax.jacobian(get_log_probs)(samples)
+    else:
+        log_prob_grads = {k: {} for k in get_log_probs(samples)}
     sample_deps = {}
     for name, grads in log_prob_grads.items():
         sample_deps[name] = {n for n in grads if n != name and (grads[n] != 0).any()}

--- a/test/test_model_rendering.py
+++ b/test/test_model_rendering.py
@@ -39,6 +39,10 @@ def discrete_to_continuous(probs, locs):
     numpyro.sample("x", dist.Normal(locs[c], 0.5))
 
 
+def discrete(prob):
+    numpyro.sample("x", dist.Bernoulli(prob))
+
+
 @pytest.mark.parametrize(
     "test_model,model_kwargs,expected_graph_spec",
     [
@@ -102,6 +106,18 @@ def discrete_to_continuous(probs, locs):
                     "x": {"is_observed": False, "distribution": "Normal"},
                 },
                 "edge_list": [("c", "x")],
+            },
+        ),
+        (
+            discrete,
+            dict(prob=0.5),
+            {
+                "plate_groups": {None: ["x"]},
+                "plate_data": {},
+                "node_data": {
+                    "x": {"is_observed": False, "distribution": "BernoulliProbs"}
+                },
+                "edge_list": [],
             },
         ),
     ],


### PR DESCRIPTION
Found an edge case within model rendering where empty inputs were being passed to [jax.jacobian](https://github.com/pyro-ppl/numpyro/blob/cf85229edab08144108623338f31c78a1a16d5d5/numpyro/contrib/render.py#L120), see [discussion](https://forum.pyro.ai/t/numpyro-render-model-valueerror-too-few-leaves-for-pytreedef/3113/2?u=bdatko) for more details.

Added fix for `render.py` along with a simple model for testing