### PR TITLE
Use parse_known_args instead of parse_args

### DIFF
--- a/examples/annotation.py
+++ b/examples/annotation.py
@@ -341,7 +341,7 @@ if __name__ == "__main__":
         ' "id" (item_difficulty), "lre" (logistic_random_effects)',
     )
     parser.add_argument("--device", default="cpu", type=str, help='use "cpu" or "gpu".')
-    args = parser.parse_args()
+    args, _ = parser.parse_known_args()
 
     numpyro.set_platform(args.device)
     numpyro.set_host_device_count(args.num_chains)

--- a/examples/baseball.py
+++ b/examples/baseball.py
@@ -226,7 +226,7 @@ if __name__ == "__main__":
         help="whether to disable progress bar",
     )
     parser.add_argument("--device", default="cpu", type=str, help='use "cpu" or "gpu".')
-    args = parser.parse_args()
+    args, _ = parser.parse_known_args()
 
     numpyro.set_platform(args.device)
     numpyro.set_host_device_count(args.num_chains)

--- a/examples/bnn.py
+++ b/examples/bnn.py
@@ -168,7 +168,7 @@ if __name__ == "__main__":
     parser.add_argument("--num-data", nargs="?", default=100, type=int)
     parser.add_argument("--num-hidden", nargs="?", default=5, type=int)
     parser.add_argument("--device", default="cpu", type=str, help='use "cpu" or "gpu".')
-    args = parser.parse_args()
+    args, _ = parser.parse_known_args()
 
     numpyro.set_platform(args.device)
     numpyro.set_host_device_count(args.num_chains)

--- a/examples/capture_recapture.py
+++ b/examples/capture_recapture.py
@@ -348,5 +348,5 @@ if __name__ == "__main__":
     parser.add_argument(
         "--algo", default="NUTS", type=str, help='whether to run "NUTS" or "HMC"'
     )
-    args = parser.parse_args()
+    args, _ = parser.parse_known_args()
     main(args)

--- a/examples/covtype.py
+++ b/examples/covtype.py
@@ -227,7 +227,7 @@ if __name__ == "__main__":
     parser.add_argument("--dense-mass", action="store_true")
     parser.add_argument("--x64", action="store_true")
     parser.add_argument("--device", default="cpu", type=str, help='use "cpu" or "gpu".')
-    args = parser.parse_args()
+    args, _ = parser.parse_known_args()
 
     numpyro.set_platform(args.device)
     numpyro.set_host_device_count(args.num_chains)

--- a/examples/dais_demo.py
+++ b/examples/dais_demo.py
@@ -166,7 +166,7 @@ if __name__ == "__main__":
     parser.add_argument("--num-samples", type=int, default=10 * 1000)
     parser.add_argument("--device", default="cpu", type=str, choices=["cpu", "gpu"])
 
-    args = parser.parse_args()
+    args, _ = parser.parse_known_args()
 
     enable_x64()
     numpyro.set_platform(args.device)

--- a/examples/funnel.py
+++ b/examples/funnel.py
@@ -116,7 +116,7 @@ if __name__ == "__main__":
     parser.add_argument("--num-warmup", nargs="?", default=1000, type=int)
     parser.add_argument("--num-chains", nargs="?", default=1, type=int)
     parser.add_argument("--device", default="cpu", type=str, help='use "cpu" or "gpu".')
-    args = parser.parse_args()
+    args, _ = parser.parse_known_args()
 
     numpyro.set_platform(args.device)
     numpyro.set_host_device_count(args.num_chains)

--- a/examples/gaussian_shells.py
+++ b/examples/gaussian_shells.py
@@ -131,7 +131,7 @@ if __name__ == "__main__":
         help="whether to enumerate over the discrete latent variable",
     )
     parser.add_argument("--device", default="cpu", type=str, help='use "cpu" or "gpu".')
-    args = parser.parse_args()
+    args, _ = parser.parse_known_args()
 
     numpyro.set_platform(args.device)
 

--- a/examples/gp.py
+++ b/examples/gp.py
@@ -184,7 +184,7 @@ if __name__ == "__main__":
         type=str,
         choices=["median", "feasible", "value", "uniform", "sample"],
     )
-    args = parser.parse_args()
+    args, _ = parser.parse_known_args()
 
     numpyro.set_platform(args.device)
     numpyro.set_host_device_count(args.num_chains)

--- a/examples/hmcecs.py
+++ b/examples/hmcecs.py
@@ -159,7 +159,7 @@ if __name__ == "__main__":
         "--rng_seed", default=37, type=int, help="random number generator seed"
     )
 
-    args = parser.parse_args()
+    args, _ = parser.parse_known_args()
 
     numpyro.set_platform(args.device)
 

--- a/examples/hmm.py
+++ b/examples/hmm.py
@@ -274,7 +274,7 @@ if __name__ == "__main__":
     parser.add_argument("--num-chains", nargs="?", default=1, type=int)
     parser.add_argument("--unroll-loop", action="store_true")
     parser.add_argument("--device", default="cpu", type=str, help='use "cpu" or "gpu".')
-    args = parser.parse_args()
+    args, _ = parser.parse_known_args()
 
     numpyro.set_platform(args.device)
     numpyro.set_host_device_count(args.num_chains)

--- a/examples/hmm_enum.py
+++ b/examples/hmm_enum.py
@@ -354,7 +354,7 @@ if __name__ == "__main__":
     parser.add_argument("--num-chains", nargs="?", default=1, type=int)
     parser.add_argument("--device", default="cpu", type=str, help='use "cpu" or "gpu".')
 
-    args = parser.parse_args()
+    args, _ = parser.parse_known_args()
 
     numpyro.set_platform(args.device)
     numpyro.set_host_device_count(args.num_chains)

