### PR TITLE
Add AutoGuideList

### DIFF
--- a/numpyro/handlers.py
+++ b/numpyro/handlers.py
@@ -225,58 +225,6 @@ class replay(Messenger):
             msg["infer"] = guide_msg["infer"].copy()
 
 
-def _block_fn(expose, expose_types, hide, hide_types, hide_all, msg):
-    if msg.get("type") == "sample" and msg.get("is_observed"):
-        msg_type = "observe"
-    else:
-        msg_type = msg.get("type")
-
-    is_not_exposed = (msg.get("name") not in expose) and (msg_type not in expose_types)
-
-    if (
-        (msg.get("name") in hide)
-        or (msg_type in hide_types)
-        or (is_not_exposed and hide_all)
-    ):
-        return True
-    else:
-        return False
-
-
-def _make_default_hide_fn(hide_all, expose_all, hide, expose, hide_types, expose_types):
-    assert (hide_all is False and expose_all is False) or (
-        hide_all != expose_all
-    ), "cannot hide and expose a site"
-
-    if hide is None:
-        hide = []
-    else:
-        hide_all = False
-
-    if expose is None:
-        expose = []
-    else:
-        hide_all = True
-
-    assert set(hide).isdisjoint(set(expose)), "cannot hide and expose a site"
-
-    if hide_types is None:
-        hide_types = []
-    else:
-        hide_all = False
-
-    if expose_types is None:
-        expose_types = []
-    else:
-        hide_all = True
-
-    assert set(hide_types).isdisjoint(
-        set(expose_types)
-    ), "cannot hide and expose a site type"
-
-    return partial(_block_fn, expose, expose_types, hide, hide_types, hide_all)
-
-
 class block(Messenger):
     """
     Given a callable `fn`, return another callable that selectively hides

--- a/numpyro/handlers.py
+++ b/numpyro/handlers.py
@@ -77,7 +77,6 @@ results for all the data points, but does so by using JAX's auto-vectorize trans
 """
 
 from collections import OrderedDict
-from functools import partial
 import warnings
 
 import numpy as np

