### PR TITLE
Fixing issue Samples are outside the support for DiscreteUniform dist…

### DIFF
--- a/numpyro/infer/hmc_gibbs.py
+++ b/numpyro/infer/hmc_gibbs.py
@@ -434,6 +434,13 @@ class DiscreteHMCGibbs(HMCGibbs):
             and site["fn"].has_enumerate_support
             and not site["is_observed"]
         }
+        self._support_enumerates = {
+            name: site["fn"].enumerate_support(False)
+            for name, site in self._prototype_trace.items()
+            if site["type"] == "sample"
+            and site["fn"].has_enumerate_support
+            and not site["is_observed"]
+        }
         self._gibbs_sites = [
             name
             for name, site in self._prototype_trace.items()

--- a/numpyro/infer/mixed_hmc.py
+++ b/numpyro/infer/mixed_hmc.py
@@ -6,6 +6,7 @@ from functools import partial
 
 from jax import grad, jacfwd, lax, random
 from jax.flatten_util import ravel_pytree
+import jax
 import jax.numpy as jnp
 
 from numpyro.infer.hmc import momentum_generator
@@ -301,6 +302,11 @@ class MixedHMC(DiscreteHMCGibbs):
             adapt_state=adapt_state,
         )
 
+        z_discrete = jax.tree.map(
+            lambda idx, support: support[idx],
+            z_discrete,
+            self._support_enumerates,
+        )
         z = {**z_discrete, **hmc_state.z}
         return MixedHMCState(z, hmc_state, rng_key, accept_prob)
 


### PR DESCRIPTION
This fixes issue #1834 for `MixedHMC` sampling with `DiscreteUniform` distribution sampling outside the support without using the `enumerate_support`.