### PR TITLE
Fix ruff not format the changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,15 @@
 all: test
 
 lint: FORCE
-	ruff .
+	ruff check .
+	ruff format . --check
 	python scripts/update_headers.py --check
 
 license: FORCE
 	python scripts/update_headers.py
 
 format: license FORCE
-	ruff . --fix
+	ruff format .
 
 install: FORCE
 	pip install -e .[dev,doc,test,examples]

--- a/examples/hmm_enum.py
+++ b/examples/hmm_enum.py
@@ -303,8 +303,13 @@ def model_6(sequences, lengths, args, include_prior=False):
         with numpyro.plate("sequences", num_sequences, dim=-2):
             with mask(mask=(t < lengths)[..., None]):
                 probs_x_t = Vindex(probs_x)[x_prev, x_curr]
-                x_prev, x_curr = x_curr, numpyro.sample(
-                    "x", dist.Categorical(probs_x_t), infer={"enumerate": "parallel"}
+                x_prev, x_curr = (
+                    x_curr,
+                    numpyro.sample(
+                        "x",
+                        dist.Categorical(probs_x_t),
+                        infer={"enumerate": "parallel"},
+                    ),
                 )
                 with numpyro.plate("tones", data_dim, dim=-1):
                     probs_y_t = probs_y[x_curr.squeeze(-1)]

--- a/examples/hsgp.py
+++ b/examples/hsgp.py
@@ -46,6 +46,7 @@ for installation instructions.
 
 
 """
+
 import argparse
 import os
 

--- a/examples/prodlda.py
+++ b/examples/prodlda.py
@@ -30,6 +30,7 @@ generate a better representation of the encoded latent vector.
 .. image:: ../_static/img/examples/prodlda.png
     :align: center
 """
+
 import argparse
 
 import matplotlib.pyplot as plt

--- a/examples/proportion_test.py
+++ b/examples/proportion_test.py
@@ -16,7 +16,6 @@ normal prior on the regression coefficients. We report the 95% highest posterior
 density interval for the effect of making a call.
 """
 
-
 import argparse
 import os
 

--- a/examples/stein_dmm.py
+++ b/examples/stein_dmm.py
@@ -18,6 +18,7 @@ The model DMM based on reference [1][2] and the Pyro DMM example: https://pyro.a
 .. image:: ../_static/img/examples/stein_dmm.png
     :align: center
 """
+
 import argparse
 
 import numpy as np

--- a/numpyro/compat/infer.py
+++ b/numpyro/compat/infer.py
@@ -126,7 +126,7 @@ class SVI(svi.SVI):
         loss_and_grads=None,
         num_samples=10,
         num_steps=0,
-        **kwargs
+        **kwargs,
     ):
         super(SVI, self).__init__(model=model, guide=guide, optim=optim, loss=loss)
         self.svi_state = None

--- a/numpyro/contrib/ecs_proxies.py
+++ b/numpyro/contrib/ecs_proxies.py
@@ -185,7 +185,6 @@ def taylor_proxy(reference_params, degree):
             ref_sum_log_lik_hessians = hessian(log_likelihood_sum)(ref_params_flat)
 
         def gibbs_init(rng_key, gibbs_sites):
-
             ref_subsamples_taylor = [
                 log_likelihood(ref_params_flat, gibbs_sites),
                 jacobian(log_likelihood)(ref_params_flat, gibbs_sites),

--- a/numpyro/contrib/einstein/steinvi.py
+++ b/numpyro/contrib/einstein/steinvi.py
@@ -217,13 +217,11 @@ class SteinVI:
 
     def _svgd_loss_and_grads(self, rng_key, unconstr_params, *args, **kwargs):
         # 0. Separate model and guide parameters, since only guide parameters are updated using Stein
-        non_mixture_uparams = (
-            {  # Includes any marked guide parameters and all model parameters
-                p: v
-                for p, v in unconstr_params.items()
-                if p not in self.guide_sites or self.non_mixture_params_fn(p)
-            }
-        )
+        non_mixture_uparams = {  # Includes any marked guide parameters and all model parameters
+            p: v
+            for p, v in unconstr_params.items()
+            if p not in self.guide_sites or self.non_mixture_params_fn(p)
+        }
         stein_uparams = {
             p: v for p, v in unconstr_params.items() if p not in non_mixture_uparams
         }

--- a/numpyro/contrib/module.py
+++ b/numpyro/contrib/module.py
@@ -254,7 +254,7 @@ def random_flax_module(
     input_shape=None,
     apply_rng=None,
     mutable=None,
-    **kwargs
+    **kwargs,
 ):
     """
     A primitive to place a prior over the parameters of the Flax module `nn_module`.
@@ -372,7 +372,7 @@ def random_flax_module(
         input_shape=input_shape,
         apply_rng=apply_rng,
         mutable=mutable,
-        **kwargs
+        **kwargs,
     )
     params = nn.args[0]
     new_params = deepcopy(params)

--- a/numpyro/contrib/tfp/distributions.py
+++ b/numpyro/contrib/tfp/distributions.py
@@ -314,9 +314,7 @@ for _name, _Dist in tfd.__dict__.items():
     _PyroDist.__doc__ = """
     Wraps `{}.{} <https://www.tensorflow.org/probability/api_docs/python/tfp/substrates/jax/distributions/{}>`_
     with :class:`~numpyro.contrib.tfp.distributions.TFPDistribution`.
-    """.format(
-        _Dist.__module__, _Dist.__name__, _Dist.__name__
-    )
+    """.format(_Dist.__module__, _Dist.__name__, _Dist.__name__)
 
     __all__.append(_name)
 
@@ -328,9 +326,7 @@ __doc__ = "\n\n".join(
     {0}
     ----------------------------------------------------------------
     .. autoclass:: numpyro.contrib.tfp.distributions.{0}
-    """.format(
-            _name
-        )
+    """.format(_name)
         for _name in __all__[:_len_all]
     ]
 )

