### PR TITLE
Extending Predicitive to allow SteinVI

### DIFF
--- a/numpyro/infer/util.py
+++ b/numpyro/infer/util.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from collections import namedtuple
-from collections.abc import Iterable
 from contextlib import contextmanager
 from functools import partial, reduce
 import operator

--- a/numpyro/infer/util.py
+++ b/numpyro/infer/util.py
@@ -1,17 +1,16 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
+import warnings
 from collections import namedtuple
 from contextlib import contextmanager
 from functools import partial
-import warnings
 
+import jax.numpy as jnp
 import numpy as np
-
 from jax import device_get, jacfwd, lax, random, value_and_grad
 from jax.flatten_util import ravel_pytree
 from jax.lax import broadcast_shapes
-import jax.numpy as jnp
 from jax.tree_util import tree_map
 
 import numpyro
@@ -90,9 +89,9 @@ class _without_rsample_stop_gradient(numpyro.primitives.Messenger):
 
     def postprocess_message(self, msg):
         if (
-            msg["type"] == "sample"
-            and (not msg["is_observed"])
-            and (not msg["fn"].has_rsample)
+                msg["type"] == "sample"
+                and (not msg["is_observed"])
+                and (not msg["fn"].has_rsample)
         ):
             msg["value"] = lax.stop_gradient(msg["value"])
             # TODO: reconsider this logic
@@ -249,16 +248,16 @@ def _init_to_unconstrained_value(site=None, values={}):
 
 
 def find_valid_initial_params(
-    rng_key,
-    model,
-    *,
-    init_strategy=init_to_uniform,
-    enum=False,
-    model_args=(),
-    model_kwargs=None,
-    prototype_params=None,
-    forward_mode_differentiation=False,
-    validate_grad=True,
+        rng_key,
+        model,
+        *,
+        init_strategy=init_to_uniform,
+        enum=False,
+        model_args=(),
+        model_kwargs=None,
+        prototype_params=None,
+        forward_mode_differentiation=False,
+        validate_grad=True,
 ):
     """
     (EXPERIMENTAL INTERFACE) Given a model with Pyro primitives, returns an initial
@@ -324,9 +323,9 @@ def find_valid_initial_params(
             constrained_values, inv_transforms = {}, {}
             for k, v in model_trace.items():
                 if (
-                    v["type"] == "sample"
-                    and not v["is_observed"]
-                    and not v["fn"].support.is_discrete
+                        v["type"] == "sample"
+                        and not v["is_observed"]
+                        and not v["fn"].support.is_discrete
                 ):
                     constrained_values[k] = v["value"]
                     with helpful_support_errors(v):
@@ -444,14 +443,14 @@ def _get_model_transforms(model, model_args=(), model_kwargs=None):
 
 
 def get_potential_fn(
-    model,
-    inv_transforms,
-    *,
-    enum=False,
-    replay_model=False,
-    dynamic_args=False,
-    model_args=(),
-    model_kwargs=None,
+        model,
+        inv_transforms,
+        *,
+        enum=False,
+        replay_model=False,
+        dynamic_args=False,
+        model_args=(),
+        model_kwargs=None,
 ):
     """
     (EXPERIMENTAL INTERFACE) Given a model with Pyro primitives, returns a
