### PR TITLE
Bug: Dirichlet distribution got invalid concentration parameter for BetaDistribution

### DIFF
--- a/numpyro/contrib/tfp/distributions.py
+++ b/numpyro/contrib/tfp/distributions.py
@@ -102,7 +102,7 @@ class BijectorTransform(Transform):
         return batch_shape + in_shape
 
 
-@biject_to.register([BijectorConstraint])
+@biject_to.register(BijectorConstraint)
 def _transform_to_bijector_constraint(constraint):
     return BijectorTransform(constraint.bijector)
 

--- a/numpyro/contrib/tfp/distributions.py
+++ b/numpyro/contrib/tfp/distributions.py
@@ -102,7 +102,7 @@ class BijectorTransform(Transform):
         return batch_shape + in_shape
 
 
-@biject_to.register(BijectorConstraint)
+@biject_to.register([BijectorConstraint])
 def _transform_to_bijector_constraint(constraint):
     return BijectorTransform(constraint.bijector)
 

--- a/numpyro/distributions/constraints.py
+++ b/numpyro/distributions/constraints.py
@@ -319,18 +319,9 @@ class _Interval(Constraint):
         )
 
 
-class _OpenInterval(Constraint):
-    def __init__(self, lower_bound, upper_bound):
-        self.lower_bound = lower_bound
-        self.upper_bound = upper_bound
-
+class _OpenInterval(_Interval):
     def __call__(self, x):
         return (x > self.lower_bound) & (x < self.upper_bound)
-
-    def feasible_like(self, prototype):
-        return jax.numpy.broadcast_to(
-            (self.lower_bound + self.upper_bound) / 2, jax.numpy.shape(prototype)
-        )
 
 
 class _LowerCholesky(Constraint):

--- a/numpyro/distributions/constraints.py
+++ b/numpyro/distributions/constraints.py
@@ -319,6 +319,20 @@ class _Interval(Constraint):
         )
 
 
+class _OpenInterval(Constraint):
+    def __init__(self, lower_bound, upper_bound):
+        self.lower_bound = lower_bound
+        self.upper_bound = upper_bound
+
+    def __call__(self, x):
+        return (x > self.lower_bound) & (x < self.upper_bound)
+
+    def feasible_like(self, prototype):
+        return jax.numpy.broadcast_to(
+            (self.lower_bound + self.upper_bound) / 2, jax.numpy.shape(prototype)
+        )
+
+
 class _LowerCholesky(Constraint):
     event_dim = 2
 
@@ -507,3 +521,4 @@ softplus_lower_cholesky = _SoftplusLowerCholesky()
 softplus_positive = _SoftplusPositive()
 sphere = _Sphere()
 unit_interval = _Interval(0.0, 1.0)
+open_interval = _OpenInterval

--- a/numpyro/distributions/continuous.py
+++ b/numpyro/distributions/continuous.py
@@ -72,10 +72,10 @@ class Beta(Distribution):
         )
         concentration1 = jnp.broadcast_to(concentration1, batch_shape)
         concentration0 = jnp.broadcast_to(concentration0, batch_shape)
+        super(Beta, self).__init__(batch_shape=batch_shape, validate_args=validate_args)
         self._dirichlet = Dirichlet(
             jnp.stack([concentration1, concentration0], axis=-1)
         )
-        super(Beta, self).__init__(batch_shape=batch_shape, validate_args=validate_args)
 
     def sample(self, key, sample_shape=()):
         assert is_prng_key(key)
