### PR TITLE
Adds model paramter to SA

### DIFF
--- a/numpyro/infer/sa.py
+++ b/numpyro/infer/sa.py
@@ -366,6 +366,10 @@ class SA(MCMCKernel):
         return init_state
 
     @property
+    def model(self):
+        return self._model
+
+    @property
     def sample_field(self):
         return "z"
 


### PR DESCRIPTION
Fixes #1135. Loading MCMC from an SA-sampled model into Arviz works fine with this update.