### PR TITLE
Support multithreading for PYRO_STACK

### DIFF
--- a/examples/threading.py
+++ b/examples/threading.py
@@ -1,0 +1,33 @@
+"""
+Examples to show how to use numpyro with multithreading.
+"""
+from collections import defaultdict
+import threading
+
+import jax
+import jax.numpy as jnp
+
+import numpyro
+from numpyro import handlers
+import numpyro.distributions as dist
+from numpyro.primitives import set_pyro_stack
+
+
+class _StackThreadDict(defaultdict):
+    def current_stack(self):
+        thread_id = threading.get_native_id()
+        return self[thread_id]
+
+
+_PYRO_THREAD_STACK = _StackThreadDict(list)
+set_pyro_stack(_PYRO_THREAD_STACK)
+
+
+def model():
+    numpyro.sample("a", dist.Normal(0, 1))
+
+
+rng_keys = jax.random.split(jax.random.PRNGKey(0), 2)
+for rng_key in rng_keys:
+    # creat a thread and trace
+    pass

--- a/numpyro/contrib/control_flow/cond.py
+++ b/numpyro/contrib/control_flow/cond.py
@@ -7,7 +7,7 @@ from jax import device_put, lax
 
 from numpyro import handlers
 from numpyro.ops.pytree import PytreeTrace
-from numpyro.primitives import _PYRO_STACK, apply_stack
+from numpyro.primitives import apply_stack, get_pyro_stack
 
 
 def _subs_wrapper(subs_map, site):
@@ -141,7 +141,7 @@ def cond(pred, true_fun, false_fun, operand):
         be any JAX PyTree (e.g. list / dict of arrays).
     :return: Output of the applied branch function.
     """
-    if not _PYRO_STACK:
+    if not get_pyro_stack():
         value, _ = cond_wrapper(pred, true_fun, false_fun, operand)
         return value
 

--- a/numpyro/contrib/control_flow/scan.py
+++ b/numpyro/contrib/control_flow/scan.py
@@ -17,7 +17,7 @@ import jax.numpy as jnp
 
 from numpyro import handlers
 from numpyro.ops.pytree import PytreeTrace
-from numpyro.primitives import _PYRO_STACK, Messenger, apply_stack
+from numpyro.primitives import Messenger, apply_stack, get_pyro_stack
 from numpyro.util import not_jax_tracer
 
 
@@ -415,7 +415,7 @@ def scan(f, init, xs, length=None, reverse=False, history=1):
         second output of f when scanned over the leading axis of the inputs".
     """
     # if there are no active Messengers, we just run and return it as expected:
-    if not _PYRO_STACK:
+    if not get_pyro_stack():
         (length, rng_key, carry), (pytree_trace, ys) = scan_wrapper(
             f, init, xs, length=length, reverse=reverse
         )

--- a/numpyro/handlers.py
+++ b/numpyro/handlers.py
@@ -87,10 +87,10 @@ import jax.numpy as jnp
 import numpyro
 from numpyro.distributions.distribution import COERCIONS
 from numpyro.primitives import (
-    _PYRO_STACK,
     CondIndepStackFrame,
     Messenger,
     apply_stack,
+    get_pyro_stack,
     plate,
 )
 from numpyro.util import find_stack_level, not_jax_tracer
@@ -291,7 +291,7 @@ class collapse(trace):
 
     def __enter__(self):
         self.preserved_plates = frozenset(
-            h.name for h in _PYRO_STACK if isinstance(h, plate)
+            h.name for h in get_pyro_stack() if isinstance(h, plate)
         )
         COERCIONS.append(self._coerce)
         return super().__enter__()

--- a/numpyro/infer/hmc_gibbs.py
+++ b/numpyro/infer/hmc_gibbs.py
@@ -918,7 +918,7 @@ class estimate_likelihood(numpyro.primitives.Messenger):
         self.gibbs_state = None
 
     def __enter__(self):
-        for handler in numpyro.primitives._PYRO_STACK[::-1]:
+        for handler in numpyro.primitives.get_pyro_stack()[::-1]:
             # the potential_fn in HMC makes the PYRO_STACK nested like trace(...); so we can extract the
             # unconstrained_params from the _unconstrain_reparam substitute_fn
             if (


### PR DESCRIPTION
Based on the discussion with @fritzo and @eb8680, it seems that the simplest way to support multithreading is to get PYRO_STACK from an intermediate function `get_pyro_stack`, where we can modify to return a stack for a particular thread.

TODOs:
- [ ] see how to do threading in jax
- [ ] finish the example