@@ -1659,7 +1659,7 @@ class BetaProportion(Beta):
     """
 
     arg_constraints = {
-        "mean": constraints.unit_interval,
+        "mean": constraints.open_interval(0.0, 1.0),
         "concentration": constraints.positive,
     }
     reparametrized_params = ["mean", "concentration"]

--- a/numpyro/distributions/transforms.py
+++ b/numpyro/distributions/transforms.py
@@ -1121,6 +1121,21 @@ def _transform_to_interval(constraint):
     )
 
 
+@biject_to.register(constraints.open_interval)
+def _transform_to_open_interval(constraint):
+    scale = constraint.upper_bound - constraint.lower_bound
+    return ComposeTransform(
+        [
+            SigmoidTransform(),
+            AffineTransform(
+                constraint.lower_bound,
+                scale,
+                domain=constraints.open_interval(0.0, 1.0),
+            ),
+        ]
+    )
+
+
 @biject_to.register(constraints.l1_ball)
 def _transform_to_l1_ball(constraint):
     return L1BallTransform()

--- a/numpyro/distributions/transforms.py
+++ b/numpyro/distributions/transforms.py
@@ -1128,9 +1128,7 @@ def _transform_to_open_interval(constraint):
         [
             SigmoidTransform(),
             AffineTransform(
-                constraint.lower_bound,
-                scale,
-                domain=constraints.open_interval(0.0, 1.0),
+                constraint.lower_bound, scale, domain=constraints.unit_interval
             ),
         ]
     )

--- a/numpyro/distributions/transforms.py
+++ b/numpyro/distributions/transforms.py
@@ -1044,14 +1044,15 @@ class ConstraintRegistry(object):
     def __init__(self):
         self._registry = {}
 
-    def register(self, constraint_list, factory=None):
+    def register(self, constraint, factory=None):
         if factory is None:
-            return lambda factory: self.register(constraint_list, factory)
+            return lambda factory: self.register(constraint, factory)
 
-        for constraint in constraint_list:
-            if isinstance(constraint, constraints.Constraint):
-                constraint = type(constraint)
-            self._registry[constraint] = factory
+        if isinstance(constraint, constraints.Constraint):
+            constraint = type(constraint)
+
+        self._registry[constraint] = factory
+        return factory
 
     def __call__(self, constraint):
         try:
@@ -1065,19 +1066,19 @@ class ConstraintRegistry(object):
 biject_to = ConstraintRegistry()
 
 
-@biject_to.register([constraints.corr_cholesky])
+@biject_to.register(constraints.corr_cholesky)
 def _transform_to_corr_cholesky(constraint):
     return CorrCholeskyTransform()
 
 
-@biject_to.register([constraints.corr_matrix])
+@biject_to.register(constraints.corr_matrix)
 def _transform_to_corr_matrix(constraint):
     return ComposeTransform(
         [CorrCholeskyTransform(), CorrMatrixCholeskyTransform().inv]
     )
 
 
-@biject_to.register([constraints.greater_than])
+@biject_to.register(constraints.greater_than)
 def _transform_to_greater_than(constraint):
     if constraint is constraints.positive:
         return ExpTransform()
@@ -1089,7 +1090,7 @@ def _transform_to_greater_than(constraint):
     )
 
 
-@biject_to.register([constraints.less_than])
+@biject_to.register(constraints.less_than)
 def _transform_to_less_than(constraint):
     return ComposeTransform(
         [
@@ -1099,14 +1100,15 @@ def _transform_to_less_than(constraint):
     )
 
 
-@biject_to.register([constraints.independent])
+@biject_to.register(constraints.independent)
 def _biject_to_independent(constraint):
     return IndependentTransform(
         biject_to(constraint.base_constraint), constraint.reinterpreted_batch_ndims
     )
 
 
-@biject_to.register([constraints.interval, constraints.open_interval])
+@biject_to.register(constraints.open_interval)
+@biject_to.register(constraints.interval)
 def _transform_to_interval(constraint):
     if constraint is constraints.unit_interval:
         return SigmoidTransform()
@@ -1121,51 +1123,51 @@ def _transform_to_interval(constraint):
     )
 
 
-@biject_to.register([constraints.l1_ball])
+@biject_to.register(constraints.l1_ball)
 def _transform_to_l1_ball(constraint):
     return L1BallTransform()
 
 
-@biject_to.register([constraints.lower_cholesky])
+@biject_to.register(constraints.lower_cholesky)
 def _transform_to_lower_cholesky(constraint):
     return LowerCholeskyTransform()
 
 
-@biject_to.register([constraints.scaled_unit_lower_cholesky])
+@biject_to.register(constraints.scaled_unit_lower_cholesky)
 def _transform_to_scaled_unit_lower_cholesky(constraint):
     return ScaledUnitLowerCholeskyTransform()
 
 
-@biject_to.register([constraints.ordered_vector])
+@biject_to.register(constraints.ordered_vector)
 def _transform_to_ordered_vector(constraint):
     return OrderedTransform()
 
 
-@biject_to.register([constraints.positive_definite])
+@biject_to.register(constraints.positive_definite)
 def _transform_to_positive_definite(constraint):
     return ComposeTransform([LowerCholeskyTransform(), CholeskyTransform().inv])
 
 
-@biject_to.register([constraints.positive_ordered_vector])
+@biject_to.register(constraints.positive_ordered_vector)
 def _transform_to_positive_ordered_vector(constraint):
     return ComposeTransform([OrderedTransform(), ExpTransform()])
 
 
-@biject_to.register([constraints.real])
+@biject_to.register(constraints.real)
 def _transform_to_real(constraint):
     return IdentityTransform()
 
 
-@biject_to.register([constraints.softplus_positive])
+@biject_to.register(constraints.softplus_positive)
 def _transform_to_softplus_positive(constraint):
     return SoftplusTransform()
 
 
-@biject_to.register([constraints.softplus_lower_cholesky])
+@biject_to.register(constraints.softplus_lower_cholesky)
 def _transform_to_softplus_lower_cholesky(constraint):
     return SoftplusLowerCholeskyTransform()
 
 
-@biject_to.register([constraints.simplex])
+@biject_to.register(constraints.simplex)
 def _transform_to_simplex(constraint):
     return StickBreakingTransform()

--- a/numpyro/distributions/transforms.py
+++ b/numpyro/distributions/transforms.py
@@ -1106,23 +1106,11 @@ def _biject_to_independent(constraint):
     )
 
 
+@biject_to.register(constraints.open_interval)
 @biject_to.register(constraints.interval)
 def _transform_to_interval(constraint):
     if constraint is constraints.unit_interval:
         return SigmoidTransform()
-    scale = constraint.upper_bound - constraint.lower_bound
-    return ComposeTransform(
-        [
-            SigmoidTransform(),
-            AffineTransform(
-                constraint.lower_bound, scale, domain=constraints.unit_interval
-            ),
-        ]
-    )
-
-
-@biject_to.register(constraints.open_interval)
-def _transform_to_open_interval(constraint):
     scale = constraint.upper_bound - constraint.lower_bound
     return ComposeTransform(
         [

--- a/numpyro/distributions/transforms.py
+++ b/numpyro/distributions/transforms.py
@@ -1044,14 +1044,14 @@ class ConstraintRegistry(object):
     def __init__(self):
         self._registry = {}
 
-    def register(self, constraint, factory=None):
+    def register(self, constraint_list, factory=None):
         if factory is None:
-            return lambda factory: self.register(constraint, factory)
+            return lambda factory: self.register(constraint_list, factory)
 
-        if isinstance(constraint, constraints.Constraint):
-            constraint = type(constraint)
-
-        self._registry[constraint] = factory
+        for constraint in constraint_list:
+            if isinstance(constraint, constraints.Constraint):
+                constraint = type(constraint)
+            self._registry[constraint] = factory
 
     def __call__(self, constraint):
         try:
@@ -1065,19 +1065,19 @@ class ConstraintRegistry(object):
 biject_to = ConstraintRegistry()
 
 
-@biject_to.register(constraints.corr_cholesky)
+@biject_to.register([constraints.corr_cholesky])
 def _transform_to_corr_cholesky(constraint):
     return CorrCholeskyTransform()
 
 
-@biject_to.register(constraints.corr_matrix)
+@biject_to.register([constraints.corr_matrix])
 def _transform_to_corr_matrix(constraint):
     return ComposeTransform(
         [CorrCholeskyTransform(), CorrMatrixCholeskyTransform().inv]
     )
 
 
-@biject_to.register(constraints.greater_than)
+@biject_to.register([constraints.greater_than])
 def _transform_to_greater_than(constraint):
     if constraint is constraints.positive:
         return ExpTransform()
@@ -1089,7 +1089,7 @@ def _transform_to_greater_than(constraint):
     )
 
 
-@biject_to.register(constraints.less_than)
+@biject_to.register([constraints.less_than])
 def _transform_to_less_than(constraint):
     return ComposeTransform(
         [
@@ -1099,15 +1099,14 @@ def _transform_to_less_than(constraint):
     )
 
 
-@biject_to.register(constraints.independent)
+@biject_to.register([constraints.independent])
 def _biject_to_independent(constraint):
     return IndependentTransform(
         biject_to(constraint.base_constraint), constraint.reinterpreted_batch_ndims
     )
 
 
-@biject_to.register(constraints.open_interval)
-@biject_to.register(constraints.interval)
+@biject_to.register([constraints.interval, constraints.open_interval])
 def _transform_to_interval(constraint):
     if constraint is constraints.unit_interval:
         return SigmoidTransform()
@@ -1122,51 +1121,51 @@ def _transform_to_interval(constraint):
     )
 
 
-@biject_to.register(constraints.l1_ball)
+@biject_to.register([constraints.l1_ball])
 def _transform_to_l1_ball(constraint):
     return L1BallTransform()
 
 
-@biject_to.register(constraints.lower_cholesky)
+@biject_to.register([constraints.lower_cholesky])
 def _transform_to_lower_cholesky(constraint):
     return LowerCholeskyTransform()
 
 
-@biject_to.register(constraints.scaled_unit_lower_cholesky)
+@biject_to.register([constraints.scaled_unit_lower_cholesky])
 def _transform_to_scaled_unit_lower_cholesky(constraint):
     return ScaledUnitLowerCholeskyTransform()
 
 
-@biject_to.register(constraints.ordered_vector)
+@biject_to.register([constraints.ordered_vector])
 def _transform_to_ordered_vector(constraint):
     return OrderedTransform()
 
 
-@biject_to.register(constraints.positive_definite)
+@biject_to.register([constraints.positive_definite])
 def _transform_to_positive_definite(constraint):
     return ComposeTransform([LowerCholeskyTransform(), CholeskyTransform().inv])
 
 
-@biject_to.register(constraints.positive_ordered_vector)
+@biject_to.register([constraints.positive_ordered_vector])
 def _transform_to_positive_ordered_vector(constraint):
     return ComposeTransform([OrderedTransform(), ExpTransform()])
 
 
-@biject_to.register(constraints.real)
+@biject_to.register([constraints.real])
 def _transform_to_real(constraint):
     return IdentityTransform()
 
 
-@biject_to.register(constraints.softplus_positive)
+@biject_to.register([constraints.softplus_positive])
 def _transform_to_softplus_positive(constraint):
     return SoftplusTransform()
 
 
-@biject_to.register(constraints.softplus_lower_cholesky)
+@biject_to.register([constraints.softplus_lower_cholesky])
 def _transform_to_softplus_lower_cholesky(constraint):
     return SoftplusLowerCholeskyTransform()
 
 
-@biject_to.register(constraints.simplex)
+@biject_to.register([constraints.simplex])
 def _transform_to_simplex(constraint):
     return StickBreakingTransform()

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -1593,6 +1593,13 @@ def test_categorical_log_prob_grad():
     assert_allclose(grad_fx, grad_gx, atol=1e-4)
 
 
+def test_beta_proportion_invalid_mean():
+    with dist.distribution.validation_enabled(), pytest.raises(
+        ValueError, match=r"^BetaProportion distribution got invalid mean parameter\.$"
+    ):
+        dist.BetaProportion(1.0, 1.0)
+
+
 ########################################
 # Tests for constraints and transforms #
 ########################################
@@ -1713,6 +1720,11 @@ def test_categorical_log_prob_grad():
             jnp.array([[1, 0, 0], [0.5, 0.5, 0]]),
             jnp.array([True, False]),
         ),
+        (
+            constraints.open_interval(0.0, 1.0),
+            jnp.array([-5, 0, 0.5, 1, 7]),
+            jnp.array([False, False, True, False, False]),
+        ),
     ],
 )
 def test_constraints(constraint, x, expected):
@@ -1754,6 +1766,7 @@ def test_constraints(constraint, x, expected):
         constraints.softplus_positive,
         constraints.softplus_lower_cholesky,
         constraints.unit_interval,
+        constraints.open_interval(0.0, 1.0),
     ],
     ids=lambda x: x.__class__,
 )


### PR DESCRIPTION
closes #1206 

Couple of changes needed to happen:
- the `mean` parameter of `BetaProportion` should be between 0 and 1 not inclusive of the extremes, otherwise one of the `concentration` parameters will be `0`
- the initialisation of `Beta` needs to happen before that of `Dirichelet`, as suggested in the issue