### PR TITLE
Update diagnostics.py

### DIFF
--- a/numpyro/diagnostics.py
+++ b/numpyro/diagnostics.py
@@ -161,7 +161,7 @@ def effective_sample_size(x):
     :return: effective sample size of ``x``.
     :rtype: numpy.ndarray
     """
-
+    x = device_get(x)
     assert x.ndim >= 2
     assert x.shape[1] >= 2
 


### PR DESCRIPTION
In `numpyro.diagnostics` , the `effective_sample_size` could throw a jax immutable array error if the user uses a jax array as input. Updating this with a conversion from jax array to np array using `jax.device_get` could remove this error. Other functions in diagnostics do not have the same problem as they do not use item assignment.