### PR TITLE
filter out tests waiting for next tfp release

### DIFF
--- a/numpyro/__init__.py
+++ b/numpyro/__init__.py
@@ -2,6 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+import warnings
+
+warnings.filterwarnings(
+    "ignore", message=".*Attempting to hash a tracer.*", category=FutureWarning
+)
+
+# ruff: noqa: E402
 
 from numpyro import compat, diagnostics, distributions, handlers, infer, ops, optim
 from numpyro.distributions.distribution import enable_validation, validation_enabled

--- a/numpyro/contrib/control_flow/scan.py
+++ b/numpyro/contrib/control_flow/scan.py
@@ -224,7 +224,7 @@ def scan_enum(
                 # return early if length = unroll_steps
                 if length == unroll_steps:
                     return wrapped_carry, (PytreeTrace({}), y0s)
-                wrapped_carry = device_put(wrapped_carry)
+                wrapped_carry = tree_map(device_put, wrapped_carry)
                 wrapped_carry, (pytree_trace, ys) = lax.scan(
                     body_fn, wrapped_carry, xs_, length - unroll_steps, reverse
                 )
@@ -324,7 +324,7 @@ def scan_wrapper(
 
         return (i + 1, rng_key, carry), (PytreeTrace(trace), y)
 
-    wrapped_carry = device_put((0, rng_key, init))
+    wrapped_carry = tree_map(device_put, (0, rng_key, init))
     last_carry, (pytree_trace, ys) = lax.scan(
         body_fn, wrapped_carry, xs, length=length, reverse=reverse
     )

--- a/numpyro/infer/__init__.py
+++ b/numpyro/infer/__init__.py
@@ -1,13 +1,6 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
-import warnings
-
-warnings.filterwarnings(
-    "ignore", message=".*Attempting to hash a tracer.*", category=FutureWarning
-)
-
-# ruff: noqa: E402
 
 from numpyro.infer.barker import BarkerMH
 from numpyro.infer.elbo import (

--- a/numpyro/infer/__init__.py
+++ b/numpyro/infer/__init__.py
@@ -1,6 +1,8 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
+import warnings
+
 from numpyro.infer.barker import BarkerMH
 from numpyro.infer.elbo import (
     ELBO,
@@ -28,6 +30,11 @@ from numpyro.infer.svi import SVI
 from numpyro.infer.util import Predictive, log_likelihood
 
 from . import autoguide, reparam
+
+warnings.filterwarnings(
+    "ignore", message=".*Attempting to hash a tracer.*", category=FutureWarning
+)
+
 
 __all__ = [
     "AIES",

--- a/numpyro/infer/__init__.py
+++ b/numpyro/infer/__init__.py
@@ -3,6 +3,12 @@
 
 import warnings
 
+warnings.filterwarnings(
+    "ignore", message=".*Attempting to hash a tracer.*", category=FutureWarning
+)
+
+# ruff: noqa: E402
+
 from numpyro.infer.barker import BarkerMH
 from numpyro.infer.elbo import (
     ELBO,
@@ -30,11 +36,6 @@ from numpyro.infer.svi import SVI
 from numpyro.infer.util import Predictive, log_likelihood
 
 from . import autoguide, reparam
-
-warnings.filterwarnings(
-    "ignore", message=".*Attempting to hash a tracer.*", category=FutureWarning
-)
-
 
 __all__ = [
     "AIES",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ known-jax = ["flax", "haiku", "jax", "optax", "tensorflow_probability"]
 addopts = ["-v", "--color=yes"]
 filterwarnings = [
     "error",
+    "ignore:.*Attempting to hash a tracer:FutureWarning",
     "ignore:numpy.ufunc size changed,:RuntimeWarning",
     "ignore:Using a non-tuple sequence:FutureWarning",
     "ignore:jax.tree_structure is deprecated:FutureWarning",

--- a/test/contrib/test_tfp.py
+++ b/test/contrib/test_tfp.py
@@ -168,6 +168,7 @@ def test_mcmc_kernels(kernel, kwargs):
     assert_allclose(jnp.mean(samples["loc"], 0), true_coef, atol=0.05)
 
 
+@pytest.mark.skip(reason="Waiting for the next  tfp release")
 @pytest.mark.parametrize(
     "kernel, kwargs",
     [

--- a/test/contrib/test_tfp.py
+++ b/test/contrib/test_tfp.py
@@ -35,6 +35,7 @@ def test_dist_pytree():
     assert res.scale == 1
 
 
+@pytest.mark.skip(reason="Waiting for the next  tfp release")
 @pytest.mark.filterwarnings("ignore:can't resolve package")
 def test_transformed_distributions():
     from tensorflow_probability.substrates.jax import (
@@ -113,6 +114,7 @@ def make_kernel_fn(target_log_prob_fn):
     )
 
 
+@pytest.mark.skip(reason="Waiting for the next  tfp release")
 @pytest.mark.parametrize(
     "kernel, kwargs",
     [
@@ -243,6 +245,7 @@ def test_sample_tfp_distributions():
 
 # test that sampling from unwrapped tensorflow_probability distributions works as
 # expected using numpyro.sample primitive
+@pytest.mark.skip(reason="Waiting for the next  tfp release")
 @pytest.mark.parametrize(
     "dist,args",
     [
@@ -270,6 +273,7 @@ def test_sample_unwrapped_tfp_distributions(dist, args):
 
 
 # test mixture distributions
+@pytest.mark.skip(reason="Waiting for the next  tfp release")
 def test_sample_unwrapped_mixture_same_family():
     from tensorflow_probability.substrates.jax import distributions as tfd
 

--- a/test/infer/test_mcmc.py
+++ b/test/infer/test_mcmc.py
@@ -1100,7 +1100,7 @@ def test_discrete_site_without_infer_enumerate():
         numpyro.sample("x", dist.Bernoulli(0.5))
 
     mcmc = MCMC(NUTS(model), num_warmup=10, num_samples=10)
-    with pytest.warns(FutureWarning, match="enumerated sites|unhashable type"):
+    with pytest.warns(FutureWarning, match="enumerated sites"):
         mcmc.run(random.PRNGKey(0))
 
 

--- a/test/infer/test_mcmc.py
+++ b/test/infer/test_mcmc.py
@@ -1100,7 +1100,7 @@ def test_discrete_site_without_infer_enumerate():
         numpyro.sample("x", dist.Bernoulli(0.5))
 
     mcmc = MCMC(NUTS(model), num_warmup=10, num_samples=10)
-    with pytest.warns(FutureWarning, match="enumerated sites"):
+    with pytest.warns(FutureWarning, match="enumerated sites|unhashable type"):
         mcmc.run(random.PRNGKey(0))
 
 


### PR DESCRIPTION
Partially addresses https://github.com/pyro-ppl/numpyro/issues/1814 . We must keep in mind removing these `skip` statements once we see a new release.