### PR TITLE
improve performance of find_stack_level

### DIFF
--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -3,6 +3,7 @@
 
 from collections import OrderedDict
 from contextlib import contextmanager
+import inspect
 from itertools import zip_longest
 import os
 import random
@@ -705,21 +706,20 @@ def find_stack_level() -> int:
     (tests notwithstanding).
 
     Source:
-    https://github.com/pandas-dev/pandas/blob/9a4fcea8de798938a434fcaf67a0aa5a46b76b5b/pandas/util/_exceptions.py#L27-L45
+    https://github.com/pandas-dev/pandas/blob/ccb25ab1d24c4fb9691270706a59c8d319750870/pandas/util/_exceptions.py#L27-L48
     """
-    import inspect
-
-    stack = inspect.stack()
-
     import numpyro
 
     pkg_dir = os.path.dirname(numpyro.__file__)
-    test_dir = os.path.join(pkg_dir, "tests")
 
-    for n in range(len(stack)):
-        fname = stack[n].filename
-        if fname.startswith(pkg_dir) and not fname.startswith(test_dir):
-            continue
+    # https://stackoverflow.com/questions/17407119/python-inspect-stack-is-slow
+    frame = inspect.currentframe()
+    n = 0
+    while frame:
+        fname = inspect.getfile(frame)
+        if fname.startswith(pkg_dir):
+            frame = frame.f_back
+            n += 1
         else:
             break
     return n


### PR DESCRIPTION
This has been improved in pandas, so bringing the improvement over https://github.com/pandas-dev/pandas/pull/45247/files

On master:
```
In [1]: from numpyro.distributions.discrete import PRNGIdentity

In [2]: %%timeit
   ...: PRNGIdentity()
   ...: 
   ...: 
<magic-timeit>:1: FutureWarning: PRNGIdentity distribution is deprecated. To get a random PRNG key, you can use `numpyro.prng_key()` instead.
3.64 ms ± 70.8 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

Here:
```
In [1]: from numpyro.distributions.discrete import PRNGIdentity

In [2]: %%timeit
   ...: PRNGIdentity()
   ...: 
   ...: 
<magic-timeit>:1: FutureWarning: PRNGIdentity distribution is deprecated. To get a random PRNG key, you can use `numpyro.prng_key()` instead.
5.68 µs ± 58.8 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```