### PR TITLE
smarter warning about discrete inference in SVI models (#1124)

### DIFF
--- a/numpyro/infer/elbo.py
+++ b/numpyro/infer/elbo.py
@@ -27,7 +27,7 @@ class ELBO:
 
     """
     Determines whether the ELBO objective can support inference of discrete latent variables.
-    
+
     Subclasses that are capable of inferring  discrete latent variables should override to `True`
     """
     can_infer_discrete = False

--- a/numpyro/infer/elbo.py
+++ b/numpyro/infer/elbo.py
@@ -25,6 +25,13 @@ class ELBO:
         (gradient) estimators.
     """
 
+    """
+    Determines whether the ELBO objective can support inference of discrete latent variables.
+    
+    Subclasses that are capable of inferring  discrete latent variables should override to `True`
+    """
+    can_infer_discrete = False
+
     def __init__(self, num_particles=1):
         self.num_particles = num_particles
 
@@ -66,14 +73,6 @@ class ELBO:
         :return: a tuple of ELBO loss and the mutable state
         """
         raise NotImplementedError("This ELBO objective does not support mutable state.")
-
-    def can_infer_discrete(self):
-        """
-        Determines whether the ELBO objective can support inference of discrete latent variables
-
-        :return: bool indicating if inference of discrete latent variables is possible
-        """
-        return False
 
 
 class Trace_ELBO(ELBO):
@@ -539,6 +538,8 @@ class TraceGraph_ELBO(ELBO):
         John Schulman, Nicolas Heess, Theophane Weber, Pieter Abbeel
     """
 
+    can_infer_discrete = True
+
     def __init__(self, num_particles=1):
         super().__init__(num_particles=num_particles)
 
@@ -604,6 +605,3 @@ class TraceGraph_ELBO(ELBO):
         else:
             rng_keys = random.split(rng_key, self.num_particles)
             return -jnp.mean(vmap(single_particle_elbo)(rng_keys))
-
-    def can_infer_discrete(self):
-        return True

--- a/numpyro/infer/elbo.py
+++ b/numpyro/infer/elbo.py
@@ -67,6 +67,15 @@ class ELBO:
         """
         raise NotImplementedError("This ELBO objective does not support mutable state.")
 
+    def can_infer_discrete(self):
+        """
+        Determines whether the ELBO objective can support inference of discrete latent variables
+
+        :return: bool indicating if inference of discrete latent variables is possible
+        """
+        return False
+
+
 
 class Trace_ELBO(ELBO):
     """
@@ -596,3 +605,6 @@ class TraceGraph_ELBO(ELBO):
         else:
             rng_keys = random.split(rng_key, self.num_particles)
             return -jnp.mean(vmap(single_particle_elbo)(rng_keys))
+
+    def can_infer_discrete(self):
+        return True

--- a/numpyro/infer/elbo.py
+++ b/numpyro/infer/elbo.py
@@ -76,7 +76,6 @@ class ELBO:
         return False
 
 
-
 class Trace_ELBO(ELBO):
     """
     A trace implementation of ELBO-based SVI. The estimator is constructed

--- a/numpyro/infer/svi.py
+++ b/numpyro/infer/svi.py
@@ -192,7 +192,7 @@ class SVI(object):
                 site["type"] == "sample"
                 and (not site["is_observed"])
                 and site["fn"].support.is_discrete
-                and not self.loss.can_infer_discrete()
+                and not self.loss.can_infer_discrete
             ):
                 s_name = type(self.loss).__name__
                 warnings.warn(
@@ -285,7 +285,7 @@ class SVI(object):
         *args,
         progress_bar=True,
         stable_update=False,
-        **kwargs
+        **kwargs,
     ):
         """
         (EXPERIMENTAL INTERFACE) Run SVI with `num_steps` iterations, then return
@@ -371,5 +371,5 @@ class SVI(object):
             self.guide,
             *args,
             **kwargs,
-            **self.static_kwargs
+            **self.static_kwargs,
         )

--- a/numpyro/infer/svi.py
+++ b/numpyro/infer/svi.py
@@ -192,9 +192,10 @@ class SVI(object):
                 site["type"] == "sample"
                 and (not site["is_observed"])
                 and site["fn"].support.is_discrete
+                and not self.loss.can_infer_discrete()
             ):
                 warnings.warn(
-                    "Currently, SVI does not support models with discrete latent variables"
+                    f"Currently, SVI with {type(self.loss).__name__} loss does not support models with discrete latent variables"
                 )
 
         if not mutable_state:

--- a/numpyro/infer/svi.py
+++ b/numpyro/infer/svi.py
@@ -194,8 +194,9 @@ class SVI(object):
                 and site["fn"].support.is_discrete
                 and not self.loss.can_infer_discrete()
             ):
+                s_name = type(self.loss).__name__
                 warnings.warn(
-                    f"Currently, SVI with {type(self.loss).__name__} loss does not support models with discrete latent variables"
+                    f"Currently, SVI with {s_name} loss does not support models with discrete latent variables"
                 )
 
         if not mutable_state:

--- a/test/pyroapi/test_pyroapi.py
+++ b/test/pyroapi/test_pyroapi.py
@@ -1,14 +1,11 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
-from numpyro.infer import (
-    RenyiELBO,
-    Trace_ELBO,
-    TraceMeanField_ELBO,
-)
 from pyroapi import pyro_backend
 from pyroapi.tests import *  # noqa F401
 import pytest
+
+from numpyro.infer import RenyiELBO, Trace_ELBO, TraceMeanField_ELBO
 
 cont_inf_only_cls_names = [
     RenyiELBO.__name__,

--- a/test/pyroapi/test_pyroapi.py
+++ b/test/pyroapi/test_pyroapi.py
@@ -1,13 +1,27 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
+from numpyro.infer import (
+    RenyiELBO,
+    Trace_ELBO,
+    TraceMeanField_ELBO,
+)
 from pyroapi import pyro_backend
 from pyroapi.tests import *  # noqa F401
 import pytest
 
+cont_inf_only_cls_names = [
+    RenyiELBO.__name__,
+    Trace_ELBO.__name__,
+    TraceMeanField_ELBO.__name__,
+]
+
 pytestmark = pytest.mark.filterwarnings(
     "ignore::numpyro.compat.util.UnsupportedAPIWarning",
-    "ignore:Currently, SVI does not support models with discrete",
+    *(
+        f"ignore:Currently, SVI with {s_name} loss does not support models with discrete latent variables"
+        for s_name in cont_inf_only_cls_names
+    ),
 )
 
 


### PR DESCRIPTION
Addresses #1124 

Added class method `can_infer_discrete` to base ELBO class indicating whether or not an ELBO class supports inference of discrete latent variables. Default is `False`. Base classes which support inference should override and return `True`.

This makes room for downstream subclasses to support discrete inference without going into type-checking instances during the SVI warning check. Might be overkill.