### PR TITLE
Fix provenance for jax 0.4.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
         pip freeze
     - name: Test with pytest
       run: |
-        CI=1 pytest -vs -k "not test_example" --durations=100 --ignore=test/infer/
+        CI=1 pytest -vs -k "not test_example" --durations=100 --ignore=test/infer/ --ignore=test/contrib/
 
 
   test-inference:
@@ -103,6 +103,7 @@ jobs:
       run: |
         pytest -vs --durations=20 test/infer/test_mcmc.py
         pytest -vs --durations=20 test/infer --ignore=test/infer/test_mcmc.py
+        pytest -vs --durations=20 test/contrib
     - name: Test x64
       run: |
         JAX_ENABLE_X64=1 pytest -vs test/infer/test_mcmc.py -k x64

--- a/numpyro/infer/elbo.py
+++ b/numpyro/infer/elbo.py
@@ -561,13 +561,14 @@ def _substitute_nonreparam(data, msg):
 
 
 def _get_latents(model, guide, args, kwargs, params):
-    model = seed(model, rng_seed=0)
-    guide = seed(guide, rng_seed=0)
-    model_tr, guide_tr = get_importance_trace(model, guide, args, kwargs, params)
-    guide_tr.update(model_tr)
+    model = seed(substitute(model, data=params), rng_seed=0)
+    guide = seed(substitute(guide, data=params), rng_seed=0)
+    guide_tr = trace(guide).get_trace(*args, **kwargs)
+    model_tr = trace(replay(model, guide_tr)).get_trace(*args, **kwargs)
+    model_tr.update(guide_tr)
     return {
         name: site["value"]
-        for name, site in guide_tr.items()
+        for name, site in model_tr.items()
         if site["type"] == "sample" and not site.get("is_observed", False)
     }
 

--- a/numpyro/infer/inspect.py
+++ b/numpyro/infer/inspect.py
@@ -11,7 +11,7 @@ import jax
 from numpyro import handlers
 import numpyro.distributions as dist
 from numpyro.infer.initialization import init_to_sample
-from numpyro.ops.provenance import ProvenanceArray, eval_provenance, get_provenance
+from numpyro.ops.provenance import eval_provenance
 from numpyro.ops.pytree import PytreeTrace
 
 
@@ -55,7 +55,7 @@ def _get_abstract_trace(model, model_args, model_kwargs):
     return jax.eval_shape(get_trace).trace
 
 
