### PR TITLE
fixing nested_sampling.py

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,7 +4,7 @@ funsor
 ipython
 jax
 jaxlib
-jaxns==2.2.6
+jaxns==2.4.8
 Jinja2
 matplotlib
 multipledispatch

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
             "flax",
             "funsor>=0.4.1",
             "graphviz",
-            "jaxns==2.2.6",
+            "jaxns==2.4.8",
             "matplotlib",
             "optax>=0.0.6",
             "pylab-sdk",  # jaxns dependency


### PR DESCRIPTION
I did a small fix for the nested sampling contributed code so that it works with jaxns 2.4.8
It tested it by running the gaussian shell example, which leads to similar results as what we would have expected before 

![Capture d’écran 2024-02-19 à 13 53 40](https://github.com/pyro-ppl/numpyro/assets/49200287/b3cd8fe8-c533-49f1-b2ec-788bd1aaa6b0)