--- a/numpyro/contrib/tfp/mcmc.py
+++ b/numpyro/contrib/tfp/mcmc.py
@@ -236,9 +236,7 @@ for _name, _Kernel in tfp.mcmc.__dict__.items():
     Wraps `{}.{} <https://www.tensorflow.org/probability/api_docs/python/tfp/substrates/jax/mcmc/{}>`_
     with :class:`~numpyro.contrib.tfp.mcmc.TFPKernel`. The first argument `target_log_prob_fn`
     in TFP kernel construction is replaced by either `model` or `potential_fn`.
-    """.format(
-        _Kernel.__module__, _Kernel.__name__, _Kernel.__name__
-    )
+    """.format(_Kernel.__module__, _Kernel.__name__, _Kernel.__name__)
 
     __all__.append(_name)
 
@@ -250,9 +248,7 @@ __doc__ = "\n\n".join(
     {0}
     ----------------------------------------------------------------
     .. autoclass:: numpyro.contrib.tfp.mcmc.{0}
-    """.format(
-            _name
-        )
+    """.format(_name)
         for _name in __all__[:1] + sorted(__all__[1:])
     ]
 )

--- a/numpyro/distributions/conjugate.py
+++ b/numpyro/distributions/conjugate.py
@@ -36,6 +36,7 @@ class BetaBinomial(Distribution):
         Beta distribution.
     :param numpy.ndarray total_count: number of Bernoulli trials.
     """
+
     arg_constraints = {
         "concentration1": constraints.positive,
         "concentration0": constraints.positive,
@@ -107,6 +108,7 @@ class DirichletMultinomial(Distribution):
         Dirichlet distribution.
     :param numpy.ndarray total_count: number of Categorical trials.
     """
