### PR TITLE
Improve current ruff rules

### DIFF
--- a/numpyro/infer/mcmc.py
+++ b/numpyro/infer/mcmc.py
@@ -723,10 +723,10 @@ class MCMC(object):
 
     def transfer_states_to_host(self):
         """
-        Reduce the memory footprint of collected samples by transfering them to the host device. 
+        Reduce the memory footprint of collected samples by transfering them to the host device.
         """
         self._states = device_get(self._states)
-        self._states_flat = device_get(self._states_flat) 
+        self._states_flat = device_get(self._states_flat)
 
     def __getstate__(self):
         state = self.__dict__.copy()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,6 @@ line-length = 120
 indent-width = 4
 
 [tool.ruff.lint]
-# Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
-# We also add isort.
 select = ["E", "F", "I", "W"]
 ignore = ["E203"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ exclude = [
 ]
 
 # Same as Black.
-line-length = 120
+line-length = 88 
 indent-width = 4
 
 [tool.ruff.lint]
@@ -44,6 +44,9 @@ unfixable = []
 
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[tool.ruff.lint.pycodestyle]
+max-line-length = 120
 
 [tool.ruff.format]
 # Like Black, use double quotes for strings.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ exclude = [
 ]
 
 # Same as Black.
-line-length = 88 
+line-length = 88
 indent-width = 4
 
 [tool.ruff.lint]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,13 +31,13 @@ exclude = [
 ]
 
 # Same as Black.
-line-length = 88
+line-length = 120
 indent-width = 4
 
 [tool.ruff.lint]
 # Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
 # We also add isort.
-select = ["E4", "E7", "E9", "F", "I"]
+select = ["E", "F", "I", "W"]
 ignore = ["E203"]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.


### PR DESCRIPTION
I keep improving the changes introduced in https://github.com/pyro-ppl/numpyro/pull/1700/. Note that in the `setup.cfg` file we had `max-line-length = 120`. This PR updates this condition and adds all the remaining `pyflake` rules.  Note this is very similar to `pyro`'s config https://github.com/pyro-ppl/pyro/blob/dev/pyproject.toml