### PR TITLE
Add MixtureSameFamily distribution

### DIFF
--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -478,6 +478,18 @@ ZeroInflatedNegativeBinomial2
 .. autofunction:: numpyro.distributions.conjugate.ZeroInflatedNegativeBinomial2
 
 
+Mixture Distributions
+---------------------
+
+MixtureSameFamily
+^^^^^^^^^^^^^^^^^
+.. autoclass:: numpyro.distributions.mixtures.MixtureSameFamily
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :member-order: bysource
+
+
 Directional Distributions
 -------------------------
 

--- a/numpyro/distributions/__init__.py
+++ b/numpyro/distributions/__init__.py
@@ -76,6 +76,7 @@ from numpyro.distributions.distribution import (
     Unit,
 )
 from numpyro.distributions.kl import kl_divergence
+from numpyro.distributions.mixtures import MixtureSameFamily
 from numpyro.distributions.transforms import biject_to
 from numpyro.distributions.truncated import (
     LeftTruncatedDistribution,
@@ -134,6 +135,7 @@ __all__ = [
     "Logistic",
     "LogNormal",
     "MaskedDistribution",
+    "MixtureSameFamily",
     "Multinomial",
     "MultinomialLogits",
     "MultinomialProbs",

--- a/numpyro/distributions/mixtures.py
+++ b/numpyro/distributions/mixtures.py
@@ -1,0 +1,211 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+import jax
+from jax import lax
+import jax.numpy as jnp
+
+from numpyro.distributions import Distribution, constraints
+from numpyro.distributions.discrete import CategoricalLogits, CategoricalProbs
+from numpyro.distributions.util import is_prng_key, validate_sample
+
+
+class MixtureSameFamily(Distribution):
+    """
+    Marginalized Finite Mixture distribution of vectorized components.
+
+    The components being a vectorized distribution implies that all components are from the same family,
+    represented by a single Distribution object.
+
+    :param numpyro.distribution.Distribution mixing_distribution:
+        The mixing distribution to select the components. Needs to be a categorical.
+    :param numpyro.distribution.Distribution component_distribution:
+        Vectorized component distribution.
+
+    As an example:
+
+    .. doctest::
+
+       >>> import jax
+       >>> import jax.numpy as jnp
+       >>> import numpyro.distributions as dist
+       >>> mixing_dist = dist.Categorical(probs=jnp.ones(3) / 3.)
+       >>> component_dist = dist.Normal(loc=jnp.zeros(3), scale=jnp.ones(3))
+       >>> mixture = dist.MixtureSameFamily(mixing_dist, component_dist)
+       >>> mixture.sample(jax.random.PRNGKey(42)).shape
+       ()
+    """
+
+    def __init__(self, mixing_distribution, component_distribution, validate_args=None):
+        # Check arguments
+        if not isinstance(mixing_distribution, (CategoricalLogits, CategoricalProbs)):
+            raise ValueError(
+                "The mixing distribution need to be a numpyro.distributions.Categorical. "
+                f"However, it is of type {type(mixing_distribution)}"
+            )
+        mixture_size = mixing_distribution.probs.shape[-1]
+        if not isinstance(component_distribution, Distribution):
+            raise ValueError(
+                "The component distribution need to be a numpyro.distributions.Distribution. "
+                f"However, it is of type {type(component_distribution)}"
+            )
+        assert component_distribution.batch_shape[-1] == mixture_size, (
+            "Component distribution batch shape last dimension "
+            f"(size={component_distribution.batch_shape[-1]}) "
+            "needs to correspond to the mixture_size={mixture_size}!"
+        )
+        # Assign checked arguments
+        self._mixing_distribution = mixing_distribution
+        self._component_distribution = component_distribution
+        self._mixture_size = mixture_size
+        batch_shape = lax.broadcast_shapes(
+            mixing_distribution.batch_shape,
+            component_distribution.batch_shape[:-1],  # Without probabilities
+        )
+        super().__init__(
+            batch_shape=batch_shape,
+            event_shape=component_distribution.event_shape,
+            validate_args=validate_args,
+        )
+
+    @property
+    def mixture_size(self):
+        """
+        Returns the number of distributions in the mixture
+
+        :return: number of mixtures.
+        :rtype: int
+        """
+        return self._mixture_size
+
+    @property
+    def mixing_distribution(self):
+        """
+        Returns the mixing distribution
+
+        :return: Categorical distribution
+        :rtype: Categorical
+        """
+        return self._mixing_distribution
+
+    @property
+    def mixture_dim(self):
+        return -self.event_dim - 1
+
+    @property
+    def component_distribution(self):
+        """
+        Return the vectorized distribution of components being mixed.
+
+        :return: Component distribution
+        :rtype: Distribution
+        """
+        return self._component_distribution
+
+    @constraints.dependent_property
+    def support(self):
+        return self.component_distribution.support
+
+    @property
+    def is_discrete(self):
+        return self.component_distribution.is_discrete
+
+    def tree_flatten(self):
+        mixing_flat, mixing_aux = self.mixing_distribution.tree_flatten()
+        component_flat, component_aux = self.component_distribution.tree_flatten()
+        params = (mixing_flat, component_flat)
+        aux_data = (
+            (type(self.mixing_distribution), type(self.component_distribution)),
+            (mixing_aux, component_aux),
+        )
+        return params, aux_data
+
+    @classmethod
+    def tree_unflatten(cls, aux_data, params):
+        mixing_params, component_params = params
+        child_clss, child_aux = aux_data
+        mixing_cls, component_cls = child_clss
+        mixing_aux, component_aux = child_aux
+        mixing_dist = mixing_cls.tree_unflatten(mixing_aux, mixing_params)
+        component_dist = component_cls.tree_unflatten(component_aux, component_params)
+        return cls(
+            mixing_distribution=mixing_dist, component_distribution=component_dist
+        )
+
+    @property
+    def mean(self):
+        probs = self.mixing_distribution.probs
+        probs = probs.reshape(probs.shape + (1,) * self.event_dim)
+        weighted_component_means = probs * self.component_distribution.mean
+        return jnp.sum(weighted_component_means, axis=self.mixture_dim)
+
+    @property
+    def variance(self):
+        probs = self.mixing_distribution.probs
+        probs = probs.reshape(probs.shape + (1,) * self.event_dim)
+        # E[Var(Y|X)]
+        mean_cond_var = jnp.sum(
+            probs * self.component_distribution.variance, axis=self.mixture_dim
+        )
+        # Variance is the expectation of the squared deviation of a random variable from its mean
+        sq_deviation = (
+            self.component_distribution.mean
+            - jnp.expand_dims(self.mean, axis=self.mixture_dim)
+        ) ** 2
+        # Var(E[Y|X])
+        var_cond_mean = jnp.sum(probs * sq_deviation, axis=self.mixture_dim)
+        # Law of total variance: Var(Y) = E[Var(Y|X)] + Var(E[Y|X])
+        return mean_cond_var + var_cond_mean
+
+    def cdf(self, samples):
+        """
+        The cumulative distribution function of this mixture distribution.
+
+        :param value: samples from this distribution.
+        :return: output of the cummulative distribution function evaluated at `value`.
+        :raises: NotImplementedError if the component distribution does not implement the cdf method.
+        """
+        cdf_components = self.component_distribution.cdf(
+            jnp.expand_dims(samples, axis=self.mixture_dim)
+        )
+        return jnp.sum(cdf_components * self.mixing_distribution.probs, axis=-1)
+
+    def sample_with_intermediates(self, key, sample_shape=()):
+        """
+        Same as ``sample`` except that the sampled mixture components are also returned.
+
+        :param jax.random.PRNGKey key: the rng_key key to be used for the distribution.
+        :param tuple sample_shape: the sample shape for the distribution.
+        :return: Tuple (samples, indices)
+        :rtype: tuple
+        """
+        assert is_prng_key(key)
+        key_comp, key_ind = jax.random.split(key)
+        # Samples from component distribution will have shape:
+        #  (*sample_shape, *batch_shape, mixture_size, *event_shape)
+        samples = self.component_distribution.expand(
+            sample_shape + self.batch_shape + (self.mixture_size,)
+        ).sample(key_comp)
+        # Sample selection indices from the categorical (shape will be sample_shape)
+        indices = self.mixing_distribution.expand(
+            sample_shape + self.batch_shape
+        ).sample(key_ind)
+        n_expand = self.event_dim + 1
+        indices_expanded = indices.reshape(indices.shape + (1,) * n_expand)
+        # Select samples according to indices samples from categorical
+        samples_selected = jnp.take_along_axis(
+            samples, indices=indices_expanded, axis=self.mixture_dim
+        )
+        # Final sample shape (*sample_shape, *batch_shape, *event_shape)
+        return jnp.squeeze(samples_selected, axis=self.mixture_dim), indices
+
+    def sample(self, key, sample_shape=()):
+        return self.sample_with_intermediates(key=key, sample_shape=sample_shape)[0]
+
+    @validate_sample
+    def log_prob(self, value, intermediates=None):
+        del intermediates
+        value = jnp.expand_dims(value, self.mixture_dim)
+        component_log_probs = self.component_distribution.log_prob(value)
+        sum_log_probs = self.mixing_distribution.logits + component_log_probs
+        return jax.nn.logsumexp(sum_log_probs, axis=-1)

--- a/test/test_distributions_mixture.py
+++ b/test/test_distributions_mixture.py
@@ -1,0 +1,130 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+import jax
+import jax.numpy as jnp
+
+import numpyro.distributions as dist
+
+rng_key = jax.random.PRNGKey(42)
+
+
+def get_normal(nb_mixtures, batch_shape):
+    """Get parameterized Normal with given batch shape."""
+    loc = jnp.zeros(nb_mixtures)
+    scale = jnp.ones(nb_mixtures)
+    for i, s in enumerate(batch_shape):
+        loc = jnp.repeat(jnp.expand_dims(loc, i), s, axis=i)
+        scale = jnp.repeat(jnp.expand_dims(scale, i), s, axis=i)
+    batch_shape = (*batch_shape, nb_mixtures)
+    normal = dist.Normal(loc=loc, scale=scale)
+    assert normal.batch_shape == batch_shape
+    return normal
+
+
+def get_mvn(nb_mixtures, batch_shape):
+    """Get parameterized MultivariateNormal with given batch shape."""
+    dimensions = 2
+    loc = jnp.zeros((nb_mixtures, dimensions))
+    cov_matrix = jnp.repeat(
+        jnp.expand_dims(jnp.eye(dimensions, dimensions), 0), nb_mixtures, axis=0
+    )
+    for i, s in enumerate(batch_shape):
+        loc = jnp.repeat(jnp.expand_dims(loc, i), s, axis=i)
+        cov_matrix = jnp.repeat(jnp.expand_dims(cov_matrix, i), s, axis=i)
+    batch_shape = (*batch_shape, nb_mixtures)
+    mvn = dist.MultivariateNormal(loc=loc, covariance_matrix=cov_matrix)
+    assert mvn.batch_shape == batch_shape
+    return mvn
+
+
+@pytest.mark.parametrize("jax_dist_getter", [get_normal, get_mvn])
+@pytest.mark.parametrize("nb_mixtures", [1, 3])
+@pytest.mark.parametrize("batch_shape", [(), (1,), (7,), (2, 5)])
+def test_mixture_same_family_same_batch_shape(
+    jax_dist_getter, nb_mixtures, batch_shape
+):
+    # Create mixture
+    mixing_probabilities = jnp.ones(nb_mixtures) / nb_mixtures
+    for i, s in enumerate(batch_shape):
+        mixing_probabilities = jnp.repeat(
+            jnp.expand_dims(mixing_probabilities, i), s, axis=i
+        )
+    assert jnp.allclose(mixing_probabilities.sum(axis=-1), 1.0)
+    component_distribution = jax_dist_getter(
+        nb_mixtures=nb_mixtures, batch_shape=batch_shape
+    )
+    mixing_distribution = dist.Categorical(probs=mixing_probabilities)
+    _test_mixture_same_family(mixing_distribution, component_distribution)
+
+
+@pytest.mark.parametrize("jax_dist_getter", [get_normal, get_mvn])
+@pytest.mark.parametrize("nb_mixtures", [3])
+@pytest.mark.parametrize("mixing_batch_shape, component_batch_shape", [[(2,), (7, 2)]])
+def test_mixture_same_family_broadcast_batch_shape(
+    jax_dist_getter, nb_mixtures, mixing_batch_shape, component_batch_shape
+):
+    # Create mixture
+    mixing_probabilities = jnp.ones(nb_mixtures) / nb_mixtures
+    for i, s in enumerate(mixing_batch_shape):
+        mixing_probabilities = jnp.repeat(
+            jnp.expand_dims(mixing_probabilities, i), s, axis=i
+        )
+    assert jnp.allclose(mixing_probabilities.sum(axis=-1), 1.0)
+    component_distribution = jax_dist_getter(
+        nb_mixtures=nb_mixtures, batch_shape=component_batch_shape
+    )
+    mixing_distribution = dist.Categorical(probs=mixing_probabilities)
+    _test_mixture_same_family(mixing_distribution, component_distribution)
+
+
+def _test_mixture_same_family(mixing_distribution, component_distribution):
+    # Create mixture
+    mixture = dist.MixtureSameFamily(
+        mixing_distribution=mixing_distribution,
+        component_distribution=component_distribution,
+    )
+    assert (
+        mixture.mixture_size == mixing_distribution.probs.shape[-1]
+    ), "Mixture size needs to be the size of the probability vector"
+    assert (
+        mixture.batch_shape == component_distribution.batch_shape[:-1]
+    ), "Mixture batch shape needs to be the component batch shape without the mixture dimension."
+    # Test samples
+    sample_shape = (11,)
+    # Samples from component distribution
+    component_samples = mixture.component_distribution.sample(rng_key, sample_shape)
+    assert component_samples.shape == (
+        *sample_shape,
+        *mixture.batch_shape,
+        mixture.mixture_size,
+        *mixture.event_shape,
+    )
+    # Samples from mixture
+    samples = mixture.sample(rng_key, sample_shape=sample_shape)
+    assert samples.shape == (*sample_shape, *mixture.batch_shape, *mixture.event_shape)
+    # Check log_prob
+    lp = mixture.log_prob(samples)
+    nb_value_dims = len(samples.shape) - mixture.event_dim
+    expected_shape = samples.shape[:nb_value_dims]
+    assert lp.shape == expected_shape
+    # Samples with indices
+    samples_, indices = mixture.sample_with_intermediates(
+        rng_key, sample_shape=sample_shape
+    )
+    assert samples_.shape == samples.shape
+    assert indices.shape == (*sample_shape, *mixture.batch_shape)
+    assert jnp.issubdtype(indices.dtype, jnp.integer)
+    assert (indices >= 0).all() and (indices < mixture.mixture_size).all()
+    # Check mean
+    mean = mixture.mean
+    assert mean.shape == mixture.shape()
+    # Check variance
+    var = mixture.variance
+    assert var.shape == mixture.shape()
+    # Check cdf
+    if isinstance(mixture.component_distribution, dist.Normal):
+        cdf = mixture.cdf(samples)
+        assert cdf.shape == (*sample_shape, *mixture.shape())


### PR DESCRIPTION
Add a NumPyro-native implementation of `MixtureSameFamily` to model marginalized mixture distributions, where the components can be given by a vectorized distribution (implies that all the components are from the same family).

This was requested, and deemed relevant, in https://github.com/pyro-ppl/numpyro/issues/1081

I would love to get some feedback on this PR to help get this in.