### PR TITLE
Fixed `log_prob` for negative correlation in `SineBivariateVonMises`

### DIFF
--- a/numpyro/distributions/directional.py
+++ b/numpyro/distributions/directional.py
@@ -399,7 +399,7 @@ class SineBivariateVonMises(Distribution):
         lbinoms = num - 2 * den
 
         fs = lbinoms.reshape(-1, 1) + m * (
-            jnp.log(jnp.clip(corr**2, a_min=jnp.finfo(float).tiny))
+            jnp.log(jnp.clip(corr**2, a_min=jnp.finfo(jnp.result_type(float)).tiny))
             - jnp.log(4 * jnp.prod(conc, axis=-1))
         )
         fs += log_I1(49, conc, terms=51).sum(-1)

--- a/numpyro/distributions/directional.py
+++ b/numpyro/distributions/directional.py
@@ -389,7 +389,7 @@ class SineBivariateVonMises(Distribution):
 
     @lazy_property
     def norm_const(self):
-        corr = jnp.reshape(self.correlation, (1, -1)) + 1e-8
+        corr = jnp.reshape(self.correlation, (1, -1))
         conc = jnp.stack(
             (self.phi_concentration, self.psi_concentration), axis=-1
         ).reshape(-1, 2)
@@ -400,7 +400,7 @@ class SineBivariateVonMises(Distribution):
 
         fs = (
             lbinoms.reshape(-1, 1)
-            + 2 * m * jnp.log(corr)
+            + m * jnp.log(corr**2)
             - m * jnp.log(4 * jnp.prod(conc, axis=-1))
         )
         fs += log_I1(49, conc, terms=51).sum(-1)

--- a/numpyro/distributions/directional.py
+++ b/numpyro/distributions/directional.py
@@ -398,14 +398,12 @@ class SineBivariateVonMises(Distribution):
         den = special.gammaln(m + 1.0)
         lbinoms = num - 2 * den
 
-        fs = (
-            lbinoms.reshape(-1, 1)
-            + m * jnp.log(corr**2)
-            - m * jnp.log(4 * jnp.prod(conc, axis=-1))
+        fs = lbinoms.reshape(-1, 1) + m * (
+            jnp.log(jnp.clip(corr**2, a_min=jnp.finfo(float).tiny))
+            - jnp.log(4 * jnp.prod(conc, axis=-1))
         )
         fs += log_I1(49, conc, terms=51).sum(-1)
-        mfs = fs.max()
-        norm_const = 2 * jnp.log(jnp.array(2 * pi)) + mfs + logsumexp(fs - mfs, 0)
+        norm_const = 2 * jnp.log(jnp.array(2 * pi)) + logsumexp(fs, 0)
         return norm_const.reshape(jnp.shape(self.phi_loc))
 
     @validate_sample


### PR DESCRIPTION
Removes bias on correlation in `SBvM` normalization and fixes `NaN` in normalization for negative correlation (`corr < 0.`).  

From #1511. 