### PR TITLE
Add auto-batched (low-rank) multivariate normal guides.

### DIFF
--- a/numpyro/distributions/transforms.py
+++ b/numpyro/distributions/transforms.py
@@ -40,6 +40,7 @@ __all__ = [
     "LowerCholeskyAffine",
     "PermuteTransform",
     "PowerTransform",
+    "ReshapeTransform",
     "SigmoidTransform",
     "SimplexToOrderedTransform",
     "SoftplusTransform",
@@ -1139,6 +1140,64 @@ class UnpackTransform(Transform):
 
     def __eq__(self, other):
         return isinstance(other, UnpackTransform) and self.unpack_fn is other.unpack_fn
+
+
+def _get_target_shape(shape, forward_shape, inverse_shape):
+    batch_ndims = len(shape) - len(inverse_shape)
+    return shape[:batch_ndims] + forward_shape
+
+
+class ReshapeTransform(Transform):
+    """
+    Reshape a sample, leaving batch dimensions unchanged.
+
+    :param forward_shape: Shape to transform the sample to.
+    :param inverse_shape: Shape of the sample for the inverse transform.
+    """
+
+    domain = constraints.real
+    codomain = constraints.real
+
+    def __init__(self, forward_shape, inverse_shape) -> None:
+        forward_size = math.prod(forward_shape)
+        inverse_size = math.prod(inverse_shape)
+        if forward_size != inverse_size:
+            raise ValueError(
+                f"forward shape {forward_shape} (size {forward_size}) and inverse "
+                f"shape {inverse_shape} (size {inverse_size}) are not compatible"
+            )
+        self._forward_shape = forward_shape
+        self._inverse_shape = inverse_shape
+
+    def forward_shape(self, shape):
+        return _get_target_shape(shape, self._forward_shape, self._inverse_shape)
+
+    def inverse_shape(self, shape):
+        return _get_target_shape(shape, self._inverse_shape, self._forward_shape)
+
+    def __call__(self, x):
+        return jnp.reshape(x, self.forward_shape(jnp.shape(x)))
+
+    def _inverse(self, y):
+        return jnp.reshape(y, self.inverse_shape(jnp.shape(y)))
+
+    def log_abs_det_jacobian(self, x, y, intermediates=None):
+        return 0.0
+
+    def tree_flatten(self):
+        aux_data = {
+            "_forward_shape": self._forward_shape,
+            "_inverse_shape": self._inverse_shape,
+        }
+        return (), ((), aux_data)
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, ReshapeTransform)
+            and self._forward_shape == other._forward_shape
+            and self._inverse_shape == other._inverse_shape
+        )
+
 
 
 ##########################################################

--- a/numpyro/infer/autoguide.py
+++ b/numpyro/infer/autoguide.py
@@ -1835,7 +1835,7 @@ class AutoBatchedMixin:
         for site in self.prototype_trace.values():
             if site["type"] == "sample" and not site["is_observed"]:
                 shape = site["value"].shape
