### PR TITLE
Include deterministic variables in AutoDelta's sample_posterior

### DIFF
--- a/test/infer/test_autoguide.py
+++ b/test/infer/test_autoguide.py
@@ -141,11 +141,12 @@ def test_logistic_regression(auto_class, Elbo):
     logits = jnp.sum(true_coefs * data, axis=-1)
     labels = dist.Bernoulli(logits=logits).sample(random.PRNGKey(1))
 
-    def model(data, labels):
+    def model(data=None, labels=None):
         coefs = numpyro.sample("coefs", dist.Normal(0, 1).expand([dim]).to_event())
-        logits = numpyro.deterministic("logits", jnp.sum(coefs * data, axis=-1))
-        with numpyro.plate("N", len(data)):
-            return numpyro.sample("obs", dist.Bernoulli(logits=logits), obs=labels)
+        if data is not None:
+            logits = numpyro.deterministic("logits", jnp.sum(coefs * data, axis=-1))
+            with numpyro.plate("N", len(data)):
+                return numpyro.sample("obs", dist.Bernoulli(logits=logits), obs=labels)
 
     adam = optim.Adam(0.01)
     rng_key_init = random.PRNGKey(1)
@@ -507,12 +508,12 @@ def test_subsample_guide(auto_class):
 )
 def test_autoguide_deterministic(auto_class):
     def model(y=None):
-        n = y.size if y is not None else 1
+        n, len_y = (y.size, len(y)) if y is not None else (1, 1)
 
         mu = numpyro.sample("mu", dist.Normal(0, 5))
         sigma = numpyro.param("sigma", 1, constraint=constraints.positive)
 
-        with numpyro.plate("N", len(y)):
+        with numpyro.plate("N", len_y):
             y = numpyro.sample("y", dist.Normal(mu, sigma).expand((n,)), obs=y)
         numpyro.deterministic("z", (y - mu) / sigma)
 
@@ -931,3 +932,34 @@ def test_autosldais(
     mf_elbo = -mf_elbo.item()
 
     assert dais_elbo > mf_elbo + 0.1
+
+
+def test_autodelta_capture_deterministic_variables():
+    def model():
+        x = numpyro.sample("x", dist.Normal())
+        numpyro.deterministic("x2", x**2)
+
+    guide = AutoDelta(model)
+    svi = SVI(model, guide, optim.Adam(0.01), Trace_ELBO())
+    svi_result = svi.run(random.PRNGKey(0), num_steps=1_000)
+    guide_samples = guide.sample_posterior(
+        rng_key=random.PRNGKey(1), params=svi_result.params
+    )
+    assert "x2" in guide_samples
+
+
+@pytest.mark.parametrize("shape", [(), (1,), (2, 3)])
+@pytest.mark.parametrize("sample_shape", [(), (1,), (2, 3)])
+def test_autodelta_sample_posterior_with_sample_shape(shape, sample_shape):
+    def model():
+        x = numpyro.sample("x", dist.Normal().expand(shape))
+        numpyro.deterministic("x2", x**2)
+
+    guide = AutoDelta(model)
+    svi = SVI(model, guide, optim.Adam(0.01), Trace_ELBO())
+    svi_result = svi.run(random.PRNGKey(0), num_steps=1_000)
+    guide_samples = guide.sample_posterior(
+        rng_key=random.PRNGKey(1), params=svi_result.params, sample_shape=sample_shape
+    )
+    assert guide_samples["x"].shape == sample_shape + shape
+    assert guide_samples["x2"].shape == sample_shape + shape


### PR DESCRIPTION
This attempts to fix #951, by including deterministic variables in the output of AutoDelta's sample_posterior

Changes made to AutoDelta's `sample_posterior` method:
- After generating latent samples, generate a list of deterministic variables
- If no deterministic variables are present in the model, return the latent samples as before
- If there are deterministic variables, create a `Predictive` instance using the latent samples and generate samples of only the deterministic variables with the `return_sites` keyword. Since the Predictive instance in the new `sample_posterior` method requires the model's `*args` and `**kwargs`, these are now passed to `sample_posterior` as well
- Add the deterministic samples to the return value of the `sample_posterior` method


**Important:** Since the `Predictive` instance is called in the new `sample_posterior` method, now the model needs to be callable without arguments, if no arguments are passed to `sample_posterior`. 
Therefore, the following existing tests have been slightly modified, such that the model can also be called without passing data
- test_autoguide_deterministic
- test_logistic_regression


New tests added:
- Test, if new `sample_posterior` method contains deterministic variables (test_autodelta_capture_deterministic_variables)
- Test shapes, if `sample_shape` argument is used in the new `sample_posterior` method (test_autodelta_sample_posterior_with_sample_shape)