### PR TITLE
Bump to 0.13.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.9]
 
     steps:
     - uses: actions/checkout@v2
@@ -51,7 +51,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.9]
 
     steps:
     - uses: actions/checkout@v2
@@ -81,7 +81,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.9]
 
     steps:
     - uses: actions/checkout@v2
@@ -120,7 +120,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/examples/annotation.py
+++ b/examples/annotation.py
@@ -320,7 +320,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert numpyro.__version__.startswith("0.12.1")
+    assert numpyro.__version__.startswith("0.13.0")
     parser = argparse.ArgumentParser(description="Bayesian Models of Annotation")
     parser.add_argument("-n", "--num-samples", nargs="?", default=1000, type=int)
     parser.add_argument("--num-warmup", nargs="?", default=1000, type=int)

--- a/examples/ar2.py
+++ b/examples/ar2.py
@@ -114,7 +114,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert numpyro.__version__.startswith("0.12.1")
+    assert numpyro.__version__.startswith("0.13.0")
     parser = argparse.ArgumentParser(description="AR2 example")
     parser.add_argument("--num-data", nargs="?", default=142, type=int)
     parser.add_argument("-n", "--num-samples", nargs="?", default=1000, type=int)

--- a/examples/baseball.py
+++ b/examples/baseball.py
@@ -210,7 +210,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert numpyro.__version__.startswith("0.12.1")
+    assert numpyro.__version__.startswith("0.13.0")
     parser = argparse.ArgumentParser(description="Baseball batting average using MCMC")
     parser.add_argument("-n", "--num-samples", nargs="?", default=3000, type=int)
     parser.add_argument("--num-warmup", nargs="?", default=1500, type=int)

--- a/examples/bnn.py
+++ b/examples/bnn.py
@@ -160,7 +160,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert numpyro.__version__.startswith("0.12.1")
+    assert numpyro.__version__.startswith("0.13.0")
     parser = argparse.ArgumentParser(description="Bayesian neural network example")
     parser.add_argument("-n", "--num-samples", nargs="?", default=2000, type=int)
     parser.add_argument("--num-warmup", nargs="?", default=1000, type=int)

