### PR TITLE
Add `RecursiveLinearTransform` for linear state space models.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ numpyro/examples/.data
 # docs
 docs/build
 docs/.DS_Store
+docs/source/examples
+docs/source/tutorials
+docs/source/getting_started.rst

--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -151,7 +151,7 @@ EulerMaruyama
     :undoc-members:
     :show-inheritance:
     :member-order: bysource
-    
+
 Exponential
 ^^^^^^^^^^^
 .. autoclass:: numpyro.distributions.continuous.Exponential
@@ -943,6 +943,15 @@ PermuteTransform
 PowerTransform
 ^^^^^^^^^^^^^^
 .. autoclass:: numpyro.distributions.transforms.PowerTransform
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :member-order: bysource
+
+RealFastFourierTransform
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. autoclass:: numpyro.distributions.transforms.RealFastFourierTransform
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -957,6 +957,15 @@ RealFastFourierTransform
     :show-inheritance:
     :member-order: bysource
 
+RecursiveLinearTransform
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. autoclass:: numpyro.distributions.transforms.RecursiveLinearTransform
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :member-order: bysource
+
 ScaledUnitLowerCholeskyTransform
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. autoclass:: numpyro.distributions.transforms.ScaledUnitLowerCholeskyTransform

--- a/numpyro/distributions/transforms.py
+++ b/numpyro/distributions/transforms.py
@@ -1288,6 +1288,98 @@ class RealFastFourierTransform(Transform):
         )
 
 
+class RecursiveLinearTransform(Transform):
+    """
+    Apply a linear transformation recursively such that
+    :math:`y_t = A y_{t - 1} + x_t` for :math:`t > 0`, where :math:`x_t` and :math:`y_t`
+    are vectors and :math:`A` is a transition matrix. The series is initialized by
+    :math:`y_0 = 0`.
+
+    :param transition_matrix: Transition matrix :math:`A` for successive states.
+
+    **Example:**
+
+    .. doctest::
+
+        >>> from jax import random
+        >>> from jax import numpy as jnp
+        >>> import numpyro
+        >>> from numpyro import distributions as dist
+        >>>
+        >>> def cauchy_random_walk():
+        ...     return numpyro.sample(
+        ...         "x",
+        ...         dist.TransformedDistribution(
+        ...             dist.Cauchy(0, 1).expand([10, 1]).to_event(1),
+        ...             dist.transforms.RecursiveLinearTransform(jnp.eye(1)),
+        ...         ),
+        ...     )
+        >>>
+        >>> numpyro.handlers.seed(cauchy_random_walk, 0)().shape
+        (10, 1)
+        >>>
+        >>> def rocket_trajectory():
+        ...     scale = numpyro.sample(
+        ...         "scale",
+        ...         dist.HalfCauchy(1).expand([2]).to_event(1),
+        ...     )
+        ...     transition_matrix = jnp.array([[1, 1], [0, 1]])
+        ...     return numpyro.sample(
+        ...         "x",
+        ...         dist.TransformedDistribution(
+        ...             dist.Normal(0, scale).expand([10, 2]).to_event(1),
+        ...             dist.transforms.RecursiveLinearTransform(transition_matrix),
+        ...         ),
+        ...     )
+        >>>
+        >>> numpyro.handlers.seed(rocket_trajectory, 0)().shape
+        (10, 2)
+    """
+
+    domain = constraints.real_matrix
+    codomain = constraints.real_matrix
+
+    def __init__(self, transition_matrix: jnp.ndarray) -> None:
+        self.transition_matrix = transition_matrix
+
+    def __call__(self, x: jnp.ndarray) -> jnp.ndarray:
+        # Move the time axis to the first position so we can scan over it.
+        x = jnp.moveaxis(x, -2, 0)
+
+        def f(y, x):
+            y = (self.transition_matrix * y[..., None, :]).sum(axis=-1) + x
+            return y, y
+
+        _, y = lax.scan(f, jnp.zeros_like(x, shape=x.shape[1:]), x)
+        return jnp.moveaxis(y, 0, -2)
+
+    def _inverse(self, y: jnp.ndarray) -> jnp.ndarray:
+        # Move the time axis to the first position so we can scan over it.
+        y = jnp.moveaxis(y, -2, 0)
+
+        def f(y_t, y_tm1):
+            x = y_t - (self.transition_matrix * y_tm1[..., None, :]).sum(axis=-1)
+            return y_tm1, x
+
+        _, x = lax.scan(f, y[-1], jnp.roll(y, 1, axis=0).at[0].set(0), reverse=True)
+        return jnp.moveaxis(x, 0, -2)
+
+    def log_abs_det_jacobian(self, x: jnp.ndarray, y: jnp.ndarray, intermediates=None):
+        slogdet = jnp.linalg.slogdet(self.transition_matrix)
+        return jnp.broadcast_to(slogdet.logabsdet, x.shape[:-2]) * x.shape[-2]
+
+    def tree_flatten(self):
+        return (self.transition_matrix,), (
+            ("transition_matrix",),
+            {},
+        )
+
+    def __eq__(self, other):
+        if not isinstance(other, RecursiveLinearTransform):
+            return False
+        return jnp.array_equal(self.transition_matrix, other.transition_matrix)
+
+
 ##########################################################
 # CONSTRAINT_REGISTRY
 ##########################################################