-                if site["value"].ndim < self.batch_ndim:
+                if site["value"].ndim < self.batch_ndim + site["fn"].event_dim:
                     raise ValueError(
                         f"Expected {self.batch_ndim} batch dimensions, but site "
                         f"`{site['name']}` only has shape {shape}."

--- a/test/infer/test_autoguide.py
+++ b/test/infer/test_autoguide.py
@@ -1309,5 +1309,5 @@ def test_auto_batched_shapes(auto_class) -> None:
         with pytest.raises(ValueError, match="inconsistent batch shapes"):
             auto_class(model)(3, 4)
 
-        with pytest.raises(ValueError, match="Expected 3 batch dimensions"):
-            auto_class(model, batch_ndim=3)(3, 3)
+        with pytest.raises(ValueError, match="Expected 2 batch dimensions"):
+            auto_class(model, batch_ndim=2)(3, 3)

--- a/test/infer/test_autoguide.py
+++ b/test/infer/test_autoguide.py
@@ -7,7 +7,7 @@ from numpy.random import RandomState
 from numpy.testing import assert_allclose
 import pytest
 
-from jax import jacobian, jit, lax, random
+from jax import jacobian, jit, lax, random, vmap
 from jax.example_libraries.stax import Dense
 import jax.numpy as jnp
 from jax.tree_util import tree_all, tree_map
@@ -23,6 +23,7 @@ from numpyro.distributions.flows import InverseAutoregressiveTransform
 from numpyro.handlers import substitute
 from numpyro.infer import SVI, Trace_ELBO, TraceMeanField_ELBO
 from numpyro.infer.autoguide import (
+    AutoBatchedMultivariateNormal,
     AutoBNAFNormal,
     AutoDAIS,
     AutoDelta,
@@ -1251,3 +1252,47 @@ def test_dais_vae(use_global_dais_params):
         assert_allclose(
             samples["x"].mean(axis=0), jnp.arange(-5, 5), atol=0.2, rtol=0.1
         )
+
+
+def test_auto_batched() -> None:
+    # Model for batched multivariate normal.
+    off_diag = jnp.asarray([-0.2, 0, 0.5])
+    covs = off_diag[:, None, None] + jnp.eye(4)
+
+    def model():
+        with numpyro.plate("N", off_diag.shape[0]):
+            numpyro.sample("x", dist.MultivariateNormal(0, covs))
+
+    # Run inference.
+    guide = AutoBatchedMultivariateNormal(model)
+    svi = SVI(model, guide, optax.adam(0.001), Trace_ELBO())
+    result = svi.run(random.PRNGKey(0), 10000)
+    samples = guide.sample_posterior(
+        random.PRNGKey(1), result.params, sample_shape=(1000,)
+    )
+
+    # Verify off-diagonal entries are correlated.
+    empirical_covs = vmap(jnp.cov)(jnp.moveaxis(samples["x"], 0, 2))
+    i, j = jnp.triu_indices(3, 1)
+    empirical_off_diag = empirical_covs[:, i, j].mean(axis=1)
+    corrcoef = jnp.corrcoef(off_diag, empirical_off_diag)[0, 1]
+    assert corrcoef > 0.99
+
+
+def test_auto_batched_shapes() -> None:
+    def model(n, m):
+        distribution = dist.Normal().expand([7]).to_event(1)
+        with numpyro.plate("n", n):
+            x = numpyro.sample("x", distribution)
+        with numpyro.plate("m", m):
+            y = numpyro.sample("y", distribution)
+        return x, y
+
+    with numpyro.handlers.seed(rng_seed=0):
+        AutoBatchedMultivariateNormal(model)(3, 3)
+
+        with pytest.raises(ValueError, match="inconsistent batch shapes"):
+            AutoBatchedMultivariateNormal(model)(3, 4)
+
+        with pytest.raises(ValueError, match="Expected 3 batch dimensions"):
+            AutoBatchedMultivariateNormal(model, batch_ndim=3)(3, 3)

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -6,7 +6,7 @@ from functools import partial
 
 import pytest
 
-from jax import jit, tree_map, vmap
+from jax import jit, random, tree_map, vmap
 import jax.numpy as jnp
 
 from numpyro.distributions.flows import (
@@ -35,6 +35,7 @@ from numpyro.distributions.transforms import (
     SoftplusLowerCholeskyTransform,
     SoftplusTransform,
     StickBreakingTransform,
+    ReshapeTransform,
     UnpackTransform,
 )
 
@@ -115,6 +116,11 @@ TRANSFORMS = {
         partial(BlockNeuralAutoregressiveTransform, _smoke_neural_network),
         (),
         dict(),
+    ),
+    "reshape": T(
+        ReshapeTransform,
+        (),
+        {"forward_shape": (3, 4), "inverse_shape": (4, 3)}
     ),
 }
 
@@ -197,3 +203,30 @@ def test_parametrized_transform_eq(cls, transform_args, transform_kwargs):
         return t1 == t2
 
     assert check_transforms(transform, transform2)
+
+
+@pytest.mark.parametrize(
+    "forward_shape, inverse_shape, batch_shape",
+    [
+        ((3, 4), (4, 3), ()),
+        ((7,), (7, 1), ()),
+        ((3, 5), (15,), ()),
+        ((2, 4), (2, 2, 2), (17,))
+    ]
+)
+def test_reshape_transform(forward_shape, inverse_shape, batch_shape):
+    x = random.normal(random.key(29), batch_shape + inverse_shape)
+    transform = ReshapeTransform(forward_shape, inverse_shape)
+    y = transform(x)
+    assert y.shape == batch_shape + forward_shape
+    x2 = transform.inv(y)
+    assert x2.shape == batch_shape + inverse_shape
+    assert jnp.allclose(x, x2).all()
+
+
+def test_reshape_transform_invalid():
+    with pytest.raises(ValueError, match="are not compatible"):
+        ReshapeTransform((3,), (4,))
+
+    with pytest.raises(TypeError, match="cannot reshape array"):
+        ReshapeTransform((2, 3), (6,))(jnp.arange(2))

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -29,13 +29,13 @@ from numpyro.distributions.transforms import (
     OrderedTransform,
     PermuteTransform,
     PowerTransform,
+    ReshapeTransform,
     ScaledUnitLowerCholeskyTransform,
     SigmoidTransform,
     SimplexToOrderedTransform,
     SoftplusLowerCholeskyTransform,
     SoftplusTransform,
     StickBreakingTransform,
-    ReshapeTransform,
     UnpackTransform,
 )
 


### PR DESCRIPTION
This PR implements auto-guides that support batching along leading dimensions of the parameters. The guides are motivated by models that have conditional independence structure but possibly strong correlation within each instance of a `plate`. The interface is exactly the same as `Auto[LowRank]MultivariateNormal` with an additional argument `batch_ndims` that specifies the number of dimensions to treat as independent in the posterior approximation.

# Example

Consider a random walk model with `n` time series and `t` observations. Then the number of parameters is `n * t + 2 * n` (matrix of latent time series, one scale parameter for random walk innovations for each series, and one scale parameter for observation noise for each series). For concreteness, here's the model.

```python
def model(n, t):
    with numpyro.plate("n", n):
        # Model for time series.
        innovation_scale = numpyro.sample(
            "innovation_scale",
            distributions.HalfCauchy(1),
        )
        innovations = numpyro.sample(
            "innovations",
            distributions.Normal().expand([t]).to_event(1),
        )
        series = numpyro.deterministic(
            "series",
            innovations.cumsum(axis=-1),
        )
        
        # Model for observations.
        noise_scale = numpyro.sample(
            "noise_scale",
            distributions.HalfCauchy(1),
        )
        data = numpyro.sample(
            "data",
            distributions.Normal(series, noise_scale[:, None]).to_event(1),
        )
```

Suppose we use different auto-guides and count the number of parameters we need to optimize. The example below is for `n = 10` and `t = 20`

```
# [guide class] [total number of parameters]
# 	[parameter shapes]
AutoDiagonalNormal 440
	 {'auto_loc': (220,), 'auto_scale': (220,)}
AutoLowRankMultivariateNormal 3740
	 {'auto_loc': (220,), 'auto_cov_factor': (220, 15), 'auto_scale': (220,)}
AutoMultivariateNormal 48620
	 {'auto_loc': (220,), 'auto_scale_tril': (220, 220)}
AutoBatchedLowRankMultivariateNormal 1540
	 {'auto_loc': (10, 22), 'auto_cov_factor': (10, 22, 5), 'auto_scale': (10, 22)}
AutoBatchedMultivariateNormal 5060
	 {'auto_loc': (10, 22), 'auto_scale_tril': (10, 22, 22)}
```

`AutoDiagonalNormal` of course has the fewest parameters and `AutoMultivariateNormal` the most. The number of location parameters is the same across all guides. The batched versions have significantly fewer scale/covariance parameters (but of course cannot model dependence between different series). There is no free lunch, but I believe these batched guides can strike a reasonable compromise between modeling dependence and computational cost.

# Implementation

The implementation uses a mixin `AutoBatchedMixin` to 
1. determine the batch shape (and verify that a batched guide is appropriate for the model) and
2. apply a reshaping transformation to account for the existence of batches in the variational approximation.

The two batched guides are implemented analogously to the non-batched guides with the addition of the mixin and slight modifications to the parameters.

I added a `ReshapeTransform` to take care of the shapes. That could probably also be squeezed into the `UnpackTransform`. I decided on the former approach because 
1. it separates the concerns rather than packing more logic into `UnpackTransform` and
2. I've found myself looking for reshaping samples in other settings.

> [!note]
> I didn't implement the `get_base_dist`, `get_transform`, and `get_posterior` methods because I couldn't find the corresponding tests.