### PR TITLE
sample from distribution without storing

### DIFF
--- a/numpyro/infer/mcmc.py
+++ b/numpyro/infer/mcmc.py
@@ -642,23 +642,24 @@ class MCMC(object):
                 )
         assert isinstance(extra_fields, (tuple, list))
 
-        field_names = set(tuple(self._default_fields) + tuple(extra_fields))
-        field_names.discard(self._sample_field)
-        remove_sites = []
-        collect_fields = [self._sample_field]
-
-        for field_name in field_names:
+        collect_fields = {}
+        remove_sites = {}
+        for field_name in (
+            (self._sample_field,) + tuple(self._default_fields) + tuple(extra_fields)
+        ):
             if field_name.startswith(f"~{self._sample_field}."):
-                remove_sites.append(field_name[len(self._sample_field) + 2 :])
+                remove_sites[(field_name[len(self._sample_field) + 2 :])] = None
             else:
-                collect_fields.append(field_name)
+                collect_fields[field_name] = None
+        collect_fields = tuple(collect_fields.keys())
+        remove_sites = tuple(remove_sites.keys())
 
         partial_map_fn = partial(
             self._single_chain_mcmc,
             args=args,
             kwargs=kwargs,
-            collect_fields=tuple(collect_fields),
-            remove_sites=tuple(remove_sites),
+            collect_fields=collect_fields,
+            remove_sites=remove_sites,
         )
         map_args = (rng_key, init_state, init_params)
         if self.num_chains == 1:

--- a/numpyro/infer/mcmc.py
+++ b/numpyro/infer/mcmc.py
@@ -634,16 +634,16 @@ class MCMC(object):
         assert isinstance(extra_fields, (tuple, list))
 
         collect_fields = {}  # we use a dictionary to ensure `sample_field` always comes first
-        remove_sites = []
+        remove_sites = {}
         for field_name in (
             (self._sample_field,) + tuple(self._default_fields) + tuple(extra_fields)
         ):
             if field_name.startswith(f"~{self._sample_field}."):
-                remove_sites.append(field_name[len(self._sample_field) + 2 :])
+                remove_sites[(field_name[len(self._sample_field) + 2 :])] = None
             else:
                 collect_fields[field_name] = None
         collect_fields = tuple(collect_fields.keys())
-        remove_sites = tuple(remove_sites)
+        remove_sites = tuple(remove_sites.keys())
 
         partial_map_fn = partial(
             self._single_chain_mcmc,

--- a/numpyro/infer/mcmc.py
+++ b/numpyro/infer/mcmc.py
@@ -192,13 +192,14 @@ def _collect_fn(collect_fields, remove_sites):
     @cached_by(_collect_fn, collect_fields, remove_sites)
     def collect(x):
         if collect_fields:
-            fields = list(attrgetter(*collect_fields)(x[0]))
+            fields = attrgetter(*collect_fields)(x[0])
+            fields = [fields] if len(collect_fields) == 1 else list(fields)
             # fields[0] is guaranteed to be `sample_field`
             sample_sites = fields[0].copy()
             for site in remove_sites:
                 del sample_sites[site]
             fields[0] = sample_sites
-            return fields
+            return fields[0] if len(collect_fields) == 1 else fields
         else:
             return x[0]
 

--- a/test/infer/test_mcmc.py
+++ b/test/infer/test_mcmc.py
@@ -1186,3 +1186,16 @@ def test_none_trajectory_length(num_steps):
         mcmc.run(rng_key, data, extra_fields=("num_steps",))
         num_steps_list = np.array(mcmc.get_extra_fields()["num_steps"])
         assert all(step == num_steps for step in num_steps_list)
+
+
+@pytest.mark.parametrize("remove_sites", [("~z.a", "~z.b"), ("~z.a", "~z.a")])
+def test_remove_sites(remove_sites):
+    def model():
+        numpyro.sample("a", dist.Normal())
+        numpyro.sample("b", dist.Normal())
+
+    mcmc = MCMC(NUTS(model), num_warmup=10, num_samples=10)
+    mcmc.run(random.PRNGKey(0))
+    samps = mcmc.get_samples()
+
+    assert all(site not in samps for site in remove_sites)

--- a/test/infer/test_mcmc.py
+++ b/test/infer/test_mcmc.py
@@ -1188,14 +1188,15 @@ def test_none_trajectory_length(num_steps):
         assert all(step == num_steps for step in num_steps_list)
 
 
+@pytest.mark.parametrize("kernel_cls", [NUTS, BarkerMH])
 @pytest.mark.parametrize("remove_sites", [("~z.a", "~z.b"), ("~z.a", "~z.a")])
-def test_remove_sites(remove_sites):
+def test_remove_sites(kernel_cls, remove_sites):
     def model():
         numpyro.sample("a", dist.Normal())
         numpyro.sample("b", dist.Normal())
 
-    mcmc = MCMC(NUTS(model), num_warmup=10, num_samples=10)
-    mcmc.run(random.PRNGKey(0))
+    mcmc = MCMC(kernel_cls(model), num_warmup=10, num_samples=10)
+    mcmc.run(random.PRNGKey(0), extra_fields=remove_sites)
     samps = mcmc.get_samples()
 
-    assert all(site not in samps for site in remove_sites)
+    assert all([site[3:] not in samps for site in remove_sites])


### PR DESCRIPTION
As discussed in #1695. Users can exclude a sample site from collection by adding `~{sample_field}.{site_name}` to `extra_fields` in `MCMC.run` or `MCMC.warmup`.

Because model initialization doesn't happen until `_single_chain_mcmc` is called and the logic to set up collect_fields happens before that, I opted not to make default_fields mutable/settable with `infer`.  