+
     arg_constraints = {
         "concentration": constraints.independent(constraints.positive, 1),
         "total_count": constraints.nonnegative_integer,
@@ -182,6 +184,7 @@ class GammaPoisson(Distribution):
     :param numpy.ndarray concentration: shape parameter (alpha) of the Gamma distribution.
     :param numpy.ndarray rate: rate parameter (beta) for the Gamma distribution.
     """
+
     arg_constraints = {
         "concentration": constraints.positive,
         "rate": constraints.positive,

--- a/numpyro/distributions/continuous.py
+++ b/numpyro/distributions/continuous.py
@@ -284,9 +284,7 @@ class Dirichlet(Distribution):
     @property
     def variance(self):
         con0 = jnp.sum(self.concentration, axis=-1, keepdims=True)
-        return (
-            self.concentration * (con0 - self.concentration) / (con0**2 * (con0 + 1))
-        )
+        return self.concentration * (con0 - self.concentration) / (con0**2 * (con0 + 1))
 
     @staticmethod
     def infer_shapes(concentration):
@@ -909,6 +907,7 @@ class LKJ(TransformedDistribution):
     [1] `Generating random correlation matrices based on vines and extended onion method`,
     Daniel Lewandowski, Dorota Kurowicka, Harry Joe
     """
+
     arg_constraints = {"concentration": constraints.positive}
     reparametrized_params = ["concentration"]
     support = constraints.corr_matrix
@@ -985,6 +984,7 @@ class LKJCholesky(Distribution):
     [1] `Generating random correlation matrices based on vines and extended onion method`,
     Daniel Lewandowski, Dorota Kurowicka, Harry Joe
     """
+
     arg_constraints = {"concentration": constraints.positive}
     reparametrized_params = ["concentration"]
     support = constraints.corr_cholesky
@@ -1961,9 +1961,10 @@ class LowRankMultivariateNormal(Distribution):
 
     @lazy_property
     def covariance_matrix(self):
-        covariance_matrix = add_diag(jnp.matmul(
-            self.cov_factor, jnp.swapaxes(self.cov_factor, -1, -2)
-        ), self.cov_diag)
+        covariance_matrix = add_diag(
+            jnp.matmul(self.cov_factor, jnp.swapaxes(self.cov_factor, -1, -2)),
+            self.cov_diag,
+        )
         return covariance_matrix
 
     @lazy_property
@@ -1976,7 +1977,7 @@ class LowRankMultivariateNormal(Distribution):
         )
         A = solve_triangular(Wt_Dinv, self._capacitance_tril, lower=True)
         inverse_cov_diag = jnp.reciprocal(self.cov_diag)
-        return add_diag(- jnp.matmul(jnp.swapaxes(A, -1, -2), A), inverse_cov_diag)
+        return add_diag(-jnp.matmul(jnp.swapaxes(A, -1, -2), A), inverse_cov_diag)
 
     def sample(self, key, sample_shape=()):
         assert is_prng_key(key)
@@ -2068,8 +2069,9 @@ class Pareto(TransformedDistribution):
     def __init__(self, scale, alpha, *, validate_args=None):
         self.scale, self.alpha = promote_shapes(scale, alpha)
         batch_shape = lax.broadcast_shapes(jnp.shape(scale), jnp.shape(alpha))
-        scale, alpha = jnp.broadcast_to(scale, batch_shape), jnp.broadcast_to(
-            alpha, batch_shape
+        scale, alpha = (
+            jnp.broadcast_to(scale, batch_shape),
+            jnp.broadcast_to(alpha, batch_shape),
         )
         base_dist = Exponential(alpha)
         transforms = [ExpTransform(), AffineTransform(loc=0, scale=scale)]

--- a/numpyro/distributions/discrete.py
+++ b/numpyro/distributions/discrete.py
@@ -679,6 +679,7 @@ class Poisson(Distribution):
     :param bool is_sparse: Whether to assume value is mostly zero when computing
         :meth:`log_prob`, which can speed up computation when data is sparse.
     """
+
     arg_constraints = {"rate": constraints.positive}
     support = constraints.nonnegative_integer
     pytree_aux_fields = ("is_sparse",)

--- a/numpyro/distributions/transforms.py
+++ b/numpyro/distributions/transforms.py
@@ -400,6 +400,7 @@ class CholeskyTransform(ParameterFreeTransform):
     Transform via the mapping :math:`y = cholesky(x)`, where `x` is a
     positive definite matrix.
     """
+
     domain = constraints.positive_definite
     codomain = constraints.lower_cholesky
 
@@ -444,6 +445,7 @@ class CorrCholeskyTransform(ParameterFreeTransform):
             c. Applies :math:`s_i = StickBreakingTransform(z_i)`.
             d. Transforms back into signed domain: :math:`y_i = (sign(r_i), 1) * \sqrt{s_i}`.
     """
+
     domain = constraints.real_vector
     codomain = constraints.corr_cholesky
 
@@ -493,6 +495,7 @@ class CorrMatrixCholeskyTransform(CholeskyTransform):
     Transform via the mapping :math:`y = cholesky(x)`, where `x` is a
     correlation matrix.
     """
+
     domain = constraints.corr_matrix
     codomain = constraints.corr_cholesky
 
@@ -624,6 +627,7 @@ class L1BallTransform(ParameterFreeTransform):
     r"""
     Transforms a uncontrained real vector :math:`x` into the unit L1 ball.
     """
+
     domain = constraints.real_vector
     codomain = constraints.l1_ball
 
@@ -687,6 +691,7 @@ class LowerCholeskyAffine(Transform):
        >>> affine(base)
        Array([0.3, 1.5], dtype=float32)
     """
+
     domain = constraints.real_vector
     codomain = constraints.real_vector
 
@@ -786,6 +791,7 @@ class ScaledUnitLowerCholeskyTransform(LowerCholeskyTransform):
     and :math:`scale\_diag` is a diagonal matrix with all positive
     entries that is parameterized with a softplus transform.
     """
+
     domain = constraints.real_vector
     codomain = constraints.scaled_unit_lower_cholesky
 
@@ -995,6 +1001,7 @@ class SoftplusTransform(ParameterFreeTransform):
     Transform from unconstrained space to positive domain via softplus :math:`y = \log(1 + \exp(x))`.
     The inverse is computed as :math:`x = \log(\exp(y) - 1)`.
     """
+
     domain = constraints.real
     codomain = constraints.softplus_positive
 
@@ -1198,7 +1205,6 @@ class ReshapeTransform(Transform):
             and self._forward_shape == other._forward_shape
             and self._inverse_shape == other._inverse_shape
         )
-
 
 
 ##########################################################

--- a/numpyro/distributions/truncated.py
+++ b/numpyro/distributions/truncated.py
@@ -263,9 +263,7 @@ class TwoSidedTruncatedDistribution(Distribution):
         if isinstance(self.base_dist, Normal):
             low_prob = jnp.exp(self.log_prob(self.low))
             high_prob = jnp.exp(self.log_prob(self.high))
-            return (
-                self.base_dist.loc + (low_prob - high_prob) * self.base_dist.scale**2
-            )
+            return self.base_dist.loc + (low_prob - high_prob) * self.base_dist.scale**2
         elif isinstance(self.base_dist, Cauchy):
             return jnp.full(self.batch_shape, jnp.nan)
         else:

--- a/numpyro/infer/autoguide.py
+++ b/numpyro/infer/autoguide.py
@@ -1858,7 +1858,7 @@ class AutoBatchedMixin:
                         f"Expected {self.batch_ndim} batch dimensions, but site "
                         f"`{site['name']}` only has shape {shape}."
                     )
