### PR TITLE
Make potential_fn_gen and postprocess_fn_gen picklable

### DIFF
--- a/numpyro/infer/autoguide.py
+++ b/numpyro/infer/autoguide.py
@@ -114,8 +114,6 @@ class AutoGuide(ABC):
     def __getstate__(self):
         state = self.__dict__.copy()
         state.pop("plates", None)
-        # TODO: Make potential_fn_gen pickable.
-        state.pop("_potential_fn_gen", None)
         return state
 
     @abstractmethod

--- a/numpyro/infer/barker.py
+++ b/numpyro/infer/barker.py
@@ -288,6 +288,5 @@ class BarkerMH(MCMCKernel):
 
     def __getstate__(self):
         state = self.__dict__.copy()
-        state["_postprocess_fn"] = None
         state["_wa_update"] = None
         return state

--- a/numpyro/infer/hmc.py
+++ b/numpyro/infer/hmc.py
@@ -763,8 +763,6 @@ class HMC(MCMCKernel):
         state = self.__dict__.copy()
         state["_sample_fn"] = None
         state["_init_fn"] = None
-        # state["_postprocess_fn"] = None
-        # state["_potential_fn_gen"] = None
         return state
 
 

--- a/numpyro/infer/hmc.py
+++ b/numpyro/infer/hmc.py
@@ -763,8 +763,8 @@ class HMC(MCMCKernel):
         state = self.__dict__.copy()
         state["_sample_fn"] = None
         state["_init_fn"] = None
-        state["_postprocess_fn"] = None
-        state["_potential_fn_gen"] = None
+        # state["_postprocess_fn"] = None
+        # state["_potential_fn_gen"] = None
         return state
 
 

--- a/numpyro/infer/sa.py
+++ b/numpyro/infer/sa.py
@@ -401,6 +401,4 @@ class SA(MCMCKernel):
         state = self.__dict__.copy()
         state["_sample_fn"] = None
         state["_init_fn"] = None
-        state["_postprocess_fn"] = None
-        state["_potential_fn_gen"] = None
         return state

--- a/numpyro/infer/util.py
+++ b/numpyro/infer/util.py
@@ -446,11 +446,13 @@ def _get_model_transforms(model, model_args=(), model_kwargs=None):
     return inv_transforms, replay_model, has_enumerate_support, model_trace
 
 
-def _args_wrapper(fn, *args, **kwargs):
+def _partial_args_kwargs(fn, *args, **kwargs):
+    """Returns a partial function of `fn` and args, kwargs."""
     return partial(fn, args, kwargs)
 
 
-def _args_dropper(fn, *args, **kwargs):
+def _drop_args_kwargs(fn, *args, **kwargs):
+    """Returns the input function `fn`, ignoring args and kwargs."""
     return fn
 
 
@@ -488,22 +490,20 @@ def get_potential_fn(
         `deterministic` sites in the model.
     """
     if dynamic_args:
-        potential_fn = partial(_args_wrapper, partial(potential_energy, model, enum=enum))
+        potential_fn = partial(
+            _partial_args_kwargs, partial(potential_energy, model, enum=enum)
+        )
         if replay_model:
             # XXX: we seed to sample discrete sites (but not collect them)
             model_ = seed(model.fn, 0) if enum else model
-            postprocess_fn = partial(_args_wrapper, partial(constrain_fn, model, return_deterministic=True))
+            postprocess_fn = partial(
+                _partial_args_kwargs,
+                partial(constrain_fn, model, return_deterministic=True),
+            )
         else:
-            postprocess_fn = partial(_args_dropper, partial(transform_fn, inv_transforms))
-
-        # def postprocess_fn(*args, **kwargs):
-        #     if replay_model:
-        #         return partial(
-        #             constrain_fn, model_, args, kwargs, return_deterministic=True
-        #         )
-        #     else:
-        #         return partial(transform_fn, inv_transforms)
-
+            postprocess_fn = partial(
+                _drop_args_kwargs, partial(transform_fn, inv_transforms)
+            )
     else:
         model_kwargs = {} if model_kwargs is None else model_kwargs
         potential_fn = partial(


### PR DESCRIPTION
This PR moves the *locally* defined `postprocess_fn` and `potential_fn` functions into partial functions, which allows them pickable.

The current tests in `test/test_pickle.py` should cover the changes. 