### PR TITLE
Add github action for releasing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Build package
         run: python -m build
       - name: Publish package to TestPyPI
-        uses: pypa/gh-action-pypi-publish@v1
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
           repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,3 +1,12 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# GitHub recommends pinning actions to a commit SHA.
+# To get a newer version, you will need to update the SHA.
+# You can also reference a tag or branch, but the action may change without warning.
+
 name: Upload Python Package
 
 on:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,8 @@
 name: Upload Python Package
 
 on:
-  pull_request:
-    branches: [ master ]
+  release:
+    type: [ published ]
 
 jobs:
   deploy:
@@ -19,9 +19,8 @@ jobs:
           pip install build
       - name: Build package
         run: python -m build
-      - name: Publish package to TestPyPI
+      - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
-          repository-url: https://test.pypi.org/legacy/
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,27 @@
+name: Upload Python Package
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+      - name: Build package
+        run: python -m build
+      - name: Publish package to TestPyPI
+        uses: pypa/gh-action-pypi-publish@v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+		  repository-url: https://test.pypi.org/legacy/
+

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,5 +23,5 @@ jobs:
         uses: pypa/gh-action-pypi-publish@v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
-		  repository-url: https://test.pypi.org/legacy/
+          repository-url: https://test.pypi.org/legacy/
 


### PR DESCRIPTION
The action is copied from https://github.com/pyro-ppl/pyro/pull/3326

TODO:
- [x] Generate secret for TEST_PYPI_API_TOKEN
- [x] Test whether we can publish to TestPyPI
- [x] Modify the action to publish to PyPI if the above action works: remove test repository-url and change action on "pull request" to "release".