### PR TITLE
Document Poisson is_sparse

### DIFF
--- a/numpyro/distributions/discrete.py
+++ b/numpyro/distributions/discrete.py
@@ -597,6 +597,18 @@ def Multinomial(total_count=1, probs=None, logits=None, validate_args=None):
 
 
 class Poisson(Distribution):
+    r"""
+    Creates a Poisson distribution parameterized by rate, the rate parameter.
+
+    Samples are nonnegative integers, with a pmf given by
+
+    .. math::
+      \mathrm{rate}^k \frac{e^{-\mathrm{rate}}}{k!}
+
+    :param numpy.ndarray rate: The rate parameter
+    :param bool is_sparse: Whether to assume value is mostly zero when computing
+        :meth:`log_prob`, which can speed up computation when data is sparse.
+    """
     arg_constraints = {"rate": constraints.positive}
     support = constraints.nonnegative_integer
 


### PR DESCRIPTION
[Poisson](https://num.pyro.ai/en/stable/distributions.html#poisson) `is_sparse` is not yet documented. This PR adds some minimal documentation to the NumPyro Poisson distribution and it's `is_sparse` parameter.
Documentation based on:
- [Pyro DirichletMultinomial](https://docs.pyro.ai/en/dev/distributions.html#pyro.distributions.DirichletMultinomial)
- [PyTorch Poisson](https://pytorch.org/docs/stable/distributions.html#poisson)

Relevant thread: https://forum.pyro.ai/t/poisson-distribution-sparse-example/3290/2