### PR TITLE
Add Other Inference Algorithms section to docs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -61,17 +61,23 @@ NumPyro documentation
    examples/horseshoe_regression
    examples/proportion_test
    examples/ucbadmit
-   examples/hmcecs
    examples/hmm
    examples/hsgp
    examples/ode
    examples/neutra
-   examples/covtype
    examples/thompson_sampling
    tutorials/bayesian_hierarchical_stacking
    examples/ssbvm_mixture
    examples/ar2
    examples/holt_winters
+
+.. nbgallery::
+   :maxdepth: 1
+   :caption: Other Inference Algorithms
+   :name: other-inference-algorithms
+
+   examples/hmcecs
+   examples/covtype
 
 
 Indices and tables


### PR DESCRIPTION
The Applications section is a bit long for now and needs refactoring. In Pyro, we have an "[Other Inference Algorithms](https://pyro.ai/examples/baseball.html)" section that we can mimic and use for SteinVI, nested sampling, hmcecs, MixedHMC, SA. Related to #833.