### PR TITLE
Fix autocontinuous not compatible with non-array init values

### DIFF
--- a/numpyro/infer/autoguide.py
+++ b/numpyro/infer/autoguide.py
@@ -485,7 +485,7 @@ def _ravel_dict(x):
     x_flat = []
     for name, value in x.items():
         shape_dict[name] = jnp.shape(value)
-        x_flat.append(value.reshape(-1))
+        x_flat.append(jnp.reshape(value, -1))
     x_flat = jnp.concatenate(x_flat) if x_flat else jnp.zeros((0,))
     return x_flat, shape_dict
 

--- a/test/infer/test_autoguide.py
+++ b/test/infer/test_autoguide.py
@@ -43,6 +43,7 @@ from numpyro.infer.initialization import (
     init_to_median,
     init_to_sample,
     init_to_uniform,
+    init_to_value,
 )
 from numpyro.infer.reparam import TransformReparam
 from numpyro.infer.util import Predictive
@@ -644,3 +645,12 @@ def test_autocontinuous_local_error():
     svi = SVI(model, guide, optim.Adam(1.0), Trace_ELBO())
     with pytest.raises(ValueError, match="local latent variables"):
         svi.init(random.PRNGKey(0))
+
+
+def test_init_to_scalar_value():
+    def model():
+        numpyro.sample("x", dist.Normal(0, 1))
+
+    guide = AutoDiagonalNormal(model, init_loc_fn=init_to_value(values={"x": 1.0}))
+    svi = SVI(model, guide, optim.Adam(1.0), Trace_ELBO())
+    svi.init(random.PRNGKey(0))


### PR DESCRIPTION
Fix a bug reported in [forum](https://forum.pyro.ai/t/svi-optimizer-scheduling/3542/16): AutoContinuous raises errors when using init_to_value with non-array init values.