### PR TITLE
Add explicit reparametrizer.

### DIFF
--- a/docs/source/reparam.rst
+++ b/docs/source/reparam.rst
@@ -60,3 +60,12 @@ Circular Distributions
     :show-inheritance:
     :member-order: bysource
     :special-members: __call__
+
+Explicit Reparameterization
+---------------------------
+.. autoclass:: numpyro.infer.reparam.ExplicitReparam
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :member-order: bysource
+    :special-members: __call__


### PR DESCRIPTION
This PR adds an `ExplicitReparam` of a latent variable `x` to a transformed space `y = transform(x)` with more amenable geometry. This reparametrizer is similar to `TransformReparam` but allows reparametrizations to be decoupled from the model declaration.