-                shape = shape[:self.batch_ndim]
+                shape = shape[: self.batch_ndim]
                 if batch_shape is None:
                     batch_shape = shape
                 elif shape != batch_shape:
@@ -1884,7 +1884,9 @@ class AutoBatchedMixin:
         )
 
     def _get_reshape_transform(self) -> ReshapeTransform:
-        return ReshapeTransform((self.latent_dim,), self._batch_shape + self._event_shape)
+        return ReshapeTransform(
+            (self.latent_dim,), self._batch_shape + self._event_shape
+        )
 
 
 class AutoBatchedMultivariateNormal(AutoBatchedMixin, AutoContinuous):
@@ -1914,7 +1916,10 @@ class AutoBatchedMultivariateNormal(AutoBatchedMixin, AutoContinuous):
             raise ValueError("Expected init_scale > 0. but got {}".format(init_scale))
         self._init_scale = init_scale
         super().__init__(
-            model, prefix=prefix, init_loc_fn=init_loc_fn, batch_ndim=batch_ndim,
+            model,
+            prefix=prefix,
+            init_loc_fn=init_loc_fn,
+            batch_ndim=batch_ndim,
         )
 
     def _get_batched_posterior(self):
@@ -2044,16 +2049,21 @@ class AutoBatchedLowRankMultivariateNormal(AutoBatchedMixin, AutoContinuous):
         self._init_scale = init_scale
         self.rank = rank
         super().__init__(
-            model, prefix=prefix, init_loc_fn=init_loc_fn, batch_ndim=batch_ndim,
+            model,
+            prefix=prefix,
+            init_loc_fn=init_loc_fn,
+            batch_ndim=batch_ndim,
         )
 
     def _get_batched_posterior(self):
-        rank = int(round(self._event_shape[0]**0.5)) if self.rank is None else self.rank
+        rank = (
+            int(round(self._event_shape[0] ** 0.5)) if self.rank is None else self.rank
+        )
         init_latent = self._init_latent.reshape(self._batch_shape + self._event_shape)
         loc = numpyro.param("{}_loc".format(self.prefix), init_latent)
         cov_factor = numpyro.param(
             "{}_cov_factor".format(self.prefix),
-            jnp.zeros(self._batch_shape + self._event_shape + (rank,))
+            jnp.zeros(self._batch_shape + self._event_shape + (rank,)),
         )
         scale = numpyro.param(
             "{}_scale".format(self.prefix),

--- a/numpyro/infer/elbo.py
+++ b/numpyro/infer/elbo.py
@@ -261,16 +261,18 @@ def _check_mean_field_requirement(model_trace, guide_trace):
     ]
     assert set(model_sites) == set(guide_sites)
     if model_sites != guide_sites:
-        warnings.warn(
-            "Failed to verify mean field restriction on the guide. "
-            "To eliminate this warning, ensure model and guide sites "
-            "occur in the same order.\n"
-            + "Model sites:\n  "
-            + "\n  ".join(model_sites)
-            + "Guide sites:\n  "
-            + "\n  ".join(guide_sites),
-            stacklevel=find_stack_level(),
-        ),
+        (
+            warnings.warn(
+                "Failed to verify mean field restriction on the guide. "
+                "To eliminate this warning, ensure model and guide sites "
+                "occur in the same order.\n"
+                + "Model sites:\n  "
+                + "\n  ".join(model_sites)
+                + "Guide sites:\n  "
+                + "\n  ".join(guide_sites),
+                stacklevel=find_stack_level(),
+            ),
+        )
 
 
 class TraceMeanField_ELBO(ELBO):

--- a/numpyro/infer/ensemble_util.py
+++ b/numpyro/infer/ensemble_util.py
@@ -18,8 +18,9 @@ def get_nondiagonal_indices(n):
     rows, cols = np.tril_indices(n, -1)  # -1 to exclude diagonal
 
     # Combine rows-cols and cols-rows pairs
-    pairs = np.column_stack([np.concatenate([rows, cols]),
-                             np.concatenate([cols, rows])])
+    pairs = np.column_stack(
+        [np.concatenate([rows, cols]), np.concatenate([cols, rows])]
+    )
 
     return jnp.asarray(pairs)
 
@@ -43,5 +44,3 @@ def batch_ravel_pytree(pytree):
     unravel_fn = jax.vmap(ravel_pytree(tree_map(lambda z: z[0], pytree))[1])
 
     return flat, unravel_fn
-
-

--- a/numpyro/infer/hmc.py
+++ b/numpyro/infer/hmc.py
@@ -287,7 +287,13 @@ def hmc(potential_fn=None, potential_fn_gen=None, kinetic_fn=None, algo="NUTS"):
             trajectory_length = lax.convert_element_type(
                 trajectory_length, jnp.result_type(float)
             )
