### PR TITLE
Fix links in bad posterior geometry

### DIFF
--- a/notebooks/source/bad_posterior_geometry.ipynb
+++ b/notebooks/source/bad_posterior_geometry.ipynb
@@ -547,7 +547,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.8.8"
   }
  },
  "nbformat": 4,

--- a/notebooks/source/bad_posterior_geometry.ipynb
+++ b/notebooks/source/bad_posterior_geometry.ipynb
@@ -155,7 +155,7 @@
     "There are basically two ways to implement this kind of reparameterization in NumPyro:\n",
     "\n",
     "- manually (i.e. by hand)\n",
-    "- using [`numpyro.infer.reparam`](http://num.pyro.ai/en/stable/reparam.html), which automates a few common reparameterization strategies\n",
+    "- using [numpyro.infer.reparam](http://num.pyro.ai/en/stable/reparam.html), which automates a few common reparameterization strategies\n",
     "\n",
     "To begin with let's do the reparameterization by hand."
    ]
@@ -184,9 +184,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Next we do the reparameterization using [`numpyro.infer.reparam`](http://num.pyro.ai/en/stable/reparam.html). \n",
+    "Next we do the reparameterization using [numpyro.infer.reparam](http://num.pyro.ai/en/stable/reparam.html). \n",
     "There are at least two ways to do this. \n",
-    "First let's use [`LocScaleReparam`](http://num.pyro.ai/en/stable/reparam.html#numpyro.infer.reparam.LocScaleReparam)."
+    "First let's use [LocScaleReparam](http://num.pyro.ai/en/stable/reparam.html#numpyro.infer.reparam.LocScaleReparam)."
    ]
   },
   {
@@ -207,7 +207,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To show the versatility of the [`numpyro.infer.reparam`](http://num.pyro.ai/en/stable/reparam.html) library let's do the reparameterization using [`TransformReparam`](http://num.pyro.ai/en/stable/reparam.html#numpyro.infer.reparam.TransformReparam) instead."
+    "To show the versatility of the [numpyro.infer.reparam](http://num.pyro.ai/en/stable/reparam.html) library let's do the reparameterization using [TransformReparam](http://num.pyro.ai/en/stable/reparam.html#numpyro.infer.reparam.TransformReparam) instead."
    ]
   },
   {
@@ -309,7 +309,7 @@
    "source": [
     "### Aside: numpyro.deterministic\n",
     "\n",
-    "In `_rep_hs_model1` above we used [`numpyro.deterministic`](http://num.pyro.ai/en/stable/primitives.html?highlight=deterministic#numpyro.primitives.deterministic) to define `scaled_betas`.\n",
+    "In `_rep_hs_model1` above we used [numpyro.deterministic](http://num.pyro.ai/en/stable/primitives.html?highlight=deterministic#numpyro.primitives.deterministic) to define `scaled_betas`.\n",
     "We note that using this primitive is not strictly necessary; however, it has the consequence that `scaled_betas` will appear in the trace and will thus appear in the summary reported by `mcmc.print_summary()`. \n",
     "In other words we could also have written:\n",
     "\n",
@@ -547,7 +547,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I was reading through this notebook and noticed that the links don't render. This is how they look on the [website](https://numpyro.readthedocs.io/en/latest/tutorials/bad_posterior_geometry.html)  :

---

![image](https://user-images.githubusercontent.com/33491632/141440015-5a81c056-79ea-4032-9cfa-a968d4c8562f.png)

---


With this PR:

---

![image](https://user-images.githubusercontent.com/33491632/141440087-bbf07ba3-5986-4919-9a88-9c4b079e7f15.png)

---

It seems that the pattern
```
[`...`](...)
```
works fine in Jupyter, but not when the notebook is rendered by Sphinx?