### PR TITLE
remove upper bound sphinx

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -15,7 +15,7 @@ pillow
 pylab-sdk
 pyyaml
 readthedocs-sphinx-search==0.1.2
-sphinxcontrib-applehelp==1.0.8
+sphinxcontrib-applehelp<1.0.8
 sphinx<5
 sphinx-gallery==0.10.1  # tutorial page is not rendered correctly with newer versions
 sphinx_rtd_theme==1.0.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -16,6 +16,7 @@ pylab-sdk
 pyyaml
 readthedocs-sphinx-search==0.1.2
 sphinxcontrib-applehelp<1.0.8
+sphinxcontrib-devhelp<1.0.6
 sphinx<5
 sphinx-gallery==0.10.1  # tutorial page is not rendered correctly with newer versions
 sphinx_rtd_theme==1.0.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -19,6 +19,7 @@ sphinxcontrib-applehelp<1.0.8
 sphinxcontrib-devhelp<1.0.6
 sphinxcontrib-htmlhelp<2.0.5
 sphinxcontrib-serializinghtml<1.1.10
+sphinxcontrib-qthelp<1.0.7
 sphinx<5
 sphinx-gallery==0.10.1  # tutorial page is not rendered correctly with newer versions
 sphinx_rtd_theme==1.0.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -20,6 +20,7 @@ sphinxcontrib-devhelp<1.0.6
 sphinxcontrib-htmlhelp<2.0.5
 sphinxcontrib-serializinghtml<1.1.10
 sphinxcontrib-qthelp<1.0.7
+sphinxcontrib-serializinghtml<1.1.10
 sphinx<5
 sphinx-gallery==0.10.1  # tutorial page is not rendered correctly with newer versions
 sphinx_rtd_theme==1.0.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -15,6 +15,7 @@ pillow
 pylab-sdk
 pyyaml
 readthedocs-sphinx-search==0.1.2
+sphinxcontrib-applehelp<1.0.8
 sphinx<5
 sphinx-gallery==0.10.1  # tutorial page is not rendered correctly with newer versions
 sphinx_rtd_theme==1.0.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -14,13 +14,7 @@ optax
 pillow
 pylab-sdk
 pyyaml
-readthedocs-sphinx-search==0.1.2
-sphinxcontrib-applehelp<1.0.8
-sphinxcontrib-devhelp<1.0.6
-sphinxcontrib-htmlhelp<2.0.5
-sphinxcontrib-serializinghtml<1.1.10
-sphinxcontrib-qthelp<1.0.7
-sphinx<5
+sphinx>=5
 sphinx-gallery==0.10.1  # tutorial page is not rendered correctly with newer versions
 sphinx_rtd_theme==1.0.0
 tensorflow_probability

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -20,7 +20,6 @@ sphinxcontrib-devhelp<1.0.6
 sphinxcontrib-htmlhelp<2.0.5
 sphinxcontrib-serializinghtml<1.1.10
 sphinxcontrib-qthelp<1.0.7
-sphinxcontrib-serializinghtml<1.1.10
 sphinx<5
 sphinx-gallery==0.10.1  # tutorial page is not rendered correctly with newer versions
 sphinx_rtd_theme==1.0.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -18,6 +18,7 @@ readthedocs-sphinx-search==0.1.2
 sphinxcontrib-applehelp<1.0.8
 sphinxcontrib-devhelp<1.0.6
 sphinxcontrib-htmlhelp<2.0.5
+sphinxcontrib-serializinghtml<1.1.10
 sphinx<5
 sphinx-gallery==0.10.1  # tutorial page is not rendered correctly with newer versions
 sphinx_rtd_theme==1.0.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -15,7 +15,7 @@ pillow
 pylab-sdk
 pyyaml
 readthedocs-sphinx-search==0.1.2
-sphinxcontrib-applehelp==1.0.7
+sphinxcontrib-applehelp==1.0.8
 sphinx<5
 sphinx-gallery==0.10.1  # tutorial page is not rendered correctly with newer versions
 sphinx_rtd_theme==1.0.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -17,6 +17,7 @@ pyyaml
 readthedocs-sphinx-search==0.1.2
 sphinxcontrib-applehelp<1.0.8
 sphinxcontrib-devhelp<1.0.6
+sphinxcontrib-htmlhelp<2.0.5
 sphinx<5
 sphinx-gallery==0.10.1  # tutorial page is not rendered correctly with newer versions
 sphinx_rtd_theme==1.0.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -15,7 +15,7 @@ pillow
 pylab-sdk
 pyyaml
 readthedocs-sphinx-search==0.1.2
-sphinxcontrib-applehelp<1.0.8
+sphinxcontrib-applehelp==1.0.7
 sphinx<5
 sphinx-gallery==0.10.1  # tutorial page is not rendered correctly with newer versions
 sphinx_rtd_theme==1.0.0

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
             "readthedocs-sphinx-search==0.1.0",
             "sphinxcontrib-applehelp<1.0.8",
             "sphinxcontrib-devhelp<1.0.6",
