### PR TITLE
add ScaledUnitLowerCholeskyTransform and change default AutoMultivariateNormal parameterization

### DIFF
--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -834,9 +834,9 @@ PowerTransform
     :show-inheritance:
     :member-order: bysource
 
-ScaledUnitLowerCholesky
-^^^^^^^^^^^^^^^^^^^^^^^
-.. autoclass:: numpyro.distributions.transforms.ScaledUnitLowerCholesky
+ScaledUnitLowerCholeskyTransform
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. autoclass:: numpyro.distributions.transforms.ScaledUnitLowerCholeskyTransform
     :members:
     :undoc-members:
     :show-inheritance:

--- a/numpyro/distributions/constraints.py
+++ b/numpyro/distributions/constraints.py
@@ -452,6 +452,10 @@ class _SoftplusLowerCholesky(_LowerCholesky):
         )
 
 
+class _ScaledUnitLowerCholesky(_LowerCholesky):
+    pass
+
+
 class _Sphere(Constraint):
     """
     Constrain to the Euclidean sphere of any dimension.
@@ -487,7 +491,7 @@ integer_greater_than = _IntegerGreaterThan
 interval = _Interval
 l1_ball = _L1Ball()
 lower_cholesky = _LowerCholesky()
-scaled_unit_lower_cholesky = _LowerCholesky()
+scaled_unit_lower_cholesky = _ScaledUnitLowerCholesky()
 multinomial = _Multinomial
 nonnegative_integer = _IntegerGreaterThan(0)
 ordered_vector = _OrderedVector()

--- a/numpyro/distributions/constraints.py
+++ b/numpyro/distributions/constraints.py
@@ -487,6 +487,7 @@ integer_greater_than = _IntegerGreaterThan
 interval = _Interval
 l1_ball = _L1Ball()
 lower_cholesky = _LowerCholesky()
+scaled_unit_lower_cholesky = _LowerCholesky()
 multinomial = _Multinomial
 nonnegative_integer = _IntegerGreaterThan(0)
 ordered_vector = _OrderedVector()

--- a/numpyro/distributions/constraints.py
+++ b/numpyro/distributions/constraints.py
@@ -336,6 +336,19 @@ class _LowerCholesky(Constraint):
         )
 
 
+class _ScaledUnitLowerCholesky(_LowerCholesky):
+    event_dim = 2
+
+    def __call__(self, x):
+        jnp = np if isinstance(x, (np.ndarray, np.generic)) else jax.numpy
+        tril = jnp.tril(x)
+        lower_triangular = jnp.all(
+            jnp.reshape(tril == x, x.shape[:-2] + (-1,)), axis=-1
+        )
+        unit_diagonal = jnp.all(jnp.diagonal(x, axis1=-2, axis2=-1) == 1.0, axis=-1)
+        return lower_triangular & unit_diagonal
+
+
 class _Multinomial(Constraint):
     is_discrete = True
     event_dim = 1
@@ -487,6 +500,7 @@ integer_greater_than = _IntegerGreaterThan
 interval = _Interval
 l1_ball = _L1Ball()
 lower_cholesky = _LowerCholesky()
+scaled_unit_lower_cholesky = _ScaledUnitLowerCholesky()
 multinomial = _Multinomial
 nonnegative_integer = _IntegerGreaterThan(0)
 ordered_vector = _OrderedVector()

--- a/numpyro/distributions/constraints.py
+++ b/numpyro/distributions/constraints.py
@@ -336,19 +336,6 @@ class _LowerCholesky(Constraint):
         )
 
 
-class _ScaledUnitLowerCholesky(_LowerCholesky):
-    event_dim = 2
-
-    def __call__(self, x):
-        jnp = np if isinstance(x, (np.ndarray, np.generic)) else jax.numpy
-        tril = jnp.tril(x)
-        lower_triangular = jnp.all(
-            jnp.reshape(tril == x, x.shape[:-2] + (-1,)), axis=-1
-        )
-        unit_diagonal = jnp.all(jnp.diagonal(x, axis1=-2, axis2=-1) == 1.0, axis=-1)
-        return lower_triangular & unit_diagonal
-
-
 class _Multinomial(Constraint):
     is_discrete = True
     event_dim = 1
@@ -500,7 +487,6 @@ integer_greater_than = _IntegerGreaterThan
 interval = _Interval
 l1_ball = _L1Ball()
 lower_cholesky = _LowerCholesky()
-scaled_unit_lower_cholesky = _ScaledUnitLowerCholesky()
 multinomial = _Multinomial
 nonnegative_integer = _IntegerGreaterThan(0)
 ordered_vector = _OrderedVector()

--- a/numpyro/distributions/transforms.py
+++ b/numpyro/distributions/transforms.py
@@ -681,6 +681,12 @@ class LowerCholeskyAffine(Transform):
 
 
 class LowerCholeskyTransform(Transform):
+    """
+    Transform a real vector to a lower triangular cholesky
+    factor, where the strictly lower triangular submatrix is
+    unconstrained and the diagonal is parameterized with an
+    exponential transform.
+    """
     domain = constraints.real_vector
     codomain = constraints.lower_cholesky
 
@@ -709,6 +715,17 @@ class LowerCholeskyTransform(Transform):
 
 
 class ScaledUnitLowerCholeskyTransform(LowerCholeskyTransform):
+    """
+    Like `LowerCholeskyTransform` this `Transform` transforms
+    a real vector to a lower triangular cholesky factor. However
+    it does so via a decomposition
+
+    :math:`y = loc + unit\_scale\_tril\ @\ scale\_diag\ @\ x`.
+
+    where :math:`unit\_scale\_tril\` has ones along the diagonal
+    and :math:`scale\_diag\` is a diagonal matrix with all positive
+    entries that is parameterized with an exponential transform.
+    """
     domain = constraints.real_vector
     codomain = constraints.scaled_unit_lower_cholesky
 

--- a/numpyro/distributions/transforms.py
+++ b/numpyro/distributions/transforms.py
@@ -1103,11 +1103,6 @@ def _transform_to_lower_cholesky(constraint):
     return LowerCholeskyTransform()
 
 
-@biject_to.register(constraints.scaled_unit_lower_cholesky)
-def _transform_to_scaled_unit_lower_cholesky(constraint):
-    return ScaledUnitLowerCholeskyTransform()
-
-
 @biject_to.register(constraints.ordered_vector)
 def _transform_to_ordered_vector(constraint):
     return OrderedTransform()

--- a/numpyro/distributions/transforms.py
+++ b/numpyro/distributions/transforms.py
@@ -716,11 +716,11 @@ class ScaledUnitLowerCholeskyTransform(LowerCholeskyTransform):
         n = round((math.sqrt(1 + 8 * x.shape[-1]) - 1) / 2)
         z = vec_to_tril_matrix(x[..., :-n], diagonal=-1)
         diag = jnp.exp(x[..., -n:])
-        return (z + jnp.identity(n)) * diag
+        return (z + jnp.identity(n)) * diag[..., None]
 
     def _inverse(self, y):
         diag = jnp.diagonal(y, axis1=-2, axis2=-1)
-        z = matrix_to_tril_vec(y / diag, diagonal=-1)
+        z = matrix_to_tril_vec(y / diag[..., None], diagonal=-1)
         return jnp.concatenate(
             [z, jnp.log(diag)], axis=-1
         )

--- a/numpyro/distributions/transforms.py
+++ b/numpyro/distributions/transforms.py
@@ -745,7 +745,7 @@ class ScaledUnitLowerCholeskyTransform(LowerCholeskyTransform):
         n = round((math.sqrt(1 + 8 * x.shape[-1]) - 1) / 2)
         diag = x[..., -n:]
         diag_softplus = jnp.diagonal(y, axis1=-2, axis2=-1)
-        return (diag_softplus * jnp.arange(n) - softplus(-diag)).sum(-1)
+        return (jnp.log(diag_softplus) * jnp.arange(n) - softplus(-diag)).sum(-1)
 
 
 class OrderedTransform(Transform):

--- a/numpyro/distributions/transforms.py
+++ b/numpyro/distributions/transforms.py
@@ -728,7 +728,7 @@ class ScaledUnitLowerCholeskyTransform(LowerCholeskyTransform):
     def log_abs_det_jacobian(self, x, y, intermediates=None):
         # the jacobian is diagonal, so logdet is the sum of diagonal `exp` transform
         n = round((math.sqrt(1 + 8 * x.shape[-1]) - 1) / 2)
-        return (x[..., -n:] * arange(1, n + 1)).sum(-1)
+        return (x[..., -n:] * jnp.arange(1, n + 1)).sum(-1)
 
 
 class OrderedTransform(Transform):

--- a/numpyro/distributions/transforms.py
+++ b/numpyro/distributions/transforms.py
@@ -721,9 +721,7 @@ class ScaledUnitLowerCholeskyTransform(LowerCholeskyTransform):
     def _inverse(self, y):
         diag = jnp.diagonal(y, axis1=-2, axis2=-1)
         z = matrix_to_tril_vec(y / diag[..., None], diagonal=-1)
-        return jnp.concatenate(
-            [z, jnp.log(diag)], axis=-1
-        )
+        return jnp.concatenate([z, jnp.log(diag)], axis=-1)
 
     def log_abs_det_jacobian(self, x, y, intermediates=None):
         # the jacobian is diagonal, so logdet is the sum of diagonal `exp` transform

--- a/numpyro/distributions/transforms.py
+++ b/numpyro/distributions/transforms.py
@@ -719,10 +719,10 @@ class ScaledUnitLowerCholeskyTransform(LowerCholeskyTransform):
         return (z + jnp.identity(n)) * diag
 
     def _inverse(self, y):
-        z = matrix_to_tril_vec(y, diagonal=-1)
         diag = jnp.diagonal(y, axis1=-2, axis2=-1)
+        z = matrix_to_tril_vec(y / diag, diagonal=-1)
         return jnp.concatenate(
-            [z / diag, jnp.log(diag)], axis=-1
+            [z, jnp.log(diag)], axis=-1
         )
 
     def log_abs_det_jacobian(self, x, y, intermediates=None):

--- a/numpyro/distributions/transforms.py
+++ b/numpyro/distributions/transforms.py
@@ -710,7 +710,7 @@ class LowerCholeskyTransform(Transform):
 
 class ScaledUnitLowerCholeskyTransform(LowerCholeskyTransform):
     domain = constraints.real_vector
-    codomain = constraints.lower_cholesky
+    codomain = constraints.scaled_unit_lower_cholesky
 
     def __call__(self, x):
         n = round((math.sqrt(1 + 8 * x.shape[-1]) - 1) / 2)
@@ -1101,6 +1101,11 @@ def _transform_to_l1_ball(constraint):
 @biject_to.register(constraints.lower_cholesky)
 def _transform_to_lower_cholesky(constraint):
     return LowerCholeskyTransform()
+
+
+@biject_to.register(constraints.scaled_unit_lower_cholesky)
+def _transform_to_scaled_unit_lower_cholesky(constraint):
+    return ScaledUnitLowerCholeskyTransform()
 
 
 @biject_to.register(constraints.ordered_vector)

--- a/numpyro/distributions/transforms.py
+++ b/numpyro/distributions/transforms.py
@@ -38,7 +38,6 @@ __all__ = [
     "L1BallTransform",
     "LowerCholeskyTransform",
     "ScaledUnitLowerCholeskyTransform",
-    "ScaledUnitLowerCholeskyAffine",
     "LowerCholeskyAffine",
     "PermuteTransform",
     "PowerTransform",
@@ -679,31 +678,6 @@ class LowerCholeskyAffine(Transform):
         if len(shape) < 1:
             raise ValueError("Too few dimensions on input")
         return lax.broadcast_shapes(shape, self.loc.shape, self.scale_tril.shape[:-1])
-
-
-class ScaledUnitLowerCholeskyAffine(LowerCholeskyAffine):
-    r"""
-    Transform via the mapping :math:`y = loc + scale\_tril\ @\ x`
-    where `scale\_tril\ = unit\_scale\_tril\ @\ diag`.
-
-    :param loc: a real vector.
-    :param unit_scale_tril: a lower triangular matrix with unit diagonal.
-    :param diag: a real vector with positive entries.
-    """
-    domain = constraints.real_vector
-    codomain = constraints.real_vector
-
-    def __init__(self, loc, unit_scale_tril, diag):
-        if jnp.ndim(unit_scale_tril) != 2:
-            raise ValueError(
-                "Only support 2-dimensional scale_tril matrix. "
-                "Please make a feature request if you need to "
-                "use this transform with batched scale_tril."
-            )
-        self.loc = loc
-        self.unit_scale_tril = unit_scale_tril
-        self.diag = diag
-        self.scale_tril = unit_scale_tril * diag
 
 
 class LowerCholeskyTransform(Transform):

--- a/numpyro/distributions/transforms.py
+++ b/numpyro/distributions/transforms.py
@@ -723,8 +723,8 @@ class ScaledUnitLowerCholeskyTransform(LowerCholeskyTransform):
 
     :math:`y = loc + unit\_scale\_tril\ @\ scale\_diag\ @\ x`.
 
-    where :math:`unit\_scale\_tril\` has ones along the diagonal
-    and :math:`scale\_diag\` is a diagonal matrix with all positive
+    where :math:`unit\_scale\_tril` has ones along the diagonal
+    and :math:`scale\_diag` is a diagonal matrix with all positive
     entries that is parameterized with a softplus transform.
     """
     domain = constraints.real_vector

--- a/numpyro/infer/autoguide.py
+++ b/numpyro/infer/autoguide.py
@@ -220,9 +220,7 @@ class AutoNormal(AutoGuide):
         automatically as usual. This is useful for data subsampling.
     """
 
-    # TODO consider switching to constraints.softplus_positive
-    # See https://github.com/pyro-ppl/numpyro/issues/855
-    scale_constraint = constraints.positive
+    scale_constraint = constraints.softplus_positive
 
     def __init__(
         self,
@@ -821,9 +819,7 @@ class AutoDiagonalNormal(AutoContinuous):
         svi = SVI(model, guide, ...)
     """
 
-    # TODO consider switching to constraints.softplus_positive
-    # See https://github.com/pyro-ppl/numpyro/issues/855
-    scale_constraint = constraints.positive
+    scale_constraint = constraints.softplus_positive
 
     def __init__(
         self,
@@ -892,8 +888,6 @@ class AutoMultivariateNormal(AutoContinuous):
         svi = SVI(model, guide, ...)
     """
 
-    # TODO consider switching to constraints.softplus_lower_cholesky
-    # See https://github.com/pyro-ppl/numpyro/issues/855
     scale_tril_constraint = constraints.scaled_unit_lower_cholesky
 
     def __init__(
@@ -966,9 +960,7 @@ class AutoLowRankMultivariateNormal(AutoContinuous):
         svi = SVI(model, guide, ...)
     """
 
-    # TODO consider switching to constraints.softplus_positive
-    # See https://github.com/pyro-ppl/numpyro/issues/855
-    scale_constraint = constraints.positive
+    scale_constraint = constraints.softplus_positive
 
     def __init__(
         self,

--- a/numpyro/infer/autoguide.py
+++ b/numpyro/infer/autoguide.py
@@ -894,7 +894,7 @@ class AutoMultivariateNormal(AutoContinuous):
 
     # TODO consider switching to constraints.softplus_lower_cholesky
     # See https://github.com/pyro-ppl/numpyro/issues/855
-    scale_tril_constraint = constraints.lower_cholesky
+    scale_tril_constraint = constraints.scaled_unit_lower_cholesky
 
     def __init__(
         self,

--- a/numpyro/infer/autoguide.py
+++ b/numpyro/infer/autoguide.py
@@ -27,7 +27,6 @@ from numpyro.distributions.transforms import (
     ComposeTransform,
     IndependentTransform,
     LowerCholeskyAffine,
-    ScaledUnitLowerCholeskyTransform,
     PermuteTransform,
     UnpackTransform,
     biject_to,
@@ -940,8 +939,7 @@ class AutoMultivariateNormal(AutoContinuous):
         Returns a multivariate Normal posterior distribution.
         """
         transform = self.get_transform(params)
-        print("dir", dir(transform))
-        return dist.MultivariateNormal(loc, transform.scale_tril)
+        return dist.MultivariateNormal(transform.loc, transform.scale_tril)
 
     def median(self, params):
         loc = params["{}_loc".format(self.prefix)]

--- a/test/infer/test_autoguide.py
+++ b/test/infer/test_autoguide.py
@@ -47,15 +47,15 @@ init_strategy = init_to_median(num_samples=2)
 @pytest.mark.parametrize(
     "auto_class",
     [
-        #AutoDiagonalNormal,
-        #AutoDAIS,
-        #AutoIAFNormal,
-        #AutoBNAFNormal,
+        AutoDiagonalNormal,
+        AutoDAIS,
+        AutoIAFNormal,
+        AutoBNAFNormal,
         AutoMultivariateNormal,
-        #AutoLaplaceApproximation,
-        #AutoLowRankMultivariateNormal,
-        #AutoNormal,
-        #AutoDelta,
+        AutoLaplaceApproximation,
+        AutoLowRankMultivariateNormal,
+        AutoNormal,
+        AutoDelta,
     ],
 )
 def test_beta_bernoulli(auto_class):

--- a/test/infer/test_autoguide.py
+++ b/test/infer/test_autoguide.py
@@ -47,15 +47,15 @@ init_strategy = init_to_median(num_samples=2)
 @pytest.mark.parametrize(
     "auto_class",
     [
-        AutoDiagonalNormal,
-        AutoDAIS,
-        AutoIAFNormal,
-        AutoBNAFNormal,
+        #AutoDiagonalNormal,
+        #AutoDAIS,
+        #AutoIAFNormal,
+        #AutoBNAFNormal,
         AutoMultivariateNormal,
-        AutoLaplaceApproximation,
-        AutoLowRankMultivariateNormal,
-        AutoNormal,
-        AutoDelta,
+        #AutoLaplaceApproximation,
+        #AutoLowRankMultivariateNormal,
+        #AutoNormal,
+        #AutoDelta,
     ],
 )
 def test_beta_bernoulli(auto_class):

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -2173,15 +2173,3 @@ def test_kl_dirichlet_dirichlet(shape):
     x = p.sample(random.PRNGKey(0), (10_000,)).copy()
     expected = jnp.mean((p.log_prob(x) - q.log_prob(x)), 0)
     assert_allclose(actual, expected, rtol=0.05)
-
-
-@pytest.mark.parametrize("dim", [1, 3])
-def test_scaled_unit_lower_cholesky_affine(dim):
-    loc = jnp.ones(dim)
-    unit_scale_tril = jnp.eye(dim)
-    diag = jnp.ones(dim)
-    t = transforms.ScaledUnitLowerCholeskyAffine(loc=loc, unit_scale_tril=unit_scale_tril, diag=diag)
-
-    x = np.random.randn(dim)
-    y = t(x)
-

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -2173,3 +2173,15 @@ def test_kl_dirichlet_dirichlet(shape):
     x = p.sample(random.PRNGKey(0), (10_000,)).copy()
     expected = jnp.mean((p.log_prob(x) - q.log_prob(x)), 0)
     assert_allclose(actual, expected, rtol=0.05)
+
+
+@pytest.mark.parametrize("dim", [1, 3])
+def test_scaled_unit_lower_cholesky_affine(dim):
+    loc = jnp.ones(dim)
+    unit_scale_tril = jnp.eye(dim)
+    diag = jnp.ones(dim)
+    t = transforms.ScaledUnitLowerCholeskyAffine(loc=loc, unit_scale_tril=unit_scale_tril, diag=diag)
+
+    x = np.random.randn(dim)
+    y = t(x)
+

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -1582,6 +1582,7 @@ def test_constraints(constraint, x, expected):
         constraints.l1_ball,
         constraints.less_than(1),
         constraints.lower_cholesky,
+        constraints.scaled_unit_lower_cholesky,
         constraints.ordered_vector,
         constraints.positive,
         constraints.positive_definite,
@@ -1666,6 +1667,7 @@ def test_biject_to(constraint, shape):
             inv_expected = np.linalg.slogdet(jax.jacobian(inv_vec_transform)(y_tril))[1]
         elif constraint in [
             constraints.lower_cholesky,
+            constraints.scaled_unit_lower_cholesky,
             constraints.positive_definite,
             constraints.softplus_lower_cholesky,
         ]:


### PR DESCRIPTION
joint work with @fehiepsi 

instead of parameterizing a lower cholesky factor as an unconstrained strictly lower triangular piece and a positive diagonal we instead parameterize as

`L = unit_scale_tril @ scale_diag` 

where `unit_scale_tril` is lower triangular with ones along the diagonal and `scale_diag` is a positive diagonal matrix.

not surprisingly (consider e.g. the [analogous parameterization](https://github.com/pyro-ppl/numpyro/blob/f787ff946413338890fb67e941e5daef48b51d70/numpyro/infer/autoguide.py#L1009) in `AutoLowRankMultivariateNormal`) this seems to lead to consistently better performance (all results use `AutoMultivariateNormal`):

### logistic regression dataset with N=50k, D=28
- elbo: `-32 430.37`          [this PR]
- elbo: `-32 590.92`          [before this PR]

### logistic regression dataset with N=50k, D=18
- elbo: `-25 112.28`          [this PR]
- elbo: `-25 280.20`          [before this PR]

### logistic regression dataset with N=37k, D=15
- elbo: `-12 576.18`          [this PR]
- elbo: `-12 592.29`          [before this PR]

### sparse FITC GP classifier with N =  37k,  D = 14, and latent dim = 128 (inducing points)
- elbo:   `9 897.12`  [this PR]
- elbo:   `9 765.09 `   [before this PR]

### sparse FITC GP classifier with N =  37k,  D = 14, and latent dim = 64 (inducing points)
- elbo:  `9 925.11`    [this PR]
- elbo:  `9 902.51`    [before this PR]

### sparse FITC GP classifier with N =  37k,  D = 14, and latent dim = 32 (inducing points)
- elbo:  `9 896.23`     [this PR]
- elbo:  `9 884.37`     [before this PR]

### sparse FITC GP classifier with N =  37k,  D = 14, and latent dim = 16 (inducing points)
- elbo:    `9 320.48`  [this PR]
- elbo:    `9 311.96`  [before this PR]

### sparse FITC GP classifier with N =  100k,  D = 27, and latent dim = 64 (inducing points)
- elbo:    `-55 858.99`  [this PR]
- elbo:    `-55 947.08`  [before this PR]

### sparse FITC GP classifier with N =  100k,  D = 17, and latent dim = 64 (inducing points)
- elbo:    `-43 956.38`  [this PR]
- elbo:    ` -44 015.16`  [before this PR]

(note: inducing points have the same initialization for each comparison; not surprisingly i was getting noisy results before i made sure this was the case; also note the N=37k GP elbos are missing a log pi term that shifts them by large amounts)

there appears to be a clear winner but do we need more experiments? @fehiepsi what do you think?

(note: whether positivity is enforced via exponential or softplus tends to be much less important)