-        nonlocal wa_update, max_treedepth, vv_update, wa_steps, forward_mode_ad, fixed_num_steps
+        nonlocal \
+            wa_update, \
+            max_treedepth, \
+            vv_update, \
+            wa_steps, \
+            forward_mode_ad, \
+            fixed_num_steps
         forward_mode_ad = forward_mode_differentiation
         wa_steps = num_warmup
         max_treedepth = (

--- a/numpyro/infer/hmc_gibbs.py
+++ b/numpyro/infer/hmc_gibbs.py
@@ -687,8 +687,6 @@ class HMCECS(HMCGibbs):
         return taylor_proxy(reference_params, degree)
 
 
-
-
 class estimate_likelihood(numpyro.primitives.Messenger):
     def __init__(self, fn=None, method=None):
         # estimate_likelihood: accept likelihood tuple (fn, value, subsample_name, subsample_dim)

--- a/numpyro/infer/hmc_util.py
+++ b/numpyro/infer/hmc_util.py
@@ -241,9 +241,11 @@ def welford_covariance(diagonal=True):
 
 def _value_and_grad(f, x, forward_mode_differentiation=False):
     if forward_mode_differentiation:
+
         def _wrapper(x):
             out = f(x)
             return out, out
+
         grads, out = jacfwd(_wrapper, has_aux=True)(x)
         return out, grads
     else:

--- a/numpyro/infer/inspect.py
+++ b/numpyro/infer/inspect.py
@@ -385,8 +385,7 @@ def get_model_relations(model, model_args=None, model_kwargs=None):
     samples = {
         name: site["value"]
         for name, site in trace.items()
-        if site["type"] == "sample"
-        or site["type"] == "deterministic"
+        if site["type"] == "sample" or site["type"] == "deterministic"
     }
 
     params = {

--- a/numpyro/infer/mixed_hmc.py
+++ b/numpyro/infer/mixed_hmc.py
@@ -74,7 +74,7 @@ class MixedHMC(DiscreteHMCGibbs):
         *,
         num_discrete_updates=None,
         random_walk=False,
-        modified=False
+        modified=False,
     ):
         super().__init__(inner_kernel, random_walk=random_walk, modified=modified)
         if inner_kernel._algo == "NUTS":

--- a/numpyro/infer/svi.py
+++ b/numpyro/infer/svi.py
@@ -283,11 +283,15 @@ class SVI(object):
             mutable_state=svi_state.mutable_state,
         )
         (loss_val, mutable_state), optim_state = self.optim.eval_and_update(
-            loss_fn, svi_state.optim_state, forward_mode_differentiation=forward_mode_differentiation
+            loss_fn,
+            svi_state.optim_state,
+            forward_mode_differentiation=forward_mode_differentiation,
         )
         return SVIState(optim_state, mutable_state, rng_key), loss_val
 
-    def stable_update(self, svi_state, *args, forward_mode_differentiation=False, **kwargs):
+    def stable_update(
+        self, svi_state, *args, forward_mode_differentiation=False, **kwargs
+    ):
         """
         Similar to :meth:`update` but returns the current state if the
         the loss or the new state contains invalid values.
@@ -314,7 +318,9 @@ class SVI(object):
             mutable_state=svi_state.mutable_state,
         )
         (loss_val, mutable_state), optim_state = self.optim.eval_and_stable_update(
-            loss_fn, svi_state.optim_state, forward_mode_differentiation=forward_mode_differentiation
+            loss_fn,
+            svi_state.optim_state,
+            forward_mode_differentiation=forward_mode_differentiation,
         )
         return SVIState(optim_state, mutable_state, rng_key), loss_val
 
@@ -378,11 +384,17 @@ class SVI(object):
         def body_fn(svi_state, _):
             if stable_update:
                 svi_state, loss = self.stable_update(
-                    svi_state, *args, forward_mode_differentiation=forward_mode_differentiation, **kwargs
+                    svi_state,
+                    *args,
+                    forward_mode_differentiation=forward_mode_differentiation,
+                    **kwargs,
                 )
             else:
                 svi_state, loss = self.update(
-                    svi_state, *args, forward_mode_differentiation=forward_mode_differentiation, **kwargs
+                    svi_state,
+                    *args,
+                    forward_mode_differentiation=forward_mode_differentiation,
+                    **kwargs,
                 )
             return svi_state, loss
 

--- a/numpyro/optim.py
+++ b/numpyro/optim.py
@@ -34,15 +34,19 @@ _Params = TypeVar("_Params")
 _OptState = TypeVar("_OptState")
 _IterOptState = tuple[int, _OptState]
 
+
 def _value_and_grad(f, x, forward_mode_differentiation=False):
     if forward_mode_differentiation:
+
         def _wrapper(x):
             out, aux = f(x)
             return out, (out, aux)
+
         grads, (out, aux) = jacfwd(_wrapper, has_aux=True)(x)
         return (out, aux), grads
     else:
         return value_and_grad(f, has_aux=True)(x)
+
 
 class _NumPyroOptim(object):
     def __init__(self, optim_fn: Callable, *args, **kwargs) -> None:
@@ -71,7 +75,10 @@ class _NumPyroOptim(object):
         return i + 1, opt_state
 
     def eval_and_update(
-            self, fn: Callable[[Any], tuple], state: _IterOptState, forward_mode_differentiation: bool = False
+        self,
+        fn: Callable[[Any], tuple],
+        state: _IterOptState,
+        forward_mode_differentiation: bool = False,
     ):
         """
         Performs an optimization step for the objective function `fn`.
