### PR TITLE
dispatch _promote_batch_shape_expanded to Independent

### DIFF
--- a/numpyro/distributions/batch_util.py
+++ b/numpyro/distributions/batch_util.py
@@ -524,8 +524,8 @@ def _default_promote_batch_shape(d: Distribution):
     return new_self
 
 
-@promote_batch_shape.register
-def _promote_batch_shape_expanded(d: Union[ExpandedDistribution, Independent]):
+@promote_batch_shape.register(Independent)
+def _promote_batch_shape_expanded(d: ExpandedDistribution):
     orig_delta_batch_shape = d.batch_shape[
         : len(d.batch_shape) - len(d.base_dist.batch_shape)
     ]
@@ -562,7 +562,6 @@ def _promote_batch_shape_expanded(d: Union[ExpandedDistribution, Independent]):
 
     new_self.base_dist = new_base_dist
     return new_self
-
 
 @promote_batch_shape.register
 def _promote_batch_shape_masked(d: MaskedDistribution):

--- a/numpyro/distributions/batch_util.py
+++ b/numpyro/distributions/batch_util.py
@@ -564,14 +564,20 @@ def _promote_batch_shape_expanded(d: ExpandedDistribution):
     return new_self
 
 
-promote_batch_shape.register(Independent, _promote_batch_shape_expanded)
-
-
 @promote_batch_shape.register
 def _promote_batch_shape_masked(d: MaskedDistribution):
     new_self = copy.copy(d)
     new_base_dist = promote_batch_shape(d.base_dist)
     new_self._batch_shape = new_base_dist.batch_shape
+    new_self.base_dist = new_base_dist
+    return new_self
+
+
+@promote_batch_shape.register
+def _promote_batch_shape_independent(d: Independent):
+    new_self = copy.copy(d)
+    new_base_dist = promote_batch_shape(d.base_dist)
+    new_self._batch_shape = new_base_dist.batch_shape[: d.event_dim]
     new_self.base_dist = new_base_dist
     return new_self
 

