### PR TITLE
Allow to use NeuTra on models with plates

### DIFF
--- a/numpyro/infer/reparam.py
+++ b/numpyro/infer/reparam.py
@@ -226,7 +226,7 @@ class NeuTraReparam(Reparam):
 
         # Step 2. Use trained guide in NeuTra MCMC
         neutra = NeuTraReparam(guide)
-        model = netra.reparam(model)
+        model = neutra.reparam(model)
         nuts = NUTS(model)
         # ...now use the model in HMC or NUTS...
 

--- a/numpyro/infer/reparam.py
+++ b/numpyro/infer/reparam.py
@@ -281,9 +281,15 @@ class NeuTraReparam(Reparam):
         compute_density = numpyro.get_mask() is not False
         if not self._x_unconstrained:  # On first sample site.
             # Sample a shared latent.
+            model_plates = {
+                msg["name"]
+                for msg in self.guide.prototype_trace.values()
+                if msg["type"] == "plate"
+            }
             z_unconstrained = numpyro.sample(
                 "{}_shared_latent".format(self.guide.prefix),
                 self.guide.get_base_dist().mask(False),
+                infer={"block_plates": model_plates},
             )
 
             # Differentiably transform.

--- a/numpyro/primitives.py
+++ b/numpyro/primitives.py
@@ -530,6 +530,12 @@ class plate(Messenger):
                 )
             return
 
+        if (
+            "block_plates" in msg.get("infer", {})
+            and self.name in msg["infer"]["block_plates"]
+        ):
+            return
+
         cond_indep_stack = msg["cond_indep_stack"]
         frame = CondIndepStackFrame(self.name, self.dim, self.subsample_size)
         cond_indep_stack.append(frame)


### PR DESCRIPTION
Fixes #1694

Currently, in NeuTra reparam, we reparam variables via an unconstrained joint value. If the first variable is inside a plate context, such joint value will also be drawn under such plate - it will be broadcasted. This PR blocks such issue by introducing a `block_plates` field in `sample(..., infer=...)`. Those plates from the model will be blocked on that joint variable.