### PR TITLE
Relax matching device pattern

### DIFF
--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -21,7 +21,7 @@ import jax.numpy as jnp
 from jax.tree_util import tree_flatten, tree_map
 
 _DISABLE_CONTROL_FLOW_PRIM = False
-_CHAIN_RE = re.compile(r"(?<=_)\d+$")  # e.g. get '3' from 'TFRT_CPU_3'
+_CHAIN_RE = re.compile(r"\d+$")  # e.g. get '3' from 'TFRT_CPU_3'
 
 
 def set_rng_seed(rng_seed):


### PR DESCRIPTION
I think this is causing some issues in [this forum thread](https://forum.pyro.ai/t/sampling-for-numpyro-breaks-running-in-parallel-show-progress-mode/3140/2). The pattern there assumes the device has the form `..._1` but in my system in recent jax release, it is `cpu:1`.

I have tested the gp examples locally. Chain MCMC tests also pass on CI.