### PR TITLE
Option to use state of previous SVI run as starting state

### DIFF
--- a/numpyro/infer/svi.py
+++ b/numpyro/infer/svi.py
@@ -309,10 +309,10 @@ class SVI(object):
             final state of previous SVI run. Usage::
 
                 svi = SVI(model, guide, optimizer, loss=Trace_ELBO())
-                svi_result = svi.run(random.PRNGKey(0), 2000, data) 
+                svi_result = svi.run(random.PRNGKey(0), 2000, data)
                 # upon inspection of svi_result the user decides that the model has not converged
                 # continue from the end of the previous svi run rather than beginning again from iteration 0
-                svi_result = svi.run(random.PRNGKey(1), 2000, data, init_state=svi_result.state) 
+                svi_result = svi.run(random.PRNGKey(1), 2000, data, init_state=svi_result.state)
 
         :param kwargs: keyword arguments to the model / guide
         :return: a namedtuple with fields `params` and `losses` where `params`


### PR DESCRIPTION
Edited the method `SVI.run()` to allow the user to supply the state object of a previous SVI run which will be used as the starting state rather than calling `SVI.init()` at the start of every call to `SVI.run()` (this is still the default behaviour).

Example usage:
```
svi = SVI(model, guide, optimizer, loss=Trace_ELBO())
svi_result = svi.run(random.PRNGKey(0), 2000, data) 

# upon inspection of svi_result the user decides that the model has not converged

# continue from the end of the previous svi run rather than beginning again from iteration 0
svi_result = svi.run(random.PRNGKey(0), 2000, data, svi_initial_state=svi_result.state)
```

This is analogous to passing `mcmc.last_state` to the `init_params` argument of `mcmc.run()`