### PR TITLE
Do not rename plates under scope handler

### DIFF
--- a/examples/hsgp.py
+++ b/examples/hsgp.py
@@ -221,7 +221,7 @@ def approx_se_ncp(x, alpha, length, L, M):
     """
     phi = eigenfunctions(x, L, M)
     spd = jnp.sqrt(diag_spectral_density(alpha, length, L, M))
-    with plate("basis", M):
+    with plate(f"basis_{M}", M):
         beta = sample("beta", dist.Normal(0, 1))
 
     f = deterministic("f", phi @ (spd * beta))

--- a/examples/hsgp.py
+++ b/examples/hsgp.py
@@ -221,7 +221,7 @@ def approx_se_ncp(x, alpha, length, L, M):
     """
     phi = eigenfunctions(x, L, M)
     spd = jnp.sqrt(diag_spectral_density(alpha, length, L, M))
-    with plate(f"basis_{M}", M):
+    with plate(f"basis", M):
         beta = sample("beta", dist.Normal(0, 1))
 
     f = deterministic("f", phi @ (spd * beta))

--- a/examples/hsgp.py
+++ b/examples/hsgp.py
@@ -221,7 +221,7 @@ def approx_se_ncp(x, alpha, length, L, M):
     """
     phi = eigenfunctions(x, L, M)
     spd = jnp.sqrt(diag_spectral_density(alpha, length, L, M))
-    with plate(f"basis", M):
+    with plate("basis", M):
         beta = sample("beta", dist.Normal(0, 1))
 
     f = deterministic("f", phi @ (spd * beta))

--- a/numpyro/contrib/control_flow/scan.py
+++ b/numpyro/contrib/control_flow/scan.py
@@ -153,7 +153,9 @@ def scan_enum(
 
         if init:
             # handler the name to match the pattern of sakkar_bilmes product
-            with handlers.scope(prefix="_PREV_" * (unroll_steps - i), divider=""):
+            with handlers.scope(
+                prefix="_PREV_" * (unroll_steps - i), divider="", hide_types=["plate"]
+            ):
                 new_carry, y = config_enumerate(seeded_fn)(carry, x)
                 trace = {}
         else:

--- a/numpyro/handlers.py
+++ b/numpyro/handlers.py
@@ -605,7 +605,7 @@ class scale(Messenger):
 
 class scope(Messenger):
     """
-    This handler prepend a prefix followed by a divider to the name of messages.
+    This handler prepend a prefix followed by a divider to the name of sample sites.
 
     **Example:**
 
@@ -623,32 +623,23 @@ class scope(Messenger):
         >>> assert "a/b.x" in trace(seed(model, 0)).get_trace()
 
     :param fn: Python callable with NumPyro primitives.
-    :param str prefix: a string to prepend to message names
+    :param str prefix: a string to prepend to sample names
     :param str divider: a string to join the prefix and sample name; default to `'/'`
-    :param tuple types: EXPERIMENTAL types of the messages to apply scope handler to.
-        Typically, each item in the tuple is one of
-        (`"sample"`, `"deterministic"`, `"plate"`, `"param"`).
+    :param bool skip_param: whether to apply scope for `param` sites. Defaults to True.
     """
-    def __init__(self, fn=None, prefix="", divider="/", *, types=("sample", "deterministic")):
+
+    def __init__(self, fn=None, prefix="", divider="/", *, skip_param=True):
         self.prefix = prefix
         self.divider = divider
-        self.types = types
+        self.skip_param = skip_param
         super().__init__(fn)
 
     def process_message(self, msg):
-        if msg["type"] not in self.types:
+        if (msg["type"] == "param" and self.skip_param) or (msg["type"] == "plate"):
             return
 
         if msg.get("name"):
             msg["name"] = f"{self.prefix}{self.divider}{msg['name']}"
-
-        if "plate" in self.types and msg.get("cond_indep_stack"):
-            msg["cond_indep_stack"] = [
-                CondIndepStackFrame(
-                    f"{self.prefix}{self.divider}{i.name}", i.dim, i.size
-                )
-                for i in msg["cond_indep_stack"]
-            ]
 
 
 class seed(Messenger):

--- a/numpyro/handlers.py
+++ b/numpyro/handlers.py
@@ -86,7 +86,13 @@ import jax.numpy as jnp
 
 import numpyro
 from numpyro.distributions.distribution import COERCIONS
-from numpyro.primitives import _PYRO_STACK, Messenger, apply_stack, plate
+from numpyro.primitives import (
+    _PYRO_STACK,
+    CondIndepStackFrame,
+    Messenger,
+    apply_stack,
+    plate,
+)
 from numpyro.util import find_stack_level, not_jax_tracer
 
 __all__ = [
@@ -619,19 +625,26 @@ class scope(Messenger):
     :param fn: Python callable with NumPyro primitives.
     :param str prefix: a string to prepend to sample names
     :param str divider: a string to join the prefix and sample name; default to `'/'`
+    :param list hide_types: an optional list of side types to skip renaming.
     """
 
