### PR TITLE
Support direct use of TFP distributions in `numpyro.sample`

### DIFF
--- a/numpyro/contrib/tfp/distributions.py
+++ b/numpyro/contrib/tfp/distributions.py
@@ -245,7 +245,7 @@ class TFPDistribution(NumPyroDistribution, metaclass=_TFPDistributionMeta):
         fn = jax.tree_util.tree_unflatten(aux_data, params)
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=FutureWarning)
-            return cls[fn.__class__](**fn.parameters)
+            return TFPDistribution[fn.__class__](**fn.parameters)
 
 
 __all__ = ["BijectorConstraint", "BijectorTransform", "TFPDistribution"]

--- a/numpyro/contrib/tfp/distributions.py
+++ b/numpyro/contrib/tfp/distributions.py
@@ -7,6 +7,7 @@ import warnings
 
 import numpy as np
 
+import jax
 import jax.numpy as jnp
 from tensorflow_probability.substrates.jax import bijectors as tfb, distributions as tfd
 
@@ -241,6 +242,16 @@ class TFPDistribution(NumPyroDistribution, metaclass=_TFPDistributionMeta):
     def is_discrete(self):
         # XXX: this should cover most cases
         return self.support is None
+
+    def tree_flatten(self):
+        return jax.tree_util.tree_flatten(self.tfp_dist)
+
+    @classmethod
+    def tree_unflatten(cls, aux_data, params):
+        fn = jax.tree_util.tree_unflatten(aux_data, params)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=FutureWarning)
+            return cls[fn.__class__](**fn.parameters)
 
 
 __all__ = ["BijectorConstraint", "BijectorTransform", "TFPDistribution"]

--- a/numpyro/contrib/tfp/distributions.py
+++ b/numpyro/contrib/tfp/distributions.py
@@ -136,7 +136,6 @@ class _TFPDistributionMeta(type(NumPyroDistribution)):
         init.__signature__ = inspect.signature(tfd_class.__init__)
 
         _PyroDist = type(tfd_class_name, (TFPDistribution,), {})
-        _PyroDist.tfd_class = tfd_class
         _PyroDist.__init__ = init
 
         if tfd_class is tfd.InverseGamma:
@@ -187,9 +186,6 @@ class TFPDistribution(NumPyroDistribution, metaclass=_TFPDistributionMeta):
         d = TFPDistribution[tfd.Normal](0, 1)
 
     """
-
-    tfd_class = None
-
     def __getattr__(self, name):
         # return parameters from the constructor
         if name in self.tfp_dist.parameters:

--- a/numpyro/contrib/tfp/distributions.py
+++ b/numpyro/contrib/tfp/distributions.py
@@ -154,12 +154,9 @@ class _TFPDistributionMeta(type(NumPyroDistribution)):
             if hasattr(numpyro_dist, tfd_class_name):
                 numpyro_dist_class = getattr(numpyro_dist, tfd_class_name)
                 # resolve FooProbs/FooLogits namespaces
-                if type(numpyro_dist_class).__name__ == "function":
-                    if not hasattr(numpyro_dist, f"{tfd_class_name}Logits"):
-                        raise ValueError
-                    numpyro_dist_class = getattr(
-                        numpyro_dist, f"{tfd_class_name}Logits"
-                    )
+                numpyro_dist_class = getattr(
+                    numpyro_dist, f"{tfd_class_name}Logits", numpyro_dist_class
+                )
                 _PyroDist.arg_constraints = numpyro_dist_class.arg_constraints
                 _PyroDist.has_enumerate_support = (
                     numpyro_dist_class.has_enumerate_support
@@ -247,10 +244,7 @@ for _name, _Dist in tfd.__dict__.items():
     if _Dist is tfd.Distribution:
         continue
 
-    try:
-        _PyroDist = TFPDistribution[_Dist]
-    except ValueError:
-        continue
+    _PyroDist = TFPDistribution[_Dist]
     _PyroDist.__module__ = __name__
     locals()[_name] = _PyroDist
 

--- a/numpyro/contrib/tfp/distributions.py
+++ b/numpyro/contrib/tfp/distributions.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from functools import lru_cache
-import inspect
 import warnings
 
 import numpy as np
@@ -133,8 +132,6 @@ class _TFPDistributionMeta(type(NumPyroDistribution)):
             )
             self.tfp_dist = tfd_class(*args, **kwargs)
 
-        init.__signature__ = inspect.signature(tfd_class.__init__)
-
         _PyroDist = type(tfd_class_name, (TFPDistribution,), {})
         _PyroDist.__init__ = init
 
@@ -186,6 +183,7 @@ class TFPDistribution(NumPyroDistribution, metaclass=_TFPDistributionMeta):
         d = TFPDistribution[tfd.Normal](0, 1)
 
     """
