### PR TITLE
Cast rate parameter to float

### DIFF
--- a/numpyro/distributions/discrete.py
+++ b/numpyro/distributions/discrete.py
@@ -692,7 +692,7 @@ class Poisson(Distribution):
             sparse_value = value[nonzero]
             sparse_rate = rate[nonzero]
             return (
-                jnp.asarray(-rate)
+                jnp.asarray(-rate, dtype=jnp.result_type(float))
                 .at[nonzero]
                 .add(
                     jnp.log(sparse_rate) * sparse_value - gammaln(sparse_value + 1),

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -603,6 +603,7 @@ DISCRETE = [
     T(dist.Poisson, np.array([2.0, 3.0, 5.0])),
     T(SparsePoisson, 2.0),
     T(SparsePoisson, np.array([2.0, 3.0, 5.0])),
+    T(SparsePoisson, 2),
     T(dist.ZeroInflatedPoisson, 0.6, 2.0),
     T(dist.ZeroInflatedPoisson, np.array([0.2, 0.7, 0.3]), np.array([2.0, 3.0, 5.0])),
     T(ZeroInflatedPoissonLogits, 2.0, 3.0),


### PR DESCRIPTION
Fix for #1296 

Casts rate parameter to float when calculating Poisson `log_prob`
Added a Poisson distribution with an `int` rate parameter to the test cases to cover this
