### PR TITLE
Add vectorized_particles to ELBO

### DIFF
--- a/numpyro/infer/elbo.py
+++ b/numpyro/infer/elbo.py
@@ -34,8 +34,9 @@ class ELBO:
 
     :param num_particles: The number of particles/samples used to form the ELBO
         (gradient) estimators.
-    :param vectorize_particles: Whether to use `jax.vmap` to obtain elbos over the
-        particles. If False, we will use `jax.lax.map`. Defaults to True.
+    :param vectorize_particles: Whether to use `jax.vmap` to compute ELBOs over the
+        num_particles-many particles in parallel. If False use `jax.lax.map`.
+        Defaults to True.
     """
 
     """
@@ -112,8 +113,9 @@ class Trace_ELBO(ELBO):
 
     :param num_particles: The number of particles/samples used to form the ELBO
         (gradient) estimators.
-    :param vectorize_particles: Whether to use `jax.vmap` to obtain elbos over the
-        particles. If False, we will use `jax.lax.map`. Defaults to True.
+    :param vectorize_particles: Whether to use `jax.vmap` to compute ELBOs over the
+        num_particles-many particles in parallel. If False use `jax.lax.map`.
+        Defaults to True.
     """
 
     def loss_with_mutable_state(
@@ -320,8 +322,9 @@ class RenyiELBO(ELBO):
         Here :math:`\alpha \neq 1`. Default is 0.
     :param num_particles: The number of particles/samples
         used to form the objective (gradient) estimator. Default is 2.
-    :param vectorize_particles: Whether to use `jax.vmap` to obtain elbos over the
-        particles. If False, we will use `jax.lax.map`. Defaults to True.
+    :param vectorize_particles: Whether to use `jax.vmap` to compute ELBOs over the
+        num_particles-many particles in parallel. If False use `jax.lax.map`.
+        Defaults to True.
 
     Example::
 

--- a/numpyro/infer/elbo.py
+++ b/numpyro/infer/elbo.py
@@ -6,6 +6,7 @@ from functools import partial
 from operator import itemgetter
 import warnings
 
+import jax
 from jax import eval_shape, random, vmap
 from jax.lax import stop_gradient
 import jax.numpy as jnp
@@ -33,6 +34,8 @@ class ELBO:
 
     :param num_particles: The number of particles/samples used to form the ELBO
         (gradient) estimators.
+    :param vectorize_particles: Whether to use `jax.vmap` to obtain elbos over the
+        particles. If False, we will use `jax.lax.map`. Defaults to True.
     """
 
     """
@@ -42,8 +45,9 @@ class ELBO:
     """
     can_infer_discrete = False
 
-    def __init__(self, num_particles=1):
+    def __init__(self, num_particles=1, vectorize_particles=True):
         self.num_particles = num_particles
+        self.vectorize_particles = vectorize_particles
 
     def loss(self, rng_key, param_map, model, guide, *args, **kwargs):
         """
@@ -108,10 +112,9 @@ class Trace_ELBO(ELBO):
 
     :param num_particles: The number of particles/samples used to form the ELBO
         (gradient) estimators.
+    :param vectorize_particles: Whether to use `jax.vmap` to obtain elbos over the
+        particles. If False, we will use `jax.lax.map`. Defaults to True.
     """
