### PR TITLE
Remove inf's in TruncatedNormal log_prob & sample (#1492)

### DIFF
--- a/numpyro/distributions/continuous.py
+++ b/numpyro/distributions/continuous.py
@@ -47,6 +47,7 @@ from jax.scipy.special import (
     xlog1py,
     xlogy,
 )
+from jax.scipy.stats import norm as jax_norm
 
 from numpyro.distributions import constraints
 from numpyro.distributions.discrete import _to_logits_bernoulli
@@ -2076,6 +2077,9 @@ class Normal(Distribution):
     def cdf(self, value):
         scaled = (value - self.loc) / self.scale
         return ndtr(scaled)
+
+    def log_cdf(self, value):
+        return jax_norm.logcdf(value, loc=self.loc, scale=self.scale)
 
     def icdf(self, q):
         return self.loc + self.scale * ndtri(q)

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -19,6 +19,7 @@ from jax import grad, lax, vmap
 import jax.numpy as jnp
 import jax.random as random
 from jax.scipy.special import expit, logsumexp
+from jax.scipy.stats import norm as jax_norm, truncnorm as jax_truncnorm
 from jax.tree_util import tree_map
 
 import numpyro.distributions as dist
@@ -2758,3 +2759,46 @@ def test_multinomial_abstract_total_count():
     x = dist.Multinomial(10, probs).sample(key)
     y = jax.jit(f)(x)
     assert_allclose(x, y, rtol=1e-6)
+
+
+def test_normal_log_cdf():
+    # test if log_cdf method agrees with jax.scipy.stats.norm.logcdf
+    # and if exp(log_cdf) agrees with cdf
+    loc = jnp.array([[0.0, -10.0, 20.0]])
+    scale = jnp.array([[1, 5, 7]])
+    values = jnp.linspace(-5, 5, 100).reshape(-1, 1)
+    numpyro_log_cdf = dist.Normal(loc=loc, scale=scale).log_cdf(values)
+    numpyro_cdf = dist.Normal(loc=loc, scale=scale).cdf(values)
+    jax_log_cdf = jax_norm.logcdf(loc=loc, scale=scale, x=values)
+    assert_allclose(numpyro_log_cdf, jax_log_cdf)
+    assert_allclose(jnp.exp(numpyro_log_cdf), numpyro_cdf, rtol=1e-6)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        -15.0,
+        jnp.array([[-15.0], [-10.0], [-5.0]]),
+        jnp.array([[[-15.0], [-10.0], [-5.0]], [[-14.0], [-9.0], [-4.0]]]),
+    ],
+)
+def test_truncated_normal_log_prob_in_tail(value):
+    # define set of distributions truncated in tail of distribution
+    loc = 1.35
+    scale = jnp.geomspace(0.01, 1, 10)
+    low, high = (-20, -1.0)
+    a, b = (low - loc) / scale, (high - loc) / scale  # rescale for jax input
+
+    numpyro_log_prob = dist.TruncatedNormal(loc, scale, low=low, high=high).log_prob(
+        value
+    )
+    jax_log_prob = jax_truncnorm.logpdf(value, loc=loc, scale=scale, a=a, b=b)
+    assert_allclose(numpyro_log_prob, jax_log_prob, rtol=1e-06)
+
+
+def test_sample_truncated_normal_in_tail():
+    # test, if samples from distributions truncated in
+    # tail of distribution returns any inf's
+    tail_dist = dist.TruncatedNormal(loc=0, scale=1, low=-16, high=-15)
+    samples = tail_dist.sample(random.PRNGKey(0), sample_shape=(10_000,))
+    assert ~jnp.isinf(samples).any()


### PR DESCRIPTION
This commit fixes #1492 by removing inf return values in log_prob and sample method of the TruncatedNormal distribution, when it is truncated in the tail of the distribution.

Changes made to remove inf's in `log_prob` method of TruncatedNormal distribution:
- Added `log_cdf` method to the Normal distribution
    - Calls the corresponding JAX implementation of the logarithmic cdf
- Modified `log_prob` calculation for the truncated Normal
    - New method is more stable in tail of distribution, since it uses the new `log_cdf`, if it is available
    - Uses `logsumexp` function to subtract required `log_cdf` values more numerically stable
    - If `log_cdf` method is not available, it falls back to original implementation with `cdf`
  
Changes made to remove inf's in `sample` method of TruncatedNormal distribution:
- Clamped input to inverse cdf `icdf` to open interval (0,1) using the `clamp_probs` utility

Tests added:
- Test implementation of `log_cdf` method by comparing to JAX implementation and to `cdf` method (test_normal_log_cdf)
- Test `log_prob` implementation by comparing to JAX (test_truncated_normal_log_prob_in_tail)
- Test `sample` method in tail of distribution to check, if any inf's are returned (test_sample_truncated_normal_in_tail)