### PR TITLE
Raise an error if there is no common scale when model enumerated

### DIFF
--- a/numpyro/infer/elbo.py
+++ b/numpyro/infer/elbo.py
@@ -970,7 +970,7 @@ class TraceEnum_ELBO(ELBO):
                         [
                             value
                             for plate, value in plate_to_scale.items()
-                            if (plate in f.inputs) or (plate is None)
+                            if plate in f.inputs
                         ]
                         for f in group_factors
                     )
@@ -986,7 +986,7 @@ class TraceEnum_ELBO(ELBO):
                         plates=group_plates,
                         eliminate=group_sum_vars | elim_plates,
                     )
-                    scale = None
+                    scale = plate_to_scale.get(None, None)
                     # combine deps
                     deps = frozenset().union(
                         *[model_deps[name] for name in group_names]

--- a/numpyro/infer/elbo.py
+++ b/numpyro/infer/elbo.py
@@ -952,38 +952,26 @@ class TraceEnum_ELBO(ELBO):
                         *(frozenset(f.inputs) & group_plates for f in group_factors)
                     )
                     elim_plates = group_plates - outermost_plates
-                    # incorporate the effects of subsampling and handlers.scale
-                    plate_to_scale = {}
-                    for name in group_names:
-                        for plate, value in (
-                            model_trace[name].get("plate_to_scale", {}).items()
-                        ):
-                            if plate in plate_to_scale:
-                                if value != plate_to_scale[plate]:
-                                    raise ValueError(
-                                        "Expected all enumerated sample sites to share a common scale factor, "
-                                        f"but found different scales at plate('{plate}')."
-                                    )
-                            else:
-                                plate_to_scale[plate] = to_funsor(value)
-
                     cost = funsor.sum_product.sum_product(
                         funsor.ops.logaddexp,
                         funsor.ops.add,
                         group_factors,
                         plates=group_plates,
                         eliminate=group_sum_vars | elim_plates,
-                        scales=plate_to_scale,
                     )
-                    scale = reduce(
-                        funsor.ops.mul,
+                    # incorporate the effects of subsampling and handlers.scale through a common scale factor
+                    scales_set = set(
                         [
-                            value
-                            for plate, value in plate_to_scale.items()
-                            if plate not in elim_plates
-                        ],
-                        funsor.Number(1.0),
+                            model_trace[name]["scale"]
+                            for name in (group_names | group_sum_vars)
+                        ]
                     )
+                    if len(scales_set) != 1:
+                        raise ValueError(
+                            "Expected all enumerated sample sites to share a common scale, "
+                            f"but found {len(scales_set)} different scales."
+                        )
+                    scale = next(iter(scales_set))
                     # combine deps
                     deps = frozenset().union(
                         *[model_deps[name] for name in group_names]

--- a/numpyro/infer/elbo.py
+++ b/numpyro/infer/elbo.py
@@ -960,12 +960,16 @@ class TraceEnum_ELBO(ELBO):
                         eliminate=group_sum_vars | elim_plates,
                     )
                     # incorporate the effects of subsampling and handlers.scale through a common scale factor
