### PR TITLE
Enforce supported python version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,7 @@ setup(
         "tpu": f"jax[tpu]{_jax_version_constraints}",
         "cuda": f"jax[cuda]{_jax_version_constraints}",
     },
+    python_requires=">=3.9",
     long_description=long_description,
     long_description_content_type="text/markdown",
     keywords="probabilistic machine learning bayesian statistics",


### PR DESCRIPTION
Fixes #1656: `numpyro` has dropped `python 3.8` support since #1629. This PR ensures that `PyPI` will provide the correct version of `numpyro`.