### PR TITLE
Updat .pre-commit hook version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,10 +3,16 @@ repos:
     hooks:
       - id: ruff
         name: ruff
-        entry: ruff
-        args: ["--fix", "--show-source"]
-        files: "numpyro/.*|tests/.*"
+        entry: ruff check
+        args: ["--fix", "--output-format=full"]
+        files: "numpyro/.*|tests/.*|examples/*.py|notebooks/*.ipynb"
         language: system
+
+      - id: ruff-format
+        name: ruff-format
+        entry: ruff format
+        language: system
+        files: "numpyro/.*|tests/.*|examples/*.py|notebooks/*.ipynb"
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,14 +5,14 @@ repos:
         name: ruff
         entry: ruff check
         args: ["--fix", "--output-format=full"]
-        files: "numpyro/.*|tests/.*|examples/*.py|notebooks/*.ipynb"
+        files: "(.py$)|(.*.ipynb$)"
         language: system
 
       - id: ruff-format
         name: ruff-format
         entry: ruff format
         language: system
-        files: "numpyro/.*|tests/.*|examples/*.py|notebooks/*.ipynb"
+        files: "(.py$)|(.*.ipynb$)"
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
         language: system
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: debug-statements
       - id: check-yaml

--- a/examples/cvae-flax/README.md
+++ b/examples/cvae-flax/README.md
@@ -1,6 +1,6 @@
 ## Conditional Variational Autoencoder in Flax
 
-Trains a *Conditional Variational Autoencoder* (CVAE) on the MNIST data using Flax' neural network API. 
+Trains a *Conditional Variational Autoencoder* (CVAE) on the MNIST data using Flax' neural network API.
 
 The model first trains a baseline to predict an entire MNIST image from a single quadrant of it (i.e., input is one quadrant of an image, output is the entire image (not the other three quadrants)).
 Then, in a second model, the generation/prior/recognition nets of the CVAE are trained while keeping the model parameters of the baseline fixed/frozen.
@@ -8,5 +8,4 @@ We use Optax' `multi_transform` to apply different gradient transformations to t
 
 Running `main.py` trains the model(s) and plots a figure in the end comparing the baseline prediction with the CVAE prediction like this one:
 
-![CVAE prediction](https://github.com/pyro-ppl/numpyro/tree/master/docs/source/_static/img/examples/cvae.png) 
-
+![CVAE prediction](https://github.com/pyro-ppl/numpyro/tree/master/docs/source/_static/img/examples/cvae.png)


### PR DESCRIPTION
Update pre-commit hook versions:

----

Edit: This was the original scope of this PR. After https://github.com/pyro-ppl/numpyro/pull/1795#issuecomment-2106398777 we decided to unco these changes as we want to keep pre-commit usage optional :)

In this PR, I want to suggest a way to improve the development experience by adding https://pre-commit.ci/ as a unique source of truth for the project's linter.

**Motivation**

Currently, the CI (GitHub actions) uses the command `make lint`, which runs `ruff`'s check. The problem is that it depends on the local version of `ruff` and is therefore ambiguous.  See:

https://github.com/pyro-ppl/numpyro/blob/2b85765e1b963b299a233e53b703df3dbfdc247e/Makefile#L3-L6

**Suggested Solution**

In other projects I have contributed to, we have seen the benefit of having this manager by https://pre-commit.ci/ to:
1. Make sure we have the package's specific versions (revisions). See https://github.com/s3alfisc/pyfixest/pull/375
2.  Have periodic automatic PR updates. See, for example, https://github.com/s3alfisc/pyfixest/pull/417

The only thing you (NumPyro devs) need to do is to add the app to the repo (one click as described in https://pre-commit.ci/)

If we merge this one, we could even remove the lint from GitHub actions (see https://github.com/s3alfisc/pyfixest/pull/397), and the linter would be managed independently. That is, remove 

https://github.com/pyro-ppl/numpyro/blob/2b85765e1b963b299a233e53b703df3dbfdc247e/.github/workflows/ci.yml#L35-L37
