### PR TITLE
Enable enumerate support for zero inflated distributions

### DIFF
--- a/numpyro/distributions/discrete.py
+++ b/numpyro/distributions/discrete.py
@@ -659,7 +659,7 @@ class ZeroInflatedProbs(Distribution):
     def __init__(self, base_dist, gate, *, validate_args=None):
         batch_shape = lax.broadcast_shapes(jnp.shape(gate), base_dist.batch_shape)
         (self.gate,) = promote_shapes(gate, shape=batch_shape)
-        assert base_dist.is_discrete
+        assert base_dist.support.is_discrete
         if base_dist.event_shape:
             raise ValueError(
                 "ZeroInflatedProbs expected empty base_dist.event_shape but got {}".format(
@@ -699,6 +699,13 @@ class ZeroInflatedProbs(Distribution):
         return (1 - self.gate) * (
             self.base_dist.mean ** 2 + self.base_dist.variance
         ) - self.mean ** 2
+
+    @property
+    def has_enumerate_support(self):
+        return self.base_dist.has_enumerate_support
+
+    def enumerate_support(self, expand=True):
+        return self.base_dist.enumerate_support(expand=expand)
 
 
 class ZeroInflatedLogits(ZeroInflatedProbs):

--- a/numpyro/infer/autoguide.py
+++ b/numpyro/infer/autoguide.py
@@ -156,7 +156,7 @@ class AutoGuide(ABC):
         self._prototype_plate_sizes = {}
         for name, site in self.prototype_trace.items():
             if site["type"] == "sample":
-                if not site["is_observed"] and site["fn"].is_discrete:
+                if not site["is_observed"] and site["fn"].support.is_discrete:
                     # raise support errors early for discrete sites
                     with helpful_support_errors(site):
                         biject_to(site["fn"].support)

--- a/numpyro/infer/initialization.py
+++ b/numpyro/infer/initialization.py
@@ -23,7 +23,7 @@ def init_to_median(site=None, num_samples=15):
     if (
         site["type"] == "sample"
         and not site["is_observed"]
-        and not site["fn"].is_discrete
+        and not site["fn"].support.is_discrete
     ):
         if site["value"] is not None:
             warnings.warn(
@@ -63,7 +63,7 @@ def init_to_uniform(site=None, radius=2):
     if (
         site["type"] == "sample"
         and not site["is_observed"]
-        and not site["fn"].is_discrete
+        and not site["fn"].support.is_discrete
     ):
         if site["value"] is not None:
             warnings.warn(

--- a/numpyro/infer/util.py
+++ b/numpyro/infer/util.py
@@ -313,7 +313,7 @@ def find_valid_initial_params(
                 if (
                     v["type"] == "sample"
                     and not v["is_observed"]
-                    and not v["fn"].is_discrete
+                    and not v["fn"].support.is_discrete
                 ):
                     constrained_values[k] = v["value"]
                     with helpful_support_errors(v):
@@ -388,7 +388,7 @@ def _get_model_transforms(model, model_args=(), model_kwargs=None):
     has_enumerate_support = False
     for k, v in model_trace.items():
         if v["type"] == "sample" and not v["is_observed"]:
-            if v["fn"].is_discrete:
+            if v["fn"].support.is_discrete:
                 has_enumerate_support = True
                 if not v["fn"].has_enumerate_support:
                     raise RuntimeError(
@@ -586,7 +586,9 @@ def initialize_model(
     constrained_values = {
         k: v["value"]
         for k, v in model_trace.items()
-        if v["type"] == "sample" and not v["is_observed"] and not v["fn"].is_discrete
+        if v["type"] == "sample"
+        and not v["is_observed"]
+        and not v["fn"].support.is_discrete
     }
 
     if has_enumerate_support:

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -2009,6 +2009,13 @@ def test_enumerate_support_smoke(jax_dist, params, support, batch_shape, expand)
     assert_allclose(actual, expected)
 
 
+def test_zero_inflated_enumerate_support():
+    base_dist = dist.Bernoulli(0.5)
+    d = dist.ZeroInflatedDistribution(base_dist, gate=0.5)
+    assert d.has_enumerate_support
+    assert_allclose(d.enumerate_support(), base_dist.enumerate_support())
+
+
 @pytest.mark.parametrize("jax_dist, sp_dist, params", CONTINUOUS + DISCRETE)
 @pytest.mark.parametrize("prepend_shape", [(), (2, 3)])
 @pytest.mark.parametrize("sample_shape", [(), (4,)])


### PR DESCRIPTION
Fix https://github.com/pyro-ppl/numpyro/issues/1177. It turns out that we haven't dispatched the enumerate_support properties to the base distribution.