### PR TITLE
An alternative implementation of general finite mixture models

### DIFF
--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -532,6 +532,10 @@ ZeroInflatedNegativeBinomial2
 Mixture Distributions
 ---------------------
 
+Mixture
+^^^^^^^
+.. autofunction:: numpyro.distributions.mixtures.Mixture
+
 MixtureSameFamily
 ^^^^^^^^^^^^^^^^^
 .. autoclass:: numpyro.distributions.mixtures.MixtureSameFamily

--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -540,6 +540,13 @@ MixtureSameFamily
     :show-inheritance:
     :member-order: bysource
 
+MixtureGeneral
+^^^^^^^^^^^^^^
+.. autoclass:: numpyro.distributions.mixtures.MixtureGeneral
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :member-order: bysource
 
 Directional Distributions
 -------------------------

--- a/numpyro/distributions/__init__.py
+++ b/numpyro/distributions/__init__.py
@@ -84,7 +84,11 @@ from numpyro.distributions.distribution import (
     Unit,
 )
 from numpyro.distributions.kl import kl_divergence
-from numpyro.distributions.mixtures import MixtureSameFamily
+from numpyro.distributions.mixtures import (
+    Mixture,
+    MixtureSameFamily,
+    MixtureGeneral,
+)
 from numpyro.distributions.transforms import biject_to
 from numpyro.distributions.truncated import (
     LeftTruncatedDistribution,
@@ -147,7 +151,9 @@ __all__ = [
     "Logistic",
     "LogNormal",
     "MaskedDistribution",
+    "Mixture",
     "MixtureSameFamily",
+    "MixtureGeneral",
     "Multinomial",
     "MultinomialLogits",
     "MultinomialProbs",

--- a/numpyro/distributions/__init__.py
+++ b/numpyro/distributions/__init__.py
@@ -84,11 +84,7 @@ from numpyro.distributions.distribution import (
     Unit,
 )
 from numpyro.distributions.kl import kl_divergence
-from numpyro.distributions.mixtures import (
-    Mixture,
-    MixtureSameFamily,
-    MixtureGeneral,
-)
+from numpyro.distributions.mixtures import Mixture, MixtureGeneral, MixtureSameFamily
 from numpyro.distributions.transforms import biject_to
 from numpyro.distributions.truncated import (
     LeftTruncatedDistribution,

--- a/numpyro/distributions/mixtures.py
+++ b/numpyro/distributions/mixtures.py
@@ -10,6 +10,21 @@ from numpyro.distributions.discrete import CategoricalLogits, CategoricalProbs
 from numpyro.distributions.util import is_prng_key, validate_sample
 
 
+def Mixture(mixing_distribution, distributions, *, validate_args=None):
+    """
+    Mixture distribution.
+
+    :param numpyro.distribution.Distribution mixing_distribution:
+        The mixing distribution to select the components. Must be a Categorical.
+    :param distributions: Either a list of component distributions or a single vectorized distribution.
+    :return: Either a MixtureGeneral or MixtureSameFamily distribution, depending on the type of
+        `distributions`.
+    """
+    if isinstance(distributions, Distribution):
+        return MixtureSameFamily(mixing_distribution, distributions, validate_args=validate_args)
+    return MixtureGeneral(mixing_distribution, distributions, validate_args=validate_args)
+
+
 class MixtureSameFamily(Distribution):
     """
     Marginalized Finite Mixture distribution of vectorized components.
@@ -40,11 +55,8 @@ class MixtureSameFamily(Distribution):
         self, mixing_distribution, component_distribution, *, validate_args=None
     ):
         # Check arguments
-        if not isinstance(mixing_distribution, (CategoricalLogits, CategoricalProbs)):
-            raise ValueError(
-                "The mixing distribution need to be a numpyro.distributions.Categorical. "
-                f"However, it is of type {type(mixing_distribution)}"
-            )
+        _check_mixing_distribution(mixing_distribution)
+
         mixture_size = mixing_distribution.probs.shape[-1]
         if not isinstance(component_distribution, Distribution):
             raise ValueError(
@@ -211,3 +223,208 @@ class MixtureSameFamily(Distribution):
         component_log_probs = self.component_distribution.log_prob(value)
         sum_log_probs = self.mixing_distribution.logits + component_log_probs
         return jax.nn.logsumexp(sum_log_probs, axis=-1)
+
+
+class MixtureGeneral(Distribution):
+    def __init__(
+        self, mixing_distribution, distributions, *, validate_args=None
+    ):
+        _check_mixing_distribution(mixing_distribution)
+
+        self._mixture_size = jnp.shape(mixing_distribution.probs)[-1]
+        if isinstance(distributions, Distribution):
+            distributions = [distributions] * self.mixture_size
+        try:
+            distributions = list(distributions)
+        except TypeError:
+            raise ValueError(
+                "The 'distributions' argument must be a list of Distribution objects"
+            )
+        for d in distributions:
+            if not isinstance(d, Distribution):
+                raise ValueError(
+                    "All elements of 'distributions' must be instaces of "
+                    "numpyro.distributions.Distribution subclasses"
+                )
+        if len(distributions) != self.mixture_size:
+            raise ValueError(
+                "The number of elements in 'distributions' must match the mixture size; "
+                f"expected {self._mixture_size}, got {len(distributions)}"
+            )
+
+        # FIXME: It would be good to check the support, but __eq__ isn't implemented
+        #        properly for most constraints...
+        # if any(
+        #     d.support != distributions[0].support for d in distributions[1:]
+        # ):
+        #     raise ValueError("All distributions must have the same support.")
+
+        self._mixing_distribution = mixing_distribution
+        self._distributions = distributions
+
+        batch_shape = lax.broadcast_shapes(
+            mixing_distribution.batch_shape,
+            *(d.batch_shape for d in distributions),
+        )
+        event_shape = lax.broadcast_shapes(
+            mixing_distribution.event_shape,
+            *(d.event_shape for d in distributions),
+        )
+
+        super().__init__(
+            batch_shape=batch_shape,
+            event_shape=event_shape,
+            validate_args=validate_args,
+        )
+
+    @property
+    def mixture_size(self):
+        """
+        The number of distributions in the mixture
+
+        :return: number of mixtures.
+        :rtype: int
+        """
+        return self._mixture_size
+
+    @property
+    def mixing_distribution(self):
+        """
+        The mixing distribution
+
+        :return: Categorical distribution
+        :rtype: Categorical
+        """
+        return self._mixing_distribution
+
+    @property
+    def distributions(self):
+        """
+        The list of component distributions being mixed
+
+        :return: The list of component distributions
+        :rtype: List[Distribution]
+        """
+        return self._distributions
+
+    @property
+    def mixture_dim(self):
+        return -self.event_dim - 1
+
+    @constraints.dependent_property
+    def support(self):
+        return self.distributions[0].support
+
+    @property
+    def is_discrete(self):
+        return self.distributions[0].is_discrete
+
+    def tree_flatten(self):
+        mixing_flat, mixing_aux = self.mixing_distribution.tree_flatten()
+        dists_flat, dists_aux = zip(*(d.tree_flatten() for d in self.distributions))
+        params = (mixing_flat, dists_flat)
+        aux_data = (
+        (type(self.mixing_distribution), tuple(type(d) for d in self.distributions)),
+            (mixing_aux, dists_aux),
+        )
+        return params, aux_data
+
+    @classmethod
+    def tree_unflatten(cls, aux_data, params):
+        params_mix, params_dists = params
+        (cls_mix, cls_dists), (mixing_aux, dists_aux) = aux_data
+        mixing_dist = cls_mix.tree_unflatten(mixing_aux, params_mix)
+        distributions = [
+            c.tree_unflatten(a, p) for c, a, p in zip(cls_dists, dists_aux, params_dists)
+        ]
+        return cls(
+            mixing_distribution=mixing_dist, distributions=distributions
+        )
+
+    @property
+    def mean(self):
+        probs = self.mixing_distribution.probs
+        probs = probs.reshape(probs.shape + (1,) * self.event_dim)
+        means = jnp.stack([d.mean for d in self.distributions], axis=self.mixture_dim)
+        return jnp.sum(probs * means, axis=self.mixture_dim)
+
+    @property
+    def variance(self):
+        probs = self.mixing_distribution.probs
+        probs = probs.reshape(probs.shape + (1,) * self.event_dim)
+
+        means = jnp.stack([d.mean for d in self.distributions], axis=self.mixture_dim)
+        variances = jnp.stack([d.variance for d in self.distributions], axis=self.mixture_dim)
+
+        # E[Var(Y|X)]
+        mean_cond_var = jnp.sum(
+            probs * variances, axis=self.mixture_dim
+        )
+        # Variance is the expectation of the squared deviation of a random variable from its mean
+        sq_deviation = (
+            means - jnp.expand_dims(self.mean, axis=self.mixture_dim)
+        ) ** 2
+        # Var(E[Y|X])
+        var_cond_mean = jnp.sum(probs * sq_deviation, axis=self.mixture_dim)
+        # Law of total variance: Var(Y) = E[Var(Y|X)] + Var(E[Y|X])
+        return mean_cond_var + var_cond_mean
+
+    def cdf(self, samples):
+        """
+        The cumulative distribution function of this mixture distribution.
+
+        :param value: samples from this distribution.
+        :return: output of the cummulative distribution function evaluated at `value`.
+        :raises: NotImplementedError if the component distribution does not implement the cdf method.
+        """
+        cdfs = jnp.stack([d.cdf(samples) for d in self.distributions], axis=self.mixture_dim)
+        return jnp.sum(cdfs * self.mixing_distribution.probs, axis=-1)
+
+    def sample_with_intermediates(self, key, sample_shape=()):
+        assert is_prng_key(key)
+
+        key_ind, *key_comp = jax.random.split(key, 1 + len(self.distributions))
+
+        samples = []
+        for k, d in zip(key_comp, self.distributions):
+            samples.append(d.expand(sample_shape + self.batch_shape).sample(k))
+        samples = jnp.stack(samples, axis=self.mixture_dim)
+
+        indices = self.mixing_distribution.expand(
+            sample_shape + self.batch_shape
+        ).sample(key_ind)
+        n_expand = self.event_dim + 1
+        indices_expanded = indices.reshape(indices.shape + (1,) * n_expand)
+
+        samples_selected = jnp.take_along_axis(
+            samples, indices=indices_expanded, axis=self.mixture_dim
+        )
+
+        return jnp.squeeze(samples_selected, axis=self.mixture_dim), indices
+
+    def sample(self, key, sample_shape=()):
+        return self.sample_with_intermediates(
+            key=key, sample_shape=sample_shape
+        )[0]
+
+    @validate_sample
+    def component_log_probs(self, value):
+        component_log_probs = jnp.stack(
+            [d.log_prob(value) for d in self.distributions],
+            axis=self.mixture_dim,
+        )
+        return self.mixing_distribution.logits + component_log_probs
+
+    @validate_sample
+    def log_prob(self, value, intermediates=None):
+        del intermediates
+        log_probs = self.component_log_probs(value)
+        return jax.nn.logsumexp(log_probs, axis=self.mixture_dim)
+
+
+def _check_mixing_distribution(mixing_distribution):
+    if not isinstance(mixing_distribution, (CategoricalLogits, CategoricalProbs)):
+        raise ValueError(
+            "The mixing distribution must be a numpyro.distributions.Categorical. "
+            f"However, it is of type {type(mixing_distribution)}"
+        )

--- a/numpyro/distributions/mixtures.py
+++ b/numpyro/distributions/mixtures.py
@@ -28,10 +28,10 @@ def Mixture(mixing_distribution, component_distributions, *, validate_args=None)
         specifying the weights for each mixture components. The size of this
         distribution specifies the number of components in the mixture,
         ``mixture_size``.
-    :param distributions: Either a list of component distributions or a single
-        vectorized distribution. When a list is provided, the number of elements
-        must equal ``mixture_size``. Otherwise, the last batch dimension of the
-        distribution must equal ``mixture_size``.
+    :param component_distributions: Either a list of component distributions or
+        a single vectorized distribution. When a list is provided, the number of
+        elements must equal ``mixture_size``. Otherwise, the last batch
+        dimension of the distribution must equal ``mixture_size``.
     :return: The mixture distribution.
     """
     if isinstance(component_distributions, Distribution):

--- a/test/test_distributions_mixture.py
+++ b/test/test_distributions_mixture.py
@@ -15,12 +15,7 @@ def get_normal(batch_shape):
     """Get parameterized Normal with given batch shape."""
     loc = jnp.zeros(batch_shape)
     scale = jnp.ones(batch_shape)
-    # for i, s in enumerate(batch_shape):
-    #     loc = jnp.repeat(jnp.expand_dims(loc, i), s, axis=i)
-    #     scale = jnp.repeat(jnp.expand_dims(scale, i), s, axis=i)
-    # batch_shape = (*batch_shape, nb_mixtures)
     normal = dist.Normal(loc=loc, scale=scale)
-    # assert normal.batch_shape == batch_shape
     return normal
 
 

--- a/test/test_distributions_mixture.py
+++ b/test/test_distributions_mixture.py
@@ -11,60 +11,60 @@ import numpyro.distributions as dist
 rng_key = jax.random.PRNGKey(42)
 
 
-def get_normal(nb_mixtures, batch_shape):
+def get_normal(batch_shape):
     """Get parameterized Normal with given batch shape."""
-    loc = jnp.zeros(nb_mixtures)
-    scale = jnp.ones(nb_mixtures)
-    for i, s in enumerate(batch_shape):
-        loc = jnp.repeat(jnp.expand_dims(loc, i), s, axis=i)
-        scale = jnp.repeat(jnp.expand_dims(scale, i), s, axis=i)
-    batch_shape = (*batch_shape, nb_mixtures)
+    loc = jnp.zeros(batch_shape)
+    scale = jnp.ones(batch_shape)
+    # for i, s in enumerate(batch_shape):
+    #     loc = jnp.repeat(jnp.expand_dims(loc, i), s, axis=i)
+    #     scale = jnp.repeat(jnp.expand_dims(scale, i), s, axis=i)
+    # batch_shape = (*batch_shape, nb_mixtures)
     normal = dist.Normal(loc=loc, scale=scale)
-    assert normal.batch_shape == batch_shape
+    # assert normal.batch_shape == batch_shape
     return normal
 
 
-def get_mvn(nb_mixtures, batch_shape):
+def get_mvn(batch_shape):
     """Get parameterized MultivariateNormal with given batch shape."""
     dimensions = 2
-    loc = jnp.zeros((nb_mixtures, dimensions))
-    cov_matrix = jnp.repeat(
-        jnp.expand_dims(jnp.eye(dimensions, dimensions), 0), nb_mixtures, axis=0
-    )
+    loc = jnp.zeros((*batch_shape, dimensions))
+    cov_matrix = jnp.eye(dimensions, dimensions)
     for i, s in enumerate(batch_shape):
         loc = jnp.repeat(jnp.expand_dims(loc, i), s, axis=i)
         cov_matrix = jnp.repeat(jnp.expand_dims(cov_matrix, i), s, axis=i)
-    batch_shape = (*batch_shape, nb_mixtures)
     mvn = dist.MultivariateNormal(loc=loc, covariance_matrix=cov_matrix)
-    assert mvn.batch_shape == batch_shape
     return mvn
 
 
 @pytest.mark.parametrize("jax_dist_getter", [get_normal, get_mvn])
 @pytest.mark.parametrize("nb_mixtures", [1, 3])
 @pytest.mark.parametrize("batch_shape", [(), (1,), (7,), (2, 5)])
-def test_mixture_same_family_same_batch_shape(
-    jax_dist_getter, nb_mixtures, batch_shape
+@pytest.mark.parametrize("same_family", [True, False])
+def test_mixture_same_batch_shape(
+    jax_dist_getter, nb_mixtures, batch_shape, same_family
 ):
-    # Create mixture
     mixing_probabilities = jnp.ones(nb_mixtures) / nb_mixtures
     for i, s in enumerate(batch_shape):
         mixing_probabilities = jnp.repeat(
             jnp.expand_dims(mixing_probabilities, i), s, axis=i
         )
     assert jnp.allclose(mixing_probabilities.sum(axis=-1), 1.0)
-    component_distribution = jax_dist_getter(
-        nb_mixtures=nb_mixtures, batch_shape=batch_shape
-    )
     mixing_distribution = dist.Categorical(probs=mixing_probabilities)
-    _test_mixture_same_family(mixing_distribution, component_distribution)
+    if same_family:
+        component_distribution = jax_dist_getter((*batch_shape, nb_mixtures))
+    else:
+        component_distribution = [
+            jax_dist_getter(batch_shape) for _ in range(nb_mixtures)
+        ]
+    _test_mixture(mixing_distribution, component_distribution)
 
 
 @pytest.mark.parametrize("jax_dist_getter", [get_normal, get_mvn])
 @pytest.mark.parametrize("nb_mixtures", [3])
 @pytest.mark.parametrize("mixing_batch_shape, component_batch_shape", [[(2,), (7, 2)]])
-def test_mixture_same_family_broadcast_batch_shape(
-    jax_dist_getter, nb_mixtures, mixing_batch_shape, component_batch_shape
+@pytest.mark.parametrize("same_family", [True, False])
+def test_mixture_broadcast_batch_shape(
+    jax_dist_getter, nb_mixtures, mixing_batch_shape, component_batch_shape, same_family
 ):
     # Create mixture
     mixing_probabilities = jnp.ones(nb_mixtures) / nb_mixtures
@@ -73,29 +73,38 @@ def test_mixture_same_family_broadcast_batch_shape(
             jnp.expand_dims(mixing_probabilities, i), s, axis=i
         )
     assert jnp.allclose(mixing_probabilities.sum(axis=-1), 1.0)
-    component_distribution = jax_dist_getter(
-        nb_mixtures=nb_mixtures, batch_shape=component_batch_shape
-    )
     mixing_distribution = dist.Categorical(probs=mixing_probabilities)
-    _test_mixture_same_family(mixing_distribution, component_distribution)
+    if same_family:
+        component_distribution = jax_dist_getter((*component_batch_shape, nb_mixtures))
+    else:
+        component_distribution = [
+            jax_dist_getter(component_batch_shape) for _ in range(nb_mixtures)
+        ]
+    _test_mixture(mixing_distribution, component_distribution)
 
 
-def _test_mixture_same_family(mixing_distribution, component_distribution):
+def _test_mixture(mixing_distribution, component_distribution):
     # Create mixture
-    mixture = dist.MixtureSameFamily(
+    mixture = dist.Mixture(
         mixing_distribution=mixing_distribution,
-        component_distribution=component_distribution,
+        component_distributions=component_distribution,
     )
     assert (
         mixture.mixture_size == mixing_distribution.probs.shape[-1]
     ), "Mixture size needs to be the size of the probability vector"
-    assert (
-        mixture.batch_shape == component_distribution.batch_shape[:-1]
-    ), "Mixture batch shape needs to be the component batch shape without the mixture dimension."
+
+    if isinstance(component_distribution, dist.Distribution):
+        assert (
+            mixture.batch_shape == component_distribution.batch_shape[:-1]
+        ), "Mixture batch shape needs to be the component batch shape without the mixture dimension."
+    else:
+        assert (
+            mixture.batch_shape == component_distribution[0].batch_shape
+        ), "Mixture batch shape needs to be the component batch shape."
     # Test samples
     sample_shape = (11,)
-    # Samples from component distribution
-    component_samples = mixture.component_distribution.sample(rng_key, sample_shape)
+    # Samples from component distribution(s)
+    component_samples = mixture.component_sample(rng_key, sample_shape)
     assert component_samples.shape == (
         *sample_shape,
         *mixture.batch_shape,
@@ -125,6 +134,6 @@ def _test_mixture_same_family(mixing_distribution, component_distribution):
     var = mixture.variance
     assert var.shape == mixture.shape()
     # Check cdf
-    if isinstance(mixture.component_distribution, dist.Normal):
+    if mixture.event_shape == ():
         cdf = mixture.cdf(samples)
         assert cdf.shape == (*sample_shape, *mixture.shape())


### PR DESCRIPTION
For a project I needed a more general Mixture* distribution allowing for component distributions from different families. Since #1413 wasn't ready for use, I implemented my own version that is somewhat more complete and consistent with the existing `MixtureSameFamily` distribution. In case it would be of interest to this project, I figured I'd open this here. If the maintainers would like such a distribution be included, I'm happy to add some tests and respond to any feedback. If it's not of interest (with a preference for #1413 or otherwise), absolutely no worries and I'm happy to close this. Thanks!!