@@ -95,8 +102,11 @@ class _NumPyroOptim(object):
         return (out, aux), self.update(grads, state)
 
     def eval_and_stable_update(
-            self, fn: Callable[[Any], tuple], state: _IterOptState, forward_mode_differentiation: bool = False
-        ):
+        self,
+        fn: Callable[[Any], tuple],
+        state: _IterOptState,
+        forward_mode_differentiation: bool = False,
+    ):
         """
         Like :meth:`eval_and_update` but when the value of the objective function
         or the gradients are not finite, we will not update the input `state`
@@ -286,8 +296,11 @@ class Minimize(_NumPyroOptim):
         self._kwargs = kwargs
 
     def eval_and_update(
-            self, fn: Callable[[Any], tuple], state: _IterOptState, forward_mode_differentiation=False
-        ):
+        self,
+        fn: Callable[[Any], tuple],
+        state: _IterOptState,
+        forward_mode_differentiation=False,
+    ):
         i, (flat_params, unravel_fn) = state
 
         def loss_fn(x):

--- a/test/contrib/test_funsor.py
+++ b/test/contrib/test_funsor.py
@@ -485,8 +485,9 @@ def test_scan_history(history, T):
         x_curr = 0
         for t in markov(range(T), history=history):
             probs = p[x_prev, x_curr, z]
-            x_prev, x_curr = x_curr, numpyro.sample(
-                "x_{}".format(t), dist.Bernoulli(probs)
+            x_prev, x_curr = (
+                x_curr,
+                numpyro.sample("x_{}".format(t), dist.Bernoulli(probs)),
             )
             numpyro.sample("y_{}".format(t), dist.Bernoulli(q[x_curr]), obs=0)
         return x_prev, x_curr

--- a/test/contrib/test_module.py
+++ b/test/contrib/test_module.py
@@ -23,7 +23,9 @@ from numpyro.contrib.module import (
 import numpyro.distributions as dist
 from numpyro.infer import MCMC, NUTS
 
-pytestmark = pytest.mark.filterwarnings("ignore:jax.tree_.+ is deprecated:FutureWarning")
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:jax.tree_.+ is deprecated:FutureWarning"
+)
 
 
 def haiku_model_by_shape(x, y):
@@ -117,12 +119,16 @@ def test_haiku_module():
         100,
         100,
     )
-    assert haiku_tr["nn$params"]["value"]["test_haiku_module/w_linear"]["b"].shape == (100,)
+    assert haiku_tr["nn$params"]["value"]["test_haiku_module/w_linear"]["b"].shape == (
+        100,
+    )
     assert haiku_tr["nn$params"]["value"]["test_haiku_module/x_linear"]["w"].shape == (
         100,
         100,
     )
-    assert haiku_tr["nn$params"]["value"]["test_haiku_module/x_linear"]["b"].shape == (100,)
+    assert haiku_tr["nn$params"]["value"]["test_haiku_module/x_linear"]["b"].shape == (
+        100,
+    )
 
 
 def test_update_params():
@@ -131,7 +137,9 @@ def test_update_params():
     new_params = deepcopy(params)
     with handlers.seed(rng_seed=0):
         _update_params(params, new_params, prior)
-    assert params == {"a": {"b": {"c": {"d": ParamShape(())}, "e": 2}, "f": ParamShape((4,))}}
+    assert params == {
+        "a": {"b": {"c": {"d": ParamShape(())}, "e": 2}, "f": ParamShape((4,))}
+    }
 
     tree_all(
         tree_map(
@@ -198,7 +206,9 @@ def test_random_module_mcmc(backend, init, callable_prior):
         numpyro.sample("y", dist.Bernoulli(logits=logits), obs=labels)
 
     kernel = NUTS(model=model)
-    mcmc = MCMC(kernel, num_warmup=num_warmup, num_samples=num_samples, progress_bar=False)
+    mcmc = MCMC(
+        kernel, num_warmup=num_warmup, num_samples=num_samples, progress_bar=False
+    )
     mcmc.run(random.PRNGKey(2), data, labels)
     mcmc.print_summary()
     samples = mcmc.get_samples()
@@ -222,7 +232,9 @@ def test_haiku_state_dropout_smoke(dropout, batchnorm):
         if dropout:
             x = hk.dropout(hk.next_rng_key(), 0.5, x)
         if batchnorm:
-            x = hk.BatchNorm(create_offset=True, create_scale=True, decay_rate=0.001)(x, is_training=True)
+            x = hk.BatchNorm(create_offset=True, create_scale=True, decay_rate=0.001)(
+                x, is_training=True
+            )
         return x
 
     def model():

--- a/test/contrib/test_tfp.py
+++ b/test/contrib/test_tfp.py
@@ -280,7 +280,8 @@ def test_sample_unwrapped_mixture_same_family():
             tfd.MixtureSameFamily(
                 mixture_distribution=tfd.Categorical(probs=[0.3, 0.7]),
                 components_distribution=tfd.Normal(
-                    loc=[-1.0, 1], scale=[0.1, 0.5]  # One for each component.
+                    loc=[-1.0, 1],
+                    scale=[0.1, 0.5],  # One for each component.
                 ),
             ),
         )

--- a/test/infer/test_compute_downstream_costs.py
+++ b/test/infer/test_compute_downstream_costs.py
@@ -24,7 +24,9 @@ from numpyro.infer.elbo import (
 
 
 def _brute_force_compute_downstream_costs(
-    model_trace, guide_trace, non_reparam_nodes  #
+    model_trace,
+    guide_trace,
+    non_reparam_nodes,  #
 ):
     model_successors = _identify_dense_edges(model_trace)
     guide_successors = _identify_dense_edges(guide_trace)

--- a/test/infer/test_ensemble_mcmc.py
+++ b/test/infer/test_ensemble_mcmc.py
@@ -20,42 +20,62 @@ true_coefs = jnp.arange(1.0, dim + 1.0)
 logits = jnp.sum(true_coefs * data, axis=-1)
 labels = dist.Bernoulli(logits=logits).sample(random.PRNGKey(1))
 
+
 def model(labels):
     coefs = numpyro.sample("coefs", dist.Normal(jnp.zeros(dim), jnp.ones(dim)))
     logits = numpyro.deterministic("logits", jnp.sum(coefs * data, axis=-1))
     return numpyro.sample("obs", dist.Bernoulli(logits=logits), obs=labels)
+
+
 # ---
 
-@pytest.mark.parametrize("kernel_cls, n_chain, method",
-                         [(AIES, 10, "sequential"),
-                          (AIES, 1, "vectorized"),
-                          (AIES, 2, "parallel"),
-                          (ESS, 10, "sequential"),
-                          (ESS, 1, "vectorized"),
-                          (ESS, 2, "parallel")])
+
+@pytest.mark.parametrize(
+    "kernel_cls, n_chain, method",
+    [
+        (AIES, 10, "sequential"),
+        (AIES, 1, "vectorized"),
+        (AIES, 2, "parallel"),
+        (ESS, 10, "sequential"),
+        (ESS, 1, "vectorized"),
+        (ESS, 2, "parallel"),
+    ],
+)
 def test_chain_smoke(kernel_cls, n_chain, method):
     kernel = kernel_cls(model)
 
-    mcmc = MCMC(kernel, num_warmup=10, num_samples=10,
-            progress_bar=False, num_chains=n_chain, chain_method=method)
+    mcmc = MCMC(
+        kernel,
+        num_warmup=10,
+        num_samples=10,
+        progress_bar=False,
+        num_chains=n_chain,
+        chain_method=method,
+    )
 
     with pytest.raises(AssertionError, match="chain_method"):
         mcmc.run(random.PRNGKey(2), labels)
+
 
 @pytest.mark.parametrize("kernel_cls", [AIES, ESS])
 def test_out_shape_smoke(kernel_cls):
     n_chains = 10
     kernel = kernel_cls(model)
 
-    mcmc = MCMC(kernel, num_warmup=10, num_samples=10,
-            progress_bar=False, num_chains=n_chains, chain_method='vectorized')
+    mcmc = MCMC(
+        kernel,
+        num_warmup=10,
+        num_samples=10,
+        progress_bar=False,
+        num_chains=n_chains,
+        chain_method="vectorized",
+    )
     mcmc.run(random.PRNGKey(2), labels)
 
-    assert (mcmc.get_samples(group_by_chain=True)['coefs'].shape[0]
-            == n_chains)
+    assert mcmc.get_samples(group_by_chain=True)["coefs"].shape[0] == n_chains
+
 
 @pytest.mark.parametrize("kernel_cls", [AIES, ESS])
 def test_invalid_moves(kernel_cls):
     with pytest.raises(AssertionError, match="Each move"):
-        kernel_cls(model, moves={'invalid': 1.})
-
+        kernel_cls(model, moves={"invalid": 1.0})

--- a/test/infer/test_ensemble_util.py
+++ b/test/infer/test_ensemble_util.py
@@ -8,28 +8,24 @@ from numpyro.infer.ensemble_util import batch_ravel_pytree, get_nondiagonal_indi
 
 
 def test_nondiagonal_indices():
-    truth = jnp.array(
-        [[1, 0],
-        [2, 0],
-        [2, 1],
-        [0, 1],
-        [0, 2],
-        [1, 2]], dtype=jnp.int32)
+    truth = jnp.array([[1, 0], [2, 0], [2, 1], [0, 1], [0, 2], [1, 2]], dtype=jnp.int32)
 
     assert jnp.all(get_nondiagonal_indices(3) == truth)
+
 
 def test_batch_ravel_pytree():
     arr1 = jnp.arange(10).reshape((5, 2))
     arr2 = jnp.arange(15).reshape((5, 3))
     arr3 = jnp.arange(20).reshape((5, 4))
 
-    tree = {'arr1': arr1, 'arr2': arr2, 'arr3': arr3}
+    tree = {"arr1": arr1, "arr2": arr2, "arr3": arr3}
 
     flattened, unravel_fn = batch_ravel_pytree(tree)
     unflattened = unravel_fn(flattened)
 
     assert flattened.shape == (5, 2 + 3 + 4)
 
-    for unflattened_leaf, original_leaf in zip(jax.tree_util.tree_leaves(unflattened),
-                                               jax.tree_util.tree_leaves(tree)):
+    for unflattened_leaf, original_leaf in zip(
+        jax.tree_util.tree_leaves(unflattened), jax.tree_util.tree_leaves(tree)
+    ):
         assert jnp.all(unflattened_leaf == original_leaf)

--- a/test/infer/test_mcmc.py
+++ b/test/infer/test_mcmc.py
@@ -40,8 +40,12 @@ def test_unnormalized_normal_x64(kernel_cls, dense_mass):
 
         init_params = random.normal(random.PRNGKey(1), (num_chains,))
         mcmc = MCMC(
-            kernel, num_warmup=num_warmup, num_samples=num_samples, progress_bar=False,
-            num_chains=num_chains, chain_method='vectorized'
+            kernel,
+            num_warmup=num_warmup,
+            num_samples=num_samples,
+            progress_bar=False,
+            num_chains=num_chains,
+            chain_method="vectorized",
         )
     elif kernel_cls in [SA, BarkerMH]:
         kernel = kernel_cls(potential_fn=potential_fn, dense_mass=dense_mass)
@@ -124,8 +128,12 @@ def test_logistic_regression_x64(kernel_cls):
         kernel = kernel_cls(model)
 
         mcmc = MCMC(
-            kernel, num_warmup=num_warmup, num_samples=samples_each_chain,
-            progress_bar=False, num_chains=num_chains, chain_method='vectorized'
+            kernel,
+            num_warmup=num_warmup,
+            num_samples=samples_each_chain,
+            progress_bar=False,
+            num_chains=num_chains,
+            chain_method="vectorized",
         )
     elif kernel_cls is SA:
         num_warmup, num_samples = (100000, 100000)
@@ -242,8 +250,12 @@ def test_beta_bernoulli_x64(kernel_cls):
         num_chains = 10
         kernel = kernel_cls(model=model)
         mcmc = MCMC(
-            kernel, num_warmup=num_warmup, num_samples=num_samples,
-            progress_bar=False, num_chains=num_chains, chain_method='vectorized'
+            kernel,
+            num_warmup=num_warmup,
+            num_samples=num_samples,
+            progress_bar=False,
+            num_chains=num_chains,
+            chain_method="vectorized",
         )
     elif kernel_cls is SA:
         kernel = SA(model=model)

--- a/test/infer/test_svi.py
+++ b/test/infer/test_svi.py
@@ -766,8 +766,8 @@ def test_forward_mode_differentiation():
         numpyro.sample("obs", dist.Normal(y, 1), obs=1.0)
 
     def guide():
-        loc = numpyro.param("loc", 0.)
-        scale = numpyro.param("scale", 1., constraint=dist.constraints.positive)
+        loc = numpyro.param("loc", 0.0)
+        scale = numpyro.param("scale", 1.0, constraint=dist.constraints.positive)
         numpyro.sample("x", dist.Normal(loc, scale))
 
     # this fails in reverse mode

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -3061,7 +3061,8 @@ def test_vmap_dist(jax_dist, sp_dist, params):
                 vmap_over(d, **{param_names[idx]: 1}),
             )
             for idx in vmappable_param_idxs
-            if isinstance(params[idx], jnp.ndarray) and jnp.array(params[idx]).ndim > 0
+            if isinstance(params[idx], jnp.ndarray)
+            and jnp.array(params[idx]).ndim > 0
             # skip this distribution because _GeneralMixture.__init__ turns
             # 1d inputs into 0d attributes, thus breaks the expectations of
             # the vmapping test case where in_axes=1, only done for rank>=1 tensors.

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -118,9 +118,7 @@ TRANSFORMS = {
         dict(),
     ),
     "reshape": T(
-        ReshapeTransform,
-        (),
-        {"forward_shape": (3, 4), "inverse_shape": (4, 3)}
+        ReshapeTransform, (), {"forward_shape": (3, 4), "inverse_shape": (4, 3)}
     ),
 }
 
@@ -211,8 +209,8 @@ def test_parametrized_transform_eq(cls, transform_args, transform_kwargs):
         ((3, 4), (4, 3), ()),
         ((7,), (7, 1), ()),
         ((3, 5), (15,), ()),
-        ((2, 4), (2, 2, 2), (17,))
-    ]
+        ((2, 4), (2, 2, 2), (17,)),
+    ],
 )
 def test_reshape_transform(forward_shape, inverse_shape, batch_shape):
     x = random.normal(random.key(29), batch_shape + inverse_shape)


### PR DESCRIPTION
Currently, `make lint` `make format` only check for lint. This PR fixes the issue by doing formatting properly.