@@ -540,22 +539,22 @@ def _validate_model(model_trace):
             batch_dims = batch_dims - 1  # remove time dimension under scan
         plate_dims = -min([0] + [frame.dim for frame in site["cond_indep_stack"]])
         assert (
-            plate_dims >= batch_dims
+                plate_dims >= batch_dims
         ), "Missing plate statement for batch dimensions at site {}".format(
             site["name"]
         )
 
 
 def initialize_model(
-    rng_key,
-    model,
-    *,
-    init_strategy=init_to_uniform,
-    dynamic_args=False,
-    model_args=(),
-    model_kwargs=None,
-    forward_mode_differentiation=False,
-    validate_grad=True,
+        rng_key,
+        model,
+        *,
+        init_strategy=init_to_uniform,
+        dynamic_args=False,
+        model_args=(),
+        model_kwargs=None,
+        forward_mode_differentiation=False,
+        validate_grad=True,
 ):
     """
     (EXPERIMENTAL INTERFACE) Helper function that calls :func:`~numpyro.infer.util.get_potential_fn`
@@ -617,8 +616,8 @@ def initialize_model(
         k: v["value"]
         for k, v in model_trace.items()
         if v["type"] == "sample"
-        and not v["is_observed"]
-        and not v["fn"].support.is_discrete
+           and not v["is_observed"]
+           and not v["fn"].support.is_discrete
     }
 
     if has_enumerate_support:
@@ -680,10 +679,10 @@ def initialize_model(
                             for w in ws:
                                 # at site information to the warning message
                                 w.message.args = (
-                                    "Site {}: {}".format(
-                                        site["name"], w.message.args[0]
-                                    ),
-                                ) + w.message.args[1:]
+                                                     "Site {}: {}".format(
+                                                         site["name"], w.message.args[0]
+                                                     ),
+                                                 ) + w.message.args[1:]
                                 warnings.showwarning(
                                     w.message,
                                     w.category,
@@ -701,15 +700,15 @@ def initialize_model(
 
 
 def _predictive(
-    rng_key,
-    model,
-    posterior_samples,
-    batch_shape,
-    return_sites=None,
-    infer_discrete=False,
-    parallel=True,
-    model_args=(),
-    model_kwargs={},
+        rng_key,
+        model,
+        posterior_samples,
+        batch_shape,
+        return_sites=None,
+        infer_discrete=False,
+        parallel=True,
+        model_args=(),
+        model_kwargs={},
 ):
     masked_model = numpyro.handlers.mask(model, mask=False)
     if infer_discrete:
@@ -759,7 +758,7 @@ def _predictive(
                 k
                 for k, site in model_trace.items()
                 if (site["type"] == "sample" and k not in samples)
-                or (site["type"] == "deterministic")
+                   or (site["type"] == "deterministic")
             }
         return {name: value for name, value in pred_samples.items() if name in sites}
 
@@ -834,17 +833,18 @@ class Predictive(object):
     """
 
     def __init__(
-        self,
-        model,
-        posterior_samples=None,
-        *,
-        guide=None,
-        params=None,
-        num_samples=None,
-        return_sites=None,
-        infer_discrete=False,
-        parallel=False,
-        batch_ndims=1,
+            self,
+            model,
+            posterior_samples=None,
+            *,
+            guide=None,
+            params=None,
+            num_samples=None,
+            return_sites=None,
+            infer_discrete=False,
+            parallel=False,
+            batch_ndims=1,
+            num_particles=None,
     ):
         if posterior_samples is None and num_samples is None:
             raise ValueError(
@@ -896,6 +896,7 @@ class Predictive(object):
         self.parallel = parallel
         self.batch_ndims = batch_ndims
         self._batch_shape = batch_shape
+        self.num_particles = num_particles
 
     def __call__(self, rng_key, *args, **kwargs):
         """
@@ -922,12 +923,23 @@ class Predictive(object):
                 model_args=args,
                 model_kwargs=kwargs,
             )
+
+        if self.num_particles is not None:
+            batch_shape = (1,) * (self.batch_ndims - 1) + (
+                self.num_samples,
+                self.num_particles,
+            )
+            for name, sample in posterior_samples.items():
+                assert self._batch_shape == sample.shape[: self.batch_ndims]
+                assert sample.shape[self.batch_ndims] == self.num_particles
+        else:
+            batch_shape = self._batch_shape
         model = substitute(self.model, self.params)
         return _predictive(
             rng_key,
             model,
             posterior_samples,
-            self._batch_shape,
+            batch_shape,
             return_sites=self.return_sites,
             infer_discrete=self.infer_discrete,
             parallel=self.parallel,
@@ -937,7 +949,7 @@ class Predictive(object):
 
 
 def log_likelihood(
-    model, posterior_samples, *args, parallel=False, batch_ndims=1, **kwargs
+        model, posterior_samples, *args, parallel=False, batch_ndims=1, **kwargs
 ):
     """
     (EXPERIMENTAL INTERFACE) Returns log likelihood at observation nodes of model,
@@ -1003,10 +1015,10 @@ def helpful_support_errors(site, raise_warnings=False):
     if raise_warnings:
         if support is constraints.circular:
             msg = (
-                f"Continuous inference poorly handles circular sample site '{name}'. "
-                + "Consider using VonMises distribution together with "
-                + "a reparameterizer, e.g. "
-                + f"numpyro.handlers.reparam(config={{'{name}': CircularReparam()}})."
+                    f"Continuous inference poorly handles circular sample site '{name}'. "
+                    + "Consider using VonMises distribution together with "
+                    + "a reparameterizer, e.g. "
+                    + f"numpyro.handlers.reparam(config={{'{name}': CircularReparam()}})."
             )
             warnings.warn(msg, UserWarning)
 

--- a/numpyro/infer/util.py
+++ b/numpyro/infer/util.py
@@ -929,8 +929,6 @@ class Predictive(object):
                 model_args=args,
                 model_kwargs=kwargs,
             )
