### PR TITLE
Update for JAX 0.3.5 

### DIFF
--- a/examples/baseball.py
+++ b/examples/baseball.py
@@ -70,8 +70,8 @@ def fully_pooled(at_bats, hits=None):
     Number of hits in $K$ at bats for each player has a Binomial
     distribution with a common probability of success, $\phi$.
 
-    :param (jnp.DeviceArray) at_bats: Number of at bats for each player.
-    :param (jnp.DeviceArray) hits: Number of hits for the given at bats.
+    :param (jnp.ndarray) at_bats: Number of at bats for each player.
+    :param (jnp.ndarray) hits: Number of hits for the given at bats.
     :return: Number of hits predicted by the model.
     """
     phi_prior = dist.Uniform(0, 1)
@@ -86,8 +86,8 @@ def not_pooled(at_bats, hits=None):
     Number of hits in $K$ at bats for each player has a Binomial
     distribution with independent probability of success, $\phi_i$.
 
-    :param (jnp.DeviceArray) at_bats: Number of at bats for each player.
-    :param (jnp.DeviceArray) hits: Number of hits for the given at bats.
+    :param (jnp.ndarray) at_bats: Number of at bats for each player.
+    :param (jnp.ndarray) hits: Number of hits for the given at bats.
     :return: Number of hits predicted by the model.
     """
     num_players = at_bats.shape[0]
@@ -105,8 +105,8 @@ def partially_pooled(at_bats, hits=None):
     $c_1 = m * kappa$, $c_2 = (1 - m) * kappa$, $m ~ Uniform(0, 1)$,
     and $kappa ~ Pareto(1, 1.5)$.
 
-    :param (jnp.DeviceArray) at_bats: Number of at bats for each player.
-    :param (jnp.DeviceArray) hits: Number of hits for the given at bats.
+    :param (jnp.ndarray) at_bats: Number of at bats for each player.
+    :param (jnp.ndarray) hits: Number of hits for the given at bats.
     :return: Number of hits predicted by the model.
     """
     m = numpyro.sample("m", dist.Uniform(0, 1))
@@ -124,8 +124,8 @@ def partially_pooled_with_logit(at_bats, hits=None):
     The logits $\alpha$ for each player is normally distributed with the
     mean and scale parameters sharing a common prior.
 
-    :param (jnp.DeviceArray) at_bats: Number of at bats for each player.
-    :param (jnp.DeviceArray) hits: Number of hits for the given at bats.
+    :param (jnp.ndarray) at_bats: Number of at bats for each player.
+    :param (jnp.ndarray) hits: Number of hits for the given at bats.
     :return: Number of hits predicted by the model.
     """
     loc = numpyro.sample("loc", dist.Normal(-1, 1))

--- a/numpyro/contrib/control_flow/scan.py
+++ b/numpyro/contrib/control_flow/scan.py
@@ -4,14 +4,7 @@
 from collections import OrderedDict
 from functools import partial
 
-from jax import (
-    device_put,
-    lax,
-    random,
-    tree_flatten,
-    tree_map,
-    tree_unflatten
-)
+from jax import device_put, lax, random, tree_flatten, tree_map, tree_unflatten
 import jax.numpy as jnp
 
 from numpyro import handlers

--- a/numpyro/contrib/control_flow/scan.py
+++ b/numpyro/contrib/control_flow/scan.py
@@ -10,8 +10,7 @@ from jax import (
     random,
     tree_flatten,
     tree_map,
-    tree_multimap,
-    tree_unflatten,
+    tree_unflatten
 )
 import jax.numpy as jnp
 
