### PR TITLE
Use python 3.9 for rtd

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.8"
+    python: "3.9"
 
 sphinx:
    configuration: docs/source/conf.py


### PR DESCRIPTION
Fixes rtd builds currently [fail](https://readthedocs.org/projects/numpyro/builds/).