### PR TITLE
fix(contrib.hsgp): convert matern spectral density from frequency domain

### DIFF
--- a/numpyro/contrib/hsgp/laplacian.py
+++ b/numpyro/contrib/hsgp/laplacian.py
@@ -8,6 +8,7 @@ This module contains functions for computing eigenvalues and eigenfunctions of t
 from __future__ import annotations
 
 from jaxlib.xla_extension import ArrayImpl
+import numpy as np
 
 import jax
 import jax.numpy as jnp
@@ -210,7 +211,7 @@ def _convert_ell(
                 "The length of ell must be equal to the dimension of the space."
             )
         ell_ = jnp.array(ell)[..., None]  # dim x 1 array
-    elif isinstance(ell, jax.Array):
+    elif isinstance(ell, jax.Array | np.ndarray):
         ell_ = ell
     if ell_.shape != (dim, 1):
         raise ValueError("ell must be a scalar or a list of length `dim`.")

--- a/numpyro/contrib/hsgp/laplacian.py
+++ b/numpyro/contrib/hsgp/laplacian.py
@@ -7,11 +7,14 @@ This module contains functions for computing eigenvalues and eigenfunctions of t
 
 from __future__ import annotations
 
+from typing import Union, get_args
+
 from jaxlib.xla_extension import ArrayImpl
 import numpy as np
 
-import jax
 import jax.numpy as jnp
+
+ARRAY_TYPE = Union[ArrayImpl, np.ndarray]
 
 
 def eigenindices(m: list[int] | int, dim: int) -> ArrayImpl:
@@ -211,7 +214,7 @@ def _convert_ell(
                 "The length of ell must be equal to the dimension of the space."
             )
         ell_ = jnp.array(ell)[..., None]  # dim x 1 array
-    elif isinstance(ell, jax.Array | np.ndarray):
+    elif isinstance(ell, get_args(ARRAY_TYPE)):
         ell_ = ell
     if ell_.shape != (dim, 1):
         raise ValueError("ell must be a scalar or a list of length `dim`.")

--- a/numpyro/contrib/hsgp/spectral_densities.py
+++ b/numpyro/contrib/hsgp/spectral_densities.py
@@ -61,7 +61,7 @@ def spectral_density_matern(
 
         S(\\boldsymbol{\\omega}) = \\alpha
             \\frac{2^{D} \\pi^{D/2} \\Gamma(\\nu + D/2) (2 \\nu)^{\\nu}}{\\Gamma(\\nu) \\ell^{2 \\nu}}
-            \\left(\\frac{2 \\nu}{\\ell^2} + 4 \\pi^2 \\boldsymbol{\\omega}^{T} \\boldsymbol{\\omega}\\right)^{-\\nu - D/2}
+            \\left(\\frac{2 \\nu}{\\ell^2} + \\boldsymbol{\\omega}^{T} \\boldsymbol{\\omega}\\right)^{-\\nu - D/2}
 
 
     **References:**

--- a/numpyro/contrib/hsgp/spectral_densities.py
+++ b/numpyro/contrib/hsgp/spectral_densities.py
@@ -86,7 +86,7 @@ def spectral_density_matern(
         * ((2 * nu) ** nu)
         * special.gamma(nu + dim / 2)
     )
-    c2 = ((2 * nu / (length**2)) + 4 * jnp.pi ** jnp.dot(w, w)) ** (-nu - dim / 2)
+    c2 = (2 * nu / (length**2) + jnp.dot(w, w)) ** (-nu - dim / 2)
     c3 = special.gamma(nu) * length ** (2 * nu)
     return c1 * c2 / c3
 

--- a/numpyro/contrib/hsgp/spectral_densities.py
+++ b/numpyro/contrib/hsgp/spectral_densities.py
@@ -166,6 +166,7 @@ def modified_bessel_first_kind(v, z):
         ) from e
 
     v = jnp.asarray(v, dtype=float)