@@ -174,7 +173,7 @@ def scan_enum(
                 carry_shapes.append([jnp.shape(x) for x in tree_flatten(new_carry)[0]])
             # make new_carry have the same shape as carry
             # FIXME: is this rigorous?
-            new_carry = tree_multimap(
+            new_carry = tree_map(
                 lambda a, b: jnp.reshape(a, jnp.shape(b)), new_carry, carry
             )
         return (i + 1, rng_key, new_carry), (PytreeTrace(trace), y)
@@ -192,7 +191,7 @@ def scan_enum(
                 )
                 if i > 0:
                     # reshape y1, y2,... to have the same shape as y0
-                    y0 = tree_multimap(
+                    y0 = tree_map(
                         lambda z0, z: jnp.reshape(z, jnp.shape(z0)), y0s[0], y0
                     )
                 y0s.append(y0)
@@ -204,7 +203,7 @@ def scan_enum(
                     )
             else:
                 # this is the last rolling step
-                y0s = tree_multimap(lambda *z: jnp.stack(z, axis=0), *y0s)
+                y0s = tree_map(lambda *z: jnp.stack(z, axis=0), *y0s)
                 # return early if length = unroll_steps
                 if length == unroll_steps:
                     return wrapped_carry, (PytreeTrace({}), y0s)
@@ -234,11 +233,11 @@ def scan_enum(
         site["infer"]["dim_to_name"][time_dim] = "_time_{}".format(first_var)
 
     # similar to carry, we need to reshape due to shape alternating in markov
-    ys = tree_multimap(
+    ys = tree_map(
         lambda z0, z: jnp.reshape(z, z.shape[:1] + jnp.shape(z0)[1:]), y0s, ys
     )
     # then join with y0s
-    ys = tree_multimap(lambda z0, z: jnp.concatenate([z0, z], axis=0), y0s, ys)
+    ys = tree_map(lambda z0, z: jnp.concatenate([z0, z], axis=0), y0s, ys)
     # we also need to reshape `carry` to match sequential behavior
     i = (length + 1) % (history + 1)
     t, rng_key, carry = wrapped_carry

--- a/numpyro/contrib/einstein/steinvi.py
+++ b/numpyro/contrib/einstein/steinvi.py
@@ -272,10 +272,10 @@ class SteinVI:
                 return force.reshape(attr_force.shape)
 
             reparam_jac = {
-                name: jax.tree_map(lambda var: _nontrivial_jac(name, var), variables)
+                name: tree_map(lambda var: _nontrivial_jac(name, var), variables)
                 for name, variables in unravel_pytree(particle).items()
             }
-            jac_params = jax.tree_multimap(
+            jac_params = tree_map(
                 _update_force,
                 unravel_pytree(attr_forces),
                 unravel_pytree(rep_forces),

--- a/numpyro/contrib/einstein/util.py
+++ b/numpyro/contrib/einstein/util.py
@@ -3,7 +3,7 @@
 
 from jax import numpy as jnp, vmap
 from jax.flatten_util import ravel_pytree
-from jax.tree_util import tree_map, tree_multimap
+from jax.tree_util import tree_map
 
 from numpyro.distributions import biject_to
 from numpyro.distributions.constraints import real
@@ -82,7 +82,7 @@ def batch_ravel_pytree(pytree, nbatch_dims=0):
     return (
         flat,
         unravel_fn,
-        lambda _flat: tree_multimap(
+        lambda _flat: tree_map(
             lambda x, shape: x.reshape(shape), vmap(unravel_fn)(_flat), shapes
         ),
     )

--- a/numpyro/distributions/continuous.py
+++ b/numpyro/distributions/continuous.py
@@ -248,20 +248,8 @@ class Dirichlet(Distribution):
 
     def sample(self, key, sample_shape=()):
         assert is_prng_key(key)
-        shape = sample_shape + self.batch_shape + self.event_shape
-        key_gamma, key_expon = random.split(key)
-        # To improve precision for the cases concentration << 1,
-        # we boost concentration to concentration + 1 and get gamma samples according to
-        #   Gamma(concentration) ~ Gamma(concentration+1) * Uniform()^(1 / concentration)
-        # When concentration << 1, u^(1 / concentration) is very near 0 and lost precision, so
-        # we will convert the samples to log space
-        #   log(Gamma(concentration)) ~ log(Gamma(concentration + 1)) - Expon() / concentration
-        # and apply softmax to get a dirichlet sample
-        gamma_samples = random.gamma(key_gamma, self.concentration + 1, shape=shape)
-        expon_samples = random.exponential(key_expon, shape=shape)
-        samples = nn.softmax(
-            jnp.log(gamma_samples) - expon_samples / self.concentration, -1
-        )
+        shape = sample_shape + self.batch_shape
+        samples = random.dirichlet(key, self.concentration, shape=shape)
         return jnp.clip(
             samples, a_min=jnp.finfo(samples).tiny, a_max=1 - jnp.finfo(samples).eps
         )

--- a/numpyro/infer/mcmc.py
+++ b/numpyro/infer/mcmc.py
@@ -13,7 +13,7 @@ from jax import jit, lax, local_device_count, pmap, random, vmap
 from jax.core import Tracer
 from jax.interpreters.xla import DeviceArray
 import jax.numpy as jnp
-from jax.tree_util import tree_flatten, tree_map, tree_multimap
+from jax.tree_util import tree_flatten, tree_map
 
 from numpyro.diagnostics import print_summary
 from numpyro.util import cached_by, find_stack_level, fori_collect, identity
@@ -161,7 +161,7 @@ def _laxmap(f, xs):
         x = jit(_get_value_from_index)(xs, i)
         ys.append(f(x))
 
-    return tree_multimap(lambda *args: jnp.stack(args), *ys)
+    return tree_map(lambda *args: jnp.stack(args), *ys)
 
 
 def _sample_fn_jit_args(state, sampler):

--- a/numpyro/infer/mcmc.py
+++ b/numpyro/infer/mcmc.py
@@ -10,8 +10,6 @@ import warnings
 import numpy as np
 
 from jax import jit, lax, local_device_count, pmap, random, vmap
-from jax.core import Tracer
-from jax.interpreters.xla import DeviceArray
 import jax.numpy as jnp
 from jax.tree_util import tree_flatten, tree_map
 

--- a/numpyro/infer/mcmc.py
+++ b/numpyro/infer/mcmc.py
@@ -187,13 +187,9 @@ def _collect_fn(collect_fields):
 
 # XXX: Is there a better hash key that we can use?
 def _hashable(x):
-    # When the arguments are JITed, ShapedArray is hashable.
-    if isinstance(x, Tracer):
-        return x
-    elif isinstance(x, DeviceArray):
-        return x.copy().tobytes()
-    elif isinstance(x, (np.ndarray, jnp.ndarray)):
-        return x.tobytes()
+    # NOTE: When the arguments are JITed, ShapedArray is hashable.
+    if isinstance(x, (np.ndarray, jnp.ndarray)):
+        return id(x)
     return x
 
 

--- a/test/contrib/einstein/test_einstein_util.py
+++ b/test/contrib/einstein/test_einstein_util.py
@@ -9,7 +9,7 @@ import pytest
 import scipy
 
 from jax import numpy as jnp
-from jax.tree_util import tree_flatten, tree_multimap
+from jax.tree_util import tree_flatten, tree_map
 
 from numpyro.contrib.einstein.util import (
     batch_ravel_pytree,
@@ -94,10 +94,10 @@ def test_safe_norm(axis, ord):
 def test_ravel_pytree_batched(pytree, nbatch_dims):
     flat, _, unravel_fn = batch_ravel_pytree(pytree, nbatch_dims)
     unravel = unravel_fn(flat)
-    tree_flatten(tree_multimap(lambda x, y: assert_allclose(x, y), unravel, pytree))
+    tree_flatten(tree_map(lambda x, y: assert_allclose(x, y), unravel, pytree))
     assert all(
         tree_flatten(
-            tree_multimap(
+            tree_map(
                 lambda x, y: jnp.result_type(x) == jnp.result_type(y), unravel, pytree
             )
         )[0]

--- a/test/contrib/test_nested_sampling.py
+++ b/test/contrib/test_nested_sampling.py
@@ -69,6 +69,7 @@ def test_log_normal(batch_shape, base_batch_shape, event_shape):
 
 
 @pytest.mark.parametrize("rho", [-0.7, 0.8])
+@pytest.mark.filterwarnings("ignore:.*tree_multimap:FutureWarning")
 def test_dense_mass(rho):
     true_cov = jnp.array([[10.0, rho], [rho, 0.1]])
 

--- a/test/infer/test_infer_util.py
+++ b/test/infer/test_infer_util.py
@@ -87,7 +87,7 @@ def test_predictive_with_guide():
         numpyro.sample("beta", dist.Beta(alpha_q, beta_q))
 
     svi = SVI(model, guide, optim.Adam(0.1), Trace_ELBO())
-    svi_result = svi.run(random.PRNGKey(1), 3000, data)
+    svi_result = svi.run(random.PRNGKey(1), 5000, data)
     params = svi_result.params
     predictive = Predictive(model, guide=guide, params=params, num_samples=1000)(
         random.PRNGKey(2), data=None

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -879,6 +879,7 @@ def test_sample_gradient(jax_dist, sp_dist, params):
     gamma_derived_params = {
         "Gamma": ["concentration"],
         "Beta": ["concentration1", "concentration0"],
+        "BetaProportion": ["mean", "concentration"],
         "Chi2": ["df"],
         "Dirichlet": ["concentration"],
         "InverseGamma": ["concentration"],

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -14,7 +14,7 @@ import scipy
 import scipy.stats as osp
 
 import jax
-from jax import grad, lax, vmap
+from jax import grad, lax, tree_map, vmap
 import jax.numpy as jnp
 import jax.random as random
 from jax.scipy.special import expit, logsumexp
@@ -2335,7 +2335,7 @@ def test_expand_pytree():
         return dist.Normal(x, 1).expand([10, 3])
 
     assert lax.map(g, jnp.ones((5, 3))).batch_shape == (5, 10, 3)
-    assert jax.tree_map(lambda x: x[None], g(0)).batch_shape == (1, 10, 3)
+    assert tree_map(lambda x: x[None], g(0)).batch_shape == (1, 10, 3)
 
 
 @pytest.mark.parametrize("batch_shape", [(), (4,), (2, 3)], ids=str)

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -780,7 +780,7 @@ def test_dist_shape(jax_dist, sp_dist, params, prepend_shape):
     rng_key = random.PRNGKey(0)
     expected_shape = prepend_shape + jax_dist.batch_shape + jax_dist.event_shape
     samples = jax_dist.sample(key=rng_key, sample_shape=prepend_shape)
-    assert isinstance(samples, jax.interpreters.xla.DeviceArray)
+    assert isinstance(samples, jnp.ndarray)
     assert jnp.shape(samples) == expected_shape
     if (
         sp_dist

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -1046,7 +1046,7 @@ def test_log_prob(jax_dist, sp_dist, params, prepend_shape, jit):
     except ValueError as e:
         # precision issue: jnp.sum(x / jnp.sum(x)) = 0.99999994 != 1
         if "The input vector 'x' must lie within the normal simplex." in str(e):
-            samples = samples.copy().astype("float64")
+            samples = jax.device_get(samples).astype("float64")
             samples = samples / samples.sum(axis=-1, keepdims=True)
             expected = sp_dist.logpdf(samples)
         else:

--- a/test/test_handlers.py
+++ b/test/test_handlers.py
@@ -5,7 +5,7 @@ import numpy as np
 from numpy.testing import assert_allclose, assert_raises
 import pytest
 
-from jax import jit, random, tree_multimap, value_and_grad, vmap
+from jax import jit, random, tree_map, value_and_grad, vmap
 import jax.numpy as jnp
 
 import numpyro
@@ -434,7 +434,7 @@ def test_subsample_gradient(scale, subsample):
                 svi_state.rng_key, svi.constrain_fn(x), svi.model, svi.guide, subsample
             )
         )(params)
-        grads = tree_multimap(lambda *vals: vals[0] + vals[1], grads1, grads2)
+        grads = tree_map(lambda *vals: vals[0] + vals[1], grads1, grads2)
         loss = loss1 + loss2
     else:
         subsample = jnp.array([0, 1])

--- a/test/test_handlers.py
+++ b/test/test_handlers.py
@@ -5,6 +5,7 @@ import numpy as np
 from numpy.testing import assert_allclose, assert_raises
 import pytest
 
+import jax
 from jax import jit, random, tree_map, value_and_grad, vmap
 import jax.numpy as jnp
 
@@ -777,7 +778,7 @@ def test_subsample_fn():
         )
 
         # test that values are not duplicated
-        assert len(set(subsamples[k].copy())) == subsample_size
+        assert len(set(jax.device_get(subsamples[k]))) == subsample_size
 
 
 def test_sites_have_unique_names():

--- a/test/test_optimizers.py
+++ b/test/test_optimizers.py
@@ -57,6 +57,7 @@ def step(opt_state, optim):
     ]
     + optax_optimizers,
 )
+@pytest.mark.filterwarnings("ignore:.*tree_multimap:FutureWarning")
 def test_optim_multi_params(optim_class, args, kwargs):
     params = {"x": jnp.array([1.0, 1.0, 1.0]), "y": jnp.array([-1, -1.0, -1.0])}
     opt = optim_class(*args, **kwargs)
@@ -84,6 +85,7 @@ def test_optim_multi_params(optim_class, args, kwargs):
     ]
     + optax_optimizers,
 )
+@pytest.mark.filterwarnings("ignore:.*tree_multimap:FutureWarning")
 def test_numpyrooptim_no_double_jit(optim_class, args, kwargs):
 
     opt = optim_class(*args, **kwargs)

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -9,7 +9,7 @@ from jax import random
 from jax.flatten_util import ravel_pytree
 import jax.numpy as jnp
 from jax.test_util import check_eq
-from jax.tree_util import tree_flatten, tree_multimap
+from jax.tree_util import tree_flatten, tree_map
 
 import numpyro
 import numpyro.distributions as dist
@@ -82,10 +82,10 @@ def test_fori_collect_return_last(progbar):
 def test_ravel_pytree(pytree):
     flat, unravel_fn = ravel_pytree(pytree)
     unravel = unravel_fn(flat)
-    tree_flatten(tree_multimap(lambda x, y: assert_allclose(x, y), unravel, pytree))
+    tree_flatten(tree_map(lambda x, y: assert_allclose(x, y), unravel, pytree))
     assert all(
         tree_flatten(
-            tree_multimap(
+            tree_map(
                 lambda x, y: jnp.result_type(x) == jnp.result_type(y), unravel, pytree
             )
         )[0]


### PR DESCRIPTION
After JAX 0.3.5, all MCMC codes are broken because we use `x.copy().tobytes()` to hash model's argument. Not only it is broken now, it was also my mistake to use that expensive operator for caching (this might be the reason for #936). I just tested that just simply using `id`, `test/infer/test_mcmc.py::test_compile_warmup_run` is still working as expected.

Also changing `tree_multimap` to `tree_map` because the former is just a duplicated version of the latter, and `tree_multimap` is deprecated now.