### PR TITLE
Fix for jax>=0.4.7

### DIFF
--- a/numpyro/ops/provenance.py
+++ b/numpyro/ops/provenance.py
@@ -2,12 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import jax
-from jax._src.pjit import pjit_p
 from jax.api_util import flatten_fun, shaped_abstractify
 import jax.core as core
+from jax.experimental.pjit import pjit_p
 from jax.interpreters.partial_eval import trace_to_jaxpr_dynamic
 from jax.interpreters.pxla import xla_pmap_p
-from jax.interpreters.xla import xla_call_p
 import jax.linear_util as lu
 import jax.numpy as jnp
 
@@ -102,7 +101,6 @@ def track_deps_call_rule(eqn, provenance_inputs):
 
 
 track_deps_rules[core.call_p] = track_deps_call_rule
-track_deps_rules[xla_call_p] = track_deps_call_rule
 track_deps_rules[xla_pmap_p] = track_deps_call_rule
 
 

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,8 @@ import sys
 from setuptools import find_packages, setup
 
 PROJECT_PATH = os.path.dirname(os.path.abspath(__file__))
-_jax_version_constraints = ">=0.4"
-_jaxlib_version_constraints = ">=0.4"
+_jax_version_constraints = ">=0.4.7"
+_jaxlib_version_constraints = ">=0.4.7"
 
 # Find version
 for line in open(os.path.join(PROJECT_PATH, "numpyro", "version.py")):


### PR DESCRIPTION
Since the release of jax 0.4.7, xla_call_p has been deprecated and merged into pjit_p. After jax 0.4.11, xla_call_p will be removed. See https://jax.readthedocs.io/en/latest/changelog.html#jax-0-4-11