### PR TITLE
reduce variance in AutoDAIS

### DIFF
--- a/numpyro/infer/autoguide.py
+++ b/numpyro/infer/autoguide.py
@@ -842,7 +842,9 @@ class AutoDAIS(AutoContinuous):
             return (z, v, v_prev_mean, log_factor), None
 
         v_0 = eps[-1]  # note the return value of scan doesn't depend on eps[-1]
-        (z, _, _, log_factor), _ = jax.lax.scan(scan_body, (z_0, v_0, jnp.zeros_like(v_0), 0.0), (eps, betas))
+        (z, _, _, log_factor), _ = jax.lax.scan(
+            scan_body, (z_0, v_0, jnp.zeros_like(v_0), 0.0), (eps, betas)
+        )
 
         numpyro.factor("{}_factor".format(self.prefix), log_factor)
 

--- a/numpyro/infer/autoguide.py
+++ b/numpyro/infer/autoguide.py
@@ -672,7 +672,7 @@ class AutoDAIS(AutoContinuous):
 
     Note that AutoDAIS cannot be used in conjuction with data subsampling.
 
-    Also note that unlike [1, 2] this implementation integrates some of the
+    Also note that unlike [1, 2] this implementation integrates out some of the
     variability associated with the kinetic energy terms, leading to reduced variance.
 
     **Reference:**

--- a/numpyro/infer/autoguide.py
+++ b/numpyro/infer/autoguide.py
@@ -672,6 +672,9 @@ class AutoDAIS(AutoContinuous):
 
     Note that AutoDAIS cannot be used in conjuction with data subsampling.
 
+    Also note that unlike [1, 2] this implementation integrates some of the
+    variability associated with the kinetic energy terms, leading to reduced variance.
+
     **Reference:**
 
     1. *MCMC Variational Inference via Uncorrected Hamiltonian Annealing*,
@@ -825,19 +828,21 @@ class AutoDAIS(AutoContinuous):
             eps, beta = eps_beta
             eta = eta0 + eta_coeff * beta
             eta = jnp.clip(eta, a_min=0.0, a_max=self.eta_max)
-            z_prev, v_prev, log_factor = carry
+            z_prev, v_prev, v_prev_mean, log_factor = carry
             z_half = z_prev + v_prev * eta * inv_mass_matrix
             q_grad = (1.0 - beta) * grad(base_z_dist.log_prob)(z_half)
             p_grad = beta * grad(log_density)(z_half)
-            v_hat = v_prev + eta * (q_grad + p_grad)
+            eta_grad = eta * (q_grad + p_grad)
+            v_hat = v_prev + eta_grad
             z = z_half + v_hat * eta * inv_mass_matrix
             v = gamma * v_hat + jnp.sqrt(1 - gamma ** 2) * eps
-            delta_ke = momentum_dist.log_prob(v_prev) - momentum_dist.log_prob(v_hat)
+            delta_ke = jnp.dot(eta_grad * inv_mass_matrix, 2.0 * v_prev_mean + eta_grad)
+            v_prev_mean = gamma * (v_prev_mean + eta_grad)
             log_factor = log_factor + delta_ke
-            return (z, v, log_factor), None
+            return (z, v, v_prev_mean, log_factor), None
 
         v_0 = eps[-1]  # note the return value of scan doesn't depend on eps[-1]
-        (z, _, log_factor), _ = jax.lax.scan(scan_body, (z_0, v_0, 0.0), (eps, betas))
+        (z, _, _, log_factor), _ = jax.lax.scan(scan_body, (z_0, v_0, jnp.zeros_like(v_0), 0.0), (eps, betas))
 
         numpyro.factor("{}_factor".format(self.prefix), log_factor)
 

--- a/test/infer/test_autoguide.py
+++ b/test/infer/test_autoguide.py
@@ -88,6 +88,9 @@ def test_beta_bernoulli(auto_class):
     svi_state = fori_loop(0, 3000, body_fn, svi_state)
     params = svi.get_params(svi_state)
 
+    final_elbo = -Trace_ELBO(num_particles=5000).loss(random.PRNGKey(1), params, model, guide, data).item()
+    print("final_elbo",final_elbo)
+
     true_coefs = (jnp.sum(data, axis=0) + 1) / (data.shape[0] + 2)
     # test .sample_posterior method
     posterior_samples = guide.sample_posterior(

--- a/test/infer/test_autoguide.py
+++ b/test/infer/test_autoguide.py
@@ -88,9 +88,6 @@ def test_beta_bernoulli(auto_class):
     svi_state = fori_loop(0, 3000, body_fn, svi_state)
     params = svi.get_params(svi_state)
 
-    final_elbo = -Trace_ELBO(num_particles=5000).loss(random.PRNGKey(1), params, model, guide, data).item()
-    print("final_elbo",final_elbo)
-
     true_coefs = (jnp.sum(data, axis=0) + 1) / (data.shape[0] + 2)
     # test .sample_posterior method
     posterior_samples = guide.sample_posterior(


### PR DESCRIPTION
@fehiepsi can you please check the algebra on this? it's very simple

basically we get a recursion `<v_{k-1}> = gamma ( <v_{k-2}> + g_{k-1} ) `where `g_k` is the gradient multiplied by eta.

also the kinetic energy difference is proportional to `dot(g_k * M^{-1}, 2 v_{k-1} + g_k)`

i checked that we get the same elbo (and lower variance) for `infer/test_autoguide.py::test_beta_bernoulli`

also compared this PR against master for a larger logistic regression dataset and this PR led to a better elbo after 25k and 80k iterations (i.e. elbo increasing more quickly per iteration). though this PR is slightly slower because of the extra carry/math