### PR TITLE
Solves #1184

### DIFF
--- a/numpyro/distributions/truncated.py
+++ b/numpyro/distributions/truncated.py
@@ -64,9 +64,7 @@ class LeftTruncatedDistribution(Distribution):
         dtype = jnp.result_type(float)
         finfo = jnp.finfo(dtype)
         minval = finfo.tiny
-        u = random.uniform(
-            key, shape=sample_shape + self.batch_shape, minval=minval
-        )
+        u = random.uniform(key, shape=sample_shape + self.batch_shape, minval=minval)
         loc = self.base_dist.loc
         sign = jnp.where(loc >= self.low, 1.0, -1.0)
         return (1 - sign) * loc + sign * self.base_dist.icdf(
@@ -134,9 +132,7 @@ class RightTruncatedDistribution(Distribution):
         dtype = jnp.result_type(float)
         finfo = jnp.finfo(dtype)
         minval = finfo.tiny
-        u = random.uniform(
-            key, shape=sample_shape + self.batch_shape, minval=minval
-        )
+        u = random.uniform(key, shape=sample_shape + self.batch_shape, minval=minval)
         return self.base_dist.icdf(u * self._cdf_at_high)
 
     @validate_sample
@@ -210,9 +206,7 @@ class TwoSidedTruncatedDistribution(Distribution):
         dtype = jnp.result_type(float)
         finfo = jnp.finfo(dtype)
         minval = finfo.tiny
-        u = random.uniform(
-            key, shape=sample_shape + self.batch_shape, minval=minval
-        )
+        u = random.uniform(key, shape=sample_shape + self.batch_shape, minval=minval)
 
         # NB: we use a more numerically stable formula for a symmetric base distribution
         #   A = icdf(cdf(low) + (cdf(high) - cdf(low)) * u) = icdf[(1 - u) * cdf(low) + u * cdf(high)]


### PR DESCRIPTION
Avoid infinities when doing inverse-transform sampling in truncated distributions
See #1184 