### PR TITLE
Do not unflatten unevaluated lazy properties.

### DIFF
--- a/numpyro/distributions/distribution.py
+++ b/numpyro/distributions/distribution.py
@@ -198,10 +198,12 @@ class Distribution(metaclass=DistributionMeta):
         d = cls.__new__(cls)
 
         for k, v in pytree_data_fields_dict.items():
-            setattr(d, k, v)
+            if v is not None or not isinstance(getattr(cls, k, None), lazy_property):
+                setattr(d, k, v)
 
         for k, v in pytree_aux_fields_dict.items():
-            setattr(d, k, v)
+            if v is not None or not isinstance(getattr(cls, k, None), lazy_property):
+                setattr(d, k, v)
 
         # disable args validation during `tree_unflatten` it is called by jax with
         # placeholder attributes that would make validation fail

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -2768,6 +2768,17 @@ def test_dist_pytree(jax_dist, sp_dist, params):
     # Test that parameters do not change after flattening.
     expected_dist = f(0)
     actual_dist = jax.jit(f)(0)
+    for name in expected_dist.arg_constraints:
+        expected_arg = getattr(expected_dist, name)
+        actual_arg = getattr(actual_dist, name)
+        assert actual_arg is not None, f"arg {name} is None"
+        if np.issubdtype(np.asarray(expected_arg).dtype, np.number):
+            assert_allclose(actual_arg, expected_arg)
+        else:
+            assert (
+                actual_arg.shape == expected_arg.shape
+                and actual_arg.dtype == expected_arg.dtype
+            )
     expected_sample = expected_dist.sample(random.PRNGKey(0))
     actual_sample = actual_dist.sample(random.PRNGKey(0))
     expected_log_prob = expected_dist.log_prob(expected_sample)


### PR DESCRIPTION
The `tree_flatten` function uses `self.__dict__.get(name)` to obtain the data field with the given name. Unevaluated lazy properties do not appear in `self.__dict__`, and they are set to `None` when the representation is unflattened. Here is an example.

```python
>>> import jax
>>> from jax import numpy as jnp
>>> import numpyro
>>> 
>>> 
>>> @jax.jit
>>> def f1(x):
...     return numpyro.distributions.MultivariateNormal(jnp.zeros(3), jnp.eye(3))
>>> 
>>> 
>>> @jax.jit
>>> def f2(x):
...     dist = numpyro.distributions.MultivariateNormal(jnp.zeros(3), jnp.eye(3))
...     dist.precision_matrix
...     return dist


>>> print(f1(0).precision_matrix)
None
>>> print(f2(0).precision_matrix)
[[1. 0. 0.]
 [0. 1. 0.]
 [0. 0. 1.]]
```

The changes in this PR only set the attribute on the reconstructed instance if the value is not `None` or if the attribute is not a lazy property. While there is ambiguity between `None` representing an unevaluated property and `None` being the value of a lazy property, the implementation remains correct: If the evaluated value is `None` it is not cached and re-evaluates to `None` the first time the attribute is accessed on the reconstructed instance.

I've also added a test.