--- a/examples/covtype.py
+++ b/examples/covtype.py
@@ -206,7 +206,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert numpyro.__version__.startswith("0.12.1")
+    assert numpyro.__version__.startswith("0.13.0")
     parser = argparse.ArgumentParser(description="parse args")
     parser.add_argument(
         "-n", "--num-samples", default=1000, type=int, help="number of samples"

--- a/examples/funnel.py
+++ b/examples/funnel.py
@@ -139,7 +139,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert numpyro.__version__.startswith("0.12.1")
+    assert numpyro.__version__.startswith("0.13.0")
     parser = argparse.ArgumentParser(
         description="Non-centered reparameterization example"
     )

--- a/examples/gaussian_shells.py
+++ b/examples/gaussian_shells.py
@@ -120,7 +120,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert numpyro.__version__.startswith("0.12.1")
+    assert numpyro.__version__.startswith("0.13.0")
     parser = argparse.ArgumentParser(description="Nested sampler for Gaussian shells")
     parser.add_argument("-n", "--num-samples", nargs="?", default=10000, type=int)
     parser.add_argument("--num-warmup", nargs="?", default=1000, type=int)

--- a/examples/gp.py
+++ b/examples/gp.py
@@ -170,7 +170,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert numpyro.__version__.startswith("0.12.1")
+    assert numpyro.__version__.startswith("0.13.0")
     parser = argparse.ArgumentParser(description="Gaussian Process example")
     parser.add_argument("-n", "--num-samples", nargs="?", default=1000, type=int)
     parser.add_argument("--num-warmup", nargs="?", default=1000, type=int)

--- a/examples/hmm.py
+++ b/examples/hmm.py
@@ -263,7 +263,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert numpyro.__version__.startswith("0.12.1")
+    assert numpyro.__version__.startswith("0.13.0")
     parser = argparse.ArgumentParser(description="Semi-supervised Hidden Markov Model")
     parser.add_argument("--num-categories", default=3, type=int)
     parser.add_argument("--num-words", default=10, type=int)

--- a/examples/holt_winters.py
+++ b/examples/holt_winters.py
@@ -180,7 +180,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert numpyro.__version__.startswith("0.12.1")
+    assert numpyro.__version__.startswith("0.13.0")
     parser = argparse.ArgumentParser(description="Holt-Winters")
     parser.add_argument("--T", nargs="?", default=6, type=int)
     parser.add_argument("--future", nargs="?", default=1, type=int)

--- a/examples/horseshoe_regression.py
+++ b/examples/horseshoe_regression.py
@@ -162,7 +162,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert numpyro.__version__.startswith("0.12.1")
+    assert numpyro.__version__.startswith("0.13.0")
     parser = argparse.ArgumentParser(description="Horseshoe regression example")
     parser.add_argument("-n", "--num-samples", nargs="?", default=2000, type=int)
     parser.add_argument("--num-warmup", nargs="?", default=1000, type=int)

--- a/examples/minipyro.py
+++ b/examples/minipyro.py
@@ -58,7 +58,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert numpyro.__version__.startswith("0.12.1")
+    assert numpyro.__version__.startswith("0.13.0")
     parser = argparse.ArgumentParser(description="Mini Pyro demo")
     parser.add_argument("-f", "--full-pyro", action="store_true", default=False)
     parser.add_argument("-n", "--num-steps", default=1001, type=int)

--- a/examples/mortality.py
+++ b/examples/mortality.py
@@ -220,7 +220,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert numpyro.__version__.startswith("0.12.1")
+    assert numpyro.__version__.startswith("0.13.0")
 
     parser = argparse.ArgumentParser(description="Mortality regression model")
     parser.add_argument("-n", "--num-samples", nargs="?", default=500, type=int)

--- a/examples/neutra.py
+++ b/examples/neutra.py
@@ -197,7 +197,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert numpyro.__version__.startswith("0.12.1")
+    assert numpyro.__version__.startswith("0.13.0")
     parser = argparse.ArgumentParser(description="NeuTra HMC")
     parser.add_argument("-n", "--num-samples", nargs="?", default=4000, type=int)
     parser.add_argument("--num-warmup", nargs="?", default=1000, type=int)

--- a/examples/ode.py
+++ b/examples/ode.py
@@ -117,7 +117,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert numpyro.__version__.startswith("0.12.1")
+    assert numpyro.__version__.startswith("0.13.0")
     parser = argparse.ArgumentParser(description="Predator-Prey Model")
     parser.add_argument("-n", "--num-samples", nargs="?", default=1000, type=int)
     parser.add_argument("--num-warmup", nargs="?", default=1000, type=int)

--- a/examples/prodlda.py
+++ b/examples/prodlda.py
@@ -314,7 +314,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert numpyro.__version__.startswith("0.12.1")
+    assert numpyro.__version__.startswith("0.13.0")
     parser = argparse.ArgumentParser(
         description="Probabilistic topic modelling with Flax and Haiku"
     )

--- a/examples/proportion_test.py
+++ b/examples/proportion_test.py
@@ -160,7 +160,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert numpyro.__version__.startswith("0.12.1")
+    assert numpyro.__version__.startswith("0.13.0")
     parser = argparse.ArgumentParser(description="Testing whether  ")
     parser.add_argument("-n", "--num-samples", nargs="?", default=500, type=int)
     parser.add_argument("--num-warmup", nargs="?", default=1500, type=int)

--- a/examples/proportion_test.py
+++ b/examples/proportion_test.py
@@ -19,7 +19,6 @@ density interval for the effect of making a call.
 
 import argparse
 import os
-from typing import Tuple
 
 from jax import random
 import jax.numpy as jnp
@@ -31,7 +30,7 @@ import numpyro.distributions as dist
 from numpyro.infer import MCMC, NUTS
 
 
-def make_dataset(rng_key) -> Tuple[jnp.ndarray, jnp.ndarray]:
+def make_dataset(rng_key) -> tuple[jnp.ndarray, jnp.ndarray]:
     """
     Make simulated dataset where potential customers who get a
     sales calls have ~2% higher chance of making another purchase.

--- a/examples/sparse_regression.py
+++ b/examples/sparse_regression.py
@@ -384,7 +384,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert numpyro.__version__.startswith("0.12.1")
+    assert numpyro.__version__.startswith("0.13.0")
     parser = argparse.ArgumentParser(description="Gaussian Process example")
     parser.add_argument("-n", "--num-samples", nargs="?", default=1000, type=int)
     parser.add_argument("--num-warmup", nargs="?", default=500, type=int)

--- a/examples/stochastic_volatility.py
+++ b/examples/stochastic_volatility.py
@@ -122,7 +122,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert numpyro.__version__.startswith("0.12.1")
+    assert numpyro.__version__.startswith("0.13.0")
     parser = argparse.ArgumentParser(description="Stochastic Volatility Model")
     parser.add_argument("-n", "--num-samples", nargs="?", default=600, type=int)
     parser.add_argument("--num-warmup", nargs="?", default=600, type=int)

--- a/examples/thompson_sampling.py
+++ b/examples/thompson_sampling.py
@@ -292,7 +292,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert numpyro.__version__.startswith("0.12.1")
+    assert numpyro.__version__.startswith("0.13.0")
     parser = argparse.ArgumentParser(description="Thompson sampling example")
     parser.add_argument(
         "--num-random", nargs="?", default=2, type=int, help="number of random draws"

--- a/examples/toy_mixture_model_discrete_enumeration.py
+++ b/examples/toy_mixture_model_discrete_enumeration.py
@@ -126,7 +126,7 @@ def get_true_pred_CPDs(CPD, posterior_param):
 
 
 if __name__ == "__main__":
-    assert numpyro.__version__.startswith("0.12.1")
+    assert numpyro.__version__.startswith("0.13.0")
     parser = argparse.ArgumentParser(description="Toy mixture model")
     parser.add_argument("-n", "--num-steps", default=4000, type=int)
     parser.add_argument("-o", "--num-obs", default=10000, type=int)

--- a/examples/ucbadmit.py
+++ b/examples/ucbadmit.py
@@ -151,7 +151,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert numpyro.__version__.startswith("0.12.1")
+    assert numpyro.__version__.startswith("0.13.0")
     parser = argparse.ArgumentParser(
         description="UCBadmit gender discrimination using HMC"
     )

--- a/examples/vae.py
+++ b/examples/vae.py
@@ -160,7 +160,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert numpyro.__version__.startswith("0.12.1")
+    assert numpyro.__version__.startswith("0.13.0")
     parser = argparse.ArgumentParser(description="parse args")
     parser.add_argument(
         "-n", "--num-epochs", default=15, type=int, help="number of training epochs"

--- a/notebooks/source/bad_posterior_geometry.ipynb
+++ b/notebooks/source/bad_posterior_geometry.ipynb
@@ -50,7 +50,7 @@
     "\n",
     "from numpyro.infer import MCMC, NUTS\n",
     "\n",
-    "assert numpyro.__version__.startswith(\"0.12.1\")\n",
+    "assert numpyro.__version__.startswith(\"0.13.0\")\n",
     "\n",
     "# NB: replace cpu by gpu to run this notebook on gpu\n",
     "numpyro.set_platform(\"cpu\")"

--- a/notebooks/source/bayesian_hierarchical_linear_regression.ipynb
+++ b/notebooks/source/bayesian_hierarchical_linear_regression.ipynb
@@ -245,7 +245,7 @@
     "import numpyro.distributions as dist\n",
     "from jax import random\n",
     "\n",
-    "assert numpyro.__version__.startswith(\"0.12.1\")"
+    "assert numpyro.__version__.startswith(\"0.13.0\")"
    ]
   },
   {

--- a/notebooks/source/bayesian_hierarchical_stacking.ipynb
+++ b/notebooks/source/bayesian_hierarchical_stacking.ipynb
@@ -96,7 +96,7 @@
     "    set_matplotlib_formats(\"svg\")\n",
     "\n",
     "numpyro.set_host_device_count(4)\n",
-    "assert numpyro.__version__.startswith(\"0.12.1\")"
+    "assert numpyro.__version__.startswith(\"0.13.0\")"
    ]
   },
   {

--- a/notebooks/source/bayesian_imputation.ipynb
+++ b/notebooks/source/bayesian_imputation.ipynb
@@ -55,7 +55,7 @@
     "if \"NUMPYRO_SPHINXBUILD\" in os.environ:\n",
     "    set_matplotlib_formats(\"svg\")\n",
     "\n",
-    "assert numpyro.__version__.startswith(\"0.12.1\")"
+    "assert numpyro.__version__.startswith(\"0.13.0\")"
    ]
   },
   {

--- a/notebooks/source/bayesian_regression.ipynb
+++ b/notebooks/source/bayesian_regression.ipynb
@@ -95,7 +95,7 @@
     "if \"NUMPYRO_SPHINXBUILD\" in os.environ:\n",
     "    set_matplotlib_formats(\"svg\")\n",
     "\n",
-    "assert numpyro.__version__.startswith(\"0.12.1\")"
+    "assert numpyro.__version__.startswith(\"0.13.0\")"
    ],
    "execution_count": 2,
    "outputs": []

--- a/notebooks/source/gmm.ipynb
+++ b/notebooks/source/gmm.ipynb
@@ -54,7 +54,7 @@
     "%matplotlib inline\n",
     "\n",
     "smoke_test = \"CI\" in os.environ\n",
-    "assert numpyro.__version__.startswith(\"0.12.1\")"
+    "assert numpyro.__version__.startswith(\"0.13.0\")"
    ]
   },
   {

--- a/notebooks/source/logistic_regression.ipynb
+++ b/notebooks/source/logistic_regression.ipynb
@@ -41,7 +41,7 @@
     "from numpyro.examples.datasets import COVTYPE, load_dataset\n",
     "from numpyro.infer import HMC, MCMC, NUTS\n",
     "\n",
-    "assert numpyro.__version__.startswith(\"0.12.1\")\n",
+    "assert numpyro.__version__.startswith(\"0.13.0\")\n",
     "\n",
     "# NB: replace gpu by cpu to run this notebook in cpu\n",
     "numpyro.set_platform(\"gpu\")"

--- a/notebooks/source/model_rendering.ipynb
+++ b/notebooks/source/model_rendering.ipynb
@@ -37,7 +37,7 @@
     "import numpyro.distributions as dist\n",
     "import numpyro.distributions.constraints as constraints\n",
     "\n",
-    "assert numpyro.__version__.startswith(\"0.12.1\")"
+    "assert numpyro.__version__.startswith(\"0.13.0\")"
    ]
   },
   {

--- a/notebooks/source/ordinal_regression.ipynb
+++ b/notebooks/source/ordinal_regression.ipynb
@@ -53,7 +53,7 @@
     "import pandas as pd\n",
     "import seaborn as sns\n",
     "\n",
-    "assert numpyro.__version__.startswith(\"0.12.1\")"
+    "assert numpyro.__version__.startswith(\"0.13.0\")"
    ]
   },
   {

--- a/notebooks/source/time_series_forecasting.ipynb
+++ b/notebooks/source/time_series_forecasting.ipynb
@@ -48,7 +48,7 @@
     "    set_matplotlib_formats(\"svg\")\n",
     "\n",
     "numpyro.set_host_device_count(4)\n",
-    "assert numpyro.__version__.startswith(\"0.12.1\")"
+    "assert numpyro.__version__.startswith(\"0.13.0\")"
    ]
   },
   {

--- a/numpyro/contrib/einstein/mixture_guide_predictive.py
+++ b/numpyro/contrib/einstein/mixture_guide_predictive.py
@@ -1,8 +1,9 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
+from collections.abc import Callable, Sequence
 from functools import partial
-from typing import Callable, Optional, Sequence
+from typing import Optional
 
 from jax import numpy as jnp, random, tree_map, vmap
 from jax.tree_util import tree_flatten

--- a/numpyro/contrib/einstein/mixture_guide_predictive.py
+++ b/numpyro/contrib/einstein/mixture_guide_predictive.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from functools import partial
-from typing import Callable, Dict, Optional, Sequence
+from typing import Callable, Optional, Sequence
 
 from jax import numpy as jnp, random, tree_map, vmap
 from jax.tree_util import tree_flatten
@@ -24,7 +24,7 @@ class MixtureGuidePredictive:
 
     :param Callable model: Python callable containing Pyro primitives.
     :param Callable guide: Python callable containing Pyro primitives to get posterior samples of sites.
-    :param Dict params:  Dictionary of values for param sites of model/guide
+    :param dict params:  Dictionary of values for param sites of model/guide
     :param Sequence guide_sites: Names of sites that contribute to the Stein mixture.
     :param Optional[int] num_samples:
     :param Optional[Sequence[str]] return_sites: Sites to return. By default, only sample sites not present
@@ -37,7 +37,7 @@ class MixtureGuidePredictive:
         self,
         model: Callable,
         guide: Callable,
-        params: Dict,
+        params: dict,
         guide_sites: Sequence,
         num_samples: Optional[int] = None,
         return_sites: Optional[Sequence[str]] = None,

--- a/numpyro/contrib/einstein/stein_kernels.py
+++ b/numpyro/contrib/einstein/stein_kernels.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from abc import ABC, abstractmethod
-from typing import Callable
+from collections.abc import Callable
 
 import numpy as np
 

--- a/numpyro/contrib/einstein/stein_kernels.py
+++ b/numpyro/contrib/einstein/stein_kernels.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from abc import ABC, abstractmethod
-from typing import Callable, Dict, List, Tuple
+from typing import Callable
 
 import numpy as np
 
@@ -30,7 +30,7 @@ class SteinKernel(ABC):
     def compute(
         self,
         particles: jnp.ndarray,
-        particle_info: Dict[str, Tuple[int, int]],
+        particle_info: dict[str, tuple[int, int]],
         loss_fn: Callable[[jnp.ndarray], float],
     ):
         """
@@ -279,7 +279,7 @@ class MixtureKernel(SteinKernel):
     :param kernel_fns: Different kernel functions to mix together
     """
 
-    def __init__(self, ws: List[float], kernel_fns: List[SteinKernel], mode="norm"):
+    def __init__(self, ws: list[float], kernel_fns: list[SteinKernel], mode="norm"):
         assert len(ws) == len(kernel_fns)
         assert len(kernel_fns) > 1
         assert all(kf.mode == mode for kf in kernel_fns)
@@ -328,7 +328,7 @@ class GraphicalKernel(SteinKernel):
     def __init__(
         self,
         mode="matrix",
-        local_kernel_fns: Dict[str, SteinKernel] = None,
+        local_kernel_fns: dict[str, SteinKernel] = None,
         default_kernel_fn: SteinKernel = RBFKernel(),
     ):
         assert mode == "matrix"
@@ -385,7 +385,7 @@ class ProbabilityProductKernel(SteinKernel):
     def compute(
         self,
         particles: jnp.ndarray,
-        particle_info: Dict[str, Tuple[int, int]],
+        particle_info: dict[str, tuple[int, int]],
         loss_fn: Callable[[jnp.ndarray], float],
     ):
         loc_idx = jnp.concatenate(

--- a/numpyro/contrib/einstein/steinvi.py
+++ b/numpyro/contrib/einstein/steinvi.py
@@ -2,12 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from collections import namedtuple
+from collections.abc import Callable
 from copy import deepcopy
 import functools
 from functools import partial
 from itertools import chain
 import operator
-from typing import Callable
 
 from jax import grad, jacfwd, numpy as jnp, random, vmap
 from jax.random import KeyArray

--- a/numpyro/distributions/mixtures.py
+++ b/numpyro/distributions/mixtures.py
@@ -350,7 +350,7 @@ class MixtureGeneral(_MixtureBase):
         """The list of component distributions in the mixture
 
         :return: The list of component distributions
-        :rtype: List[Distribution]
+        :rtype: list[Distribution]
         """
         return self._component_distributions
 

--- a/numpyro/infer/autoguide.py
+++ b/numpyro/infer/autoguide.py
@@ -11,16 +11,9 @@ import numpy as np
 
 import jax
 from jax import grad, hessian, lax, random
-from jax.tree_util import tree_map
-
-from numpyro.util import _versiontuple, find_stack_level
-
-if _versiontuple(jax.__version__) >= (0, 2, 25):
-    from jax.example_libraries import stax
-else:
-    from jax.experimental import stax
-
+from jax.example_libraries import stax
 import jax.numpy as jnp
+from jax.tree_util import tree_map
 
 import numpyro
 from numpyro import handlers
@@ -54,7 +47,7 @@ from numpyro.infer.util import (
 )
 from numpyro.nn.auto_reg_nn import AutoregressiveNN
 from numpyro.nn.block_neural_arn import BlockNeuralAutoregressiveNN
-from numpyro.util import not_jax_tracer
+from numpyro.util import find_stack_level, not_jax_tracer
 
 __all__ = [
     "AutoContinuous",

--- a/numpyro/infer/inspect.py
+++ b/numpyro/infer/inspect.py
@@ -4,7 +4,7 @@
 from functools import partial
 import itertools
 from pathlib import Path
-from typing import Callable, Dict, Optional
+from typing import Callable, Optional
 
 import jax
 
@@ -72,7 +72,7 @@ def get_dependencies(
     model: Callable,
     model_args: Optional[tuple] = None,
     model_kwargs: Optional[dict] = None,
-) -> Dict[str, object]:
+) -> dict[str, object]:
     r"""
     Infers dependency structure about a conditioned model.
 

--- a/numpyro/infer/inspect.py
+++ b/numpyro/infer/inspect.py
@@ -1,10 +1,11 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
+from collections.abc import Callable
 from functools import partial
 import itertools
 from pathlib import Path
-from typing import Callable, Optional
+from typing import Optional
 
 import jax
 

--- a/numpyro/infer/svi.py
+++ b/numpyro/infer/svi.py
@@ -1,21 +1,14 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
-from functools import namedtuple, partial
+from collections import namedtuple
+from functools import partial
 import warnings
 
 import tqdm
 
-import jax
-
-from numpyro.util import _versiontuple, find_stack_level
-
-if _versiontuple(jax.__version__) >= (0, 2, 25):
-    from jax.example_libraries import optimizers
-else:
-    from jax.experimental import optimizers  # pytype: disable=import-error
-
 from jax import jit, lax, random
+from jax.example_libraries import optimizers
 import jax.numpy as jnp
 from jax.tree_util import tree_map
 
@@ -24,6 +17,7 @@ from numpyro.distributions.transforms import biject_to
 from numpyro.handlers import replay, seed, substitute, trace
 from numpyro.infer.util import helpful_support_errors, transform_fn
 from numpyro.optim import _NumPyroOptim, optax_to_numpyro
+from numpyro.util import find_stack_level
 
 SVIState = namedtuple("SVIState", ["optim_state", "mutable_state", "rng_key"])
 """

--- a/numpyro/infer/util.py
+++ b/numpyro/infer/util.py
@@ -4,7 +4,7 @@
 from collections import namedtuple
 from contextlib import contextmanager
 from functools import partial
-from typing import Callable, Dict, List, Optional
+from typing import Callable, Optional
 import warnings
 
 import numpy as np
@@ -896,12 +896,12 @@ class Predictive(object):
     def __init__(
         self,
         model: Callable,
-        posterior_samples: Optional[Dict] = None,
+        posterior_samples: Optional[dict] = None,
         *,
         guide: Optional[Callable] = None,
-        params: Optional[Dict] = None,
+        params: Optional[dict] = None,
         num_samples: Optional[int] = None,
-        return_sites: Optional[List[str]] = None,
+        return_sites: Optional[list[str]] = None,
         infer_discrete: bool = False,
         parallel: bool = False,
         batch_ndims: Optional[int] = None,

--- a/numpyro/nn/auto_reg_nn.py
+++ b/numpyro/nn/auto_reg_nn.py
@@ -5,15 +5,7 @@
 
 import numpy as np
 
-import jax
-
-from numpyro.util import _versiontuple
-
-if _versiontuple(jax.__version__) >= (0, 2, 25):
-    from jax.example_libraries import stax
-else:
-    from jax.experimental import stax
-
+from jax.example_libraries import stax
 import jax.numpy as jnp
 
 from numpyro.nn.masked_dense import MaskedDense

--- a/numpyro/nn/block_neural_arn.py
+++ b/numpyro/nn/block_neural_arn.py
@@ -3,16 +3,8 @@
 
 import numpy as np
 
-import jax
 from jax import random
-
-from numpyro.util import _versiontuple
-
-if _versiontuple(jax.__version__) >= (0, 2, 25):
-    from jax.example_libraries import stax
-else:
-    from jax.experimental import stax
-
+from jax.example_libraries import stax
 from jax.nn import sigmoid, softplus
 from jax.nn.initializers import glorot_uniform, normal, uniform
 import jax.numpy as jnp

--- a/numpyro/optim.py
+++ b/numpyro/optim.py
@@ -8,7 +8,8 @@ suited for working with NumPyro inference algorithms.
 """
 
 from collections import namedtuple
-from typing import Any, Callable, TypeVar
+from collections.abc import Callable
+from typing import Any, TypeVar
 
 from jax import lax, value_and_grad
 from jax.example_libraries import optimizers

--- a/numpyro/optim.py
+++ b/numpyro/optim.py
@@ -8,7 +8,7 @@ suited for working with NumPyro inference algorithms.
 """
 
 from collections import namedtuple
-from typing import Any, Callable, Tuple, TypeVar
+from typing import Any, Callable, TypeVar
 
 from jax import lax, value_and_grad
 from jax.example_libraries import optimizers
@@ -31,7 +31,7 @@ __all__ = [
 
 _Params = TypeVar("_Params")
 _OptState = TypeVar("_OptState")
-_IterOptState = Tuple[int, _OptState]
+_IterOptState = tuple[int, _OptState]
 
 
 class _NumPyroOptim(object):
@@ -60,7 +60,7 @@ class _NumPyroOptim(object):
         opt_state = self.update_fn(i, g, opt_state)
         return i + 1, opt_state
 
-    def eval_and_update(self, fn: Callable[[Any], Tuple], state: _IterOptState):
+    def eval_and_update(self, fn: Callable[[Any], tuple], state: _IterOptState):
         """
         Performs an optimization step for the objective function `fn`.
         For most optimizers, the update is performed based on the gradient
@@ -79,7 +79,7 @@ class _NumPyroOptim(object):
         (out, aux), grads = value_and_grad(fn, has_aux=True)(params)
         return (out, aux), self.update(grads, state)
 
-    def eval_and_stable_update(self, fn: Callable[[Any], Tuple], state: _IterOptState):
+    def eval_and_stable_update(self, fn: Callable[[Any], tuple], state: _IterOptState):
         """
         Like :meth:`eval_and_update` but when the value of the objective function
         or the gradients are not finite, we will not update the input `state`
@@ -265,7 +265,7 @@ class Minimize(_NumPyroOptim):
         self._method = method
         self._kwargs = kwargs
 
-    def eval_and_update(self, fn: Callable[[Any], Tuple], state: _IterOptState):
+    def eval_and_update(self, fn: Callable[[Any], tuple], state: _IterOptState):
         i, (flat_params, unravel_fn) = state
 
         def loss_fn(x):

--- a/numpyro/optim.py
+++ b/numpyro/optim.py
@@ -10,16 +10,8 @@ suited for working with NumPyro inference algorithms.
 from collections import namedtuple
 from typing import Any, Callable, Tuple, TypeVar
 
-import jax
 from jax import lax, value_and_grad
-
-from numpyro.util import _versiontuple
-
-if _versiontuple(jax.__version__) >= (0, 2, 25):
-    from jax.example_libraries import optimizers
-else:
-    from jax.experimental import optimizers  # pytype: disable=import-error
-
+from jax.example_libraries import optimizers
 from jax.flatten_util import ravel_pytree
 import jax.numpy as jnp
 from jax.scipy.optimize import minimize

--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -717,19 +717,6 @@ def _format_table(rows):
     )
 
 
-def _versiontuple(version):
-    """
-    :param str version: Version, in string format.
-    Parse version string into tuple of ints.
-
-    Only to be used for the standard 'major.minor.patch' format,
-    such as ``'0.2.13'``.
-
-    Source: https://stackoverflow.com/a/11887825/4451315
-    """
-    return tuple([int(number) for number in version.split(".")])
-
-
 def find_stack_level() -> int:
     """
     Find the first place in the stack that is not inside numpyro

--- a/numpyro/version.py
+++ b/numpyro/version.py
@@ -1,4 +1,4 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
-__version__ = "0.12.1"
+__version__ = "0.13.0"

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,8 @@ import sys
 from setuptools import find_packages, setup
 
 PROJECT_PATH = os.path.dirname(os.path.abspath(__file__))
-_jax_version_constraints = ">=0.4.7"
-_jaxlib_version_constraints = ">=0.4.7"
+_jax_version_constraints = ">=0.4.14"
+_jaxlib_version_constraints = ">=0.4.14"
 
 # Find version
 for line in open(os.path.join(PROJECT_PATH, "numpyro", "version.py")):

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,6 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: POSIX :: Linux",
         "Operating System :: MacOS :: MacOS X",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",

--- a/test/infer/test_autoguide.py
+++ b/test/infer/test_autoguide.py
@@ -7,18 +7,10 @@ from numpy.random import RandomState
 from numpy.testing import assert_allclose
 import pytest
 
-import jax
 from jax import jacobian, jit, lax, random
-from jax.tree_util import tree_all, tree_map
-
-from numpyro.util import _versiontuple
-
-if _versiontuple(jax.__version__) >= (0, 2, 25):
-    from jax.example_libraries.stax import Dense
-else:
-    from jax.experimental.stax import Dense
-
+from jax.example_libraries.stax import Dense
 import jax.numpy as jnp
+from jax.tree_util import tree_all, tree_map
 import optax
 from optax import piecewise_constant_schedule
 

--- a/test/infer/test_svi.py
+++ b/test/infer/test_svi.py
@@ -9,15 +9,9 @@ import pytest
 
 import jax
 from jax import jit, random, value_and_grad
+from jax.example_libraries import optimizers
 import jax.numpy as jnp
 from jax.tree_util import tree_all, tree_map
-
-from numpyro.util import _versiontuple
-
-if _versiontuple(jax.__version__) >= (0, 2, 25):
-    from jax.example_libraries import optimizers
-else:
-    from jax.experimental import optimizers  # pytype: disable=import-error
 
 import numpyro
 from numpyro import optim

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -2112,7 +2112,7 @@ def test_beta_proportion_invalid_mean():
         (constraints.real, -1, True),
         (
             constraints.real,
-            np.array([np.inf, np.NINF, np.nan, np.pi]),
+            np.array([np.inf, -np.inf, np.nan, np.pi]),
             np.array([False, False, False, True]),
         ),
         (constraints.simplex, np.array([0.1, 0.3, 0.6]), True),

--- a/test/test_flows.py
+++ b/test/test_flows.py
@@ -7,15 +7,8 @@ import numpy as np
 from numpy.testing import assert_allclose
 import pytest
 
-import jax
 from jax import jacfwd, random
-
-from numpyro.util import _versiontuple
-
-if _versiontuple(jax.__version__) >= (0, 2, 25):
-    from jax.example_libraries import stax
-else:
-    from jax.experimental import stax
+from jax.example_libraries import stax
 
 from numpyro.distributions.flows import (
     BlockNeuralAutoregressiveTransform,

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7,16 +7,8 @@ import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal
 import pytest
 
-import jax
 from jax import jacfwd, random, vmap
-
-from numpyro.util import _versiontuple
-
-if _versiontuple(jax.__version__) >= (0, 2, 25):
-    from jax.example_libraries.stax import serial
-else:
-    from jax.experimental.stax import serial
-
+from jax.example_libraries.stax import serial
 import jax.numpy as jnp
 
 from numpyro.distributions.util import matrix_to_tril_vec


### PR DESCRIPTION
JAX released 0.4.14 version last month, which drops support for python 3.8. So we'll also drop support for 3.8 and bump the version to 0.13.0.

Also remove the check `if _versiontuple(jax.__version__) >= (0, 2, 25):` which is unnecessary for a while.