--- a/numpyro/distributions/batch_util.py
+++ b/numpyro/distributions/batch_util.py
@@ -53,6 +53,7 @@ from numpyro.distributions.distribution import (
     ExpandedDistribution,
     MaskedDistribution,
     Unit,
+    Independent,
 )
 from numpyro.distributions.transforms import (
     AffineTransform,
@@ -524,7 +525,7 @@ def _default_promote_batch_shape(d: Distribution):
 
 
 @promote_batch_shape.register
-def _promote_batch_shape_expanded(d: ExpandedDistribution):
+def _promote_batch_shape_expanded(d: Union[ExpandedDistribution, Independent]):
     orig_delta_batch_shape = d.batch_shape[
         : len(d.batch_shape) - len(d.base_dist.batch_shape)
     ]

--- a/numpyro/distributions/batch_util.py
+++ b/numpyro/distributions/batch_util.py
@@ -51,9 +51,9 @@ from numpyro.distributions.discrete import (
 from numpyro.distributions.distribution import (
     Distribution,
     ExpandedDistribution,
+    Independent,
     MaskedDistribution,
     Unit,
-    Independent,
 )
 from numpyro.distributions.transforms import (
     AffineTransform,

--- a/numpyro/distributions/batch_util.py
+++ b/numpyro/distributions/batch_util.py
@@ -524,7 +524,7 @@ def _default_promote_batch_shape(d: Distribution):
     return new_self
 
 
-@promote_batch_shape.register(Independent)
+@promote_batch_shape.register
 def _promote_batch_shape_expanded(d: ExpandedDistribution):
     orig_delta_batch_shape = d.batch_shape[
         : len(d.batch_shape) - len(d.base_dist.batch_shape)
@@ -562,6 +562,9 @@ def _promote_batch_shape_expanded(d: ExpandedDistribution):
 
     new_self.base_dist = new_base_dist
     return new_self
+
+
+promote_batch_shape.register(Independent, _promote_batch_shape_expanded)
 
 
 @promote_batch_shape.register

--- a/numpyro/distributions/batch_util.py
+++ b/numpyro/distributions/batch_util.py
@@ -563,6 +563,7 @@ def _promote_batch_shape_expanded(d: ExpandedDistribution):
     new_self.base_dist = new_base_dist
     return new_self
 
+
 @promote_batch_shape.register
 def _promote_batch_shape_masked(d: MaskedDistribution):
     new_self = copy.copy(d)

--- a/test/contrib/test_control_flow.py
+++ b/test/contrib/test_control_flow.py
@@ -12,7 +12,7 @@ from numpyro.contrib.control_flow import cond, scan
 import numpyro.distributions as dist
 from numpyro.handlers import mask, seed, substitute, trace
 from numpyro.infer import MCMC, NUTS, SVI, Predictive, Trace_ELBO
-from numpyro.infer.util import potential_energy
+from numpyro.infer.util import potential_energy, log_density
 
 
 def test_scan():
@@ -237,4 +237,5 @@ def test_scan_plate_mask():
         return (x, y)
 
     with numpyro.handlers.seed(rng_seed=0):
-        x, y = model()
+        model_density, model_trace = log_density(model, (None, 10), {}, {})
+        assert model_density

--- a/test/contrib/test_control_flow.py
+++ b/test/contrib/test_control_flow.py
@@ -10,7 +10,7 @@ import jax.numpy as jnp
 import numpyro
 from numpyro.contrib.control_flow import cond, scan
 import numpyro.distributions as dist
-from numpyro.handlers import seed, substitute, trace, mask
+from numpyro.handlers import mask, seed, substitute, trace
 from numpyro.infer import MCMC, NUTS, SVI, Predictive, Trace_ELBO
 from numpyro.infer.util import potential_energy
 

--- a/test/contrib/test_control_flow.py
+++ b/test/contrib/test_control_flow.py
@@ -12,7 +12,7 @@ from numpyro.contrib.control_flow import cond, scan
 import numpyro.distributions as dist
 from numpyro.handlers import mask, seed, substitute, trace
 from numpyro.infer import MCMC, NUTS, SVI, Predictive, Trace_ELBO
-from numpyro.infer.util import potential_energy, log_density
+from numpyro.infer.util import log_density, potential_energy
 
 
 def test_scan():

--- a/test/contrib/test_control_flow.py
+++ b/test/contrib/test_control_flow.py
@@ -239,3 +239,5 @@ def test_scan_plate_mask():
     with numpyro.handlers.seed(rng_seed=0):
         model_density, model_trace = log_density(model, (None, 10), {}, {})
         assert model_density
+        assert model_trace["x"]["fn"].batch_shape == (10,)
+        assert model_trace["x"]["fn"].event_shape == (3,)

--- a/test/contrib/test_control_flow.py
+++ b/test/contrib/test_control_flow.py
@@ -10,7 +10,7 @@ import jax.numpy as jnp
 import numpyro
 from numpyro.contrib.control_flow import cond, scan
 import numpyro.distributions as dist
-from numpyro.handlers import seed, substitute, trace
+from numpyro.handlers import seed, substitute, trace, mask
 from numpyro.infer import MCMC, NUTS, SVI, Predictive, Trace_ELBO
 from numpyro.infer.util import potential_energy
 
@@ -210,3 +210,21 @@ def test_scan_promote():
     tr = numpyro.handlers.trace(model).get_trace()
     assert tr["x"]["value"].shape == (10, 1)
     assert tr["x"]["fn"].log_prob(tr["x"]["value"]).shape == (10, 3)
+
+
+def test_scan_masked():
+    def model(y=None, T=10):
+        def transition(carry, y_curr):
+            x_prev, t = carry
+            with numpyro.plate("N", 10, dim=-1):
+                with mask(mask=(t < T)):
+                    x_curr = numpyro.sample('x', dist.Normal(jnp.zeros((10, 3)), jnp.ones((10, 3))).to_event(1))
+                    y_curr = numpyro.sample('y', dist.Normal(x_curr, jnp.ones((10, 3))).to_event(1), obs=y_curr)
+                    return (x_curr, t + 1), None
+        x0 = numpyro.sample('x_0', dist.Normal(jnp.zeros((10, 3)), jnp.ones((10, 3))).to_event(1))
+
+        x, t = scan(transition, (x0, 0), y, length=T)
+        return (x, y)
+
+    with numpyro.handlers.seed(rng_seed=0):
+        x, y = model()


### PR DESCRIPTION
Independent distributions aren't dispatched to in batch_utils - the fix reuses the batch promoting for ExpandedDistribution and runs without errors, but hasn't been tested thoroughly, perhaps @pierreglaser can review?