### PR TITLE
Make replay consistent with Pyro

### DIFF
--- a/numpyro/distributions/distribution.py
+++ b/numpyro/distributions/distribution.py
@@ -762,8 +762,8 @@ class Independent(Distribution):
         return self.base_dist.has_enumerate_support
 
     @property
-    def reparameterized_params(self):
-        return self.base_dist.reparameterized_params
+    def reparametrized_params(self):
+        return self.base_dist.reparametrized_params
 
     @property
     def mean(self):

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -880,23 +880,23 @@ def test_sample_gradient(jax_dist, sp_dist, params):
     params_dict = dict(zip(dist_args[: len(params)], params))
 
     jax_class = type(jax_dist(**params_dict))
-    reparameterized_params = [
+    reparametrized_params = [
         p for p in jax_class.reparametrized_params if p not in gamma_derived_params
     ]
-    if not reparameterized_params:
+    if not reparametrized_params:
         pytest.skip("{} not reparametrized.".format(jax_class.__name__))
 
     nonrepara_params_dict = {
-        k: v for k, v in params_dict.items() if k not in reparameterized_params
+        k: v for k, v in params_dict.items() if k not in reparametrized_params
     }
     repara_params = tuple(
-        v for k, v in params_dict.items() if k in reparameterized_params
+        v for k, v in params_dict.items() if k in reparametrized_params
     )
 
     rng_key = random.PRNGKey(0)
 
     def fn(args):
-        args_dict = dict(zip(reparameterized_params, args))
+        args_dict = dict(zip(reparametrized_params, args))
         return jnp.sum(
             jax_dist(**args_dict, **nonrepara_params_dict).sample(key=rng_key)
         )


### PR DESCRIPTION
Currently, `replay` messenger is not consistent with Pyro behavior and does not have some checks for validation. This PR makes the behavior consistent. Also fixes typos of `reparametrized` parameters in distributions.

Also add docstring for `apply_stack` to clarify its content.