### PR TITLE
Support optional pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,7 @@ repos:
       - id: ruff
         name: ruff
         entry: ruff
+        args: ["--fix", "--show-source"]
         files: "numpyro/.*|tests/.*"
         language: system
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+repos:
+  - repo: local
+    hooks:
+      - id: ruff
+        name: ruff
+        entry: ruff
+        files: "numpyro/.*|tests/.*"
+        language: system
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: debug-statements
+      - id: check-yaml
+      - id: check-added-large-files

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,19 @@ pytest -vs {path_to_test}::{test_name}
 JAX_PLATFORM_NAME=gpu JAX_ENABLE_X64=1 pytest -vs {path_to_test}::{test_name}
 ```
 
+## Pre-Commit Hooks
+
+For local development we recommend using [pre-commit](https://pre-commit.com/) hooks to automatically format your code before committing.
+
+To install pre-commit hooks, run
+```sh
+pip install pre-commit
+pre-commit install
+```
+
+After each commit, pre-commit will run and verify that your code is formatted correctly. The pre-commit hooks can be skipped by adding the `--no-verify` flag to your `git commit` command.
+
+
 # Profiling
 
 TensorBoard can be used to profile NumPyro following the instructions following [JAX documentation](https://jax.readthedocs.io/en/latest/profiling.html).
@@ -58,5 +71,5 @@ In your PR, please include:
 
 If you add new files, please run `make license` to automatically add copyright headers.
 
-For speculative changes meant for early-stage review, include `[WIP]` in the PR's title. 
+For speculative changes meant for early-stage review, include `[WIP]` in the PR's title.
 (One of the maintainers will add the `WIP` tag.)


### PR DESCRIPTION
For local development, [pre-commit](https://pre-commit.com/) hooks are very useful so that the contributor can check the code formatting before every-commit. 

For now, this is optional and does not intervene with the CI. In the future, you might want to use the pre-commit configuration as the linter so that everything is in sync and the versions of ruff are not open. See, for example, https://github.com/pymc-labs/pymc-marketing/blob/main/.github/workflows/ci.yml#L25-L26. If you ever decide to go this path I will be happy to support :)