### PR TITLE
tighten test_improper_normal bound

### DIFF
--- a/test/infer/test_mcmc.py
+++ b/test/infer/test_mcmc.py
@@ -183,7 +183,7 @@ def test_improper_normal(max_tree_depth):
     mcmc = MCMC(kernel, num_warmup=1000, num_samples=1000)
     mcmc.run(random.PRNGKey(0), data)
     samples = mcmc.get_samples()
-    assert_allclose(jnp.mean(samples["loc"], 0), true_coef, atol=0.05)
+    assert_allclose(jnp.mean(samples["loc"], 0), true_coef, atol=0.007)
 
 
 @pytest.mark.parametrize("kernel_cls", [HMC, NUTS, SA, BarkerMH])


### PR DESCRIPTION
Hi,

The test `test_improper_normal` in `test_mcmc.py` has an assertion bound (`assert_allclose(jnp.mean(samples["loc"], 0), true_coef, atol=0.05)`) that is too loose. This means potential bug in the code could still pass the original test.

To quantify this I conducted some experiments where I generated multiple mutations of the source code under test and ran each mutant and the original code 100 times to build a distribution of their outputs. Each mutant is generated using simple mutation operators (e.g. > can become < ) on source code covered by the test. I used KS-test to find mutants that produced a different distribution from the original and use those mutants as a proxy for bugs that could be introduced. In the graph below I show the distribution of both the original code and also the mutants with a different distribution.

<p align="center">
<img src="https://user-images.githubusercontent.com/95935342/150861877-ecc94a5a-3f1f-4db4-9ddd-1abdff439afe.png" width="450">
</p>

Here we see that the bound of `0.05` is too loose since the original distribution (in orange) is less than `0.05`. Furthermore in this graph we can observe that there are many mutants (proxy for bugs) that are below the bound as well and that is undesirable since the test should aim to catch potential bugs in code. I quantify the "bug detection" of this assertion by varying the bound in a trade-off graph below.

<p align="center">
<img src="https://user-images.githubusercontent.com/95935342/150861924-2ae49c3f-bda7-4907-bc73-6016bb8f4879.png" width="450">
</p>

In this graph, I plot the mutant catch rate (ratio of mutant outputs that fail the test) and the original pass rate (ratio of original output that pass the test). The original bound of `0.05` (red dotted line) has a catch rate of 0.23.

To improve this test, I propose to tighten the bound to `0.007` (the blue dotted line). The new bound has a catch rate of 0.28 (+0.05 increase compare to original) while still has >99 % pass rate (test is not flaky, I ran the updated test 500 times and observed 100 % pass rate). I think this is a good balance between improving the bug-detection ability of the test while keep the flakiness of the test low.

Do you guys think this makes sense? Please let me know if this looks good or if you have any other suggestions or questions. 

My Environment:
```
python=3.7.11
numpy=1.21.4 
```

my numpyro ml-agents Experiment SHA:
`9987eb737e4b6da5d83da961e636d51a5ae36dde`