--- a/numpyro/distributions/transforms.py
+++ b/numpyro/distributions/transforms.py
@@ -1348,7 +1348,7 @@ class RecursiveLinearTransform(Transform):
         x = jnp.moveaxis(x, -2, 0)
 
         def f(y, x):
-            y = y @ self.transition_matrix.T + x
+            y = jnp.einsum("...ij,...j->...i", self.transition_matrix, y) + x
             return y, y
 
         _, y = lax.scan(f, jnp.zeros_like(x, shape=x.shape[1:]), x)
@@ -1359,7 +1359,7 @@ class RecursiveLinearTransform(Transform):
         y = jnp.moveaxis(y, -2, 0)
 
         def f(y, prev):
-            x = y - prev @ self.transition_matrix.T
+            x = y - jnp.einsum("...ij,...j->...i", self.transition_matrix, prev)
             return prev, x
 
         _, x = lax.scan(f, y[-1], jnp.roll(y, 1, axis=0).at[0].set(0), reverse=True)

--- a/numpyro/distributions/transforms.py
+++ b/numpyro/distributions/transforms.py
@@ -1292,10 +1292,11 @@ class RecursiveLinearTransform(Transform):
     """
     Apply a linear transformation recursively such that
     :math:`y_t = A y_{t - 1} + x_t` for :math:`t > 0`, where :math:`x_t` and :math:`y_t`
-    are vectors and :math:`A` is a transition matrix. The series is initialized by
-    :math:`y_0 = 0`.
+    are vectors and :math:`A` is a square transition matrix. The series is initialized
+    by :math:`y_0 = 0`.
 
-    :param transition_matrix: Transition matrix :math:`A` for successive states.
+    :param transition_matrix: Squared transition matrix :math:`A` for successive states
+        or a batch of transition matrices.
 
     **Example:**
 

--- a/numpyro/infer/reparam.py
+++ b/numpyro/infer/reparam.py
@@ -380,6 +380,7 @@ class ExplicitReparam(Reparam):
         >>> mcmc.run(random.PRNGKey(2))  # doctest: +SKIP
         sample: 100%|██████████| 2000/2000 [00:00<00:00, 2306.47it/s, 3 steps of size 9.65e-01. acc. prob=0.93]
     """
+
     def __init__(self, transform):
         if isinstance(transform, Iterable) and all(
             isinstance(t, dist.transforms.Transform) for t in transform

--- a/scripts/update_headers.py
+++ b/scripts/update_headers.py
@@ -7,7 +7,7 @@ import os
 import sys
 
 root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-blacklist = ["/build/", "/dist/", "/pyro_api.egg"]
+blacklist = ["/build/", "/dist/", "/pyro_api.egg", "/venv/"]
 file_types = [("*.py", "# {}"), ("*.cpp", "// {}")]
 
 parser = argparse.ArgumentParser()

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -284,7 +284,10 @@ def test_real_fast_fourier_transform(input_shape, shape, ndims):
         (PowerTransform(2.5), ()),
         (RealFastFourierTransform(7), (7,)),
         (RealFastFourierTransform((8, 9), 2), (8, 9)),
-        (RecursiveLinearTransform(jnp.eye(4)), (10, 4)),
+        (
+            RecursiveLinearTransform(random.normal(random.key(17), (4, 4))),
+            (7, 4),
+        ),
         (ReshapeTransform((5, 2), (10,)), (10,)),
         (ReshapeTransform((15,), (3, 5)), (3, 5)),
         (ScaledUnitLowerCholeskyTransform(), (6,)),

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -340,3 +340,14 @@ def test_bijective_transforms(transform, shape):
         )
         slogdet = jnp.linalg.slogdet(jac)
         assert jnp.allclose(log_abs_det_jacobian, slogdet.logabsdet, atol=atol)