-                    scales_set = set(
-                        [
-                            model_trace[name]["scale"]
-                            for name in (group_names | group_sum_vars)
-                        ]
-                    )
+                    scales_set = set()
+                    for name in group_names | group_sum_vars:
+                        site_scale = model_trace[name]["scale"]
+                        if site_scale is None:
+                            site_scale = 1.0
+                        if isinstance(site_scale, jnp.ndarray) and site_scale.ndim:
+                            raise ValueError(
+                                "enumeration only supports scalar handlers.scale"
+                            )
+                        scales_set.add(float(site_scale))
                     if len(scales_set) != 1:
                         raise ValueError(
                             "Expected all enumerated sample sites to share a common scale, "

--- a/numpyro/infer/elbo.py
+++ b/numpyro/infer/elbo.py
@@ -965,9 +965,9 @@ class TraceEnum_ELBO(ELBO):
                         site_scale = model_trace[name]["scale"]
                         if site_scale is None:
                             site_scale = 1.0
-                        if isinstance(site_scale, jnp.ndarray) and site_scale.ndim:
+                        if isinstance(site_scale, jnp.ndarray):
                             raise ValueError(
-                                "enumeration only supports scalar handlers.scale"
+                                "Enumeration only supports scalar handlers.scale"
                             )
                         scales_set.add(float(site_scale))
                     if len(scales_set) != 1:

--- a/test/contrib/test_enum_elbo.py
+++ b/test/contrib/test_enum_elbo.py
@@ -2259,7 +2259,8 @@ def test_elbo_enumerate_plate_13():
 
 @pytest.mark.parametrize("scale", [1, 10])
 def test_model_enum_subsample_1(scale):
-    # Model: enumerate a
+    # Enumerate: a
+    # Subsample: b
     #  a - [-> b  ]
     @config_enumerate
     @handlers.scale(scale=scale)
@@ -2325,7 +2326,8 @@ def test_model_enum_subsample_1(scale):
 
 @pytest.mark.parametrize("scale", [1, 10])
 def test_model_enum_subsample_2(scale):
-    # Model: enumerate a
+    # Enumerate: a
+    # Subsample: b, c
     #  a - [-> b  ]
     #   \
     #    - [-> c  ]
@@ -2399,7 +2401,8 @@ def test_model_enum_subsample_2(scale):
 
 @pytest.mark.parametrize("scale", [1, 10])
 def test_model_enum_subsample_3(scale):
-    # Model: enumerate a
+    # Enumerate: a
+    # Subsample: a, b, c
     # [ a - [----> b    ]
     # [  \  [           ]
     # [   - [- [-> c  ] ]

--- a/test/contrib/test_enum_elbo.py
+++ b/test/contrib/test_enum_elbo.py
@@ -2385,6 +2385,12 @@ def test_model_enum_subsample_2(scale):
 
 @pytest.mark.parametrize("scale", [1, 10])
 def test_model_enum_subsample_3(scale):
+    #      +--------------------+
+    #      |       +----------+ |
+    #  a ----> b ----> c      | |
+    #      |       |      N=2 | |
+    #      | M=2   +----------+ |
+    #      +--------------------+
     @config_enumerate
     @handlers.scale(scale=scale)
     def model(params):

--- a/test/contrib/test_enum_elbo.py
+++ b/test/contrib/test_enum_elbo.py
@@ -139,7 +139,7 @@ def test_elbo_enumerate_1(scale):
     assert_equal(auto_grad, hand_grad, prec=1e-5)
 
 
-@pytest.mark.parametrize("scale", [1, 10])
+@pytest.mark.parametrize("scale", [1, 10, jnp.array(10)])
 def test_elbo_enumerate_2(scale):
     params = {}
     params["guide_probs_x"] = jnp.array([0.1, 0.9])

--- a/test/contrib/test_enum_elbo.py
+++ b/test/contrib/test_enum_elbo.py
@@ -139,7 +139,7 @@ def test_elbo_enumerate_1(scale):
     assert_equal(auto_grad, hand_grad, prec=1e-5)
 
 
-@pytest.mark.parametrize("scale", [1, 10, jnp.array(10)])
+@pytest.mark.parametrize("scale", [1, 10])
 def test_elbo_enumerate_2(scale):
     params = {}
     params["guide_probs_x"] = jnp.array([0.1, 0.9])

--- a/test/contrib/test_enum_elbo.py
+++ b/test/contrib/test_enum_elbo.py
@@ -2259,6 +2259,8 @@ def test_elbo_enumerate_plate_13():
 
 @pytest.mark.parametrize("scale", [1, 10])
 def test_model_enum_subsample_1(scale):
+    # Model: enumerate a
+    #  a - [-> b  ]
     @config_enumerate
     @handlers.scale(scale=scale)
     def model(params):
@@ -2311,14 +2313,22 @@ def test_model_enum_subsample_1(scale):
         }
         return elbo.loss(random.PRNGKey(0), {}, model_subsample, guide, params)
 
