### PR TITLE
Fix/bvm sampler

### DIFF
--- a/numpyro/contrib/einstein/kernels.py
+++ b/numpyro/contrib/einstein/kernels.py
@@ -4,14 +4,15 @@
 from abc import ABC, abstractmethod
 from typing import Callable, Dict, List, Tuple
 
+import numpy as np
+
+from jax import random
 import jax.numpy as jnp
 import jax.scipy.linalg
 import jax.scipy.stats
-import numpy as np
-from jax import random
 
-import numpyro.distributions as dist
 from numpyro.contrib.einstein.util import safe_norm, sqrth_and_inv_sqrth
+import numpyro.distributions as dist
 
 
 class PrecondMatrix(ABC):
@@ -337,10 +338,6 @@ class MixtureKernel(SteinKernel):
         for kf in self.kernel_fns:
             rng_key, krng_key = random.split(rng_key)
             kf.init(krng_key, particles_shape)
-
-
-class GaussianProbabilityProductKernel(SteinKernel):
-    pass
 
 
 class HessianPrecondMatrix(PrecondMatrix):

--- a/numpyro/contrib/einstein/kernels.py
+++ b/numpyro/contrib/einstein/kernels.py
@@ -4,15 +4,14 @@
 from abc import ABC, abstractmethod
 from typing import Callable, Dict, List, Tuple
 
-import numpy as np
-
-from jax import random
 import jax.numpy as jnp
 import jax.scipy.linalg
 import jax.scipy.stats
+import numpy as np
+from jax import random
 
-from numpyro.contrib.einstein.util import safe_norm, sqrth_and_inv_sqrth
 import numpyro.distributions as dist
+from numpyro.contrib.einstein.util import safe_norm, sqrth_and_inv_sqrth
 
 
 class PrecondMatrix(ABC):
@@ -338,6 +337,10 @@ class MixtureKernel(SteinKernel):
         for kf in self.kernel_fns:
             rng_key, krng_key = random.split(rng_key)
             kf.init(krng_key, particles_shape)
+
+
+class GaussianProbabilityProductKernel(SteinKernel):
+    pass
 
 
 class HessianPrecondMatrix(PrecondMatrix):

--- a/numpyro/distributions/directional.py
+++ b/numpyro/distributions/directional.py
@@ -467,7 +467,7 @@ class SineBivariateVonMises(Distribution):
                 (phi + jnp.reshape(self.phi_loc, -1) + pi) % (2 * pi) - pi,
                 (psi + jnp.reshape(self.psi_loc, -1) + pi) % (2 * pi) - pi,
             ),
-            axis=-1,
+            axis=1,
         )
         phi_psi = jnp.transpose(phi_psi, (0, 2, 1))
         return phi_psi.reshape(*sample_shape, *self.batch_shape, *self.event_shape)
@@ -505,7 +505,9 @@ class SineBivariateVonMises(Distribution):
             )
             assert lg_inv.shape == lf.shape
 
-            accepted = random.uniform(accept_key, shape) < jnp.exp(lf + lg_inv)
+            accepted = random.uniform(accept_key, (shape[0], shape[2]))[
+                :, None
+            ] < jnp.exp(lf + lg_inv)
 
             phi = jnp.where(accepted, x, phi)
             return PhiMarginalState(i + 1, done | accepted, phi, key)


### PR DESCRIPTION
Fixed sampling in sine distribution. The accept-reject sampler can accept only one dimension of the ACG envelope distribution.