### PR TITLE
Pin Sphinx for readthedocs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,7 +8,7 @@ jaxns>=0.0.7
 optax>=0.0.6
 nbsphinx==0.8.6
 readthedocs-sphinx-search==0.1.0
-sphinx==4.1.2
+sphinx==4.0.3
 sphinx-gallery
 sphinx_rtd_theme==0.5.2
 tensorflow_probability>=0.13


### PR DESCRIPTION
Follow-up to #1113, pinning older version of sphinx to avoid [this issue](https://github.com/spatialaudio/nbsphinx/issues/584)