### PR TITLE
Docsting note for `MCMCKernel.postprocess_fn`

### DIFF
--- a/numpyro/infer/hmc.py
+++ b/numpyro/infer/hmc.py
@@ -511,6 +511,8 @@ class HMC(MCMCKernel):
     Hamiltonian Monte Carlo inference, using fixed trajectory length, with
     provision for step size and mass matrix adaptation.
 
+    .. note:: until the kernel is used in an MCMC run, `postprocess_fn` will return the identity
+
     **References:**
 
     1. *MCMC Using Hamiltonian Dynamics*,
@@ -765,6 +767,8 @@ class NUTS(HMC):
     """
     Hamiltonian Monte Carlo inference, using the No U-Turn Sampler (NUTS)
     with adaptive path length and mass matrix adaptation.
+
+    .. note:: until the kernel is used in an MCMC run, `postprocess_fn` will return the identity
 
     **References:**
 

--- a/numpyro/infer/mcmc.py
+++ b/numpyro/infer/mcmc.py
@@ -74,8 +74,6 @@ class MCMCKernel(ABC):
         constrained to the site's support, in addition to returning deterministic
         sites in the model.
 
-        .. note:: until the kernel is used in an MCMC run, `postprocess_fn` will return the identity
-
         :param model_args: Arguments to the model.
         :param model_kwargs: Keyword arguments to the model.
         """

--- a/numpyro/infer/mcmc.py
+++ b/numpyro/infer/mcmc.py
@@ -74,6 +74,8 @@ class MCMCKernel(ABC):
         constrained to the site's support, in addition to returning deterministic
         sites in the model.
 
+        .. note:: until the kernel is used in an MCMC run, `postprocess_fn` will return the identity
+
         :param model_args: Arguments to the model.
         :param model_kwargs: Keyword arguments to the model.
         """


### PR DESCRIPTION
Added a note to the docstring of `MCMCKernel.postprocess_fn` clarifying that this will return the identity function unless an MCMC has been run with this kernel.

Background: using [blackjax](https://github.com/blackjax-devs/blackjax) to sample a numpyro model returns unconstrained values. I tried to use (the function returned by) `MCMCKernel.postprocess_fn` to transform to constrained values, but unexpectedly this returned the identity function until an mcmc had been run, i.e.

```
def model():
    numpyro.sample('x', dist.HalfNormal(1.))
kernel = NUTS(model)
ppf = kernel.postprocess_fn((), {})
```

`ppf` is the identity function,

```
mcmc = MCMC(kernel, num_samples=1, num_warmup=1)
mcmc.run(rng_key)
ppf = kernel.postprocess_fn((), {})
```

`ppf` is now the expected function.