### PR TITLE
Update test python version to 3.7 and fix failing tests

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -11,5 +11,6 @@ readthedocs-sphinx-search==0.1.0
 sphinx==4.0.3
 sphinx-gallery
 sphinx_rtd_theme==0.5.2
-tensorflow_probability>=0.13
+# TODO: change to tensorflow_probability when it is stable
+tfp-nightly
 tqdm

--- a/examples/gaussian_shells.py
+++ b/examples/gaussian_shells.py
@@ -22,6 +22,7 @@ import argparse
 
 import matplotlib.pyplot as plt
 
+import jax
 from jax import random
 import jax.numpy as jnp
 
@@ -62,7 +63,9 @@ def run_inference(args, data):
     print("=== Performing Nested Sampling ===")
     ns = NestedSampler(model)
     ns.run(random.PRNGKey(0), **data, enum=args.enum)
-    ns.print_summary()
+    # TODO: Remove this condition when jaxns is compatible with the latest jax version.
+    if jax.__version__ < "0.2.21":
+        ns.print_summary()
     # samples obtained from nested sampler are weighted, so
     # we need to provide random key to resample from those weighted samples
     ns_samples = ns.get_samples(random.PRNGKey(1), num_samples=args.num_samples)

--- a/examples/hmm_enum.py
+++ b/examples/hmm_enum.py
@@ -313,7 +313,7 @@ def main(args):
     # find all the notes that are present at least once in the training set
     present_notes = (sequences == 1).sum(0).sum(0) > 0
     # remove notes that are never played (we remove 37/88 notes with default args)
-    sequences = sequences[..., present_notes]
+    sequences = sequences[:, :, present_notes]
 
     if args.truncate:
         lengths = lengths.clip(0, args.truncate)

--- a/examples/ode.py
+++ b/examples/ode.py
@@ -100,7 +100,8 @@ def main(args):
 
     # predict populations
     pop_pred = Predictive(model, mcmc.get_samples())(PRNGKey(2), data.shape[0])["y"]
-    mu, pi = jnp.mean(pop_pred, 0), jnp.percentile(pop_pred, (10, 90), 0)
+    mu = jnp.mean(pop_pred, 0)
+    pi = jnp.percentile(pop_pred, jnp.array([10, 90]), 0)
     plt.figure(figsize=(8, 6), constrained_layout=True)
     plt.plot(year, data[:, 0], "ko", mfc="none", ms=4, label="true hare", alpha=0.67)
     plt.plot(year, data[:, 1], "bx", label="true lynx")

--- a/numpyro/infer/hmc_util.py
+++ b/numpyro/infer/hmc_util.py
@@ -540,7 +540,7 @@ def warmup_adapter(
         find_reasonable_step_size = identity
     ss_init, ss_update = dual_averaging()
     mm_init, mm_update, mm_final = welford_covariance(diagonal=not dense_mass)
-    adaptation_schedule = jnp.array(build_adaptation_schedule(num_adapt_steps))
+    adaptation_schedule = build_adaptation_schedule(num_adapt_steps)
     num_windows = len(adaptation_schedule)
 
     def init_fn(
@@ -677,7 +677,7 @@ def warmup_adapter(
                 identity,
             )
 
-        t_at_window_end = t == adaptation_schedule[window_idx, 1]
+        t_at_window_end = t == jnp.asarray(adaptation_schedule)[window_idx, 1]
         window_idx = jnp.where(t_at_window_end, window_idx + 1, window_idx)
         state = HMCAdaptState(
             step_size,

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,8 @@ setup(
             "graphviz",
             "jaxns==0.0.7",
             "optax>=0.0.6",
-            "tensorflow_probability>=0.13",
+            # TODO: change to tensorflow_probability when it is stable
+            "tfp-nightly",
         ],
         "examples": [
             "arviz",
@@ -89,9 +90,9 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: POSIX :: Linux",
         "Operating System :: MacOS :: MacOS X",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
 )


### PR DESCRIPTION
Currently, we are testing numpyro using python version 3.6, whose support from jax devs has been dropped for a while. This PR updates python version and fixes failing tests.