### PR TITLE
Add support for JAX custom PRNG

### DIFF
--- a/numpyro/distributions/util.py
+++ b/numpyro/distributions/util.py
@@ -614,6 +614,8 @@ def safe_normalize(x, *, p=2):
 
 # src: https://github.com/google/jax/blob/5a41779fbe12ba7213cd3aa1169d3b0ffb02a094/jax/_src/random.py#L95
 def is_prng_key(key):
+    if isinstance(key, jax.random.PRNGKeyArray):
+        return key.shape == ()
     try:
         return key.shape == (2,) and key.dtype == np.uint32
     except AttributeError:

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -2812,3 +2812,9 @@ def test_sample_truncated_normal_in_tail():
     tail_dist = dist.TruncatedNormal(loc=0, scale=1, low=-16, high=-15)
     samples = tail_dist.sample(random.PRNGKey(0), sample_shape=(10_000,))
     assert ~jnp.isinf(samples).any()
+
+
+@jax.enable_custom_prng()
+def test_jax_custom_prng():
+    samples = dist.Normal(0, 5).sample(random.PRNGKey(0), sample_shape=(1000,))
+    assert ~jnp.isinf(samples).any()


### PR DESCRIPTION
JAX is in the progress of introducing customizable PRNGs (more details at [https://github.com/google/jax/issues/9263](https://www.google.com/url?sa=D&q=https%3A%2F%2Fgithub.com%2Fgoogle%2Fjax%2Fissues%2F9263)). This change updates numpyro PRNG handling to be compatible with both states of `jax_enable_custom_prng`.

Tested more comprehensively by running the following:
```
$ JAX_ENABLE_CUSTOM_PRNG=true pytest test/test_distributions.py
```