+
+
+def test_batched_recursive_linear_transform():
+    batch_shape = (4, 17)
+    x = random.normal(random.key(8), batch_shape + (10, 3))
+    # Get a batch of matrices with eigenvalues that don't blow up the sequence.
+    A = CorrCholeskyTransform()(random.normal(random.key(7), batch_shape + (3,)))
+    transform = RecursiveLinearTransform(A)
+    y = transform(x)
+    assert y.shape == x.shape
+    assert jnp.allclose(x, transform.inv(y), atol=1e-6)

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -3,10 +3,11 @@
 
 from collections import namedtuple
 from functools import partial
+import math
 
 import pytest
 
-from jax import jit, random, tree_map, vmap
+from jax import jacfwd, jit, random, tree_map, vmap
 import jax.numpy as jnp
 
 from numpyro.distributions.flows import (
@@ -30,6 +31,7 @@ from numpyro.distributions.transforms import (
     PermuteTransform,
     PowerTransform,
     RealFastFourierTransform,
+    RecursiveLinearTransform,
     ReshapeTransform,
     ScaledUnitLowerCholeskyTransform,
     SigmoidTransform,
@@ -89,6 +91,11 @@ TRANSFORMS = {
         RealFastFourierTransform,
         (),
         dict(transform_shape=(3, 4, 5), transform_ndims=3),
+    ),
+    "recursive_linear": T(
+        RecursiveLinearTransform,
+        (jnp.eye(5),),
+        dict(),
     ),
     "simplex_to_ordered": T(
         SimplexToOrderedTransform,
@@ -277,6 +284,7 @@ def test_real_fast_fourier_transform(input_shape, shape, ndims):
         (PowerTransform(2.5), ()),
         (RealFastFourierTransform(7), (7,)),
         (RealFastFourierTransform((8, 9), 2), (8, 9)),
+        (RecursiveLinearTransform(jnp.eye(4)), (10, 4)),
         (ReshapeTransform((5, 2), (10,)), (10,)),
         (ReshapeTransform((15,), (3, 5)), (3, 5)),
         (ScaledUnitLowerCholeskyTransform(), (6,)),


### PR DESCRIPTION
This PR adds a `RecursiveLinearTransform` which is a linear transformation applied recursively such that $y_t = A y_{t - 1} + x_t$ for $t > 0$, where $x_t$ and $y_t$ are $p$-vectors and $A$ is a $p\times p$ transition matrix. The series is initialized by $y_0 = 0$.

This transform can be used to easily declare linear state space models, e.g., a Cauchy random walk is

```python
>>> from jax import random
>>> from jax import numpy as jnp
>>> import numpyro
>>> from numpyro import distributions as dist
>>>
>>> def cauchy_random_walk():
...     return numpyro.sample(
...         "x",
...         dist.TransformedDistribution(
...             dist.Cauchy(0, 1).expand([10, 1]).to_event(1),
...             dist.transforms.RecursiveLinearTransform(jnp.eye(1)),
...         ),
...     )
```

A Kalman-style model for a rocket with state `y = (position, velocity)` is

```python
>>> def rocket_trajectory():
...     scale = numpyro.sample(
...         "scale",
...         dist.HalfCauchy(1).expand([2]).to_event(1),
...     )
...     transition_matrix = jnp.array([[1, 1], [0, 1]])
...     return numpyro.sample(
...         "x",
...         dist.TransformedDistribution(
...             dist.Normal(0, scale).expand([10, 2]).to_event(1),
...             dist.transforms.RecursiveLinearTransform(transition_matrix),
...         ),
...     )
```

This PR also makes a few minor changes (happy to factor out if you prefer):

- Reformat the `ExplicitReparam` from #1754 to comply with the stricter linting.
- Add the `RealFastFourierTransform` from #1762 to the documentation.
- Ignore `venv` directory in the `update_headers.py` script.
- Add autogenerated documentation sources `docs/source/{examples,tutorials,getting_started.rst}` to `.gitignore`.
- Verify `log_abs_det_jacobian` implementation using autodiff.