--- a/numpyro/infer/autoguide.py
+++ b/numpyro/infer/autoguide.py
@@ -255,6 +255,14 @@ class AutoGuideList(AutoGuide):
         :param part: a partial guide to add
         :type part: AutoGuide
         """
+        if (
+            isinstance(part, numpyro.infer.autoguide.AutoDAIS)
+            or isinstance(part, numpyro.infer.autoguide.AutoSemiDAIS)
+            or isinstance(part, numpyro.infer.autoguide.AutoSurrogateLikelihoodDAIS)
+        ):
+            raise ValueError(
+                "AutoDAIS, AutoSemiDAIS, and AutoSurrogateLikelihoodDAIS are not supported."
+            )
         self._guides.append(part)
 
     def __call__(self, *args, **kwargs):
@@ -283,9 +291,9 @@ class AutoGuideList(AutoGuide):
     def sample_posterior(self, rng_key, params, *args, sample_shape=(), **kwargs):
         result = {}
         for part in self._guides:
-            if isinstance(part, numpyro.infer.autoguide.AutoDelta) or isinstance(
-                part, numpyro.infer.autoguide.AutoSemiDAIS
-            ):
+            # TODO: remove this when sample_posterior() signatures are consistent
+            # we know part is not AutoDAIS, AutoSemiDAIS, or AutoSurrogateLikelihoodDAIS
+            if isinstance(part, numpyro.infer.autoguide.AutoDelta):
                 result.update(
                     part.sample_posterior(
                         rng_key, params, *args, sample_shape=sample_shape, **kwargs

--- a/numpyro/infer/autoguide.py
+++ b/numpyro/infer/autoguide.py
@@ -52,6 +52,7 @@ from numpyro.util import find_stack_level, not_jax_tracer
 __all__ = [
     "AutoContinuous",
     "AutoGuide",
+    "AutoGuideList",
     "AutoDAIS",
     "AutoDiagonalNormal",
     "AutoLaplaceApproximation",

--- a/test/infer/test_autoguide.py
+++ b/test/infer/test_autoguide.py
@@ -27,6 +27,7 @@ from numpyro.infer.autoguide import (
     AutoDAIS,
     AutoDelta,
     AutoDiagonalNormal,
+    AutoGuideList,
     AutoIAFNormal,
     AutoLaplaceApproximation,
     AutoLowRankMultivariateNormal,
@@ -62,6 +63,7 @@ init_strategy = init_to_median(num_samples=2)
         AutoLowRankMultivariateNormal,
         AutoNormal,
         AutoDelta,
+        AutoGuideList,
     ],
 )
 def test_beta_bernoulli(auto_class):
@@ -76,6 +78,9 @@ def test_beta_bernoulli(auto_class):
     adam = optim.Adam(0.01)
     if auto_class == AutoDAIS:
         guide = auto_class(model, init_loc_fn=init_strategy, base_dist="cholesky")
+    elif auto_class == AutoGuideList:
+        guide = AutoGuideList(model)
+        guide.append(AutoNormal(handlers.block(model, hide=[])))
     else:
         guide = auto_class(model, init_loc_fn=init_strategy)
     svi = SVI(model, guide, adam, Trace_ELBO())
@@ -96,9 +101,14 @@ def test_beta_bernoulli(auto_class):
     posterior_mean = jnp.mean(posterior_samples["beta"], 0)
     assert_allclose(posterior_mean, true_coefs, atol=0.05)
 
-    if auto_class not in [AutoDAIS, AutoDelta, AutoIAFNormal, AutoBNAFNormal]:
-        quantiles = guide.quantiles(params, [0.2, 0.5, 0.8])
-        assert quantiles["beta"].shape == (3, 2)
+    # assume AutoGuideList does not have AutoDAIS, AutoDelta, AutoIAFNormal, or AutoBNAFNormal
+    if auto_class not in (AutoDAIS, AutoIAFNormal, AutoBNAFNormal):
+        median = guide.median(params)
+        assert median["beta"].shape == (2,)
+        # test .quantile method
+        if auto_class is not AutoDelta:
+            quantiles = guide.quantiles(params, [0.2, 0.5, 0.8])
+            assert quantiles["beta"].shape == (3, 2)
 
     # Predictive can be instantiated from posterior samples...
     predictive = Predictive(model, posterior_samples=posterior_samples)
@@ -123,6 +133,7 @@ def test_beta_bernoulli(auto_class):
         AutoLowRankMultivariateNormal,
         AutoNormal,
         AutoDelta,
+        AutoGuideList,
     ],
 )
 @pytest.mark.parametrize("Elbo", [Trace_ELBO, TraceMeanField_ELBO])
@@ -142,12 +153,19 @@ def test_logistic_regression(auto_class, Elbo):
 
     adam = optim.Adam(0.01)
     rng_key_init = random.PRNGKey(1)
-    guide = auto_class(model, init_loc_fn=init_strategy)
+    if auto_class == AutoGuideList:
+        guide = AutoGuideList(model)
+        guide.append(AutoNormal(handlers.block(model, hide=[])))
+    else:
+        guide = auto_class(model, init_loc_fn=init_strategy)
     svi = SVI(model, guide, adam, Elbo())
     svi_state = svi.init(rng_key_init, data, labels)
 
     # smoke test if analytic KL is used
-    if auto_class is AutoNormal and Elbo is TraceMeanField_ELBO:
+    # assume that AutoGuideList has AutoNormal
+    if (
+        auto_class is AutoNormal or auto_class is AutoGuideList
+    ) and Elbo is TraceMeanField_ELBO:
         _, mean_field_loss = svi.update(svi_state, data, labels)
         svi.loss = Trace_ELBO()
         _, elbo_loss = svi.update(svi_state, data, labels)
@@ -160,13 +178,14 @@ def test_logistic_regression(auto_class, Elbo):
 
     svi_state = fori_loop(0, 2000, body_fn, svi_state)
     params = svi.get_params(svi_state)
+    # assume that AutoGuideList does not have AutoDAIS, AutoIAFNormal, or AutoBNAFNormal
     if auto_class not in (AutoDAIS, AutoIAFNormal, AutoBNAFNormal):
         median = guide.median(params)
         assert_allclose(median["coefs"], true_coefs, rtol=0.1)
         # test .quantile method
         if auto_class is not AutoDelta:
-            median = guide.quantiles(params, [0.2, 0.5])
-            assert_allclose(median["coefs"][1], true_coefs, rtol=0.1)
+            quantiles = guide.quantiles(params, [0.2, 0.5])
+            assert_allclose(quantiles["coefs"][1], true_coefs, rtol=0.1)
     # test .sample_posterior method
     posterior_samples = guide.sample_posterior(
         random.PRNGKey(1), params, sample_shape=(1000,)
@@ -997,3 +1016,140 @@ def test_autodelta_sample_posterior_with_sample_shape(shape, sample_shape):
     )
     assert guide_samples["x"].shape == sample_shape + shape
     assert guide_samples["x2"].shape == sample_shape + shape
+
+
+@pytest.mark.parametrize(
+    "auto_classes",
+    [
+        (AutoNormal, AutoDiagonalNormal),
+        (AutoNormal, AutoIAFNormal),
+        (AutoNormal, AutoBNAFNormal),
+        (AutoNormal, AutoMultivariateNormal),
+        (AutoNormal, AutoLaplaceApproximation),
+        (AutoNormal, AutoLowRankMultivariateNormal),
+        (AutoNormal, AutoNormal),
+        (AutoNormal, AutoDelta),
+    ],
+)
+@pytest.mark.parametrize("Elbo", [Trace_ELBO, TraceMeanField_ELBO])
+def test_autoguidelist(auto_classes, Elbo):
+    sigma = 0.05
+
+    def model(x, y=None):
+        a = numpyro.sample("a", dist.Normal(0, 1))
+        b = numpyro.sample("b", dist.Normal(jnp.ones((2, 1)), 1))
+        mu = a + x @ b
+        with numpyro.plate("N", len(x), dim=-2):
+            numpyro.sample("y", dist.Normal(mu, sigma), obs=y)
+
+    N = 500
+    a = 1
+    b = jnp.asarray([[-0.5], [-1]])
+    x = random.normal(random.PRNGKey(0), (N, 2))
+    y = a + x @ b + sigma * random.normal(random.PRNGKey(1), (N, 1))
+
+    guide = AutoGuideList(model)
+    guide.append(
+        auto_classes[0](
+            numpyro.handlers.block(
+                numpyro.handlers.seed(model, rng_seed=0), expose=["a"]
+            )
+        )
+    )
+    guide.append(
+        auto_classes[1](
+            numpyro.handlers.block(numpyro.handlers.seed(model, rng_seed=1), hide=["a"])
+        )
+    )
+
+    optimiser = numpyro.optim.Adam(step_size=0.1)
+    svi = SVI(model, guide, optimiser, Elbo())
+
+    svi_result = svi.run(random.PRNGKey(0), num_steps=500, x=x, y=y)
+    params = svi_result.params
+    posterior_samples = guide.sample_posterior(
+        random.PRNGKey(0), params, x=x, sample_shape=(1_000,)
+    )
+
+    assert posterior_samples["a"].shape == (1_000,)
+    assert posterior_samples["b"].shape == (1_000, 2, 1)
+
+    assert_allclose(jnp.mean(posterior_samples["a"], 0), a, atol=0.05)
+    assert_allclose(jnp.mean(posterior_samples["b"], 0), b, atol=0.05)
+
+    # Predictive can be instantiated from posterior samples...
+    predictive = Predictive(model, posterior_samples=posterior_samples)
+    predictive_samples = predictive(random.PRNGKey(1), x)
+    assert predictive_samples["y"].shape == (1_000, N, 1)
+
+    # ... or from the guide + params
+    predictive = Predictive(model, guide=guide, params=params, num_samples=1_000)
+    predictive_samples = predictive(random.PRNGKey(1), x)
+    assert predictive_samples["y"].shape == (1_000, N, 1)
+
+    # median and quantiles from guide
+    if any(
+        auto_class in [AutoDAIS, AutoDelta, AutoIAFNormal, AutoBNAFNormal]
+        for auto_class in auto_classes
+    ):
+        with pytest.raises(NotImplementedError):
+            quantiles = guide.quantiles(params=params, quantiles=[0.2, 0.5, 0.8])
+    else:
+        quantiles = guide.quantiles(params=params, quantiles=[0.2, 0.5, 0.8])
+        assert quantiles["a"].shape == (3,)
+        assert quantiles["b"].shape == (3, 2, 1)
+
+    # median and quantiles from partial guides
+    for auto_class, part in zip(auto_classes, guide):
+        if auto_class not in (AutoDAIS, AutoIAFNormal, AutoBNAFNormal):
+            part.median(params=params)
+        if auto_class not in [AutoDAIS, AutoDelta, AutoIAFNormal, AutoBNAFNormal]:
+            part.quantiles(params=params, quantiles=[0.2, 0.5, 0.8])
+
+
+@pytest.mark.parametrize(
+    "auto_class",
+    [
+        AutoDiagonalNormal,
+        AutoDAIS,
+        AutoIAFNormal,
+        AutoBNAFNormal,
+        AutoMultivariateNormal,
+        AutoLaplaceApproximation,
+        AutoLowRankMultivariateNormal,
+        AutoNormal,
+        AutoDelta,
+    ],
+)
+@pytest.mark.parametrize("shape", [(), (1,), (2, 3)])
+@pytest.mark.parametrize("sample_shape", [(), (1,), (2, 3)])
+def test_autoguidelist_sample_posterior_with_sample_shape(
+    auto_class, shape, sample_shape
+):
+    def model():
+        x = numpyro.sample("x", dist.Normal().expand(shape))
+        numpyro.deterministic("x2", x**2)
+
+    guide = AutoGuideList(model)
+    guide.append(auto_class(model))
+    svi = SVI(model, guide, optim.Adam(0.01), Trace_ELBO())
+    if auto_class in (AutoIAFNormal, AutoBNAFNormal) and max(shape, default=0) <= 1:
+        with pytest.raises(
+            ValueError,
+            match="latent dim = 1. Consider using AutoDiagonalNormal instead",
+        ):
+            svi_result = svi.run(random.PRNGKey(0), num_steps=1_000)
+            guide_samples = guide.sample_posterior(
+                rng_key=random.PRNGKey(1),
+                params=svi_result.params,
+                sample_shape=sample_shape,
+            )
+    else:
+        svi_result = svi.run(random.PRNGKey(0), num_steps=1_000)
+        guide_samples = guide.sample_posterior(
+            rng_key=random.PRNGKey(1),
+            params=svi_result.params,
+            sample_shape=sample_shape,
+        )
+        assert guide_samples["x"].shape == sample_shape + shape
+        assert guide_samples["x2"].shape == sample_shape + shape


### PR DESCRIPTION
Hello! This PR eventually aims to address #1638.

Using the Pyro implementation (please see [guides.py](https://github.com/pyro-ppl/pyro/blob/dev/pyro/infer/autoguide/guides.py#L183-L275) and [block_messenger.py](https://github.com/pyro-ppl/pyro/blob/dev/pyro/poutine/block_messenger.py#L9-L142)) as an example I implemented `numpyro.infer.autoguide.AutoGuideList` and modified `numpyro.handlers.block` with the following main differences:
- discarded the deprecated `add` alias from `numpyro.infer.autoguide.AutoGuideList`
- the order of parameters in the constructor of the `block` handler differs from Pyro as I thought changing the positions of the current parameters could break things

Here is a simple example using`AutoGuideList`
```python
from jax import random
import jax.numpy as jnp

import numpyro
from numpyro import handlers, optim
import numpyro.distributions as dist
from numpyro.infer import SVI, Trace_ELBO, Predictive
from numpyro.infer.autoguide import AutoNormal, AutoDelta, AutoGuideList

N, dim = 3000, 3
data = random.normal(random.PRNGKey(0), (N, dim))
true_coefs = jnp.arange(1.0, dim + 1.0)
logits = jnp.sum(true_coefs * data, axis=-1)
labels = dist.Bernoulli(logits=logits).sample(random.PRNGKey(1))


def model(data, labels):
    coefs = numpyro.sample("coefs", dist.Normal(jnp.zeros(dim), jnp.ones(dim)))
    offset = numpyro.sample("offset", dist.Uniform(-1, 1))
    logits = offset + jnp.sum(coefs * data, axis=-1)
    return numpyro.sample("obs", dist.Bernoulli(logits=logits), obs=labels)


adam = optim.Adam(0.01)
rng_key_init = random.PRNGKey(0)

guide = AutoGuideList(model)
guide.append(
    AutoNormal(
        numpyro.handlers.block(numpyro.handlers.seed(model, rng_seed=0), hide=["coefs"])
    )
)
guide.append(
    AutoDelta(
        numpyro.handlers.block(
            numpyro.handlers.seed(model, rng_seed=1), expose=["coefs"]
        )
    )
)

svi = SVI(model, guide, adam, Trace_ELBO())
svi_result = svi.run(rng_key_init, 2000, data, labels)

params = svi_result.params

predictive = Predictive(guide, params=params, num_samples=1000)
posterior_samples = predictive(random.PRNGKey(2), data=data)
```

I think I encountered the same problem as mentioned [here](https://forum.pyro.ai/t/question-about-a-strange-error-when-using-block-in-numpyro/4400). To overcome (I think?) the problem, I wrapped the NumPyro model in a `seed` handler before wrapping it in a `block` handler. I don't know whether there is a better way.

Should we implement [`AutoCallable`](https://github.com/pyro-ppl/pyro/blob/dev/pyro/infer/autoguide/guides.py#L278-L315) from Pyro?

No tests have been implemented yet.