--- a/examples/horseshoe_regression.py
+++ b/examples/horseshoe_regression.py
@@ -169,7 +169,7 @@ if __name__ == "__main__":
     parser.add_argument("--num-chains", nargs="?", default=1, type=int)
     parser.add_argument("--num-data", nargs="?", default=100, type=int)
     parser.add_argument("--device", default="cpu", type=str, help='use "cpu" or "gpu".')
-    args = parser.parse_args()
+    args, _ = parser.parse_known_args()
 
     numpyro.set_platform(args.device)
     numpyro.set_host_device_count(args.num_chains)

--- a/examples/hsgp.py
+++ b/examples/hsgp.py
@@ -668,7 +668,7 @@ def parse_arguments():
         type=str,
         help="Path where to save the plot with matplotlib.",
     )
-    args = parser.parse_args()
+    args, _ = parser.parse_known_args()
     return args
 
 

--- a/examples/minipyro.py
+++ b/examples/minipyro.py
@@ -63,5 +63,5 @@ if __name__ == "__main__":
     parser.add_argument("-f", "--full-pyro", action="store_true", default=False)
     parser.add_argument("-n", "--num-steps", default=1001, type=int)
     parser.add_argument("-lr", "--learning-rate", default=0.02, type=float)
-    args = parser.parse_args()
+    args, _ = parser.parse_known_args()
     main(args)

--- a/examples/neutra.py
+++ b/examples/neutra.py
@@ -205,7 +205,7 @@ if __name__ == "__main__":
     parser.add_argument("--hidden-factor", nargs="?", default=8, type=int)
     parser.add_argument("--num-iters", nargs="?", default=10000, type=int)
     parser.add_argument("--device", default="cpu", type=str, help='use "cpu" or "gpu".')
-    args = parser.parse_args()
+    args, _ = parser.parse_known_args()
 
     numpyro.set_platform(args.device)
     numpyro.set_host_device_count(args.num_chains)

--- a/examples/ode.py
+++ b/examples/ode.py
@@ -122,7 +122,7 @@ if __name__ == "__main__":
     parser.add_argument("--num-warmup", nargs="?", default=1000, type=int)
     parser.add_argument("--num-chains", nargs="?", default=1, type=int)
     parser.add_argument("--device", default="cpu", type=str, help='use "cpu" or "gpu".')
-    args = parser.parse_args()
+    args, _ = parser.parse_known_args()
 
     numpyro.set_platform(args.device)
     numpyro.set_host_device_count(args.num_chains)

--- a/examples/prodlda.py
+++ b/examples/prodlda.py
@@ -343,7 +343,7 @@ if __name__ == "__main__":
             '"flax" or "haiku".'
         ),
     )
-    args = parser.parse_args()
+    args, _ = parser.parse_known_args()
 
     numpyro.set_platform(args.device)
     main(args)

--- a/examples/proportion_test.py
+++ b/examples/proportion_test.py
@@ -167,7 +167,7 @@ if __name__ == "__main__":
     parser.add_argument("--num-chains", nargs="?", default=1, type=int)
     parser.add_argument("--interval-size", nargs="?", default=0.95, type=float)
     parser.add_argument("--device", default="cpu", type=str, help='use "cpu" or "gpu".')
-    args = parser.parse_args()
+    args, _ = parser.parse_known_args()
 
     numpyro.set_platform(args.device)
     numpyro.set_host_device_count(args.num_chains)

--- a/examples/sparse_regression.py
+++ b/examples/sparse_regression.py
@@ -410,7 +410,7 @@ if __name__ == "__main__":
     parser.add_argument("--num-dimensions", nargs="?", default=20, type=int)
     parser.add_argument("--active-dimensions", nargs="?", default=3, type=int)
     parser.add_argument("--device", default="cpu", type=str, help='use "cpu" or "gpu".')
-    args = parser.parse_args()
+    args, _ = parser.parse_known_args()
 
     numpyro.set_platform(args.device)
     numpyro.set_host_device_count(args.num_chains)

--- a/examples/stochastic_volatility.py
+++ b/examples/stochastic_volatility.py
@@ -130,7 +130,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--rng_seed", default=21, type=int, help="random number generator seed"
     )
-    args = parser.parse_args()
+    args, _ = parser.parse_known_args()
 
     numpyro.set_platform(args.device)
 

--- a/examples/thompson_sampling.py
+++ b/examples/thompson_sampling.py
@@ -314,7 +314,7 @@ if __name__ == "__main__":
         help="number of steps for optimization",
     )
     parser.add_argument("--device", default="cpu", type=str, help='use "cpu" or "gpu".')
-    args = parser.parse_args()
+    args, _ = parser.parse_known_args()
 
     numpyro.set_platform(args.device)
 

--- a/examples/ucbadmit.py
+++ b/examples/ucbadmit.py
@@ -159,7 +159,7 @@ if __name__ == "__main__":
     parser.add_argument("--num-warmup", nargs="?", default=500, type=int)
     parser.add_argument("--num-chains", nargs="?", default=1, type=int)
     parser.add_argument("--device", default="cpu", type=str, help='use "cpu" or "gpu".')
-    args = parser.parse_args()
+    args, _ = parser.parse_known_args()
 
     numpyro.set_platform(args.device)
     numpyro.set_host_device_count(args.num_chains)

--- a/examples/vae.py
+++ b/examples/vae.py
@@ -175,5 +175,5 @@ if __name__ == "__main__":
         type=int,
         help="size of hidden layer in encoder/decoder networks",
     )
-    args = parser.parse_args()
+    args, _ = parser.parse_known_args()
     main(args)


### PR DESCRIPTION
Resolves #1103

This allows users to run example scripts in jupyter notebook, without having to modify the argparse code.