### PR TITLE
Support pickling MCMC objects with enumeration

### DIFF
--- a/numpyro/contrib/funsor/infer_util.py
+++ b/numpyro/contrib/funsor/infer_util.py
@@ -80,7 +80,9 @@ def config_enumerate(fn=None, default="parallel"):
     if fn is None:  # support use as a decorator
         return functools.partial(config_enumerate, default=default)
     else:
-        return infer_config(fn, functools.partial(_config_fn_enumerate, default=default))
+        return infer_config(
+            fn, functools.partial(_config_fn_enumerate, default=default)
+        )
 
 
 def _config_fn_kl(site, sites):

--- a/test/test_pickle.py
+++ b/test/test_pickle.py
@@ -75,17 +75,14 @@ def logistic_regression():
 def gmm(data, K):
     mix_proportions = numpyro.sample("phi", dist.Dirichlet(jnp.ones(K)))
     with numpyro.plate("num_clusters", K, dim=-1):
-        cluster_means = numpyro.sample(
-            "cluster_means", dist.Normal(jnp.arange(K), 1.0)
-        )
+        cluster_means = numpyro.sample("cluster_means", dist.Normal(jnp.arange(K), 1.0))
     with numpyro.plate("data", data.shape[0], dim=-1):
         assignments = numpyro.sample(
-            "assignments", dist.Categorical(mix_proportions),
-            infer={'enumerate': 'parallel'}
+            "assignments",
+            dist.Categorical(mix_proportions),
+            infer={"enumerate": "parallel"},
         )
-        numpyro.sample(
-            "obs", dist.Normal(cluster_means[assignments], 1.0), obs=data
-        )
+        numpyro.sample("obs", dist.Normal(cluster_means[assignments], 1.0), obs=data)
 
 
 @pytest.mark.parametrize("kernel", [BarkerMH, HMC, NUTS, SA])


### PR DESCRIPTION
This PR aims to solve the issue reported in https://github.com/pyro-ppl/numpyro/issues/1576.

Moved the inner functions
https://github.com/pyro-ppl/numpyro/blob/0589859404433e3cfe08e90a37ab0ca272392d69/numpyro/contrib/funsor/infer_util.py#L72-L79 and  https://github.com/pyro-ppl/numpyro/blob/0589859404433e3cfe08e90a37ab0ca272392d69/numpyro/contrib/funsor/infer_util.py#L110-L119 outside of the functions `config_enumerate` and `config_kl`, respectively. I'm not sure in which use cases the current version of `config_kl` would produce issues but since it was using the same nested function pattern I updated it as well.

Implemented a couple of tests based on some existing tests to verify the appropriateness of the changes.