### PR TITLE
Fix incorrect unflattenning of inverse transforms

### DIFF
--- a/numpyro/distributions/transforms.py
+++ b/numpyro/distributions/transforms.py
@@ -163,9 +163,10 @@ class _InverseTransform(Transform):
     def tree_flatten(self):
         return (self._inv,), (("_inv",), dict())
 
-    @classmethod
-    def tree_unflatten(cls, aux_data, params):
-        return cls(params)
+    def __eq__(self, other):
+        if not isinstance(other, _InverseTransform):
+            return False
+        return self._inv == other._inv
 
 
 class AbsTransform(ParameterFreeTransform):

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -140,6 +140,8 @@ def test_parametrized_transform_pytree(cls, transform_args, transform_kwargs):
     assert jitted_in_t(transform, 1.0) == 1.0
     assert jitted_out_t(transform, 1.0) == transform
 
+    assert jitted_out_t(transform.inv, 1.0) == transform.inv
+
     assert jnp.allclose(
         vmap(in_t, in_axes=(None, 0), out_axes=0)(transform, jnp.ones(3)),
         jnp.ones(3),


### PR DESCRIPTION
#1575 has introduced an incorrect flattening routine of `_InverseTransform`. This PR fixes it. 