### PR TITLE
Fix math rendering in variationally inferred parameterization tutorial

### DIFF
--- a/notebooks/source/variationally_inferred_parameterization.ipynb
+++ b/notebooks/source/variationally_inferred_parameterization.ipynb
@@ -751,10 +751,10 @@
     "## **2. Model**\n",
     "We will be using a logistic regression model with hierarchical prior on coefficient scales\n",
     "\n",
-    "\\begin{aligned}\n",
+    "\\begin{align}\n",
     "\\log \\tau_0 & \\sim \\mathcal{N}(0,10) & \\log \\tau_i & \\sim \\mathcal{N}\\left(\\log \\tau_0, 1\\right) \\\\\n",
     "\\beta_i & \\sim \\mathcal{N}\\left(0, \\tau_i\\right) & y & \\sim \\operatorname{Bernoulli}\\left(\\sigma\\left(\\beta X^T\\right)\\right)\n",
-    "\\end{aligned}"
+    "\\end{align}"
    ]
   },
   {
@@ -1017,14 +1017,14 @@
    },
    "source": [
     "Thus, using the above transformation the joint density can be transformed as follows:\n",
-    "\\begin{aligned}\n",
+    "\\begin{align}\n",
     "p(\\theta, \\hat{\\mu}, \\mathbf{y}) & =\\mathcal{N}(\\theta \\mid 0,1) \\times\n",
     "\\mathcal{N}\\left(\\mu \\mid \\theta, \\sigma_\\mu\\right) \\times \\mathcal{N}(\\mathbf{y} \\mid \\mu, \\sigma)\n",
-    "\\end{aligned}\n",
+    "\\end{align}\n",
     "\n",
-    "\\begin{aligned}\n",
+    "\\begin{align}\n",
     "p(\\theta, \\hat{\\mu}, \\mathbf{y}) & =\\mathcal{N}(\\theta \\mid 0,1) \\times \\mathcal{N}\\left(\\hat{\\mu} \\mid \\lambda \\theta, \\sigma_\\mu^\\lambda\\right) \\times \\mathcal{N}\\left(\\mathbf{y} \\mid \\theta+\\sigma_\\mu^{1-\\lambda}(\\hat{\\mu}-\\lambda \\theta), \\sigma\\right)\n",
-    "\\end{aligned}\n"
+    "\\end{align}\n"
    ]
   },
   {

--- a/numpyro/infer/reparam.py
+++ b/numpyro/infer/reparam.py
@@ -380,6 +380,7 @@ class ExplicitReparam(Reparam):
         >>> mcmc.run(random.PRNGKey(2))  # doctest: +SKIP
         sample: 100%|██████████| 2000/2000 [00:00<00:00, 2306.47it/s, 3 steps of size 9.65e-01. acc. prob=0.93]
     """
+
     def __init__(self, transform):
         if isinstance(transform, Iterable) and all(
             isinstance(t, dist.transforms.Transform) for t in transform


### PR DESCRIPTION
currently renders partially compiled by nbsphinx-math 
<img width="683" alt="image" src="https://github.com/pyro-ppl/numpyro/assets/5204646/42b09170-ba01-408e-80f3-9386e735df32">
https://num.pyro.ai/en/stable/tutorials/variationally_inferred_parameterization.html

nbsphinx-math appears to not like the `aligned` environment. switching to `align` resolves the issue.