### PR TITLE
Add ICDF and CDF to BernoulliProbs

### DIFF
--- a/numpyro/distributions/discrete.py
+++ b/numpyro/distributions/discrete.py
@@ -102,6 +102,13 @@ class BernoulliProbs(Distribution):
     def variance(self):
         return self.probs * (1 - self.probs)
 
+    def cdf(self, value):
+        return ((1 - self.probs) * jnp.heaviside(value, 1)
+                + self.probs * jnp.heaviside(value - 1, 1))
+
+    def icdf(self, q):
+        return jnp.heaviside(q - (1 - self.probs), 1)
+
     def enumerate_support(self, expand=True):
         values = jnp.arange(2).reshape((-1,) + (1,) * len(self.batch_shape))
         if expand:


### PR DESCRIPTION
I was using `numpyro` for a particular application which required an ICDF and CDF for a Bernoulli, however this was not yet implemented.

I use Heaviside functions to calculate the CDF and ICDF. Tests are a little more complicated, as for a Bernoulli one doesn't recover the original quantiles when passing uniform samples through an ICDF, and then back through a CDF. I added a few specific lines for the Bernoulli such that the mean of ICDF(quantiles) is roughly equal to the probability parameter for the bernoulli. To test the CDF, I check that the proportion of ones yielded through CDF(ICDF(quantiles)) is roughly equal to p, and that the proportion of (1 - p) values through the same function is roughly equal to (1 - p).