### PR TITLE
raise value error if num_steps bad in svi.run

### DIFF
--- a/numpyro/infer/svi.py
+++ b/numpyro/infer/svi.py
@@ -311,6 +311,9 @@ class SVI(object):
         :rtype: SVIRunResult
         """
 
+        if num_steps < 1:
+            raise ValueError("num_steps must be a positive integer.")
+
         def body_fn(svi_state, _):
             if stable_update:
                 svi_state, loss = self.stable_update(svi_state, *args, **kwargs)


### PR DESCRIPTION
e.g. for `num_steps == 0` we get errors like

```
    svi_result = svi.run(svi_key, args.num_svi_steps, X, Y)
  File "/home/BROAD.MIT.EDU/mjankowi/numpyro/numpyro/infer/svi.py", line 345, in run
    losses = jnp.stack(losses)
  File "/home/BROAD.MIT.EDU/mjankowi/miniconda3/envs/torch/lib/python3.8/site-packages/jax/_src/numpy/lax_numpy.py", line 2944, in stack
    raise ValueError("Need at least one array to stack.")
ValueError: Need at least one array to stack.
```