### PR TITLE
Distribution flatten/unflatten: Do not sort attrs.

### DIFF
--- a/numpyro/distributions/distribution.py
+++ b/numpyro/distributions/distribution.py
@@ -142,15 +142,13 @@ class Distribution(metaclass=DistributionMeta):
 
     def tree_flatten(self):
         return (
-            tuple(
-                getattr(self, param) for param in sorted(self.arg_constraints.keys())
-            ),
+            tuple(getattr(self, param) for param in self.arg_constraints.keys()),
             None,
         )
 
     @classmethod
     def tree_unflatten(cls, aux_data, params):
-        return cls(**dict(zip(sorted(cls.arg_constraints.keys()), params)))
+        return cls(**dict(zip(cls.arg_constraints.keys(), params)))
 
     @staticmethod
     def set_default_validate_args(value):


### PR DESCRIPTION
Currently, `Distribution.tree_flatten` sorts distribution attrs alphabetically, so the order is sometimes different from what is declared in the definition, e.g. the beta distribution `Beta(concentration1, concentration0).tree_flatten() = (concentration0, concentration1)`. With this PR, attrs are used in the same order as declared within `Distribution.arg_constraints`.