### PR TITLE
add LogUniform

### DIFF
--- a/numpyro/distributions/__init__.py
+++ b/numpyro/distributions/__init__.py
@@ -33,6 +33,7 @@ from numpyro.distributions.continuous import (
     Logistic,
     LogNormal,
     LowRankMultivariateNormal,
+    LogUniform,
     MultivariateNormal,
     MultivariateStudentT,
     Normal,

--- a/numpyro/distributions/continuous.py
+++ b/numpyro/distributions/continuous.py
@@ -1033,6 +1033,33 @@ class Logistic(Distribution):
         return self.loc + self.scale * logit(q)
 
 
+class LogUniform(TransformedDistribution):
+    arg_constraints = {"low": constraints.positive, "high": constraints.positive}
+    support = constraints.positive
+    reparametrized_params = ["low", "high"]
+
+    def __init__(self, low=1., high=10., *, validate_args=None):
+        base_dist = Uniform(jnp.log(low), jnp.log(high))
+        self.low, self.high = low, high
+        super(LogUniform, self).__init__(
+            base_dist, ExpTransform(), validate_args=validate_args
+        )
+
+    @property
+    def mean(self):
+        return (self.high - self.low) / jnp.log(self.high / self.low)
+
+    @property
+    def variance(self):
+        return 0.5 * (self.high**2 - self.low**2) / jnp.log(self.high / self.low) - self.mean**2
+
+    def tree_flatten(self):
+        return super(TransformedDistribution, self).tree_flatten()
+
+    def cdf(self, x):
+        return self.base_dist.cdf(jnp.log(x))
+
+
 def _batch_mahalanobis(bL, bx):
     if bL.shape[:-1] == bx.shape:
         # no need to use the below optimization procedure


### PR DESCRIPTION
adds loguniform dist as in #1398. note

- no docs yet. no docstrings in other distributions. how do I doc this?
- no tests yet, I'm looking into it
- the low and high bounds are those of the un-logged parameter, i.e. `LogUniform(1, 10)` means `log_10 X` is uniform between 0 and 1.