-    def __init__(self, fn=None, prefix="", divider="/"):
+    def __init__(self, fn=None, prefix="", divider="/", *, hide_types=None):
         self.prefix = prefix
         self.divider = divider
+        self.hide_types = [] if hide_types is None else hide_types
         super().__init__(fn)
 
     def process_message(self, msg):
-        if msg["type"] == "plate":
-            return
-
-        if msg.get("name"):
+        if msg.get("name") and msg["type"] not in self.hide_types:
             msg["name"] = f"{self.prefix}{self.divider}{msg['name']}"
+
+        if msg.get("cond_indep_stack") and "plate" not in self.hide_types:
+            msg["cond_indep_stack"] = [
+                CondIndepStackFrame(
+                    f"{self.prefix}{self.divider}{i.name}", i.dim, i.size
+                )
+                for i in msg["cond_indep_stack"]
+            ]
 
 
 class seed(Messenger):

--- a/numpyro/handlers.py
+++ b/numpyro/handlers.py
@@ -86,12 +86,7 @@ import jax.numpy as jnp
 
 import numpyro
 from numpyro.distributions.distribution import COERCIONS
-from numpyro.primitives import (
-    _PYRO_STACK,
-    Messenger,
-    apply_stack,
-    plate,
-)
+from numpyro.primitives import _PYRO_STACK, Messenger, apply_stack, plate
 from numpyro.util import find_stack_level, not_jax_tracer
 
 __all__ = [

--- a/numpyro/handlers.py
+++ b/numpyro/handlers.py
@@ -619,17 +619,15 @@ class scope(Messenger):
     :param fn: Python callable with NumPyro primitives.
     :param str prefix: a string to prepend to sample names
     :param str divider: a string to join the prefix and sample name; default to `'/'`
-    :param bool skip_param: whether to apply scope for `param` sites. Defaults to True.
     """
 
-    def __init__(self, fn=None, prefix="", divider="/", *, skip_param=True):
+    def __init__(self, fn=None, prefix="", divider="/"):
         self.prefix = prefix
         self.divider = divider
-        self.skip_param = skip_param
         super().__init__(fn)
 
     def process_message(self, msg):
-        if (msg["type"] == "param" and self.skip_param) or (msg["type"] == "plate"):
+        if msg["type"] == "plate":
             return
 
         if msg.get("name"):

--- a/numpyro/handlers.py
+++ b/numpyro/handlers.py
@@ -88,7 +88,6 @@ import numpyro
 from numpyro.distributions.distribution import COERCIONS
 from numpyro.primitives import (
     _PYRO_STACK,
-    CondIndepStackFrame,
     Messenger,
     apply_stack,
     plate,

--- a/test/test_handlers.py
+++ b/test/test_handlers.py
@@ -577,7 +577,8 @@ def test_block():
 
 def test_scope():
     def fn():
-        return numpyro.sample("x", dist.Normal())
+        with numpyro.plate("N", 10):
+            return numpyro.sample("x", dist.Normal())
 
     with handlers.trace() as trace:
         with handlers.seed(rng_seed=1):
@@ -587,8 +588,7 @@ def test_scope():
                 with handlers.scope(prefix="a"):
                     fn()
 
-    assert "a/x" in trace
-    assert "b/a/x" in trace
+    assert set(trace) == {"a/x", "b/a/x", "N"}
 
 
 def test_scope_frames():

--- a/test/test_handlers.py
+++ b/test/test_handlers.py
@@ -585,10 +585,10 @@ def test_scope():
             with handlers.scope(prefix="a"):
                 fn()
             with handlers.scope(prefix="b"):
-                with handlers.scope(prefix="a"):
+                with handlers.scope(prefix="a", hide_types=["plate"]):
                     fn()
 
-    assert set(trace) == {"a/x", "b/a/x", "N"}
+    assert set(trace) == {"a/x", "b/a/x", "a/N", "b/N"}
 
 
 def test_scope_frames():


### PR DESCRIPTION
Fixes #1335

I think the current behavior is confusing and not originally intended. It is unnecessary to have `scope` for the plate (which has caused some [confusion](https://github.com/pyro-ppl/numpyro/issues/1176)). I'm not sure if anyone wants to apply `scope` for `param` but it might be good to allow such behavior (and to use a single parameter, we can simply call `param` once and pass that param around different scopes).