+            "sphinxcontrib-htmlhelp<2.0.5",
             "sphinx<5",
             "sphinx_rtd_theme",
             "sphinx-gallery",

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
             "sphinxcontrib-applehelp<1.0.8",
             "sphinxcontrib-devhelp<1.0.6",
             "sphinxcontrib-htmlhelp<2.0.5",
+            "sphinxcontrib-serializinghtml<1.1.10",
             "sphinx<5",
             "sphinx_rtd_theme",
             "sphinx-gallery",

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
             "sphinxcontrib-devhelp<1.0.6",
             "sphinxcontrib-htmlhelp<2.0.5",
             "sphinxcontrib-serializinghtml<1.1.10",
+            "sphinxcontrib-qthelp<1.0.7",
             "sphinx<5",
             "sphinx_rtd_theme",
             "sphinx-gallery",

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
             "nbsphinx>=0.8.5",
             "readthedocs-sphinx-search==0.1.0",
             "sphinxcontrib-applehelp<1.0.8",
-            "sphinxcontrib-devhelp<1.0.6"
+            "sphinxcontrib-devhelp<1.0.6",
             "sphinx<5",
             "sphinx_rtd_theme",
             "sphinx-gallery",

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,8 @@ setup(
             "ipython",  # sphinx needs this to render codes
             "nbsphinx>=0.8.5",
             "readthedocs-sphinx-search==0.1.0",
-            "sphinx",
+            "sphinxcontrib-applehelp<1.0.8"
+            "sphinx<5",
             "sphinx_rtd_theme",
             "sphinx-gallery",
         ],

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ setup(
             "sphinxcontrib-htmlhelp<2.0.5",
             "sphinxcontrib-serializinghtml<1.1.10",
             "sphinxcontrib-qthelp<1.0.7",
-            "sphinxcontrib-serializinghtml<1.1.10",
             "sphinx<5",
             "sphinx_rtd_theme",
             "sphinx-gallery",

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
             "ipython",  # sphinx needs this to render codes
             "nbsphinx>=0.8.5",
             "readthedocs-sphinx-search==0.1.0",
-            "sphinxcontrib-applehelp<1.0.8"
+            "sphinxcontrib-applehelp<1.0.8",
             "sphinx<5",
             "sphinx_rtd_theme",
             "sphinx-gallery",

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
             "nbsphinx>=0.8.5",
             "readthedocs-sphinx-search==0.1.0",
             "sphinxcontrib-applehelp<1.0.8",
+            "sphinxcontrib-devhelp<1.0.6"
             "sphinx<5",
             "sphinx_rtd_theme",
             "sphinx-gallery",

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(
             "sphinxcontrib-htmlhelp<2.0.5",
             "sphinxcontrib-serializinghtml<1.1.10",
             "sphinxcontrib-qthelp<1.0.7",
+            "sphinxcontrib-serializinghtml<1.1.10",
             "sphinx<5",
             "sphinx_rtd_theme",
             "sphinx-gallery",

--- a/setup.py
+++ b/setup.py
@@ -44,12 +44,7 @@ setup(
             "ipython",  # sphinx needs this to render codes
             "nbsphinx>=0.8.5",
             "readthedocs-sphinx-search==0.1.0",
-            "sphinxcontrib-applehelp<1.0.8",
-            "sphinxcontrib-devhelp<1.0.6",
-            "sphinxcontrib-htmlhelp<2.0.5",
-            "sphinxcontrib-serializinghtml<1.1.10",
-            "sphinxcontrib-qthelp<1.0.7",
-            "sphinx<5",
+            "sphinx>=5",
             "sphinx_rtd_theme",
             "sphinx-gallery",
         ],


### PR DESCRIPTION
Trying to fix the error found in https://github.com/pyro-ppl/numpyro/pull/1720

It seems there is a big upgrade in Jan 13 2024.

```bash
make -C docs html
make[1]: Entering directory '/home/runner/work/numpyro/numpyro/docs'
Running Sphinx v4.5.0
/opt/hostedtoolcache/Python/3.9.1[8](https://github.com/pyro-ppl/numpyro/actions/runs/7531465780/job/20500091407?pr=1720#step:6:9)/x64/lib/python3.[9](https://github.com/pyro-ppl/numpyro/actions/runs/7531465780/job/20500091407?pr=1720#step:6:10)/site-packages/nbsphinx.py:1450: RuntimeWarning: You are using an unsupported version of pandoc (2.9.2.1).
Your version must be at least (2.14.2) but less than (4.0.0).
Refer to https://pandoc.org/installing.html.
Continuing with doubts...
  nbconvert.utils.pandoc.check_pandoc_version()
loading translations [en]... done

Sphinx version error:
The sphinxcontrib.applehelp extension used by this project needs at least Sphinx v5.0; it therefore cannot be built with this version.
make[1]: *** [Makefile:20: html] Error 2
make[1]: Leaving directory '/home/runner/work/numpyro/numpyro/docs'
make: *** [Makefile:26: docs] Error 2
Error: Process completed with exit code 2.
```