-            print({k: v.shape for k, v in posterior_samples.items()})
-
         model = substitute(self.model, self.params)
         return _predictive(
             rng_key,

--- a/numpyro/infer/util.py
+++ b/numpyro/infer/util.py
@@ -1,16 +1,17 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
-import warnings
 from collections import namedtuple
 from contextlib import contextmanager
 from functools import partial
+import warnings
 
-import jax.numpy as jnp
 import numpy as np
+
 from jax import device_get, jacfwd, lax, random, value_and_grad
 from jax.flatten_util import ravel_pytree
 from jax.lax import broadcast_shapes
+import jax.numpy as jnp
 from jax.tree_util import tree_map
 
 import numpyro
@@ -89,9 +90,9 @@ class _without_rsample_stop_gradient(numpyro.primitives.Messenger):
 
     def postprocess_message(self, msg):
         if (
-                msg["type"] == "sample"
-                and (not msg["is_observed"])
-                and (not msg["fn"].has_rsample)
+            msg["type"] == "sample"
+            and (not msg["is_observed"])
+            and (not msg["fn"].has_rsample)
         ):
             msg["value"] = lax.stop_gradient(msg["value"])
             # TODO: reconsider this logic
@@ -248,16 +249,16 @@ def _init_to_unconstrained_value(site=None, values={}):
 
 
 def find_valid_initial_params(
-        rng_key,
-        model,
-        *,
-        init_strategy=init_to_uniform,
-        enum=False,
-        model_args=(),
-        model_kwargs=None,
-        prototype_params=None,
-        forward_mode_differentiation=False,
-        validate_grad=True,
+    rng_key,
+    model,
+    *,
+    init_strategy=init_to_uniform,
+    enum=False,
+    model_args=(),
+    model_kwargs=None,
+    prototype_params=None,
+    forward_mode_differentiation=False,
+    validate_grad=True,
 ):
     """
     (EXPERIMENTAL INTERFACE) Given a model with Pyro primitives, returns an initial
@@ -323,9 +324,9 @@ def find_valid_initial_params(
             constrained_values, inv_transforms = {}, {}
             for k, v in model_trace.items():
                 if (
-                        v["type"] == "sample"
-                        and not v["is_observed"]
-                        and not v["fn"].support.is_discrete
+                    v["type"] == "sample"
+                    and not v["is_observed"]
+                    and not v["fn"].support.is_discrete
                 ):
                     constrained_values[k] = v["value"]
                     with helpful_support_errors(v):
@@ -443,14 +444,14 @@ def _get_model_transforms(model, model_args=(), model_kwargs=None):
 
 
 def get_potential_fn(
-        model,
-        inv_transforms,
-        *,
-        enum=False,
-        replay_model=False,
-        dynamic_args=False,
-        model_args=(),
-        model_kwargs=None,
+    model,
+    inv_transforms,
+    *,
+    enum=False,
+    replay_model=False,
+    dynamic_args=False,
+    model_args=(),
+    model_kwargs=None,
 ):
     """
     (EXPERIMENTAL INTERFACE) Given a model with Pyro primitives, returns a
@@ -539,22 +540,22 @@ def _validate_model(model_trace):
             batch_dims = batch_dims - 1  # remove time dimension under scan
         plate_dims = -min([0] + [frame.dim for frame in site["cond_indep_stack"]])
         assert (
-                plate_dims >= batch_dims
+            plate_dims >= batch_dims
         ), "Missing plate statement for batch dimensions at site {}".format(
             site["name"]
         )
 
 
 def initialize_model(
-        rng_key,
-        model,
-        *,
-        init_strategy=init_to_uniform,
-        dynamic_args=False,
-        model_args=(),
-        model_kwargs=None,
-        forward_mode_differentiation=False,
-        validate_grad=True,
+    rng_key,
+    model,
+    *,
+    init_strategy=init_to_uniform,
+    dynamic_args=False,
+    model_args=(),
+    model_kwargs=None,
+    forward_mode_differentiation=False,
+    validate_grad=True,
 ):
     """
     (EXPERIMENTAL INTERFACE) Helper function that calls :func:`~numpyro.infer.util.get_potential_fn`
@@ -616,8 +617,8 @@ def initialize_model(
         k: v["value"]
         for k, v in model_trace.items()
         if v["type"] == "sample"
-           and not v["is_observed"]
-           and not v["fn"].support.is_discrete
+        and not v["is_observed"]
+        and not v["fn"].support.is_discrete
     }
 
     if has_enumerate_support:
@@ -679,10 +680,10 @@ def initialize_model(
                             for w in ws:
                                 # at site information to the warning message
                                 w.message.args = (
-                                                     "Site {}: {}".format(
-                                                         site["name"], w.message.args[0]
-                                                     ),
-                                                 ) + w.message.args[1:]
+                                    "Site {}: {}".format(
+                                        site["name"], w.message.args[0]
+                                    ),
+                                ) + w.message.args[1:]
                                 warnings.showwarning(
                                     w.message,
                                     w.category,
@@ -700,15 +701,15 @@ def initialize_model(
 
 
 def _predictive(
-        rng_key,
-        model,
-        posterior_samples,
-        batch_shape,
-        return_sites=None,
-        infer_discrete=False,
-        parallel=True,
-        model_args=(),
-        model_kwargs={},
+    rng_key,
+    model,
+    posterior_samples,
+    batch_shape,
+    return_sites=None,
+    infer_discrete=False,
+    parallel=True,
+    model_args=(),
+    model_kwargs={},
 ):
     masked_model = numpyro.handlers.mask(model, mask=False)
     if infer_discrete:
@@ -758,7 +759,7 @@ def _predictive(
                 k
                 for k, site in model_trace.items()
                 if (site["type"] == "sample" and k not in samples)
-                   or (site["type"] == "deterministic")
+                or (site["type"] == "deterministic")
             }
         return {name: value for name, value in pred_samples.items() if name in sites}
 
@@ -833,18 +834,18 @@ class Predictive(object):
     """
 
     def __init__(
-            self,
-            model,
-            posterior_samples=None,
-            *,
-            guide=None,
-            params=None,
-            num_samples=None,
-            return_sites=None,
-            infer_discrete=False,
-            parallel=False,
-            batch_ndims=1,
-            num_particles=None,
+        self,
+        model,
+        posterior_samples=None,
+        *,
+        guide=None,
+        params=None,
+        num_samples=None,
+        return_sites=None,
+        infer_discrete=False,
+        parallel=False,
+        batch_ndims=1,
+        num_particles=None,
     ):
         if posterior_samples is None and num_samples is None:
             raise ValueError(
@@ -949,7 +950,7 @@ class Predictive(object):
 
 
 def log_likelihood(
-        model, posterior_samples, *args, parallel=False, batch_ndims=1, **kwargs
+    model, posterior_samples, *args, parallel=False, batch_ndims=1, **kwargs
 ):
     """
     (EXPERIMENTAL INTERFACE) Returns log likelihood at observation nodes of model,
@@ -1015,10 +1016,10 @@ def helpful_support_errors(site, raise_warnings=False):
     if raise_warnings:
         if support is constraints.circular:
             msg = (
-                    f"Continuous inference poorly handles circular sample site '{name}'. "
-                    + "Consider using VonMises distribution together with "
-                    + "a reparameterizer, e.g. "
-                    + f"numpyro.handlers.reparam(config={{'{name}': CircularReparam()}})."
+                f"Continuous inference poorly handles circular sample site '{name}'. "
+                + "Consider using VonMises distribution together with "
+                + "a reparameterizer, e.g. "
+                + f"numpyro.handlers.reparam(config={{'{name}': CircularReparam()}})."
             )
             warnings.warn(msg, UserWarning)
 

--- a/test/infer/test_infer_util.py
+++ b/test/infer/test_infer_util.py
@@ -119,8 +119,8 @@ def test_predictive_with_particles():
         model,
         guide=guide,
         params=params,
-        num_samples=num_samples,
-        num_particles=num_particles,
+        num_samples=(num_samples, num_particles),
+        batch_ndims=1,
     )(random.PRNGKey(0), x)
     assert predictions["y"].shape == (num_samples, num_particles, num_data)
 

--- a/test/infer/test_infer_util.py
+++ b/test/infer/test_infer_util.py
@@ -111,6 +111,7 @@ def test_predictive_with_particles():
         latent_loc = numpyro.param(
             "latent_loc", jnp.ones(fdim), constraint=constraints.real
         )
+        assert latent_loc.ndim == 1
         numpyro.sample("latent", dist.Normal(latent_loc, 1.0).to_event(1))
 
     params = {"latent_loc": jnp.zeros((num_particles, fdim))}
@@ -119,7 +120,7 @@ def test_predictive_with_particles():
         model,
         guide=guide,
         params=params,
-        num_samples=(num_samples, num_particles),
+        num_samples=num_samples,
         batch_ndims=1,
     )(random.PRNGKey(0), x)
     assert predictions["y"].shape == (num_samples, num_particles, num_data)
@@ -157,6 +158,7 @@ def test_prior_predictive(batch_ndims):
 
     # check shapes
     batch_shape = (1,) * (batch_ndims - 1) + (100,)
+    print(batch_shape)
     assert predictive_samples["beta"].shape == batch_shape + true_probs.shape
     assert predictive_samples["obs"].shape == batch_shape + data.shape
 

--- a/test/infer/test_infer_util.py
+++ b/test/infer/test_infer_util.py
@@ -123,7 +123,6 @@ def test_predictive_with_particles():
         num_samples=num_samples,
         batch_ndims=1,
     )(random.PRNGKey(0), x)
-    print(predictions)
     assert predictions["y"].shape == (num_samples, num_particles, num_data)
 
 
@@ -159,7 +158,6 @@ def test_prior_predictive(batch_ndims):
 
     # check shapes
     batch_shape = (1,) * (batch_ndims - 1) + (100,)
-    print(batch_shape)
     assert predictive_samples["beta"].shape == batch_shape + true_probs.shape
     assert predictive_samples["obs"].shape == batch_shape + data.shape
 

--- a/test/infer/test_infer_util.py
+++ b/test/infer/test_infer_util.py
@@ -123,6 +123,7 @@ def test_predictive_with_particles():
         num_samples=num_samples,
         batch_ndims=1,
     )(random.PRNGKey(0), x)
+    print(predictions)
     assert predictions["y"].shape == (num_samples, num_particles, num_data)
 
 

--- a/test/infer/test_infer_util.py
+++ b/test/infer/test_infer_util.py
@@ -96,6 +96,35 @@ def test_predictive_with_guide():
     assert_allclose(jnp.mean(obs_pred), 0.8, atol=0.05)
 
 
+def test_predictive_with_particles():
+    num_particles = 5
+    num_samples = 2
+    fdim = 3
+    num_data = 10
+
+    def model(x, y=None):
+        latent = numpyro.sample("latent", dist.Normal(0.0, jnp.ones(fdim)).to_event(1))
+        with numpyro.plate("data", x.shape[0]):
+            numpyro.sample("y", dist.Normal(jnp.matmul(x, latent), 1.0), obs=y)
+
+    def guide(x, y=None):
+        latent_loc = numpyro.param(
+            "latent_loc", jnp.ones(fdim), constraint=constraints.real
+        )
+        numpyro.sample("latent", dist.Normal(latent_loc, 1.0).to_event(1))
+
+    params = {"latent_loc": jnp.zeros((num_particles, fdim))}
+    x = dist.Normal(jnp.full(3, 0.2), 1.0).sample(random.PRNGKey(0), (num_data,))
+    predictions = Predictive(
+        model,
+        guide=guide,
+        params=params,
+        num_samples=num_samples,
+        num_particles=num_particles,
+    )(random.PRNGKey(0), x)
+    assert predictions["y"].shape == (num_samples, num_particles, num_data)
+
+
 def test_predictive_with_improper():
     true_coef = 0.9
 


### PR DESCRIPTION
To use the `Predictive` class with SteinVI, the [`batch_shape`](https://github.com/pyro-ppl/numpyro/blob/master/numpyro/infer/util.py#L707) must be promoted to include an extra (right) dimension for the particles. Consider the following linear regression model: 
``` python
def model(x, y):
  n, m = x.shape
  prec = sample("prec", 
                Gamma(1.0,0.1))  # One per particle 
  feat = sample("feat",
                 Normal(zeros(m),
                 1/prec))  # broadcast to (m,)
  with plate('data',  n):
    sample("y", Normal(x @ feat, 1), obs=y)
```
Currently, `Predictive(model, guide=AutoDelta(model), params=results.params, num_samples=1)` will make the `batch_shape=(1,)` so the [soft_vmaps](https://github.com/pyro-ppl/numpyro/blob/master/numpyro/infer/util.py#L771-L773) `batch_ndim=1`. The `Normal` will try to promote the shapes `(1,), (m,), (num_particles)` which will fail for arbitrary choice of particles.

This PR introduces `num_particles` as a parameter to `Predictive` that expands `batch_shape` with `num_particles` as a new right most dimension, i.e.
``` python
batch_shape = (1,) * (self.batch_ndims - 1) + (
                self.num_samples,
                self.num_particles,
            )
```
An alternative (suggested by @fehiepsi) is to allow tuples of integers for `num_samples` instead. For SteinVI, we would then have `num_sample=(num_sample, num_particles)`. This solution is more general than the one presented above. We may need to check the site shapes in the prototype against the `num_samples`. I'll sketch the solution to be sure.

Once we settle on a solution I'll add some test cases. PR related to #833.