### PR TITLE
set self._postprocess_fn = None in BarkerMH

### DIFF
--- a/numpyro/infer/barker.py
+++ b/numpyro/infer/barker.py
@@ -132,7 +132,7 @@ class BarkerMH(MCMCKernel):
         self._dense_mass = dense_mass
         self._target_accept_prob = target_accept_prob
         self._init_strategy = init_strategy
-        #self._postprocess_fn = None
+        self._postprocess_fn = None
 
     @property
     def model(self):

--- a/numpyro/infer/barker.py
+++ b/numpyro/infer/barker.py
@@ -132,6 +132,7 @@ class BarkerMH(MCMCKernel):
         self._dense_mass = dense_mass
         self._target_accept_prob = target_accept_prob
         self._init_strategy = init_strategy
+        #self._postprocess_fn = None
 
     @property
     def model(self):

--- a/test/infer/test_mcmc.py
+++ b/test/infer/test_mcmc.py
@@ -35,10 +35,8 @@ def test_unnormalized_normal_x64(kernel_cls, dense_mass):
         return 0.5 * jnp.sum(((z - true_mean) / true_std) ** 2)
 
     init_params = jnp.array(0.0)
-    if kernel_cls is SA:
-        kernel = SA(potential_fn=potential_fn, dense_mass=dense_mass)
-    elif kernel_cls is BarkerMH:
-        kernel = SA(potential_fn=potential_fn, dense_mass=dense_mass)
+    if kernel_cls in [SA, BarkerMH]:
+        kernel = kernel_cls(potential_fn=potential_fn, dense_mass=dense_mass)
     else:
         kernel = kernel_cls(
             potential_fn=potential_fn, trajectory_length=8, dense_mass=dense_mass


### PR DESCRIPTION
i found this is necessary to use BarkerMH with a `potential_fn` so i'm a bit confused why some of the tests in `test_mcmc.py` pass, but in any case some logic like this seems to be missing