### PR TITLE
Add format_shapes utility

### DIFF
--- a/docs/source/utilities.rst
+++ b/docs/source/utilities.rst
@@ -104,3 +104,7 @@ Visualization Utilities
 render_model
 ------------
 .. autofunction:: numpyro.contrib.render.render_model
+
+Trace inspection
+----------------
+.. autofunction:: numpyro.util.format_shapes

--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -462,6 +462,12 @@ def format_shapes(trace, *, title="Trace Shapes:", last_site=None, log_prob=Fals
                     + [str(size) for size in batch_shape]
                     + ["|", None]
                 )
+        elif site["type"] == "plate":
+            shape = getattr(site["value"], "shape", ())
+            rows.append(
+                [f"{name} plate", None] + [str(size) for size in shape] + ["|", None]
+            )
+
         if name == last_site:
             break
 

--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -414,6 +414,13 @@ def format_shapes(trace, *, title="Trace Shapes:", last_site=None, log_prob=Fals
     """
     Returns a string showing a table of the shapes of all sites in the
     trace.
+
+    :param dict trace: The model trace to format. Use ``numpyro.handlers.trace`` to
+        produce the trace.
+    :param str title: Title for the table of shapes.
+    :param str last_site: Name of a site in the model. If supplied, subsequent sites
+        are not displayed in the table.
+    :param bool log_prob: Display shapes of log probabilities for each sample site.
     """
     if not trace.keys():
         return title

--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -410,7 +410,7 @@ def soft_vmap(fn, xs, batch_ndims=1, chunk_size=None):
     return tree_map(lambda y: jnp.reshape(y, batch_shape + jnp.shape(y)[1:]), ys)
 
 
-def format_trace_shapes(trace, title="Trace Shapes:", last_site=None, log_prob=False):
+def format_shapes(trace, *, title="Trace Shapes:", last_site=None, log_prob=False):
     """
     Returns a string showing a table of the shapes of all sites in the
     trace.

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -119,19 +119,28 @@ def test_format_shapes():
         model_test()
 
     assert (
-        format_shapes(t)
-        == "Trace Shapes:       \n Param Sites:       \n         mean    100\n"
-        "Sample Sites:       \n   data plate 10   |\n       x dist 10   |\n        "
-        "value 10   |"
+        format_shapes(t) == "Trace Shapes:       \n"
+        " Param Sites:       \n"
+        "         mean    100\n"
+        "Sample Sites:       \n"
+        "   data plate 10   |\n"
+        "       x dist 10   |\n"
+        "        value 10   |"
     )
     assert (
-        format_shapes(t, log_prob=True)
-        == "Trace Shapes:       \n Param Sites:       \n         mean    100\n"
-        "Sample Sites:       \n   data plate 10   |\n       x dist 10   |\n        "
-        "value 10   |\n     log_prob 10   |"
+        format_shapes(t, log_prob=True) == "Trace Shapes:       \n"
+        " Param Sites:       \n"
+        "         mean    100\n"
+        "Sample Sites:       \n"
+        "   data plate 10   |\n"
+        "       x dist 10   |\n"
+        "        value 10   |\n"
+        "     log_prob 10   |"
     )
     assert (
-        format_shapes(t, last_site="data")
-        == "Trace Shapes:       \n Param Sites:       \n         mean    100\n"
-        "Sample Sites:       \n   data plate 10   |"
+        format_shapes(t, last_site="data") == "Trace Shapes:       \n"
+        " Param Sites:       \n"
+        "         mean    100\n"
+        "Sample Sites:       \n"
+        "   data plate 10   |"
     )

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -132,7 +132,7 @@ def test_format_shapes():
         "        value 10   |  "
     )
     assert (
-        format_shapes(t, log_prob=True) == "Trace Shapes:         \n"
+        format_shapes(t, compute_log_prob=True) == "Trace Shapes:         \n"
         " Param Sites:         \n"
         "         mean    100  \n"
         "Sample Sites:         \n"
@@ -143,6 +143,19 @@ def test_format_shapes():
         "       x dist 10   |  \n"
         "        value 10   |  \n"
         "     log_prob 10   |  "
+    )
+    assert (
+        format_shapes(t, compute_log_prob=lambda site: site["name"] == "scale")
+        == "Trace Shapes:         \n"
+        " Param Sites:         \n"
+        "         mean    100  \n"
+        "Sample Sites:         \n"
+        "   scale dist      | 3\n"
+        "        value      | 3\n"
+        "     log_prob      |  \n"
+        "   data plate 10   |  \n"
+        "       x dist 10   |  \n"
+        "        value 10   |  "
     )
     assert (
         format_shapes(t, last_site="data") == "Trace Shapes:         \n"

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -110,37 +110,46 @@ def test_format_shapes():
 
     def model_test():
         mean = numpyro.param("mean", jnp.zeros(len(data)))
+        scale = numpyro.sample("scale", dist.Normal(0, 1).expand([3]).to_event(1))
+        scale = scale.sum()
         with numpyro.plate("data", len(data), subsample_size=10) as ind:
             batch = data[ind]
             mean_batch = mean[ind]
-            numpyro.sample("x", dist.Normal(mean_batch, 1), obs=batch)
+            numpyro.sample("x", dist.Normal(mean_batch, scale), obs=batch)
 
     with numpyro.handlers.seed(rng_seed=0), numpyro.handlers.trace() as t:
         model_test()
 
     assert (
-        format_shapes(t) == "Trace Shapes:       \n"
-        " Param Sites:       \n"
-        "         mean    100\n"
-        "Sample Sites:       \n"
-        "   data plate 10   |\n"
-        "       x dist 10   |\n"
-        "        value 10   |"
+        format_shapes(t) == "Trace Shapes:         \n"
+        " Param Sites:         \n"
+        "         mean    100  \n"
+        "Sample Sites:         \n"
+        "   scale dist      | 3\n"
+        "        value      | 3\n"
+        "   data plate 10   |  \n"
+        "       x dist 10   |  \n"
+        "        value 10   |  "
     )
     assert (
-        format_shapes(t, log_prob=True) == "Trace Shapes:       \n"
-        " Param Sites:       \n"
-        "         mean    100\n"
-        "Sample Sites:       \n"
-        "   data plate 10   |\n"
-        "       x dist 10   |\n"
-        "        value 10   |\n"
-        "     log_prob 10   |"
+        format_shapes(t, log_prob=True) == "Trace Shapes:         \n"
+        " Param Sites:         \n"
+        "         mean    100  \n"
+        "Sample Sites:         \n"
+        "   scale dist      | 3\n"
+        "        value      | 3\n"
+        "     log_prob      |  \n"
+        "   data plate 10   |  \n"
+        "       x dist 10   |  \n"
+        "        value 10   |  \n"
+        "     log_prob 10   |  "
     )
     assert (
-        format_shapes(t, last_site="data") == "Trace Shapes:       \n"
-        " Param Sites:       \n"
-        "         mean    100\n"
-        "Sample Sites:       \n"
-        "   data plate 10   |"
+        format_shapes(t, last_site="data") == "Trace Shapes:         \n"
+        " Param Sites:         \n"
+        "         mean    100  \n"
+        "Sample Sites:         \n"
+        "   scale dist      | 3\n"
+        "        value      | 3\n"
+        "   data plate 10   |  "
     )


### PR DESCRIPTION
This is a proposed solution to #1104. It's a pretty direct port of `.format_shapes` from [Pyro](https://github.com/pyro-ppl/pyro/blob/b7ba915b851d51c61d805da741bf7a74fcf9319d/pyro/poutine/trace_struct.py#L435-L534).

I've created [a gist](https://gist.github.com/tcbegley/70cb8e34a681c8324533b88cc5d99b1d) with examples from the Pyro docs.

Would love some feedback on a few things in particular:
- Function name + location. I just put it in `numpyro.util` for now.
- The main difference between this and Pyro that I'm aware of is that in Pyro plates are traced as `"sample"` sites, which means they show up in the result of `format_shapes`. I can add some logic to add `"plate"` sites from NumPyro traces to the result. Should they be mixed in with the sample sites like in Pyro or should they get their own section?
- Added a `log_prob` argument to mimic the effect of running `trace.compute_log_prob()` before `trace.format_shapes()` in Pyro. Is this a reasonable solution?
- Couldn't see any tests in the Pyro repo for this to replicate. Is it worth writing tests for?

TODO:

- [x] Update docstring