### PR TITLE
Fix import for jaxns compatibility

### DIFF
--- a/numpyro/contrib/nested_sampling.py
+++ b/numpyro/contrib/nested_sampling.py
@@ -10,7 +10,6 @@ try:
     from jaxns import (
         ExactNestedSampler as OrigNestedSampler,
         Model,
-        NestedSamplerResults,
         Prior,
         TerminationCondition,
         plot_cornerplot,
@@ -18,6 +17,7 @@ try:
         resample,
         summary,
     )
+    from jaxns.internals.types import NestedSamplerResults
 except ImportError as e:
     raise ImportError(
         "To use this module, please install `jaxns` package. It can be"

--- a/numpyro/contrib/nested_sampling.py
+++ b/numpyro/contrib/nested_sampling.py
@@ -8,7 +8,7 @@ import jax.numpy as jnp
 
 try:
     from jaxns import (
-        ExactNestedSampler as OrigNestedSampler,
+        DefaultNestedSampler,
         Model,
         Prior,
         TerminationCondition,
@@ -257,7 +257,6 @@ class NestedSampler:
 
         default_constructor_kwargs = dict(
             num_live_points=model.U_ndims * 25,
-            num_parallel_samplers=1,
             max_samples=1e4,
         )
         default_termination_kwargs = dict(live_evidence_frac=1e-4)
@@ -276,7 +275,7 @@ class NestedSampler:
             )
         )
 
-        exact_ns = OrigNestedSampler(
+        exact_ns = DefaultNestedSampler(
             model=model,
             **self.constructor_kwargs,
         )
@@ -285,7 +284,7 @@ class NestedSampler:
             rng_sampling,
             term_cond=TerminationCondition(**self.termination_kwargs),
         )
-        results = exact_ns.to_results(state, termination_reason)
+        results = exact_ns.to_results(termination_reason, state)
 
         # transform base samples back to original domains
         # Here we only transform the first valid num_samples samples


### PR DESCRIPTION
I ran the [nested sampling for gaussian shells](https://num.pyro.ai/en/stable/examples/gaussian_shells.html) tutorial which depends on `jaxns`, and I found that importing anything from `numpyro/contrib/nested_sampling.py` produces an error. The error occurs because the `NestedSamplerResults` class is not in the top-level `jaxns` namespace. 

This PR simply imports from the correct submodule.