### PR TITLE
Draft of switch `StudentT` `cdf` to use tfp's `betainc`

### DIFF
--- a/numpyro/distributions/continuous.py
+++ b/numpyro/distributions/continuous.py
@@ -27,7 +27,6 @@
 
 import numpy as np
 
-import jax
 from jax import lax
 from jax.experimental.sparse import BCOO
 import jax.nn as nn

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
             "jaxns==1.0.0",
             "optax>=0.0.6",
             "pyyaml",  # flax dependency
-            "tensorflow_probability>=0.15.0",
+            "tensorflow_probability>=0.17.0",
         ],
         "examples": [
             "arviz",


### PR DESCRIPTION
Jax's `betainc` doesn't have gradients defined for all parameters while tfp's does.

See the related PR here: https://github.com/pyro-ppl/numpyro/pull/1471 and the initial discussion here: https://github.com/pyro-ppl/numpyro/issues/1452.

I'm not sure exactly how you want to handle the dependency declarations since `tensorflow` and `tensorflow-probability` are sort of heavy dependencies to bring in (i.e. should they be promoted to `install_requires`?).

Also, the type casting stuff is a bit ugly but tfp checks that array types match and `self.df` sometimes had a `float64` dtype in tests while `beta_value` has a `float32` dtype in each test.