+
     def __getattr__(self, name):
         # return parameters from the constructor
         if name in self.tfp_dist.parameters:

--- a/numpyro/contrib/tfp/distributions.py
+++ b/numpyro/contrib/tfp/distributions.py
@@ -282,6 +282,6 @@ __doc__ = "\n\n".join(
     """.format(
             _name
         )
-        for _name in __all__[:_len_all] + sorted(__all__[_len_all:])
+        for _name in __all__[:_len_all]
     ]
 )

--- a/numpyro/contrib/tfp/distributions.py
+++ b/numpyro/contrib/tfp/distributions.py
@@ -1,6 +1,7 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
+from functools import lru_cache
 import inspect
 import warnings
 
@@ -116,6 +117,7 @@ def _onehot_enumerate_support(self, expand=True):
 
 
 class _TFPDistributionMeta(type(NumPyroDistribution)):
+    @lru_cache(maxsize=None)
     def __getitem__(cls, tfd_class):
         assert issubclass(tfd_class, tfd.Distribution)
 

--- a/numpyro/contrib/tfp/distributions.py
+++ b/numpyro/contrib/tfp/distributions.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import inspect
+import warnings
 
 import numpy as np
 
@@ -121,6 +122,12 @@ class _TFPDistributionMeta(type(NumPyroDistribution)):
         tfd_class_name = tfd_class.__name__
 
         def init(self, *args, **kwargs):
+            warnings.warn(
+                "Importing distributions from numpyro.contrib.tfp.distributions is "
+                "deprecated. You should import distributions directly from "
+                "tensorflow_probability.substrates.jax.distributions instead.",
+                FutureWarning,
+            )
             self.tfp_dist = tfd_class(*args, **kwargs)
 
         init.__signature__ = inspect.signature(tfd_class.__init__)

--- a/numpyro/primitives.py
+++ b/numpyro/primitives.py
@@ -159,8 +159,11 @@ def sample(
                 raise type_error
 
             if isinstance(fn, tfd.Distribution):
-                # if fn is a tfp distribution we need to wrap it
-                fn = TFPDistribution[fn.__class__](**fn.parameters)
+                with warnings.catch_warnings():
+                    # ignore FutureWarnings when instantiating TFPDistribution
+                    warnings.simplefilter("ignore", category=FutureWarning)
+                    # if fn is a tfp distribution we need to wrap it
+                    fn = TFPDistribution[fn.__class__](**fn.parameters)
             else:
                 # if tensorflow_probability imported, but fn is not tfd.Distribution we
                 # still need to raise a type error

--- a/test/contrib/test_tfp.py
+++ b/test/contrib/test_tfp.py
@@ -1,7 +1,6 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
-import inspect
 import os
 
 from numpy.testing import assert_allclose
@@ -15,21 +14,6 @@ import numpyro.distributions as dist
 from numpyro.distributions.transforms import AffineTransform
 from numpyro.infer import MCMC, NUTS
 from numpyro.infer.reparam import TransformReparam
-
-
-# XXX: for some reasons, pytest raises ImportWarning when we import tfp
-@pytest.mark.filterwarnings("ignore:can't resolve package")
-def test_api_consistent():
-    from numpyro.contrib.tfp import distributions as tfd
-
-    for name in tfd.__all__:
-        if name in numpyro.distributions.__all__:
-            tfp_dist = getattr(tfd, name)
-            numpyro_dist = getattr(numpyro.distributions, name)
-            if type(numpyro_dist).__name__ == "function":
-                numpyro_dist = getattr(numpyro.distributions, name + "Logits")
-            for p in tfp_dist.arg_constraints:
-                assert p in inspect.getfullargspec(tfp_dist.__init__)[0]
 
 
 def test_dist_pytree():

--- a/test/contrib/test_tfp.py
+++ b/test/contrib/test_tfp.py
@@ -292,4 +292,4 @@ def test_mcmc_unwrapped_tfp_distributions():
     mcmc.run(random.PRNGKey(0), jnp.array([0, 0, 1, 1, 1]))
     samples = mcmc.get_samples()
 
-    assert_allclose(jnp.mean(samples["p"]), 4 / 7, atol=0.01)
+    assert_allclose(jnp.mean(samples["p"]), 4 / 7, atol=0.05)

--- a/test/contrib/test_tfp.py
+++ b/test/contrib/test_tfp.py
@@ -32,6 +32,7 @@ def test_api_consistent():
                 assert p in inspect.getfullargspec(tfp_dist.__init__)[0]
 
 
+@pytest.mark.filterwarnings("ignore:Importing distributions")
 def test_dist_pytree():
     from numpyro.contrib.tfp import distributions as tfd
 
@@ -42,6 +43,7 @@ def test_dist_pytree():
 
 
 @pytest.mark.filterwarnings("ignore:can't resolve package")
+@pytest.mark.filterwarnings("ignore:Importing distributions")
 def test_independent():
     from numpyro.contrib.tfp import distributions as tfd
 
@@ -53,6 +55,7 @@ def test_independent():
 
 
 @pytest.mark.filterwarnings("ignore:can't resolve package")
+@pytest.mark.filterwarnings("ignore:Importing distributions")
 def test_transformed_distributions():
     from tensorflow_probability.substrates.jax import bijectors as tfb
     from tensorflow_probability.substrates.jax.distributions import Normal as TFPNormal
@@ -74,14 +77,14 @@ def test_transformed_distributions():
 
 @pytest.mark.filterwarnings("ignore:can't resolve package")
 def test_logistic_regression():
-    from numpyro.contrib.tfp import distributions as tfd
+    from tensorflow_probability.substrates.jax import distributions as tfd
 
     N, dim = 3000, 3
     num_warmup, num_samples = (1000, 1000)
     data = random.normal(random.PRNGKey(0), (N, dim))
     true_coefs = jnp.arange(1.0, dim + 1.0)
     logits = jnp.sum(true_coefs * data, axis=-1)
-    labels = tfd.Bernoulli(logits=logits)(rng_key=random.PRNGKey(1))
+    labels = tfd.Bernoulli(logits=logits).sample(seed=random.PRNGKey(1))
 
     def model(labels):
         coefs = numpyro.sample("coefs", tfd.Normal(jnp.zeros(dim), jnp.ones(dim)))
@@ -102,7 +105,7 @@ def test_logistic_regression():
 # TODO: remove after https://github.com/tensorflow/probability/issues/1072 is resolved
 @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
 def test_beta_bernoulli():
-    from numpyro.contrib.tfp import distributions as tfd
+    from tensorflow_probability.substrates.jax import distributions as tfd
 
     num_warmup, num_samples = (500, 2000)
 
@@ -114,7 +117,9 @@ def test_beta_bernoulli():
         return p_latent
 
     true_probs = jnp.array([0.9, 0.1])
-    data = tfd.Bernoulli(true_probs)(rng_key=random.PRNGKey(1), sample_shape=(1000, 2))
+    data = tfd.Bernoulli(true_probs).sample(
+        seed=random.PRNGKey(1), sample_shape=(1000, 2)
+    )
     kernel = NUTS(model=model, trajectory_length=0.1)
     mcmc = MCMC(kernel, num_warmup=num_warmup, num_samples=num_samples)
     mcmc.run(random.PRNGKey(2), data)
@@ -240,6 +245,7 @@ def test_unnormalized_normal_chain(kernel, kwargs, num_chains):
 # test if sampling from tfp distributions works as expected using
 # numpyro sample function: numpyro.sample("name", dist) (bug)
 @pytest.mark.filterwarnings("ignore:can't resolve package")
+@pytest.mark.filterwarnings("ignore:Importing distributions")
 def test_sample_tfp_distributions():
     from numpyro.contrib.tfp import distributions as tfd
 

--- a/test/contrib/test_tfp.py
+++ b/test/contrib/test_tfp.py
@@ -43,36 +43,18 @@ def test_dist_pytree():
 
 
 @pytest.mark.filterwarnings("ignore:can't resolve package")
-@pytest.mark.filterwarnings("ignore:Importing distributions")
-def test_independent():
-    from numpyro.contrib.tfp import distributions as tfd
-
-    d = tfd.Independent(
-        tfd.Normal(jnp.zeros(10), jnp.ones(10)), reinterpreted_batch_ndims=1
-    )
-    assert d.event_shape == (10,)
-    assert d.batch_shape == ()
-
-
-@pytest.mark.filterwarnings("ignore:can't resolve package")
-@pytest.mark.filterwarnings("ignore:Importing distributions")
 def test_transformed_distributions():
-    from tensorflow_probability.substrates.jax import bijectors as tfb
-    from tensorflow_probability.substrates.jax.distributions import Normal as TFPNormal
-
-    from numpyro.contrib.tfp import distributions as tfd
+    from tensorflow_probability.substrates.jax import (
+        bijectors as tfb,
+        distributions as tfd,
+    )
 
     d = dist.TransformedDistribution(dist.Normal(0, 1), dist.transforms.ExpTransform())
-    d1 = tfd.TransformedDistribution(TFPNormal(0, 1), tfb.Exp())
-    d2 = dist.TransformedDistribution(
-        dist.Normal(0, 1), tfd.BijectorTransform(tfb.Exp())
-    )
+    d1 = tfd.TransformedDistribution(tfd.Normal(0, 1), tfb.Exp())
     x = random.normal(random.PRNGKey(0), (1000,))
     d_x = d.log_prob(x).sum()
     d1_x = d1.log_prob(x).sum()
-    d2_x = d2.log_prob(x).sum()
     assert_allclose(d_x, d1_x)
-    assert_allclose(d_x, d2_x)
 
 
 @pytest.mark.filterwarnings("ignore:can't resolve package")

--- a/test/contrib/test_tfp.py
+++ b/test/contrib/test_tfp.py
@@ -265,7 +265,10 @@ def test_sample_tfp_distributions():
         ["Cauchy", (0, 1)],
         ["Dirichlet", ([1, 2, 0.5],)],
         ["Exponential", (1,)],
+        ["InverseGamma", (1, 1)],
         ["Normal", (0, 1)],
+        ["OrderedLogistic", ([0, 1], 0.5)],
+        ["Pareto", (1,)],
     ],
 )
 def test_sample_unwrapped_tfp_distributions(dist, args):
@@ -276,6 +279,23 @@ def test_sample_unwrapped_tfp_distributions(dist, args):
         # since we import tfd inside the test, distributions have to be parametrized as
         # strings, which is why we use getattr here
         numpyro.sample("sample", getattr(tfd, dist)(*args))
+
+
+# test mixture distributions
+def test_sample_unwrapped_mixture_same_family():
+    from tensorflow_probability.substrates.jax import distributions as tfd
+
+    # test no error is raised
+    with numpyro.handlers.seed(rng_seed=random.PRNGKey(0)):
+        numpyro.sample(
+            "sample",
+            tfd.MixtureSameFamily(
+                mixture_distribution=tfd.Categorical(probs=[0.3, 0.7]),
+                components_distribution=tfd.Normal(
+                    loc=[-1.0, 1], scale=[0.1, 0.5]  # One for each component.
+                ),
+            ),
+        )
 
 
 # test that MCMC works with unwrapped tensorflow_probability distributions

--- a/test/contrib/test_tfp.py
+++ b/test/contrib/test_tfp.py
@@ -23,12 +23,11 @@ def test_dist_pytree():
 
     @jit
     def f(x):
-        with numpyro.handlers.trace() as tr:
+        with numpyro.handlers.seed(rng_seed=0), numpyro.handlers.trace() as tr:
             numpyro.sample("x", tfd.Normal(x, 1))
         return tr["x"]["fn"]
 
-    with numpyro.handlers.seed(rng_seed=0):
-        res = f(0.0)
+    res = f(0.0)
 
     assert isinstance(res, TFPDistribution)
     assert res.loc == 0
@@ -222,10 +221,12 @@ def test_unnormalized_normal_chain(kernel, kwargs, num_chains):
 @pytest.mark.filterwarnings("ignore:can't resolve package")
 @pytest.mark.filterwarnings("ignore:Importing distributions")
 def test_sample_tfp_distributions():
-    from numpyro.contrib.tfp import distributions as tfd
+    from tensorflow_probability.substrates.jax import distributions as tfd
+
+    from numpyro.contrib.tfp.distributions import TFPDistribution
 
     # test no error raised
-    d = tfd.Normal(0, 1)
+    d = TFPDistribution[tfd.Normal](0, 1)
     with numpyro.handlers.seed(rng_seed=random.PRNGKey(0)):
         numpyro.sample("normal", d)
 


### PR DESCRIPTION
This PR automatically wraps instances of `tfd.Distribution` inside `numpyro.sample` so that distributions can be imported directly from `tfd` rather than `numpyro.contrib.tfp.distributions`.

Added a couple of tests, but let me know if you think something more extensive is needed.

Fixes #1106 