### PR TITLE
Pin jaxns version to 2.1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
             "flax",
             "funsor>=0.4.1",
             "graphviz",
-            "jaxns>=2.0.1",
+            "jaxns==2.1.0",
             "matplotlib",
             "optax>=0.0.6",
             "pylab-sdk",  # jaxns dependency


### PR DESCRIPTION
The latest jaxns (2.2.0) fails tests.