### PR TITLE
Avoid unnecessary reshape for trivial expand

### DIFF
--- a/numpyro/distributions/distribution.py
+++ b/numpyro/distributions/distribution.py
@@ -583,7 +583,7 @@ class ExpandedDistribution(Distribution):
                 )
         return (
             tuple(reversed(reversed_shape)),
-            OrderedDict(expanded_sizes),
+            OrderedDict(reversed(expanded_sizes)),
             OrderedDict(interstitial_sizes),
         )
 
@@ -601,6 +601,8 @@ class ExpandedDistribution(Distribution):
         batch_shape = expanded_sizes + interstitial_sizes
         # shape = sample_shape + expanded_sizes + interstitial_sizes + base_dist.shape()
         samples, intermediates = sample_fn(key, sample_shape=sample_shape + batch_shape)
+        if not interstitial_sizes:
+            return samples, intermediates
 
         interstitial_dims = tuple(self._interstitial_sizes.keys())
         event_dim = len(self.event_shape)

--- a/numpyro/distributions/distribution.py
+++ b/numpyro/distributions/distribution.py
@@ -1140,6 +1140,8 @@ class Delta(Distribution):
         return constraints.independent(constraints.real, self.event_dim)
 
     def sample(self, key, sample_shape=()):
+        if not sample_shape:
+            return self.v
         shape = sample_shape + self.batch_shape + self.event_shape
         return jnp.broadcast_to(self.v, shape)
 

--- a/numpyro/distributions/distribution.py
+++ b/numpyro/distributions/distribution.py
@@ -1140,8 +1140,6 @@ class Delta(Distribution):
         return constraints.independent(constraints.real, self.event_dim)
 
     def sample(self, key, sample_shape=()):
-        if not sample_shape:
-            return self.v
         shape = sample_shape + self.batch_shape + self.event_shape
         return jnp.broadcast_to(self.v, shape)
 

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -1110,8 +1110,6 @@ def test_dist_shape(jax_dist, sp_dist, params, prepend_shape):
     rng_key = random.PRNGKey(0)
     expected_shape = prepend_shape + jax_dist.batch_shape + jax_dist.event_shape
     samples = jax_dist.sample(key=rng_key, sample_shape=prepend_shape)
-    if jax_dist is dist.Delta:
-        samples = jnp.asarray(samples)
     assert isinstance(samples, jnp.ndarray)
     assert jnp.shape(samples) == expected_shape
     if (
@@ -2622,7 +2620,7 @@ def test_expand(jax_dist, sp_dist, params, prepend_shape, sample_shape):
     rng_key = random.PRNGKey(0)
     samples = expanded_dist.sample(rng_key, sample_shape)
     assert expanded_dist.batch_shape == new_batch_shape
-    assert jnp.shape(samples) == sample_shape + new_batch_shape + jax_dist.event_shape
+    assert samples.shape == sample_shape + new_batch_shape + jax_dist.event_shape
     assert expanded_dist.log_prob(samples).shape == sample_shape + new_batch_shape
     # test expand of expand
     assert (

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -1110,6 +1110,8 @@ def test_dist_shape(jax_dist, sp_dist, params, prepend_shape):
     rng_key = random.PRNGKey(0)
     expected_shape = prepend_shape + jax_dist.batch_shape + jax_dist.event_shape
     samples = jax_dist.sample(key=rng_key, sample_shape=prepend_shape)
+    if jax_dist is dist.Delta:
+        samples = jnp.asarray(samples)
     assert isinstance(samples, jnp.ndarray)
     assert jnp.shape(samples) == expected_shape
     if (
@@ -2620,7 +2622,7 @@ def test_expand(jax_dist, sp_dist, params, prepend_shape, sample_shape):
     rng_key = random.PRNGKey(0)
     samples = expanded_dist.sample(rng_key, sample_shape)
     assert expanded_dist.batch_shape == new_batch_shape
-    assert samples.shape == sample_shape + new_batch_shape + jax_dist.event_shape
+    assert jnp.shape(samples) == sample_shape + new_batch_shape + jax_dist.event_shape
     assert expanded_dist.log_prob(samples).shape == sample_shape + new_batch_shape
     # test expand of expand
     assert (


### PR DESCRIPTION
This PR saves unnecessary transpose, reshape operators of ExpandedDistribution's sample method. The current tests should cover the change.

This requires us to revert the order of `expanded_sizes` such that the dimensions are ordered from left to right (rather than the current right -> left).