### PR TITLE
Properly handle contraction of guide plates in `TraceEnum_ELBO`

### DIFF
--- a/numpyro/infer/elbo.py
+++ b/numpyro/infer/elbo.py
@@ -1020,7 +1020,6 @@ class TraceEnum_ELBO(ELBO):
                 if (scale is not None) and (not is_identically_one(scale)):
                     cost = cost * scale
 
-                # TODO
                 elbo = elbo + cost.reduce(funsor.ops.add)
 
             return to_data(elbo)


### PR DESCRIPTION
There was a bug in `TraceEnum_ELBO` demonstrated in a new `test_enum_elbo::test_guide_plate_contraction` test. When a cost term depends on a non-reparameterizable guide site with extra plate dims they need to be product-contracted. Instead these plate dims were passed to `_eager_contract_tensors` as `reduced_vars` and sum-contracted. So I replaced `_eager_contract_tensors` with `funsor.sum_product.sum_product` which can do plated sum-products and eliminate plates.