-    actual_loss, actual_grads = jax.value_and_grad(actual_loss_fn)(params_raw)
+    with pytest.raises(
+        ValueError, match="Expected all enumerated sample sites to share a common scale"
+    ):
+        # This never gets run because we don't support this yet.
+        actual_loss, actual_grads = jax.value_and_grad(actual_loss_fn)(params_raw)
 
-    assert_equal(actual_loss, expected_loss, prec=1e-5)
-    assert_equal(actual_grads, expected_grads, prec=1e-5)
+        assert_equal(actual_loss, expected_loss, prec=1e-5)
+        assert_equal(actual_grads, expected_grads, prec=1e-5)
 
 
 @pytest.mark.parametrize("scale", [1, 10])
 def test_model_enum_subsample_2(scale):
+    # Model: enumerate a
+    #  a - [-> b  ]
+    #   \
+    #    - [-> c  ]
     @config_enumerate
     @handlers.scale(scale=scale)
     def model(params):
@@ -2377,20 +2387,22 @@ def test_model_enum_subsample_2(scale):
         }
         return elbo.loss(random.PRNGKey(0), {}, model_subsample, guide, params)
 
-    actual_loss, actual_grads = jax.value_and_grad(actual_loss_fn)(params_raw)
+    with pytest.raises(
+        ValueError, match="Expected all enumerated sample sites to share a common scale"
+    ):
+        # This never gets run because we don't support this yet.
+        actual_loss, actual_grads = jax.value_and_grad(actual_loss_fn)(params_raw)
 
-    assert_equal(actual_loss, expected_loss, prec=1e-5)
-    assert_equal(actual_grads, expected_grads, prec=1e-5)
+        assert_equal(actual_loss, expected_loss, prec=1e-5)
+        assert_equal(actual_grads, expected_grads, prec=1e-5)
 
 
 @pytest.mark.parametrize("scale", [1, 10])
 def test_model_enum_subsample_3(scale):
-    #      +--------------------+
-    #      |       +----------+ |
-    #  a ----> b ----> c      | |
-    #      |       |      N=2 | |
-    #      | M=2   +----------+ |
-    #      +--------------------+
+    # Model: enumerate a
+    # [ a - [----> b    ]
+    # [  \  [           ]
+    # [   - [- [-> c  ] ]
     @config_enumerate
     @handlers.scale(scale=scale)
     def model(params):
@@ -2449,7 +2461,11 @@ def test_model_enum_subsample_3(scale):
         }
         return elbo.loss(random.PRNGKey(0), {}, model_subsample, guide, params)
 
-    actual_loss, actual_grads = jax.value_and_grad(actual_loss_fn)(params_raw)
+    with pytest.raises(
+        ValueError, match="Expected all enumerated sample sites to share a common scale"
+    ):
+        # This never gets run because we don't support this yet.
+        actual_loss, actual_grads = jax.value_and_grad(actual_loss_fn)(params_raw)
 
-    assert_equal(actual_loss, expected_loss, prec=1e-3)
-    assert_equal(actual_grads, expected_grads, prec=1e-5)
+        assert_equal(actual_loss, expected_loss, prec=1e-3)
+        assert_equal(actual_grads, expected_grads, prec=1e-5)


### PR DESCRIPTION
It turns out that current subsample scaling logic is not handled correctly in `TraceEnum_ELBO` (sorry for that). I added some tests to demonstrate that. I think the best place to handle subsampling scaling is in `funsor.sum_product.sum_product`. For now I added a check for a common scale which raises an error if there is no common scale.