### PR TITLE
Mixture assert message string should be an f-string

### DIFF
--- a/numpyro/distributions/mixtures.py
+++ b/numpyro/distributions/mixtures.py
@@ -196,7 +196,7 @@ class MixtureSameFamily(_MixtureBase):
         assert component_distribution.batch_shape[-1] == mixture_size, (
             "Component distribution batch shape last dimension "
             f"(size={component_distribution.batch_shape[-1]}) "
-            "needs to correspond to the mixture_size={mixture_size}!"
+            f"needs to correspond to the mixture_size={mixture_size}!"
         )
         self._mixing_distribution = mixing_distribution
         self._component_distribution = component_distribution


### PR DESCRIPTION
This is a very minor PR, but I just hit this error message while working on a model and noticed that it should be an f-string. 