### PR TITLE
Avoid comparing constraints positive and unit_interval

### DIFF
--- a/numpyro/distributions/constraints.py
+++ b/numpyro/distributions/constraints.py
@@ -379,6 +379,11 @@ class _OpenInterval(_Interval):
         return fmt_string
 
 
+class _Circular(_Interval):
+    def __init__(self):
+        super().__init__(-math.pi, math.pi)
+
+
 class _LowerCholesky(Constraint):
     event_dim = 2
 
@@ -540,7 +545,7 @@ class _Sphere(Constraint):
 # See https://github.com/pytorch/pytorch/issues/50616
 
 boolean = _Boolean()
-circular = _Interval(-math.pi, math.pi)
+circular = _Circular()
 corr_cholesky = _CorrCholesky()
 corr_matrix = _CorrMatrix()
 dependent = _Dependent()

--- a/numpyro/distributions/transforms.py
+++ b/numpyro/distributions/transforms.py
@@ -1067,7 +1067,7 @@ def _transform_to_corr_matrix(constraint):
 
 @biject_to.register(constraints.greater_than)
 def _transform_to_greater_than(constraint):
-    if constraint is constraints.positive:
+    if constraint.lower_bound in [0, 0.0]:
         return ExpTransform()
     return ComposeTransform(
         [
@@ -1097,7 +1097,7 @@ def _biject_to_independent(constraint):
 @biject_to.register(constraints.open_interval)
 @biject_to.register(constraints.interval)
 def _transform_to_interval(constraint):
-    if constraint is constraints.unit_interval:
+    if (constraint.lower_bound in [0, 0.0]) and (constraint.upper_bound in [1, 1.0]):
         return SigmoidTransform()
     scale = constraint.upper_bound - constraint.lower_bound
     return ComposeTransform(

--- a/numpyro/distributions/transforms.py
+++ b/numpyro/distributions/transforms.py
@@ -1067,8 +1067,6 @@ def _transform_to_corr_matrix(constraint):
 
 @biject_to.register(constraints.greater_than)
 def _transform_to_greater_than(constraint):
-    if constraint.lower_bound in [0, 0.0]:
-        return ExpTransform()
     return ComposeTransform(
         [
             ExpTransform(),
@@ -1097,8 +1095,6 @@ def _biject_to_independent(constraint):
 @biject_to.register(constraints.open_interval)
 @biject_to.register(constraints.interval)
 def _transform_to_interval(constraint):
-    if (constraint.lower_bound in [0, 0.0]) and (constraint.upper_bound in [1, 1.0]):
-        return SigmoidTransform()
     scale = constraint.upper_bound - constraint.lower_bound
     return ComposeTransform(
         [

--- a/numpyro/infer/util.py
+++ b/numpyro/infer/util.py
@@ -209,7 +209,10 @@ def _unconstrain_reparam(params, site):
             if jnp.ndim(p) > expected_unconstrained_dim:
                 p = p[i]
 
-        if support in [constraints.real, constraints.real_vector]:
+        if support is constraints.real or (
+            isinstance(support, constraints.independent)
+            and support.base_constraint is constraints.real
+        ):
             return p
         value = t(p)
 


### PR DESCRIPTION
Following #1507, this PR revises the logic for several unexpected usages which check for positive and unit_interval constraints.