### PR TITLE
Predictive fix when deterministic sites are present

### DIFF
--- a/numpyro/handlers.py
+++ b/numpyro/handlers.py
@@ -825,37 +825,6 @@ class substitute(Messenger):
             msg["value"] = value
 
 
-class predictive_substitute(substitute):
-    """A subclass of substitute specifically for use within Numpyro's `Predictive`.
-    This subclass does the same thing as `substitute`, but it ignores deterministic sites,
-    which allows for Predictive to perform new samples on deterministic sites.
-
-    .. note:: This handler is mainly used for internal algorithms.
-        Please see `substitute` for more details.
-    """
-
-    def process_message(self, msg):
-        if (msg["type"] not in ("sample", "param", "mutable", "plate")) or msg.get(
-            "_control_flow_done", False
-        ):
-            if msg["type"] == "control_flow":
-                if self.data is not None:
-                    msg["kwargs"]["substitute_stack"].append(("substitute", self.data))
-                if self.substitute_fn is not None:
-                    msg["kwargs"]["substitute_stack"].append(
-                        ("substitute", self.substitute_fn)
-                    )
-            return
-
-        if self.data is not None:
-            value = self.data.get(msg["name"])
-        else:
-            value = self.substitute_fn(msg)
-
-        if value is not None:
-            msg["value"] = value
-
-
 class do(Messenger):
     """
     Given a stochastic function with some sample statements and a dictionary

--- a/numpyro/handlers.py
+++ b/numpyro/handlers.py
@@ -825,6 +825,37 @@ class substitute(Messenger):
             msg["value"] = value
 
 
+class predictive_substitute(substitute):
+    """A subclass of substitute specifically for use within Numpyro's `Predictive`.
+    This subclass does the same thing as `substitute`, but it ignores deterministic sites,
+    which allows for Predictive to perform new samples on deterministic sites.
+
+    .. note:: This handler is mainly used for internal algorithms.
+        Please see `substitute` for more details.
+    """
+
+    def process_message(self, msg):
+        if (msg["type"] not in ("sample", "param", "mutable", "plate")) or msg.get(
+            "_control_flow_done", False
+        ):
+            if msg["type"] == "control_flow":
+                if self.data is not None:
+                    msg["kwargs"]["substitute_stack"].append(("substitute", self.data))
+                if self.substitute_fn is not None:
+                    msg["kwargs"]["substitute_stack"].append(
+                        ("substitute", self.substitute_fn)
+                    )
+            return
+
+        if self.data is not None:
+            value = self.data.get(msg["name"])
+        else:
+            value = self.substitute_fn(msg)
+
+        if value is not None:
+            msg["value"] = value
+
+
 class do(Messenger):
     """
     Given a stochastic function with some sample statements and a dictionary

--- a/numpyro/infer/util.py
+++ b/numpyro/infer/util.py
@@ -781,7 +781,7 @@ def _predictive(
             posterior_samples,
         )
         prototype_trace = trace(
-            seed(substitute(masked_model, prototype_sample), subkey)
+            seed(predictive_substitute(masked_model, prototype_sample), subkey)
         ).get_trace(*model_args, **model_kwargs)
         first_available_dim = -_guess_max_plate_nesting(prototype_trace) - 1
 
@@ -803,7 +803,7 @@ def _predictive(
             )
         else:
             model_trace = trace(
-                seed(substitute(masked_model, samples), rng_key)
+                seed(predictive_substitute(masked_model, samples), rng_key)
             ).get_trace(*model_args, **model_kwargs)
             pred_samples = {name: site["value"] for name, site in model_trace.items()}
 

--- a/numpyro/infer/util.py
+++ b/numpyro/infer/util.py
@@ -20,7 +20,14 @@ import numpyro
 from numpyro.distributions import constraints
 from numpyro.distributions.transforms import biject_to
 from numpyro.distributions.util import is_identically_one, sum_rightmost
