### PR TITLE
Fix ruff not fixing linter errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ license: FORCE
 	python scripts/update_headers.py
 
 format: license FORCE
+	ruff check --fix .
 	ruff format .
 
 install: FORCE


### PR DESCRIPTION
Currently `make format` doesn't fix linter errors such as isorting. This PR adds `ruff check --fix .` command to `make format` to fix it.