### PR TITLE
Verify result of `biject_to` satisfies the constraint.

### DIFF
--- a/numpyro/distributions/constraints.py
+++ b/numpyro/distributions/constraints.py
@@ -168,9 +168,9 @@ class _CorrMatrix(_SingletonConstraint):
     def __call__(self, x):
         jnp = np if isinstance(x, (np.ndarray, np.generic)) else jax.numpy
         # check for symmetric
-        symmetric = jnp.all(jnp.all(x == jnp.swapaxes(x, -2, -1), axis=-1), axis=-1)
+        symmetric = jnp.all(jnp.isclose(x, jnp.swapaxes(x, -2, -1)), axis=(-2, -1))
         # check for the smallest eigenvalue is positive
-        positive = jnp.linalg.eigh(x)[0][..., 0] > 0
+        positive = jnp.linalg.eigvalsh(x)[..., 0] > 0
         # check for diagonal equal to 1
         unit_variance = jnp.all(
             jnp.abs(jnp.diagonal(x, axis1=-2, axis2=-1) - 1) < 1e-6, axis=-1

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -5,6 +5,7 @@ from collections import namedtuple
 from functools import partial
 import math
 
+import numpy as np
 import pytest
 
 from jax import jacfwd, jit, random, tree_map, vmap
@@ -49,9 +50,6 @@ def _unpack(x):
     return (x,)
 
 
-_a = jnp.asarray
-
-
 def _smoke_neural_network():
     return None, None
 
@@ -61,14 +59,12 @@ class T(namedtuple("TestCase", ["transform_cls", "params", "kwargs"])):
 
 
 TRANSFORMS = {
-    "affine": T(
-        AffineTransform, (jnp.array([1.0, 2.0]), jnp.array([3.0, 4.0])), dict()
-    ),
+    "affine": T(AffineTransform, (np.array([1.0, 2.0]), np.array([3.0, 4.0])), dict()),
     "compose": T(
         ComposeTransform,
         (
             [
-                AffineTransform(jnp.array([1.0, 2.0]), jnp.array([3.0, 4.0])),
+                AffineTransform(np.array([1.0, 2.0]), np.array([3.0, 4.0])),
                 ExpTransform(),
             ],
         ),
@@ -76,16 +72,16 @@ TRANSFORMS = {
     ),
     "independent": T(
         IndependentTransform,
-        (AffineTransform(jnp.array([1.0, 2.0]), jnp.array([3.0, 4.0])),),
+        (AffineTransform(np.array([1.0, 2.0]), np.array([3.0, 4.0])),),
         dict(reinterpreted_batch_ndims=1),
     ),
     "lower_cholesky_affine": T(
-        LowerCholeskyAffine, (jnp.array([1.0, 2.0]), jnp.eye(2)), dict()
+        LowerCholeskyAffine, (np.array([1.0, 2.0]), np.eye(2)), dict()
     ),
-    "permute": T(PermuteTransform, (jnp.array([1, 0]),), dict()),
+    "permute": T(PermuteTransform, (np.array([1, 0]),), dict()),
     "power": T(
         PowerTransform,
-        (_a(2.0),),
+        (np.array(2.0),),
         dict(),
     ),
     "rfft": T(
@@ -95,12 +91,12 @@ TRANSFORMS = {
     ),
     "recursive_linear": T(
         RecursiveLinearTransform,
-        (jnp.eye(5),),
+        (np.eye(5),),
         dict(),
     ),
     "simplex_to_ordered": T(
         SimplexToOrderedTransform,
-        (_a(1.0),),
+        (np.array(1.0),),
         dict(),
     ),
     "unpack": T(UnpackTransform, (), dict(unpack_fn=_unpack)),
@@ -124,7 +120,7 @@ TRANSFORMS = {
         # autoregressive_nn is a non-jittable arg, which does not fit well with
         # the current test pipeline, which assumes jittable args, and non-jittable kwargs
         partial(InverseAutoregressiveTransform, _smoke_neural_network),
-        (_a(-1.0), _a(1.0)),
+        (np.array(-1.0), np.array(1.0)),
         dict(),
     ),
     "bna": T(
@@ -278,10 +274,10 @@ def test_real_fast_fourier_transform(input_shape, shape, ndims):
         (IdentityTransform(), ()),
         (IndependentTransform(ExpTransform(), 2), (3, 4)),
         (L1BallTransform(), (9,)),
-        (LowerCholeskyAffine(jnp.ones(3), jnp.eye(3)), (3,)),
+        (LowerCholeskyAffine(np.ones(3), np.eye(3)), (3,)),
         (LowerCholeskyTransform(), (10,)),
         (OrderedTransform(), (5,)),
-        (PermuteTransform(jnp.roll(jnp.arange(7), 2)), (7,)),
+        (PermuteTransform(np.roll(np.arange(7), 2)), (7,)),
         (PowerTransform(2.5), ()),
         (RealFastFourierTransform(7), (7,)),
         (RealFastFourierTransform((8, 9), 2), (8, 9)),


### PR DESCRIPTION
Following on from #1751, this PR adds a test that the result of calling `biject_to` satisfies the desired constraint. It also updates the correlation matrix constraint to reduce sensitivity to numerical errors. cc @kylejcaron