+    z = jnp.asarray(z, dtype=float)
     return jnp.exp(jnp.abs(z)) * tfp.math.bessel_ive(v, z)
 
 

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
             "ruff>=0.1.8",
             "pytest>=4.1",
             "pyro-api>=0.1.1",
+            "scikit-learn",
             "scipy>=1.9",
         ],
         "dev": [

--- a/test/contrib/hsgp/test_approximation.py
+++ b/test/contrib/hsgp/test_approximation.py
@@ -7,6 +7,7 @@ from functools import reduce
 from operator import mul
 from typing import Literal
 
+import numpy as np
 import pytest
 from sklearn.gaussian_process.kernels import RBF, ExpSineSquared, Matern
 
@@ -75,11 +76,11 @@ def synthetic_two_dim_data() -> tuple[ArrayImpl, ArrayImpl]:
 @pytest.mark.parametrize(
     argnames="x1, x2, length, ell",
     argvalues=[
-        (jnp.array([[1.0]]), jnp.array([[0.0]]), jnp.array([1.0]), 5.0),
+        (np.array([[1.0]]), np.array([[0.0]]), np.array([1.0]), 5.0),
         (
-            jnp.array([[1.5, 1.25]]),
-            jnp.array([[0.0, 0.0]]),
-            jnp.array([1.0]),
+            np.array([[1.5, 1.25]]),
+            np.array([[0.0, 0.0]]),
+            np.array([1.0]),
             5.0,
         ),
     ],
@@ -111,20 +112,20 @@ def test_kernel_approx_squared_exponential(
 @pytest.mark.parametrize(
     argnames="x1, x2, nu, length, ell",
     argvalues=[
-        (jnp.array([[1.0]]), jnp.array([[0.0]]), 3 / 2, jnp.array([1.0]), 5.0),
-        (jnp.array([[1.0]]), jnp.array([[0.0]]), 5 / 2, jnp.array([1.0]), 5.0),
+        (np.array([[1.0]]), np.array([[0.0]]), 3 / 2, np.array([1.0]), 5.0),
+        (np.array([[1.0]]), np.array([[0.0]]), 5 / 2, np.array([1.0]), 5.0),
         (
-            jnp.array([[1.5, 1.25]]),
-            jnp.array([[0.0, 0.0]]),
+            np.array([[1.5, 1.25]]),
+            np.array([[0.0, 0.0]]),
             3 / 2,
-            jnp.array([1.0]),
+            np.array([1.0]),
             5.0,
         ),
         (
-            jnp.array([[1.5, 1.25]]),
-            jnp.array([[0.0, 0.0]]),
+            np.array([[1.5, 1.25]]),
+            np.array([[0.0, 0.0]]),
             5 / 2,
-            jnp.array([1.0]),
+            np.array([1.0]),
             5.0,
         ),
     ],
@@ -160,8 +161,8 @@ def test_kernel_approx_squared_matern(
 @pytest.mark.parametrize(
     argnames="x1, x2, w0, length",
     argvalues=[
-        (jnp.array([1.0]), jnp.array([0.0]), 1.0, 1.0),
-        (jnp.array([1.0]), jnp.array([0.0]), 1.5, 1.0),
+        (np.array([1.0]), np.array([0.0]), 1.0, 1.0),
+        (np.array([1.0]), np.array([0.0]), 1.5, 1.0),
     ],
     ids=[
         "1d,w0=1.0",
@@ -199,10 +200,10 @@ def test_kernel_approx_periodic(
 @pytest.mark.parametrize(
     argnames="x, alpha, length, ell, m, non_centered",
     argvalues=[
-        (jnp.linspace(0, 1, 10), 1.0, 0.2, 12, 10, True),
-        (jnp.linspace(0, 1, 10), 1.0, 0.2, 12, 10, False),
-        (jnp.linspace(0, 10, 100), 3.0, 0.5, 120, 100, True),
-        (jnp.linspace(jnp.zeros(2), jnp.ones(2), 10), 1.0, 0.2, 12, [3, 3], True),
+        (np.linspace(0, 1, 10), 1.0, 0.2, 12, 10, True),
+        (np.linspace(0, 1, 10), 1.0, 0.2, 12, 10, False),
+        (np.linspace(0, 10, 100), 3.0, 0.5, 120, 100, True),
+        (np.linspace(np.zeros(2), np.ones(2), 10), 1.0, 0.2, 12, [3, 3], True),
     ],
     ids=["non_centered", "centered", "non_centered-large-domain", "non_centered-2d"],
 )
@@ -242,11 +243,11 @@ def test_approximation_squared_exponential(
 @pytest.mark.parametrize(
     argnames="x, nu, alpha, length, ell, m, non_centered",
     argvalues=[
-        (jnp.linspace(0, 1, 10), 3 / 2, 1.0, 0.2, 12, 10, True),
-        (jnp.linspace(0, 1, 10), 5 / 2, 1.0, 0.2, 12, 10, False),
-        (jnp.linspace(0, 10, 100), 7 / 2, 3.0, 0.5, 120, 100, True),
+        (np.linspace(0, 1, 10), 3 / 2, 1.0, 0.2, 12, 10, True),
+        (np.linspace(0, 1, 10), 5 / 2, 1.0, 0.2, 12, 10, False),
+        (np.linspace(0, 10, 100), 7 / 2, 3.0, 0.5, 120, 100, True),
         (
-            jnp.linspace(jnp.zeros(2), jnp.ones(2), 10),
+            np.linspace(np.zeros(2), np.ones(2), 10),
             3 / 2,
             1.0,
             0.2,
@@ -420,9 +421,9 @@ def test_matern_gp_model(
 @pytest.mark.parametrize(
     argnames="w0, m",
     argvalues=[
-        (2 * jnp.pi / 7, 2),
-        (2 * jnp.pi / 10, 3),
-        (2 * jnp.pi / 5, 10),
+        (2 * np.pi / 7, 2),
+        (2 * np.pi / 10, 3),
+        (2 * np.pi / 5, 10),
     ],
     ids=["m=2", "m=3", "m=10"],
 )

--- a/test/contrib/hsgp/test_laplacian.py
+++ b/test/contrib/hsgp/test_laplacian.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from functools import reduce
 from operator import mul
 
+import numpy as np
 import pytest
 
 from jax._src.array import ArrayImpl
@@ -96,13 +97,13 @@ def test_sqrt_eigenvalues(ell: float | int, m: int | list[int], dim: int):
 @pytest.mark.parametrize(
     argnames="x, ell, m",
     argvalues=[
-        (jnp.linspace(0, 1, 10), 1, 1),
-        (jnp.linspace(-1, 1, 10), 1, 21),
-        (jnp.linspace(-2, -1, 10), 2, 10),
-        (jnp.linspace(0, 100, 500), 120, 100),
-        (jnp.linspace(jnp.zeros(3), jnp.ones(3), 10), 2, [2, 2, 3]),
+        (np.linspace(0, 1, 10), 1, 1),
+        (np.linspace(-1, 1, 10), 1, 21),
+        (np.linspace(-2, -1, 10), 2, 10),
+        (np.linspace(0, 100, 500), 120, 100),
+        (np.linspace(np.zeros(3), np.ones(3), 10), 2, [2, 2, 3]),
         (
-            jnp.linspace(jnp.zeros(3), jnp.ones(3), 100).reshape((10, 10, 3)),
+            np.linspace(np.zeros(3), np.ones(3), 100).reshape((10, 10, 3)),
             2,
             [2, 2, 3],
         ),
@@ -129,8 +130,8 @@ def test_eigenfunctions(x: ArrayImpl, ell: float | int, m: int | list[int]):
         (1, 1, False),
         (1, 2, False),
         ([1, 1], 2, False),
-        (jnp.array([1, 1])[..., None], 2, False),
-        (jnp.array([1, 1]), 2, True),
+        (np.array([1, 1])[..., None], 2, False),
+        (np.array([1, 1]), 2, True),
         ([1, 1], 1, True),
     ],
     ids=[

--- a/test/contrib/hsgp/test_spectral_densities.py
+++ b/test/contrib/hsgp/test_spectral_densities.py
@@ -4,6 +4,7 @@
 from functools import reduce
 from operator import mul
 
+import numpy as np
 import pytest
 
 import jax.numpy as jnp
@@ -22,8 +23,8 @@ from numpyro.contrib.hsgp.spectral_densities import (
     argnames="dim, w, alpha, length",
     argvalues=[
         (1, 0.1, 1.0, 0.2),
-        (2, jnp.array([0.1, 0.2]), 1.0, 0.2),
-        (3, jnp.array([0.1, 0.2, 0.3]), 1.0, 5.0),
+        (2, np.array([0.1, 0.2]), 1.0, 0.2),
+        (3, np.array([0.1, 0.2, 0.3]), 1.0, 5.0),
     ],
     ids=["dim=1", "dim=2", "dim=3"],
 )
@@ -39,8 +40,8 @@ def test_spectral_density_squared_exponential(dim, w, alpha, length):
     argnames="dim, nu, w, alpha, length",
     argvalues=[
         (1, 3 / 2, 0.1, 1.0, 0.2),
-        (2, 5 / 2, jnp.array([0.1, 0.2]), 1.0, 0.2),
-        (3, 5 / 2, jnp.array([0.1, 0.2, 0.3]), 1.0, 5.0),
+        (2, 5 / 2, np.array([0.1, 0.2]), 1.0, 0.2),
+        (3, 5 / 2, np.array([0.1, 0.2, 0.3]), 1.0, 5.0),
     ],
     ids=["dim=1", "dim=2", "dim=3"],
 )
@@ -113,8 +114,8 @@ def test_modified_bessel_first_kind_one_dim(v, z):
 @pytest.mark.parametrize(
     argnames="v, z",
     argvalues=[
-        (jnp.linspace(0.1, 1.0, 10), jnp.array([0.1])),
-        (jnp.linspace(0.1, 1.0, 10), jnp.linspace(0.1, 1.0, 10)),
+        (np.linspace(0.1, 1.0, 10), np.array([0.1])),
+        (np.linspace(0.1, 1.0, 10), np.linspace(0.1, 1.0, 10)),
     ],
     ids=["z=0.1", "z=0.2"],
 )


### PR DESCRIPTION
- add tests to compare approximate covariance functions to exact versions from sklearn

As I was implementing these tests (to support development in #1805) I noticed that the Matérn spectral density implementation was not giving results consistent with scikit-learn. After staring at Rasmussen and Williams Chapter 4 for a bit I finally noticed that their spectral densities are in the frequency domain, with the inputs scaled by $2 \pi$. Riutort-Mayol 2023 adopt Rasmussen and Williams' parameterization initially but note that the input vectors are frequencies and convert appropriately for the specific $\nu = \infty$, $\nu =3/2$ and $\nu =5/2$ examples (see screenshots below).

After dropping the $4 \pi^2$ term from the Matern spectral density function I am able to replicate the exact covariance functions from scikit-learn. 

<img width="393" alt="image" src="https://github.com/pyro-ppl/numpyro/assets/5204646/e9e67836-bd65-4567-90f0-4e3cb4648956">

<img width="407" alt="image" src="https://github.com/pyro-ppl/numpyro/assets/5204646/3a2bce5a-15a3-47ff-bfcc-a2c225c36acb">

@juanitorduz let me know if I'm missing anything or misunderstanding here -- still trying to wrap my head around some of this stuff and get the terminology right. Additionally, let me know if you have any suggestions on how to make the test suite stronger. The goal is to add vector-valued alpha and length examples to the tests and use those to guide development on #1805.