### PR TITLE
fix typo in docs for dim param of plate

### DIFF
--- a/numpyro/contrib/funsor/enum_messenger.py
+++ b/numpyro/contrib/funsor/enum_messenger.py
@@ -476,7 +476,7 @@ class plate(GlobalNamedMessenger):
         This can be used to apply a scaling factor by inference algorithms. e.g.
         when computing ELBO using a mini-batch.
     :param int dim: Optional argument to specify which dimension in the tensor
-        is used as the plate dim. If `None` (default), the leftmost available dim
+        is used as the plate dim. If `None` (default), the rightmost available dim
         is allocated.
     """
 

--- a/numpyro/primitives.py
+++ b/numpyro/primitives.py
@@ -390,7 +390,7 @@ class plate(Messenger):
         This can be used to apply a scaling factor by inference algorithms. e.g.
         when computing ELBO using a mini-batch.
     :param int dim: Optional argument to specify which dimension in the tensor
-        is used as the plate dim. If `None` (default), the leftmost available dim
+        is used as the plate dim. If `None` (default), the rightmost available dim
         is allocated.
     """
 


### PR DESCRIPTION
`dim` param for plate within both `./numpyro/primitives.py` and `./numpyro/contrib/funsor/enum_messenger.py` mean to specify the default as the rightmost dimension, not leftmost dimension. See the relevant discussion on the [forum](https://forum.pyro.ai/t/numpyro-plate-dim-bayesian-naive-bayes/3143/2?u=bdatko).