### PR TITLE
Modify ExpTransform to return a positive ordered vector when the domain is ordered vector

### DIFF
--- a/numpyro/distributions/transforms.py
+++ b/numpyro/distributions/transforms.py
@@ -458,7 +458,9 @@ class ExpTransform(Transform):
 
     @property
     def codomain(self):
-        if self.domain is constraints.real:
+        if self.domain is constraints.ordered_vector:
+            return constraints.positive_ordered_vector
+        elif self.domain is constraints.real:
             return constraints.positive
         elif isinstance(self.domain, constraints.greater_than):
             return constraints.greater_than(self.__call__(self.domain.lower_bound))

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(
             "sphinx-gallery",
         ],
         "test": [
+            "importlib-metadata<5.0",
             "black[jupyter]>=21.8b0",
             "flake8",
             "isort>=5.0",


### PR DESCRIPTION
As per [this comment](https://forum.pyro.ai/t/composetransform-not-working-when-combining-positive-and-ordered-transform/4660/2) by @fehiepsi