-def _get_log_probs(model, model_args, model_kwargs, sample):
+def _get_log_probs(model, model_args, model_kwargs, **sample):
     # Note: We use seed 0 for parameter initialization.
     with handlers.trace() as tr, handlers.seed(rng_seed=0), handlers.substitute(
         data=sample
@@ -199,14 +199,12 @@ def get_dependencies(
 
     # Find direct prior dependencies among latent and observed sites.
     samples = {
-        name: ProvenanceArray(site["value"], frozenset({name}))
+        name: site["value"]
         for name, site in trace.items()
         if site["type"] == "sample" and not site["is_observed"]
     }
-    sample_deps = get_provenance(
-        eval_provenance(
-            partial(_get_log_probs, model, model_args, model_kwargs), samples
-        )
+    sample_deps = eval_provenance(
+        partial(_get_log_probs, model, model_args, model_kwargs), **samples
     )
     prior_dependencies = {n: {n: set()} for n in plates}  # no deps yet
     for i, downstream in enumerate(sample_sites):
@@ -384,24 +382,17 @@ def get_model_relations(model, model_args=None, model_kwargs=None):
         return provenance_arrays
 
     samples = {
-        name: ProvenanceArray(site["value"], frozenset({name}))
+        name: site["value"]
         for name, site in trace.items()
         if (site["type"] == "sample" and not site["is_observed"])
         or site["type"] == "deterministic"
     }
 
     params = {
-        name: jax.tree_util.tree_map(
-            lambda x: ProvenanceArray(x, frozenset({name})), site["value"]
-        )
-        for name, site in trace.items()
-        if site["type"] == "param"
+        name: site["value"] for name, site in trace.items() if site["type"] == "param"
     }
 
-    sample_and_params = {**samples, **params}
-    sample_params_deps = get_provenance(
-        eval_provenance(get_log_probs, sample_and_params)
-    )
+    sample_params_deps = eval_provenance(get_log_probs, **samples, **params)
 
     sample_sample = {}
     sample_param = {}

--- a/numpyro/infer/inspect.py
+++ b/numpyro/infer/inspect.py
@@ -358,7 +358,7 @@ def get_model_relations(model, model_args=None, model_kwargs=None):
         k: [name for name in trace if name in v] for k, v in plate_samples.items()
     }
 
-    def get_log_probs(sample):
+    def get_log_probs(**sample):
         class substitute_deterministic(handlers.substitute):
             def process_message(self, msg):
                 if msg["type"] == "deterministic":

--- a/numpyro/ops/provenance.py
+++ b/numpyro/ops/provenance.py
@@ -100,7 +100,7 @@ def eval_provenance(fun, *args, **kwargs):
     # flatten the function and its arguments
     args_flat, in_tree = jax.tree_util.tree_flatten((args, kwargs))
     wrapped_fun, out_tree = jax.api_util.flatten_fun(wrap_init(fun), in_tree)
-    # After the merge of jit & pjit in jax 0.4.5, our provenance trace is
+    # After the merge of jit & pjit in jax 0.4.4, our provenance trace is
     # no longer composed with jitted primitives (like jnp.sin), so we need
     # to play with jaxpr, which does not involve jitting.
     args_struct = jax.tree_util.tree_map(

--- a/numpyro/ops/provenance.py
+++ b/numpyro/ops/provenance.py
@@ -5,7 +5,7 @@ import jax
 from jax._src.pjit import pjit_p
 from jax.api_util import flatten_fun, shaped_abstractify
 import jax.core as core
-from jax.interpreters.partial_eval import trace_to_jaxpr_dynamic
+from jax.interpreters.partial_eval import debug_info, trace_to_jaxpr_dynamic
 from jax.interpreters.pxla import xla_pmap_p
 from jax.interpreters.xla import xla_call_p
 import jax.linear_util as lu
@@ -41,8 +41,9 @@ def eval_provenance(fn, **kwargs):
     # XXX: we split out the process of abstract evaluation and provenance tracking
     # for simplicity. In principle, they can be merged so that we only need to walk
     # through the equations once.
+    info = debug_info(fn, in_tree, True, "eval_shape")
     jaxpr, avals_out, _ = trace_to_jaxpr_dynamic(
-        lu.wrap_init(wrapped_fun.call_wrapped), avals
+        lu.wrap_init(wrapped_fun.call_wrapped, {}), avals, info
     )
 
     # get provenances of flatten kwargs

--- a/numpyro/ops/provenance.py
+++ b/numpyro/ops/provenance.py
@@ -94,7 +94,7 @@ track_deps_rules = {}
 
 # XXX: Currently, we use default rule for scan_p, cond_p, while_p, remat_p
 def _default_track_deps_rules(eqn, provenance_inputs):
-    provenance_outputs = frozenset.union(*provenance_inputs)
+    provenance_outputs = frozenset().union(*provenance_inputs)
     return [provenance_outputs] * len(eqn.outvars)
 
 

--- a/numpyro/ops/provenance.py
+++ b/numpyro/ops/provenance.py
@@ -94,7 +94,7 @@ track_deps_rules = {}
 
 # XXX: Currently, we use default rule for scan_p, cond_p, while_p, remat_p
 def _default_track_deps_rules(eqn, provenance_inputs):
-    provenance_outputs = frozenset().union(*provenance_inputs)
+    provenance_outputs = frozenset.union(*provenance_inputs)
     return [provenance_outputs] * len(eqn.outvars)
 
 

--- a/numpyro/ops/provenance.py
+++ b/numpyro/ops/provenance.py
@@ -104,8 +104,13 @@ def eval_provenance(fun, *args, **kwargs):
     # no longer composed with jitted primitives (like jnp.sin), so we need
     # to play with jaxpr, which does not involve jitting.
     args_struct = jax.tree_util.tree_map(
-        lambda x: (jax.ShapeDtypeStruct(x.shape, x.dtype)
-			if isinstance(x, ProvenanceArray) else x), args_flat)
+        lambda x: (
+            jax.ShapeDtypeStruct(x.shape, x.dtype)
+            if isinstance(x, ProvenanceArray)
+            else x
+        ),
+        args_flat,
+    )
     jaxpr = jax.make_jaxpr(wrapped_fun.call_wrapped)(*args_struct)
     fun = wrap_init(jax.core.jaxpr_as_fun(jaxpr))
     avals = jax.util.safe_map(jax.api_util.shaped_abstractify, args_flat)

--- a/numpyro/ops/provenance.py
+++ b/numpyro/ops/provenance.py
@@ -38,6 +38,9 @@ def eval_provenance(fn, **kwargs):
     wrapped_fun, out_tree = flatten_fun(lu.wrap_init(fn), in_tree)
     # Abstract eval to get output pytree
     avals = core.safe_map(shaped_abstractify, args)
+    # XXX: we split out the process of abstract evaluation and provenance tracking
+    # for simplicity. In principle, they can be merged so that we only need to walk
+    # through the equations once.
     jaxpr, avals_out, _ = trace_to_jaxpr_dynamic(
         lu.wrap_init(wrapped_fun.call_wrapped), avals
     )

--- a/numpyro/ops/provenance.py
+++ b/numpyro/ops/provenance.py
@@ -73,6 +73,12 @@ class ProvenanceArray:
         self.dtype = jnp.result_type(data)
         self.named_shape = {"_provenance": provenance}
 
+    def __repr__(self):
+        return (
+            f"ProvenanceArray(shape={self.shape}, dtype={self.dtype}, "
+            f"provenance={self.named_shape.get('_provenance', frozenset())})"
+        )
+
 
 def get_provenance(data):
     """

--- a/numpyro/ops/provenance.py
+++ b/numpyro/ops/provenance.py
@@ -2,130 +2,116 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import jax
-from jax.interpreters import partial_eval
-from jax.linear_util import wrap_init
+from jax._src.pjit import pjit_p
+from jax.api_util import flatten_fun, shaped_abstractify
+import jax.core as core
+from jax.interpreters.partial_eval import trace_to_jaxpr_dynamic
+from jax.interpreters.pxla import xla_pmap_p
+from jax.interpreters.xla import xla_call_p
+import jax.linear_util as lu
 import jax.numpy as jnp
 
 
-class _ProvenanceJaxprTrace(partial_eval.DynamicJaxprTrace):
-    """A JAX class to control the behavior of primitives on tracers."""
-
-    def process_primitive(self, primitive, tracers, params):
-        # remove "_provenance" dimension in arguments before executing the function
-        provenances = [
-            t.aval.named_shape.pop("_provenance", frozenset()) for t in tracers
-        ]
-        out_tracers = super().process_primitive(primitive, tracers, params)
-        # add "_provenance" dimensions to arguments again
-        for t, p in zip(tracers, provenances):
-            if p:
-                t.aval.named_shape["_provenance"] = p
-
-        # update outputs' provenance
-        out_provenance = frozenset().union(*provenances)
-        if out_provenance:
-            out_tracers = out_tracers if primitive.multiple_results else [out_tracers]
-            for t in out_tracers:
-                t.aval.named_shape["_provenance"] = out_provenance
-                # Also update provenance of the cached tracer -> aval dict.
-                aval_cache = self.frame.tracer_to_var[id(t)].aval
-                aval_cache.named_shape["_provenance"] = out_provenance
-            out_tracers = out_tracers if primitive.multiple_results else out_tracers[0]
-        return out_tracers
-
-
-class ProvenanceArray:
+def eval_provenance(fn, **kwargs):
     """
-    Provenance tracking implementation in JAX.
-
-    This class wraps an ndarray to track provenance through JAX ops,
-    where provenance is a user-defined frozenset of objects. The
-    provenance of the output arrays of any op is the union of provenances
-    of input arrays.
-
-    -   To start tracking provenance in a function, wrap input arrays in
-        :class:`ProvenanceArray` with user-defined initial provenance,
-        then use :func:`eval_provenance` to get the provenance output array.
-    -   To read the provenance of an ndarray use :func:`get_provenance` .
+    Compute the provenance output of ``fun`` using JAX's abstract
+    interpretation machinery. There is no actual array computation performed.
 
     Example::
 
-        >>> a = ProvenanceArray(jnp.zeros(3), frozenset({"a"}))
-        >>> b = ProvenanceArray(jnp.ones(3), frozenset({"b"}))
-        >>> c = jnp.arange(3)
-        >>> f = lambda a, b, c: a + b + c
-        >>> o = eval_provenance(f, a, b, c)
-        >>> assert get_provenance(o) == frozenset({"a", "b"})
+        >>> o = eval_provenance(lambda x, y, z: x + y, x=1, y=2, z=3)
+        >>> assert o == frozenset({"x", "y"})
 
     **References**
 
     [1] David Wingate, Noah Goodman, Andreas Stuhlmüller, Jeffrey Siskind (2011)
         Nonstandard Interpretations of Probabilistic Programs for Efficient Inference
         http://papers.neurips.cc/paper/4309-nonstandard-interpretations-of-probabilistic-programs-for-efficient-inference.pdf
-
-    :param data: An initial data to start tracking. The data needs
-        to have attributes `shape` and `dtype`.
-    :param frozenset provenance: An initial provenance set.
-    """
-
-    def __init__(self, data, provenance=frozenset()):
-        self.shape = jnp.shape(data)
-        self.dtype = jnp.result_type(data)
-        self.named_shape = {"_provenance": provenance}
-
-    def __repr__(self):
-        return (
-            f"ProvenanceArray(shape={self.shape}, dtype={self.dtype}, "
-            f"provenance={self.named_shape.get('_provenance', frozenset())})"
-        )
-
-
-def get_provenance(data):
-    """
-    Reads the provenance of a recursive data structure possibly containing ndarray.
-
-    :param data: An input data.
-    :returns: A provenance frozenset.
-    :rtype: frozenset
-    """
-    return jax.tree_util.tree_map(
-        lambda a: a.named_shape.get("_provenance", frozenset()), data
-    )
-
-
-def eval_provenance(fun, *args, **kwargs):
-    """
-    Compute the provenance output of ``fun`` using JAX's abstract
-    interpretation machinery. There is no actual array computation performed.
+    [2] https://jax.readthedocs.io/en/latest/notebooks/Writing_custom_interpreters_in_Jax.html
 
     :param fun: A callable to track provenance of its (keyword) arguments.
-    :param args: Positional arguments of `fun`.
     :param kwargs: Keyword arguments of `fun`.
-    :returns: A pytree of :class:`ProvenanceArray`.
+    :returns: A pytree of :class:`frozenset` indicating the dependency on the inputs.
     """
-    # flatten the function and its arguments
-    args_flat, in_tree = jax.tree_util.tree_flatten((args, kwargs))
-    wrapped_fun, out_tree = jax.api_util.flatten_fun(wrap_init(fun), in_tree)
-    # After the merge of jit & pjit in jax 0.4.4, our provenance trace is
-    # no longer composed with jitted primitives (like jnp.sin), so we need
-    # to play with jaxpr, which does not involve jitting.
-    args_struct = [
-        jax.ShapeDtypeStruct(x.shape, x.dtype) if isinstance(x, ProvenanceArray) else x
-        for x in args_flat
-    ]
-    jaxpr = jax.make_jaxpr(wrapped_fun.call_wrapped)(*args_struct)
-    fun = wrap_init(jax.core.jaxpr_as_fun(jaxpr))
-    avals = jax.util.safe_map(jax.api_util.shaped_abstractify, args_flat)
-
-    # execute the function and trace provenance
-    with jax.core.new_main(_ProvenanceJaxprTrace, dynamic=True) as main:
-        main.jaxpr_stack = ()
-        out = partial_eval.trace_to_subjaxpr_dynamic(fun, main, avals)[1]
-
-    # unflatten the output and get its provenance
-    out = [jax.ShapeDtypeStruct(x.shape, x.dtype, x.named_shape) for x in out]
-    out = jax.tree_util.tree_unflatten(out_tree(), out)
-    return jax.tree_util.tree_map(
-        lambda x: ProvenanceArray(x, x.named_shape.get("_provenance", frozenset())),
-        out,
+    # Flatten the function and its arguments
+    args, in_tree = jax.tree_util.tree_flatten(((), kwargs))
+    wrapped_fun, out_tree = flatten_fun(lu.wrap_init(fn), in_tree)
+    # Abstract eval to get output pytree
+    avals = core.safe_map(shaped_abstractify, args)
+    jaxpr, avals_out, _ = trace_to_jaxpr_dynamic(
+        lu.wrap_init(wrapped_fun.call_wrapped), avals
     )
+
+    # get provenances of flatten kwargs
+    aval_kwargs = {}
+    for n, v in kwargs.items():
+        aval = jax.ShapeDtypeStruct((), jnp.bool_, {"provenance": frozenset({n})})
+        aval_kwargs[n] = jax.tree_util.tree_map(lambda _: aval, v)
+    aval_args, _ = jax.tree_util.tree_flatten(((), aval_kwargs))
+    provenance_inputs = jax.tree_util.tree_map(
+        lambda x: x.named_shape["provenance"], aval_args
+    )
+
+    provenance_outputs = track_deps_jaxpr(jaxpr, provenance_inputs)
+    out_flat = []
+    for v, p in zip(avals_out, provenance_outputs):
+        val = jax.ShapeDtypeStruct(jnp.shape(v), jnp.result_type(v), {"provenance": p})
+        out_flat.append(val)
+    out = jax.tree_util.tree_unflatten(out_tree(), out_flat)
+    return jax.tree_util.tree_map(lambda x: x.named_shape["provenance"], out)
+
+
+def track_deps_jaxpr(jaxpr, provenance_inputs):
+    # Mapping from variable -> provenance
+    env = {}
+
+    def read(v):
+        if isinstance(v, core.Literal):
+            return frozenset()
+        return env.get(v, frozenset())
+
+    def write(v, p):
+        if isinstance(v, core.Literal):
+            return
+        env[v] = read(v) | p
+
+    core.safe_map(write, jaxpr.invars, provenance_inputs)
+    for eqn in jaxpr.eqns:
+        provenance_inputs = core.safe_map(read, eqn.invars)
+        rule = track_deps_rules.get(eqn.primitive, _default_track_deps_rules)
+        provenance_outputs = rule(eqn, provenance_inputs)
+        core.safe_map(write, eqn.outvars, provenance_outputs)
+
+    return core.safe_map(read, jaxpr.outvars)
+
+
+track_deps_rules = {}
+
+
+# XXX: Currently, we use default rule for scan_p, cond_p, while_p, remat_p
+def _default_track_deps_rules(eqn, provenance_inputs):
+    provenance_outputs = frozenset().union(*provenance_inputs)
+    return [provenance_outputs] * len(eqn.outvars)
+
+
+def track_deps_call_rule(eqn, provenance_inputs):
+    return track_deps_jaxpr(eqn.params["call_jaxpr"], provenance_inputs)
+
+
+track_deps_rules[core.call_p] = track_deps_call_rule
+track_deps_rules[xla_call_p] = track_deps_call_rule
+track_deps_rules[xla_pmap_p] = track_deps_call_rule
+
+
+def track_deps_closed_call_rule(eqn, provenance_inputs):
+    return track_deps_jaxpr(eqn.params["call_jaxpr"].jaxpr, provenance_inputs)
+
+
+track_deps_rules[core.closed_call_p] = track_deps_closed_call_rule
+
+
+def track_deps_pjit_rule(eqn, provenance_inputs):
+    return track_deps_jaxpr(eqn.params["jaxpr"].jaxpr, provenance_inputs)
+
+
+track_deps_rules[pjit_p] = track_deps_call_rule

--- a/numpyro/ops/provenance.py
+++ b/numpyro/ops/provenance.py
@@ -118,4 +118,4 @@ def track_deps_pjit_rule(eqn, provenance_inputs):
     return track_deps_jaxpr(eqn.params["jaxpr"].jaxpr, provenance_inputs)
 
 
-track_deps_rules[pjit_p] = track_deps_call_rule
+track_deps_rules[pjit_p] = track_deps_pjit_rule

--- a/numpyro/ops/provenance.py
+++ b/numpyro/ops/provenance.py
@@ -103,14 +103,10 @@ def eval_provenance(fun, *args, **kwargs):
     # After the merge of jit & pjit in jax 0.4.4, our provenance trace is
     # no longer composed with jitted primitives (like jnp.sin), so we need
     # to play with jaxpr, which does not involve jitting.
-    args_struct = jax.tree_util.tree_map(
-        lambda x: (
-            jax.ShapeDtypeStruct(x.shape, x.dtype)
-            if isinstance(x, ProvenanceArray)
-            else x
-        ),
-        args_flat,
-    )
+    args_struct = [
+        jax.ShapeDtypeStruct(x.shape, x.dtype) if isinstance(x, ProvenanceArray) else x
+        for x in args_flat
+    ]
     jaxpr = jax.make_jaxpr(wrapped_fun.call_wrapped)(*args_struct)
     fun = wrap_init(jax.core.jaxpr_as_fun(jaxpr))
     avals = jax.util.safe_map(jax.api_util.shaped_abstractify, args_flat)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2,11 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-os.environ['JAX_JIT_PJIT_API_MERGE'] = '1'
 
-from jax.config import config
+os.environ["JAX_JIT_PJIT_API_MERGE"] = "0"
 
-from numpyro.util import set_rng_seed
+from jax.config import config  # noqa: E402
+
+from numpyro.util import set_rng_seed  # noqa: E402
 
 config.update("jax_platform_name", "cpu")  # noqa: E702
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -3,11 +3,9 @@
 
 import os
 
-os.environ["JAX_JIT_PJIT_API_MERGE"] = "0"
+from jax.config import config
 
-from jax.config import config  # noqa: E402
-
-from numpyro.util import set_rng_seed  # noqa: E402
+from numpyro.util import set_rng_seed
 
 config.update("jax_platform_name", "cpu")  # noqa: E702
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+os.environ['JAX_JIT_PJIT_API_MERGE'] = '0'
 
 from jax.config import config
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-os.environ['JAX_JIT_PJIT_API_MERGE'] = '0'
 
 from jax.config import config
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+os.environ['JAX_JIT_PJIT_API_MERGE'] = '1'
 
 from jax.config import config
 

--- a/test/infer/test_compute_downstream_costs.py
+++ b/test/infer/test_compute_downstream_costs.py
@@ -101,21 +101,6 @@ def _provenance_compute_downstream_costs(
     return downstream_costs, downstream_guide_cost_nodes
 
 
-def _get_log_probs(get_traces_fn):
-    model_tr, guide_tr = get_traces_fn()
-    model_log_probs = {
-        name: site["log_prob"]
-        for name, site in model_tr.items()
-        if site["type"] == "sample"
-    }
-    guide_log_probs = {
-        name: site["log_prob"]
-        for name, site in guide_tr.items()
-        if site["type"] == "sample"
-    }
-    return model_log_probs, guide_log_probs
-
-
 def big_model_guide(
     include_obs=True,
     include_single=False,
@@ -399,11 +384,9 @@ def plate_reuse_model_guide(include_obs=True, dim1=3, dim2=2):
 @pytest.mark.parametrize("dim2", [3, 4])
 def test_compute_downstream_costs_plate_reuse(dim1, dim2):
     def _get_traces_and_deps():
-        model = partial(
-            plate_reuse_model_guide, includes_obs=True, dim1=dim1, dim2=dim2
-        )
+        model = partial(plate_reuse_model_guide, include_obs=True, dim1=dim1, dim2=dim2)
         guide = partial(
-            plate_reuse_model_guide, includes_obs=False, dim1=dim1, dim2=dim2
+            plate_reuse_model_guide, include_obs=False, dim1=dim1, dim2=dim2
         )
         seeded_guide = handlers.seed(guide, rng_seed=0)
         guide_trace = handlers.trace(seeded_guide).get_trace()

--- a/test/infer/test_compute_downstream_costs.py
+++ b/test/infer/test_compute_downstream_costs.py
@@ -236,7 +236,6 @@ def test_compute_downstream_costs_big_model_guide_pair(
     )
 
     assert dc_nodes == dc_nodes_brute
-    print("DEPENDS", model_deps, guide_deps)
 
     for name, nodes in dc_nodes_provenance.items():
         assert nodes.issubset(dc_nodes[name])

--- a/test/infer/test_compute_downstream_costs.py
+++ b/test/infer/test_compute_downstream_costs.py
@@ -236,6 +236,7 @@ def test_compute_downstream_costs_big_model_guide_pair(
     )
 
     assert dc_nodes == dc_nodes_brute
+    print("DEPENDS", model_deps, guide_deps)
 
     for name, nodes in dc_nodes_provenance.items():
         assert nodes.issubset(dc_nodes[name])

--- a/test/ops/test_provenance.py
+++ b/test/ops/test_provenance.py
@@ -14,6 +14,7 @@ from numpyro.ops.provenance import ProvenanceArray, eval_provenance, get_provena
         (lambda x, y: x + y, ({"a"}, {"b"}), {"a", "b"}),
         (lambda x, y: x + y, ({"a", "c"}, {"a", "b"}), {"a", "b", "c"}),
         (lambda x, y, z: x + y, ({"a"}, {"b"}, {"c"}), {"a", "b"}),
+        (lambda x, y: {"sum": x + y, "zero": 0}, ({"a"}, {"b"}), {"sum": {"a", "b"}, "zero": set()}),
     ],
 )
 def test_provenance(f, inputs, expected_output):

--- a/test/ops/test_provenance.py
+++ b/test/ops/test_provenance.py
@@ -1,26 +1,86 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
-import numpy as np
+import inspect
+
 import pytest
 
-from numpyro.ops.provenance import ProvenanceArray, eval_provenance, get_provenance
+import jax
+from jax.api_util import flatten_fun_nokwargs
+import jax.core as core
+import jax.linear_util as lu
+import jax.numpy as jnp
+
+from numpyro.ops.provenance import eval_provenance
 
 
 @pytest.mark.parametrize(
     "f, inputs, expected_output",
     [
-        (lambda x, y: x + y, ({"a"}, {}), {"a"}),
-        (lambda x, y: x + y, ({"a"}, {"b"}), {"a", "b"}),
-        (lambda x, y: x + y, ({"a", "c"}, {"a", "b"}), {"a", "b", "c"}),
-        (lambda x, y, z: x + y, ({"a"}, {"b"}, {"c"}), {"a", "b"}),
+        (lambda a, b: a + 1, ("a", "b"), {"a"}),
+        (lambda a, b: jax.scipy.special.xlogy(a, b), ("a", "b"), {"a", "b"}),
+        (lambda a, b, c: a + b, ("a", "b", "c"), {"a", "b"}),
         (
-            lambda x, y: {"sum": x + y, "zero": 0},
-            ({"a"}, {"b"}),
+            lambda a, b: {"sum": a + b, "zero": 0},
+            ("a", "b"),
             {"sum": {"a", "b"}, "zero": set()},
         ),
     ],
 )
 def test_provenance(f, inputs, expected_output):
-    inputs = [ProvenanceArray(np.array([0]), p) for p in inputs]
-    assert get_provenance(eval_provenance(f, *inputs)) == expected_output
+    inputs = {p: 0 for p in inspect.getfullargspec(f).args}
+    assert eval_provenance(f, **inputs) == expected_output
+
+
+def test_provenance_const():
+    def f(x):
+        with jax.ensure_compile_time_eval():
+            y = jnp.ones(4)
+        return x + y
+
+    jaxpr = jax.make_jaxpr(f)(jnp.zeros((3, 4), jnp.float32))
+    assert len(jaxpr.consts) == 1
+    assert eval_provenance(f, x=3) == {"x"}
+
+
+def test_provenance_fori():
+    def f(x, y, z):
+        del z
+        return jax.lax.fori_loop(0, 5, lambda _, x: x + y, x)
+
+    assert eval_provenance(f, x=3, y=2, z=1) == {"x", "y"}
+
+
+def test_provenance_vmap():
+    def f(x, y):
+        del x
+        return jax.vmap(jnp.sin)(y)
+
+    assert eval_provenance(f, x=3, y=jnp.ones(3)) == {"y"}
+
+
+def test_provenance_pytree_in():
+    def f(x, y):
+        return x["v"] * y, x["u"]
+
+    assert eval_provenance(f, x={"v": 2, "u": 1}, y=1) == ({"x", "y"}, {"x"})
+
+
+def test_provenance_call():
+    def identity(x):
+        args, in_tree = jax.tree_util.tree_flatten((x,))
+        fn, out_tree = flatten_fun_nokwargs(lu.wrap_init(lambda x: x), in_tree)
+        out = core.closed_call_p.bind(fn, *args)
+        return jax.tree_util.tree_unflatten(out_tree(), out)
+
+    assert eval_provenance(identity, x={"v": 2}) == {"v": frozenset({"x"})}
+
+
+def test_provenance_closed_call():
+    def identity(x):
+        args, in_tree = jax.tree_util.tree_flatten((x,))
+        fn, out_tree = flatten_fun_nokwargs(lu.wrap_init(lambda x: x), in_tree)
+        out = core.closed_call_p.bind(fn, *args)
+        return jax.tree_util.tree_unflatten(out_tree(), out)
+
+    assert eval_provenance(identity, x={"v": 2}) == {"v": frozenset({"x"})}

--- a/test/ops/test_provenance.py
+++ b/test/ops/test_provenance.py
@@ -14,7 +14,11 @@ from numpyro.ops.provenance import ProvenanceArray, eval_provenance, get_provena
         (lambda x, y: x + y, ({"a"}, {"b"}), {"a", "b"}),
         (lambda x, y: x + y, ({"a", "c"}, {"a", "b"}), {"a", "b", "c"}),
         (lambda x, y, z: x + y, ({"a"}, {"b"}, {"c"}), {"a", "b"}),
-        (lambda x, y: {"sum": x + y, "zero": 0}, ({"a"}, {"b"}), {"sum": {"a", "b"}, "zero": set()}),
+        (
+            lambda x, y: {"sum": x + y, "zero": 0},
+            ({"a"}, {"b"}),
+            {"sum": {"a", "b"}, "zero": set()},
+        ),
     ],
 )
 def test_provenance(f, inputs, expected_output):


### PR DESCRIPTION
Fixes #1542

After the merge of jit & pjit in jax 0.4.4, our provenance trace is no longer composed with jitted primitives (like jnp.sin), so we need to play with jaxpr, which does not involve jitting.