### PR TITLE
Fix provenance logic for jax 0.2.28

### DIFF
--- a/numpyro/ops/provenance.py
+++ b/numpyro/ops/provenance.py
@@ -26,6 +26,9 @@ class _ProvenanceJaxprTrace(partial_eval.DynamicJaxprTrace):
             out_tracers = out_tracers if primitive.multiple_results else [out_tracers]
             for t in out_tracers:
                 t.aval.named_shape["_provenance"] = out_provenance
+                # Also update provenance of the cached tracer -> aval dict.
+                aval_cache = self.frame.tracer_to_var[id(t)].aval
+                aval_cache.named_shape["_provenance"] = out_provenance
             out_tracers = out_tracers if primitive.multiple_results else out_tracers[0]
         return out_tracers
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ import sys
 from setuptools import find_packages, setup
 
 PROJECT_PATH = os.path.dirname(os.path.abspath(__file__))
-_jax_version_constraints = ">=0.2.13,<0.2.28"
+_jax_version_constraints = ">=0.2.13"
 _jaxlib_version_constraints = ">=0.1.65"
 
 # Find version


### PR DESCRIPTION
Fixes #1318

tldr; I have tested the change and it works for the old jax versions.

The recent jax release made provenance logic failing because the cached abstract value might be a different object w.r.t. the one stored in the output of `process_primitive`, while we only updated `provenance` for the output previously.

I think we'll need to make a patch release after this fix.