### PR TITLE
Fix typo at publish workflow that triggers the upload many times

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ name: Upload Python Package
 
 on:
   release:
-    type: [ published ]
+    types: [ published ]
 
 jobs:
   deploy:


### PR DESCRIPTION
See examples at: https://github.com/pyro-ppl/numpyro/actions?query=event%3Arelease