### PR TITLE
Update fori_collect for new ravel_pytree behavior

### DIFF
--- a/numpyro/distributions/continuous.py
+++ b/numpyro/distributions/continuous.py
@@ -27,7 +27,7 @@
 
 
 from jax import lax
-from jax._src.scipy.special import gammainc
+from jax.scipy.special import gammainc
 import jax.nn as nn
 import jax.numpy as jnp
 import jax.random as random

--- a/numpyro/distributions/continuous.py
+++ b/numpyro/distributions/continuous.py
@@ -27,12 +27,20 @@
 
 
 from jax import lax
-from jax.scipy.special import gammainc
 import jax.nn as nn
 import jax.numpy as jnp
 import jax.random as random
 from jax.scipy.linalg import cho_solve, solve_triangular
-from jax.scipy.special import betainc, expit, gammaln, logit, multigammaln, ndtr, ndtri
+from jax.scipy.special import (
+    betainc,
+    expit,
+    gammainc,
+    gammaln,
+    logit,
+    multigammaln,
+    ndtr,
+    ndtri,
+)
 
 from numpyro.distributions import constraints
 from numpyro.distributions.distribution import Distribution, TransformedDistribution

--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -330,7 +330,8 @@ def fori_collect(
         )
         return val, collection, start_idx, thinning
 
-    collection = jnp.zeros((collection_size,) + init_val_flat.shape)
+    collection = jnp.zeros((collection_size,) + init_val_flat.shape,
+                           dtype=init_val_flat.dtype)
     if not progbar:
         last_val, collection, _, _ = fori_loop(
             0, upper, _body_fn, (init_val, collection, start_idx, thinning)

--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -330,8 +330,9 @@ def fori_collect(
         )
         return val, collection, start_idx, thinning
 
-    collection = jnp.zeros((collection_size,) + init_val_flat.shape,
-                           dtype=init_val_flat.dtype)
+    collection = jnp.zeros(
+        (collection_size,) + init_val_flat.shape, dtype=init_val_flat.dtype
+    )
     if not progbar:
         last_val, collection, _, _ = fori_loop(
             0, upper, _body_fn, (init_val, collection, start_idx, thinning)


### PR DESCRIPTION
After https://github.com/google/jax/pull/8951, `ravel_pytree` might return non-float dtype, so we need to make sure that the placeholder `collection` has the same dtype as `ravel_pytree` output.

Tested locally that the change passes the jax master branch.