### PR TITLE
NumPyro doesn't raise if a determinstic variable has the same name as a random variable

### DIFF
--- a/numpyro/handlers.py
+++ b/numpyro/handlers.py
@@ -154,7 +154,7 @@ class trace(Messenger):
             # which has no name
             return
         assert not (
-            msg["type"] == "sample" and msg["name"] in self.trace
+            msg["type"] in ("sample", "deterministic") and msg["name"] in self.trace
         ), "all sites must have unique names but got `{}` duplicated".format(
             msg["name"]
         )


### PR DESCRIPTION
closes #1280 

With this change, the traceback from the same example gives:
```
$ python t.py 
Traceback (most recent call last):
  File "t.py", line 13, in <module>
    mcmc.run(jax.random.PRNGKey(0))
  File "/home/marco/numpyro-dev/numpyro/infer/mcmc.py", line 599, in run
    states_flat, last_state = partial_map_fn(map_args)
  File "/home/marco/numpyro-dev/numpyro/infer/mcmc.py", line 387, in _single_chain_mcmc
    init_state = self.sampler.init(
  File "/home/marco/numpyro-dev/numpyro/infer/hmc.py", line 696, in init
    init_params = self._init_state(
  File "/home/marco/numpyro-dev/numpyro/infer/hmc.py", line 642, in _init_state
    init_params, potential_fn, postprocess_fn, model_trace = initialize_model(
  File "/home/marco/numpyro-dev/numpyro/infer/util.py", line 608, in initialize_model
    ) = _get_model_transforms(substituted_model, model_args, model_kwargs)
  File "/home/marco/numpyro-dev/numpyro/infer/util.py", line 399, in _get_model_transforms
    model_trace = trace(model).get_trace(*model_args, **model_kwargs)
  File "/home/marco/numpyro-dev/numpyro/handlers.py", line 171, in get_trace
    self(*args, **kwargs)
  File "/home/marco/numpyro-dev/numpyro/primitives.py", line 87, in __call__
    return self.fn(*args, **kwargs)
  File "/home/marco/numpyro-dev/numpyro/primitives.py", line 87, in __call__
    return self.fn(*args, **kwargs)
  File "/home/marco/numpyro-dev/numpyro/primitives.py", line 87, in __call__
    return self.fn(*args, **kwargs)
  File "t.py", line 9, in model
    numpyro.deterministic("alpha", alpha * 2)
  File "/home/marco/numpyro-dev/numpyro/primitives.py", line 279, in deterministic
    msg = apply_stack(initial_msg)
  File "/home/marco/numpyro-dev/numpyro/primitives.py", line 41, in apply_stack
    handler.postprocess_message(msg)
  File "/home/marco/numpyro-dev/numpyro/handlers.py", line 156, in postprocess_message
    assert not (
AssertionError: all sites must have unique names but got `alpha` duplicated
```