### PR TITLE
bump jaxns to 2.x

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,7 +4,7 @@ funsor
 ipython<=8.6.0  # strict the version for https://github.com/ipython/ipython/issues/13845
 jax
 jaxlib
-jaxns==1.0.0
+jaxns>=2.0.0
 Jinja2<3.1
 multipledispatch
 nbsphinx==0.8.9

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
             "flax",
             "funsor>=0.4.1",
             "graphviz",
-            "jaxns==1.0.0",
+            "jaxns>=2.0.0",
             "optax>=0.0.6",
             "pyyaml",  # flax dependency
             "tensorflow_probability>=0.17.0",


### PR DESCRIPTION
* reqs are now `jaxns>==2.0.0`
* adjusted the wrapped to use new structure.
* Note, that jaxns likes the user to not jit-compile the top-level nested sampling run. This is because it breaks up the algorithm into static parts and non-static parts. 