### PR TITLE
Hot fix: remove version requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "numpyro"
-requires-python = ">=3.9"
-
 [tool.ruff]
 # Exclude a variety of commonly ignored directories.
 exclude = [


### PR DESCRIPTION
Follow up of https://github.com/pyro-ppl/numpyro/pull/1700. The `[project]` config needs a version, but we are not using it for the package itself. We can safely simply remove it.