### PR TITLE
Relax check of positive definite constraint.

### DIFF
--- a/numpyro/distributions/constraints.py
+++ b/numpyro/distributions/constraints.py
@@ -603,7 +603,7 @@ class _PositiveDefinite(_SingletonConstraint):
     def __call__(self, x):
         jnp = np if isinstance(x, (np.ndarray, np.generic)) else jax.numpy
         # check for symmetric
-        symmetric = jnp.all(jnp.all(x == jnp.swapaxes(x, -2, -1), axis=-1), axis=-1)
+        symmetric = jnp.all(jnp.isclose(x, jnp.swapaxes(x, -2, -1)), axis=(-2, -1))
         # check for the smallest eigenvalue is positive
         positive = jnp.linalg.eigh(x)[0][..., 0] > 0
         return symmetric & positive


### PR DESCRIPTION
This PR brings the check for positive definite matrices in line with the check for correlation matrices which allows small variations due to numerical issues.

### Before

```python
>>> from jax import numpy as jnp
>>> from jax import random
>>> from numpyro.distributions.constraints import positive_definite

>>> x = jnp.eye(3)
>>> positive_definite(x)
Array(True, dtype=bool)

>>> y = x + 1e-15 * random.normal(random.key(7), x.shape)
>>> positive_definite(y)
Array(False, dtype=bool)
```

### After

```python
>>> positive_definite(y)
Array(True, dtype=bool)
```