-
-    def __init__(self, num_particles=1):
-        self.num_particles = num_particles
 
     def loss_with_mutable_state(
         self, rng_key, param_map, model, guide, *args, **kwargs
@@ -163,7 +166,10 @@ class Trace_ELBO(ELBO):
             return {"loss": -elbo, "mutable_state": mutable_state}
         else:
             rng_keys = random.split(rng_key, self.num_particles)
-            elbos, mutable_state = vmap(single_particle_elbo)(rng_keys)
+            if self.vectorize_particles:
+                elbos, mutable_state = vmap(single_particle_elbo)(rng_keys)
+            else:
+                elbos, mutable_state = jax.lax.map(single_particle_elbo, rng_keys)
             return {"loss": -jnp.mean(elbos), "mutable_state": mutable_state}
 
 
@@ -291,7 +297,10 @@ class TraceMeanField_ELBO(ELBO):
             return {"loss": -elbo, "mutable_state": mutable_state}
         else:
             rng_keys = random.split(rng_key, self.num_particles)
-            elbos, mutable_state = vmap(single_particle_elbo)(rng_keys)
+            if self.vectorize_particles:
+                elbos, mutable_state = vmap(single_particle_elbo)(rng_keys)
+            else:
+                elbos, mutable_state = jax.lax.map(single_particle_elbo, rng_keys)
             return {"loss": -jnp.mean(elbos), "mutable_state": mutable_state}
 
 
@@ -311,6 +320,8 @@ class RenyiELBO(ELBO):
         Here :math:`\alpha \neq 1`. Default is 0.
     :param num_particles: The number of particles/samples
         used to form the objective (gradient) estimator. Default is 2.
+    :param vectorize_particles: Whether to use `jax.vmap` to obtain elbos over the
+        particles. If False, we will use `jax.lax.map`. Defaults to True.
 
     Example::
 
@@ -427,7 +438,10 @@ class RenyiELBO(ELBO):
         )
 
         rng_keys = random.split(rng_key, self.num_particles)
-        elbos, common_plate_scale = vmap(single_particle_elbo)(rng_keys)
+        if self.vectorize_particles:
+            elbos, common_plate_scale = vmap(single_particle_elbo)(rng_keys)
+        else:
+            elbos, common_plate_scale = jax.lax.map(single_particle_elbo, rng_keys)
         assert common_plate_scale.shape == (self.num_particles,)
         assert elbos.shape[0] == self.num_particles
         scaled_elbos = (1.0 - self.alpha) * elbos
@@ -695,8 +709,10 @@ class TraceGraph_ELBO(ELBO):
 
     can_infer_discrete = True
 
-    def __init__(self, num_particles=1):
-        super().__init__(num_particles=num_particles)
+    def __init__(self, num_particles=1, vectorize_particles=True):
+        super().__init__(
+            num_particles=num_particles, vectorize_particles=vectorize_particles
+        )
 
     def loss(self, rng_key, param_map, model, guide, *args, **kwargs):
         """
@@ -771,7 +787,10 @@ class TraceGraph_ELBO(ELBO):
             return -single_particle_elbo(rng_key)
         else:
             rng_keys = random.split(rng_key, self.num_particles)
-            return -jnp.mean(vmap(single_particle_elbo)(rng_keys))
+            if self.vectorize_particles:
+                return -jnp.mean(vmap(single_particle_elbo)(rng_keys))
+            else:
+                return -jnp.mean(jax.lax.map(single_particle_elbo, rng_keys))
 
 
 def get_importance_trace_enum(
@@ -953,9 +972,13 @@ class TraceEnum_ELBO(ELBO):
 
     can_infer_discrete = True
 
-    def __init__(self, num_particles=1, max_plate_nesting=float("inf")):
+    def __init__(
+        self, num_particles=1, max_plate_nesting=float("inf"), vectorize_particles=True
+    ):
         self.max_plate_nesting = max_plate_nesting
-        super().__init__(num_particles=num_particles)
+        super().__init__(
+            num_particles=num_particles, vectorize_particles=vectorize_particles
+        )
 
     def loss(self, rng_key, param_map, model, guide, *args, **kwargs):
         def single_particle_elbo(rng_key):
@@ -1128,4 +1151,7 @@ class TraceEnum_ELBO(ELBO):
             return -single_particle_elbo(rng_key)
         else:
             rng_keys = random.split(rng_key, self.num_particles)
-            return -jnp.mean(vmap(single_particle_elbo)(rng_keys))
+            if self.vectorize_particles:
+                return -jnp.mean(vmap(single_particle_elbo)(rng_keys))
+            else:
+                return -jnp.mean(jax.lax.map(single_particle_elbo, rng_keys))


### PR DESCRIPTION
Allow to use lax.map instead of vmap in ELBO to reduce memory requirement