### PR TITLE
Fix bug in SineBivariateVonMises sampler

### DIFF
--- a/numpyro/distributions/directional.py
+++ b/numpyro/distributions/directional.py
@@ -477,7 +477,7 @@ class SineBivariateVonMises(Distribution):
             phi_key, key = random.split(key)
             accept_key, acg_key, phi_key = random.split(phi_key, 3)
 
-            x = jnp.sqrt(1 + 2 * eig / b0) * random.normal(acg_key, shape)
+            x = 1./jnp.sqrt(1 + 2 * eig / b0) * random.normal(acg_key, shape)
             x /= jnp.linalg.norm(
                 x, axis=1, keepdims=True
             )  # Angular Central Gaussian distribution

--- a/numpyro/distributions/directional.py
+++ b/numpyro/distributions/directional.py
@@ -477,7 +477,7 @@ class SineBivariateVonMises(Distribution):
             phi_key, key = random.split(key)
             accept_key, acg_key, phi_key = random.split(phi_key, 3)
 
-            x = 1./jnp.sqrt(1 + 2 * eig / b0) * random.normal(acg_key, shape)
+            x = lax.rsqrt(1 + 2 * eig / b0) * random.normal(acg_key, shape)
             x /= jnp.linalg.norm(
                 x, axis=1, keepdims=True
             )  # Angular Central Gaussian distribution


### PR DESCRIPTION
See https://cran.r-project.org/web/packages/simdd/index.html for R implementation.
Before fix, highly correlated distributions would fail to sample correctly, and max_sample_iter would exceed the default 1000, silently.
After fix, the same distribution sample correctly distributed values.