### PR TITLE
removed last line of stacking function

### DIFF
--- a/notebooks/source/bayesian_hierarchical_stacking.ipynb
+++ b/notebooks/source/bayesian_hierarchical_stacking.ipynb
@@ -835,8 +835,7 @@
     "        # test set stacking weights (in unconstrained space)\n",
     "        f_test = jnp.hstack([X_test @ beta.T, jnp.zeros((N_test, 1))])\n",
     "        # test set stacking weights (constrained to sum to 1)\n",
-    "        w_test = numpyro.deterministic(\"w_test\", jax.nn.softmax(f_test, axis=1))\n",
-    "        numpyro.deterministic(\"w_test\", w_test)"
+    "        w_test = numpyro.deterministic(\"w_test\", jax.nn.softmax(f_test, axis=1))"
    ]
   },
   {
@@ -1218,7 +1217,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.8"
   },
   "papermill": {
    "default_parameters": {},


### PR DESCRIPTION
This is in regard to Issue 1323

https://github.com/pyro-ppl/numpyro/issues/1323

Only change is last line of stacking function is removed. It is redundant and prevents the notebook from functioning due to duplicative 'w_test' name.