-from numpyro.handlers import condition, replay, seed, substitute, trace
+from numpyro.handlers import (
+    condition,
+    predictive_substitute,
+    replay,
+    seed,
+    substitute,
+    trace,
+)
 from numpyro.infer.initialization import init_to_uniform, init_to_value
 from numpyro.util import (
     _validate_model,
@@ -973,7 +980,7 @@ class Predictive(object):
         if self.guide is not None:
             rng_key, guide_rng_key = random.split(rng_key)
             # use return_sites='' as a special signal to return all sites
-            guide = substitute(self.guide, params)
+            guide = predictive_substitute(self.guide, params)
             posterior_samples = _predictive(
                 guide_rng_key,
                 guide,
@@ -984,7 +991,7 @@ class Predictive(object):
                 model_args=args,
                 model_kwargs=kwargs,
             )
-        model = substitute(self.model, self.params)
+        model = predictive_substitute(self.model, self.params)
         return _predictive(
             rng_key,
             model,

--- a/numpyro/infer/util.py
+++ b/numpyro/infer/util.py
@@ -775,7 +775,7 @@ def _predictive(
             posterior_samples,
         )
         prototype_trace = trace(
-            seed(substitute(masked_model, prototype_sample), subkey)
+            seed(condition(masked_model, prototype_sample), subkey)
         ).get_trace(*model_args, **model_kwargs)
         first_available_dim = -_guess_max_plate_nesting(prototype_trace) - 1
 

--- a/numpyro/infer/util.py
+++ b/numpyro/infer/util.py
@@ -882,9 +882,7 @@ class Predictive(object):
 
         + set `batch_ndims=1` to get predictions from a one dimensional batch of the guide and parameters
           with shapes `(num_samples x batch_size x ...)`
-    :param exclude_deterministic: indicates whether deterministic sites should get sampled
-        regardless of whether they're in the params input or not. If true, deterministic params that
-        are inputted get ignored
+    :param exclude_deterministic: indicates whether to ignore deterministic sites from the posterior samples.
 
     :return: dict of samples from the predictive distribution.
 

--- a/numpyro/infer/util.py
+++ b/numpyro/infer/util.py
@@ -761,7 +761,7 @@ def _predictive(
     return_sites=None,
     infer_discrete=False,
     parallel=True,
-    exclude_deterministic_params: bool = True,
+    exclude_deterministic: bool = True,
     model_args=(),
     model_kwargs={},
 ):
@@ -804,7 +804,7 @@ def _predictive(
 
             substituted_model = (
                 substitute(masked_model, substitute_fn=_samples_wo_deterministic)
-                if exclude_deterministic_params
+                if exclude_deterministic
                 else substitute(masked_model, samples)
             )
             model_trace = trace(seed(substituted_model, rng_key)).get_trace(
@@ -882,7 +882,7 @@ class Predictive(object):
 
         + set `batch_ndims=1` to get predictions from a one dimensional batch of the guide and parameters
           with shapes `(num_samples x batch_size x ...)`
-    :param exclude_deterministic_params: indicates whether deterministic sites should get sampled
+    :param exclude_deterministic: indicates whether deterministic sites should get sampled
         regardless of whether they're in the params input or not. If true, deterministic params that
         are inputted get ignored
 
@@ -922,7 +922,7 @@ class Predictive(object):
         infer_discrete: bool = False,
         parallel: bool = False,
         batch_ndims: Optional[int] = None,
-        exclude_deterministic_params: bool = True,
+        exclude_deterministic: bool = True,
     ):
         if posterior_samples is None and num_samples is None:
             raise ValueError(
@@ -983,7 +983,7 @@ class Predictive(object):
         self.parallel = parallel
         self.batch_ndims = batch_ndims
         self._batch_shape = batch_shape
-        self.exclude_deterministic_params = exclude_deterministic_params
+        self.exclude_deterministic = exclude_deterministic
 
     def _call_with_params(self, rng_key, params, args, kwargs):
         posterior_samples = self.posterior_samples
@@ -1000,7 +1000,7 @@ class Predictive(object):
                 parallel=self.parallel,
                 model_args=args,
                 model_kwargs=kwargs,
-                exclude_deterministic_params=self.exclude_deterministic_params,
+                exclude_deterministic=self.exclude_deterministic,
             )
         model = substitute(self.model, self.params)
         return _predictive(
@@ -1013,7 +1013,7 @@ class Predictive(object):
             parallel=self.parallel,
             model_args=args,
             model_kwargs=kwargs,
-            exclude_deterministic_params=self.exclude_deterministic_params,
+            exclude_deterministic=self.exclude_deterministic,
         )
 
     def __call__(self, rng_key, *args, **kwargs):

--- a/numpyro/infer/util.py
+++ b/numpyro/infer/util.py
@@ -781,7 +781,7 @@ def _predictive(
             posterior_samples,
         )
         prototype_trace = trace(
-            seed(predictive_substitute(masked_model, prototype_sample), subkey)
+            seed(substitute(masked_model, prototype_sample), subkey)
         ).get_trace(*model_args, **model_kwargs)
         first_available_dim = -_guess_max_plate_nesting(prototype_trace) - 1
 
@@ -980,7 +980,7 @@ class Predictive(object):
         if self.guide is not None:
             rng_key, guide_rng_key = random.split(rng_key)
             # use return_sites='' as a special signal to return all sites
-            guide = predictive_substitute(self.guide, params)
+            guide = substitute(self.guide, params)
             posterior_samples = _predictive(
                 guide_rng_key,
                 guide,
@@ -991,7 +991,7 @@ class Predictive(object):
                 model_args=args,
                 model_kwargs=kwargs,
             )
-        model = predictive_substitute(self.model, self.params)
+        model = substitute(self.model, self.params)
         return _predictive(
             rng_key,
             model,

--- a/numpyro/infer/util.py
+++ b/numpyro/infer/util.py
@@ -20,13 +20,7 @@ import numpyro
 from numpyro.distributions import constraints
 from numpyro.distributions.transforms import biject_to
 from numpyro.distributions.util import is_identically_one, sum_rightmost
-from numpyro.handlers import (
-    condition,
-    replay,
-    seed,
-    substitute,
-    trace,
-)
+from numpyro.handlers import condition, replay, seed, substitute, trace
 from numpyro.infer.initialization import init_to_uniform, init_to_value
 from numpyro.util import (
     _validate_model,

--- a/test/infer/test_infer_util.py
+++ b/test/infer/test_infer_util.py
@@ -52,6 +52,22 @@ def beta_bernoulli():
 
     return model, data, true_probs
 
+def linear_regression():
+    N = 800
+    X = dist.Normal(0, 1).sample(random.PRNGKey(0), (N,))
+    y = 1.5 + X*0.7
+
+
+    def model(X, y=None):
+        alpha = numpyro.sample("alpha", dist.Normal(0.0, 5))
+        beta = numpyro.sample("beta", dist.Normal(0.0, 1.0))
+        sigma = numpyro.sample("sigma", dist.Exponential(1.0))
+        with numpyro.plate("plate", len(X)):
+            mu = numpyro.deterministic("mu", alpha + X*beta)
+            numpyro.sample("obs", dist.Normal(sigma, sigma), obs=y)
+
+    return model, X, y
+
 
 @pytest.mark.parametrize("parallel", [True, False])
 def test_predictive(parallel):
@@ -73,6 +89,27 @@ def test_predictive(parallel):
     obs = predictive_samples["obs"].reshape((-1,) + true_probs.shape).astype(np.float32)
     assert_allclose(obs.mean(0), true_probs, rtol=0.1)
 
+@pytest.mark.parametrize("parallel", [True, False])
+def test_predictive_with_deterministic(parallel):
+    """Tests that the default behavior when predicting from models with
+    deterministic sites doesn't lead to static deterministic sites in the predictive.
+    """
+    n_preds = 400
+    model, X, y = linear_regression()
+    mcmc = MCMC(NUTS(model), num_warmup=100, num_samples=100)
+    mcmc.run(random.PRNGKey(0), X=X, y=y)
+    samples = mcmc.get_samples()
+    predictive = Predictive(model, samples, parallel=parallel)
+    # change the input (X) shape to make sure the deterministic shape changes
+    predictive_samples = predictive(random.PRNGKey(1), X=X[:n_preds])
+    assert predictive_samples.keys() == {"mu", "obs"}
+
+    predictive.return_sites = ["beta", "mu", "obs"]
+    # change the input (X) shape to make sure the deterministic shape changes
+    predictive_samples = predictive(random.PRNGKey(1), X=X[:n_preds])
+    # check shapes
+    assert predictive_samples["mu"].shape == (100,) + X[:n_preds].shape
+    assert predictive_samples["obs"].shape == (100,) + X[:n_preds].shape
 
 def test_predictive_with_guide():
     data = jnp.array([1] * 8 + [0] * 2)

--- a/test/infer/test_infer_util.py
+++ b/test/infer/test_infer_util.py
@@ -52,19 +52,19 @@ def beta_bernoulli():
 
     return model, data, true_probs
 
+
 def linear_regression():
     N = 800
     X = dist.Normal(0, 1).sample(random.PRNGKey(0), (N,))
-    y = 1.5 + X*0.7
-
+    y = 1.5 + X * 0.7
 
     def model(X, y=None):
         alpha = numpyro.sample("alpha", dist.Normal(0.0, 5))
         beta = numpyro.sample("beta", dist.Normal(0.0, 1.0))
         sigma = numpyro.sample("sigma", dist.Exponential(1.0))
         with numpyro.plate("plate", len(X)):
-            mu = numpyro.deterministic("mu", alpha + X*beta)
-            numpyro.sample("obs", dist.Normal(sigma, sigma), obs=y)
+            mu = numpyro.deterministic("mu", alpha + X * beta)
+            numpyro.sample("obs", dist.Normal(mu, sigma), obs=y)
 
     return model, X, y
 
@@ -89,6 +89,7 @@ def test_predictive(parallel):
     obs = predictive_samples["obs"].reshape((-1,) + true_probs.shape).astype(np.float32)
     assert_allclose(obs.mean(0), true_probs, rtol=0.1)
 
+
 @pytest.mark.parametrize("parallel", [True, False])
 def test_predictive_with_deterministic(parallel):
     """Tests that the default behavior when predicting from models with
@@ -110,6 +111,7 @@ def test_predictive_with_deterministic(parallel):
     # check shapes
     assert predictive_samples["mu"].shape == (100,) + X[:n_preds].shape
     assert predictive_samples["obs"].shape == (100,) + X[:n_preds].shape
+
 
 def test_predictive_with_guide():
     data = jnp.array([1] * 8 + [0] * 2)


### PR DESCRIPTION
This PR attempts to fix #1772 - when deterministic sites are included in `Predictive` with params, `Predictive` won't generate new samples for those deterministic sites. 

This PR solves that by ignoring deterministic sites in the Predictive `substitute` call. Added a new test to cover this scenario as well.