### PR TITLE
Add sphinx-search to docs and pin version numbers

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,11 +1,15 @@
 dm-haiku
 flax
 funsor>=0.4.1
+ipython
 jax>=0.2.11
 jaxlib>=0.1.62
 jaxns>=0.0.7
 optax>=0.0.6
-nbsphinx>=0.8.5
+nbsphinx==0.8.6
+readthedocs-sphinx-search==0.1.0
+sphinx==4.1.2
 sphinx-gallery
+sphinx_rtd_theme==0.5.2
 tensorflow_probability>=0.13
 tqdm

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -73,6 +73,7 @@ extensions = [
     "sphinx.ext.mathjax",
     "sphinx.ext.viewcode",
     "sphinx_gallery.gen_gallery",
+    'sphinx_search.extension',
 ]
 
 # Enable documentation inheritance

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -73,7 +73,7 @@ extensions = [
     "sphinx.ext.mathjax",
     "sphinx.ext.viewcode",
     "sphinx_gallery.gen_gallery",
-    'sphinx_search.extension',
+    "sphinx_search.extension",
 ]
 
 # Enable documentation inheritance

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
         "doc": [
             "ipython",  # sphinx needs this to render codes
             "nbsphinx>=0.8.5",
+            "readthedocs-sphinx-search==0.1.0",
             "sphinx",
             "sphinx_rtd_theme",
             "sphinx-gallery",


### PR DESCRIPTION
This PR pins some of the dependencies in `docs/requirements.txt`. The goal is to add support for `readthedocs-sphinx-search`, and also fix syntax highlighting issues in examples / tutorials rendered from notebooks.

Docs build and look ok for me in a fresh virtual environment installing only from `docs/requirements.txt` (I think this is what happens in the build on readthedocs itself?). I added `ipython` after initially getting an error `Pygments lexer name 'ipython3' is not known` when it was not included as a dependency.

Note that the search feature apparently only works when the documentation is actually hosted on readthedocs itself, so I haven't been able to verify that it's configured correctly locally. (The following is logged to the browser console).

```sh
[INFO] Docs are not being served on Read the Docs, readthedocs-sphinx-search will not work.
```

Fixes #1111 