### PR TITLE
WIP: Initial port of check_model_guide_match to numpyro/util.py

### DIFF
--- a/numpyro/infer/elbo.py
+++ b/numpyro/infer/elbo.py
@@ -13,6 +13,7 @@ from numpyro.distributions.kl import kl_divergence
 from numpyro.distributions.util import scale_and_mask
 from numpyro.handlers import replay, seed, substitute, trace
 from numpyro.infer.util import get_importance_trace, log_density
+from numpyro.util import check_model_guide_match
 
 
 class ELBO:
@@ -121,6 +122,8 @@ class Trace_ELBO(ELBO):
             }
             params.update(mutable_params)
             seeded_model = replay(seeded_model, guide_trace)
+            model_trace = trace(seeded_model).get_trace(*args, **kwargs)
+            check_model_guide_match(model_trace, guide_trace)
             model_log_density, model_trace = log_density(
                 seeded_model, args, kwargs, params
             )

--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -3,6 +3,7 @@
 
 from collections import OrderedDict
 from contextlib import contextmanager
+from itertools import zip_longest
 import os
 import random
 import re
@@ -505,6 +506,119 @@ def format_shapes(
             break
 
     return _format_table(rows)
+
+
+def check_model_guide_match(model_trace, guide_trace, max_plate_nesting=float("inf")):
+    """
+    :param dict model_trace: The model trace to check.
+    :param dict guide_trace: The guide trace to check.
+    :raises: RuntimeWarning, ValueError
+    Checks the following assumptions:
+    1. Each sample site in the model also appears in the guide and is not
+        marked auxiliary.
+    2. Each sample site in the guide either appears in the model or is marked,
+        auxiliary via ``infer={'is_auxiliary': True}``.
+    3. Each :class:``~numpyro.plate`` statement in the guide also appears in the
+        model.
+    4. At each sample site that appears in both the model and guide, the model
+        and guide agree on sample shape.
+    """
+    # Check ordinary sample sites.
+    guide_vars = set(
+        name for name, site in guide_trace.items() if site["type"] == "sample"
+    )
+    aux_vars = set(
+        name
+        for name, site in guide_trace.items()
+        if site["type"] == "sample"
+        if site["infer"].get("is_auxiliary")
+    )
+    model_vars = set(
+        name
+        for name, site in model_trace.items()
+        if site["type"] == "sample" and not site["is_observed"]
+    )
+    enum_vars = set(
+        name
+        for name, site in model_trace.items()
+        if site["type"] == "sample" and not site["is_observed"]
+        if name not in guide_vars
+    )
+    if aux_vars & model_vars:
+        warnings.warn(
+            "Found auxiliary vars in the model: {}".format(aux_vars & model_vars)
+        )
+    if not (guide_vars <= model_vars | aux_vars):
+        warnings.warn(
+            "Found non-auxiliary vars in guide but not model, "
+            "consider marking these infer={{'is_auxiliary': True}}:\n{}".format(
+                guide_vars - aux_vars - model_vars
+            )
+        )
+    if not (model_vars <= guide_vars | enum_vars):
+        warnings.warn(
+            "Found vars in model but not guide: {}".format(
+                model_vars - guide_vars - enum_vars
+            )
+        )
+
+    # Check shapes agree.
+    for name in model_vars & guide_vars:
+        model_site = model_trace[name]
+        guide_site = guide_trace[name]
+
+        if hasattr(model_site["fn"], "event_dim") and hasattr(
+            guide_site["fn"], "event_dim"
+        ):
+            if model_site["fn"].event_dim != guide_site["fn"].event_dim:
+                raise ValueError(
+                    "Model and guide event_dims disagree at site '{}': {} vs {}".format(
+                        name, model_site["fn"].event_dim, guide_site["fn"].event_dim
+                    )
+                )
+
+        if hasattr(model_site["fn"], "shape") and hasattr(guide_site["fn"], "shape"):
+            model_shape = model_site["fn"].shape(model_site["kwargs"]["sample_shape"])
+            guide_shape = guide_site["fn"].shape(guide_site["kwargs"]["sample_shape"])
+            if model_shape == guide_shape:
+                continue
+
+            # Allow broadcasting outside of max_plate_nesting.
+            if len(model_shape) > max_plate_nesting:
+                model_shape = model_shape[
+                    len(model_shape) - max_plate_nesting - model_site["fn"].event_dim :
+                ]
+            if len(guide_shape) > max_plate_nesting:
+                guide_shape = guide_shape[
+                    len(guide_shape) - max_plate_nesting - guide_site["fn"].event_dim :
+                ]
+            if model_shape == guide_shape:
+                continue
+            for model_size, guide_size in zip_longest(
+                reversed(model_shape), reversed(guide_shape), fillvalue=1
+            ):
+                if model_size != guide_size:
+                    raise ValueError(
+                        "Model and guide shapes disagree at site '{}': {} vs {}".format(
+                            name, model_shape, guide_shape
+                        )
+                    )
+
+    # Check subsample sites introduced by plate.
+    model_vars = set(
+        name
+        for name, site in model_trace.items()
+        if site["type"] == "sample" and not site["is_observed"]
+    )
+    guide_vars = set(
+        name for name, site in guide_trace.items() if site["type"] == "sample"
+    )
+    if not (guide_vars <= model_vars):
+        warnings.warn(
+            "Found plate statements in guide but not model: {}".format(
+                guide_vars - model_vars
+            )
+        )
 
 
 def _format_table(rows):


### PR DESCRIPTION
Hey @fehiepsi, sorry for the delay, I have now started to take a look at this. I think I'm broadly okay with what is going on but am unsure about how to integrate it into the wider NumPyro library. I'd love to get your feedback and apologise in advance if I've done anything stupid, I'm still getting to grips with everything :grimacing:. 

### Summary

This will close #1119. Port of [check_model_guide_match](https://github.com/pyro-ppl/pyro/blob/7e293c5627458948db100c6a12d1e566f9f45327/pyro/util.py#L238) from Pyro to check consistency between model and guide RV shapes.

No tests have been added yet but will be once we get a bit closer to agreeing the changes. 

### Changes vs. Pyro [check_model_guide_match](https://github.com/pyro-ppl/pyro/blob/7e293c5627458948db100c6a12d1e566f9f45327/pyro/util.py#L238)

1. Removed `_Subsample` conditional statements as I couldn't see this referenced anywhere in NumPyro. E.g. removing the:

```python
if type(site["fn"]).__name__ != "_Subsample"
```

statements when getting the `model_vars`, `guide_vars` and `enum_vars`.

2. Removed `_enumerate_dim` conditional statements as I couldn't see this referenced anywhere in NumPyro. So the:

```python
if site["infer"].get("_enumerate_dim
```

statement was removed when getting `enum_vars`.

3. Obtaining the `model_shape` and `guide_shape` doesn't pass `*args` and `**kwargs` to `.shape()` [as is the case in Pyro](https://github.com/pyro-ppl/pyro/blob/7e293c5627458948db100c6a12d1e566f9f45327/pyro/util.py#L316) as `.shape()` complains about `rng_key` not being a keyword argument. Instead `sample_shape` is the only thing passed to `.shape()`. So, for example, we do: 

```python
model_shape = model_site["fn"].shape(model_site["kwargs"]["sample_shape"])
```

instead. 

### Questions

**1. Where to add the calls to `check_model_guide_match` in NumPyro?** 

As a check I tried adding a call to `check_model_guide_match` in `numpyro/infer/elbo.py` and this seems to work as expected when the shapes don't match. 

However, I had to grab the `model_trace` again **before** the call to `log_density` (which is where it's currently returned from). If I don't grab the `model_trace` before the call to `log_density` then this function errors when the shapes cannot be broadcast and I assume the point of `check_model_guide_match` is to catch the error before this happens and raise something more informative. 

I don't know what to do here so any input is welcome, and on the wider point of where to add calls to `check_model_guide_match`. 

**2. What to do about the `max_plate_nesting` argument?** 

I don't think I understand how this is used (i.e. from where it would be passed to `check_model_guide_match`) at the moment but have left it as a keyword argument for now.