### PR TITLE
avoids setting jax tracer as lazy property attribute 

### DIFF
--- a/numpyro/distributions/util.py
+++ b/numpyro/distributions/util.py
@@ -14,6 +14,8 @@ import jax.numpy as jnp
 from jax.scipy.linalg import solve_triangular
 from jax.scipy.special import digamma
 
+from numpyro.util import not_jax_tracer
+
 # Parameters for Transformed Rejection with Squeeze (TRS) algorithm - page 3.
 _tr_params = namedtuple(
     "tr_params", ["c", "b", "a", "alpha", "u_r", "v_r", "m", "log_p", "log1_p", "log_h"]
@@ -692,7 +694,8 @@ class lazy_property(object):
         if instance is None:
             return self
         value = self.wrapped(instance)
-        setattr(instance, self.wrapped.__name__, value)
+        if not_jax_tracer(value):
+            setattr(instance, self.wrapped.__name__, value)
         return value
 
 

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -3423,4 +3423,3 @@ def test_gaussian_random_walk_linear_recursive_equivalence():
     x2 = dist2.sample(random.PRNGKey(7))
     assert jnp.allclose(x1, x2.squeeze())
     assert jnp.allclose(dist1.log_prob(x1), dist2.log_prob(x2))
-

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -23,6 +23,7 @@ import jax.random as random
 from jax.scipy.special import expit, logsumexp
 from jax.scipy.stats import norm as jax_norm, truncnorm as jax_truncnorm
 
+import numpyro
 import numpyro.distributions as dist
 from numpyro.distributions import (
     SineBivariateVonMises,
@@ -49,6 +50,7 @@ from numpyro.distributions.util import (
     sum_rightmost,
     vec_to_tril_matrix,
 )
+from numpyro.infer import MCMC, NUTS, Predictive
 from numpyro.nn import AutoregressiveNN
 
 TEST_FAILURE_RATE = 2e-5  # For all goodness-of-fit tests.
@@ -3423,3 +3425,65 @@ def test_gaussian_random_walk_linear_recursive_equivalence():
     x2 = dist2.sample(random.PRNGKey(7))
     assert jnp.allclose(x1, x2.squeeze())
     assert jnp.allclose(dist1.log_prob(x1), dist2.log_prob(x2))
+
+
+@pytest.mark.parametrize(
+    "my_dist",
+    [
+        dist.TruncatedNormal(low=-1, high=1),
+        dist.TruncatedCauchy(low=-1, high=1),
+    ],
+)
+def test_tracer_leakage_in_parallel_truncated_distribution(my_dist):
+    n_data_samples = 1
+    n_mcmc_samples = 10
+    n_mcmc_warmup = 10
+    n_mcmc_chains = 2
+    rng_key = jax.random.PRNGKey(0)
+
+    data_samples = my_dist.sample(rng_key, (n_data_samples,))
+
+    def my_model():
+        numpyro.sample("obs", my_dist, obs=data_samples)
+
+    nuts_kernel = NUTS(my_model)
+    mcmc = MCMC(
+        nuts_kernel,
+        num_warmup=n_mcmc_warmup,
+        num_samples=n_mcmc_samples,
+        num_chains=n_mcmc_chains,
+    )
+    mcmc.run(rng_key)
+
+
+@pytest.mark.parametrize(
+    "my_dist",
+    [
+        dist.TruncatedNormal(low=-1, high=1),
+        dist.TruncatedCauchy(low=-1, high=1),
+    ],
+)
+def test_repeated_predictive_method_in_truncated_distribution(my_dist):
+    n_data_samples = 10
+    n_prior_samples = 10
+    n_mcmc_samples = 10
+    n_mcmc_warmup = 10
+    n_mcmc_chains = 2
+    rng_key = jax.random.PRNGKey(0)
+
+    data_samples = my_dist.sample(rng_key, (n_data_samples,))
+
+    def my_model(obs=None):
+        numpyro.sample("obs", my_dist, obs=obs)
+
+    prior_predictive = Predictive(my_model, num_samples=n_prior_samples)
+    prior_predictive(rng_key)
+
+    nuts_kernel = NUTS(my_model)
+    mcmc = MCMC(
+        nuts_kernel,
+        num_warmup=n_mcmc_warmup,
+        num_samples=n_mcmc_samples,
+        num_chains=n_mcmc_chains,
+    )
+    mcmc.run(rng_key, obs=data_samples)

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -3435,7 +3435,7 @@ def test_gaussian_random_walk_linear_recursive_equivalence():
         dist.TruncatedCauchy(low=-1, high=1),
     ],
 )
-def test_tracer_leakage_in_truncated_distribution(my_dist):
+def test_no_tracer_leakage_in_truncated_distribution(my_dist):
     """
     Tests parallel sampling and use of multiple predictve methods
     on models using truncated distributions.

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -53,6 +53,7 @@ from numpyro.distributions.util import (
 from numpyro.infer import MCMC, NUTS, Predictive
 from numpyro.nn import AutoregressiveNN
 
+numpyro.set_host_device_count(2)
 TEST_FAILURE_RATE = 2e-5  # For all goodness-of-fit tests.
 
 

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -3434,36 +3434,13 @@ def test_gaussian_random_walk_linear_recursive_equivalence():
         dist.TruncatedCauchy(low=-1, high=1),
     ],
 )
-def test_tracer_leakage_in_parallel_truncated_distribution(my_dist):
-    n_data_samples = 1
-    n_mcmc_samples = 10
-    n_mcmc_warmup = 10
-    n_mcmc_chains = 2
-    rng_key = jax.random.PRNGKey(0)
-
-    data_samples = my_dist.sample(rng_key, (n_data_samples,))
-
-    def my_model():
-        numpyro.sample("obs", my_dist, obs=data_samples)
-
-    nuts_kernel = NUTS(my_model)
-    mcmc = MCMC(
-        nuts_kernel,
-        num_warmup=n_mcmc_warmup,
-        num_samples=n_mcmc_samples,
-        num_chains=n_mcmc_chains,
-    )
-    mcmc.run(rng_key)
-
-
-@pytest.mark.parametrize(
-    "my_dist",
-    [
-        dist.TruncatedNormal(low=-1, high=1),
-        dist.TruncatedCauchy(low=-1, high=1),
-    ],
-)
-def test_repeated_predictive_method_in_truncated_distribution(my_dist):
+def test_tracer_leakage_in_truncated_distribution(my_dist):
+    """
+    Tests parallel sampling and use of multiple predictve methods
+    on models using truncated distributions.
+    Reference: https://github.com/pyro-ppl/numpyro/issues/1836, and
+    https://github.com/CDCgov/multisignal-epi-inference/issues/282
+    """
     n_data_samples = 10
     n_prior_samples = 10
     n_mcmc_samples = 10

--- a/test/test_distributions_util.py
+++ b/test/test_distributions_util.py
@@ -8,13 +8,12 @@ from numpy.testing import assert_allclose
 import pytest
 import scipy
 
+import jax
 from jax import lax, random, vmap
 import jax.numpy as jnp
 from jax.scipy.special import expit, xlog1py, xlogy
 
-import jax
 import numpyro.distributions as dist
-
 from numpyro.distributions.util import (
     add_diag,
     binary_cross_entropy_with_logits,
@@ -190,11 +189,9 @@ def test_add_diag(matrix_shape: tuple, diag_shape: tuple) -> None:
 @pytest.mark.parametrize(
     "my_dist",
     [
-        dist.TruncatedNormal(low=-1., high=2.),
+        dist.TruncatedNormal(low=-1.0, high=2.0),
         dist.TruncatedCauchy(low=-5, high=10),
-        dist.TruncatedDistribution(
-            dist.StudentT(3),
-            low=1.5)
+        dist.TruncatedDistribution(dist.StudentT(3), low=1.5),
     ],
 )
 def test_no_tracer_leak_at_lazy_property_log_prob(my_dist):
@@ -207,16 +204,15 @@ def test_no_tracer_leak_at_lazy_property_log_prob(my_dist):
     """
     jit_lp = jax.jit(my_dist.log_prob)
     with jax.check_tracer_leaks():
-        jit_lp(1.)
+        jit_lp(1.0)
+
 
 @pytest.mark.parametrize(
     "my_dist",
     [
-        dist.TruncatedNormal(low=-1., high=2.),
+        dist.TruncatedNormal(low=-1.0, high=2.0),
         dist.TruncatedCauchy(low=-5, high=10),
-        dist.TruncatedDistribution(
-            dist.StudentT(3),
-            low=1.5)
+        dist.TruncatedDistribution(dist.StudentT(3), low=1.5),
     ],
 )
 def test_no_tracer_leak_at_lazy_property_sample(my_dist):


### PR DESCRIPTION
Add a conditional if `numpyro.util.not_jax_tracer(value)` before setting `lazy_property` as an attribute of `TruncatedDistribution`

This resolves errors described in #1836 and https://github.com/CDCgov/multisignal-epi-inference/issues/282

tests added:
check valid sampling of `TruncatedDistribution` in parallel (failed previously as described in #1836 )
check predictive methods (prior predictive and inference) can be run multiple times on the same model built using `TruncatedDistribution` (error encountered here https://github.com/CDCgov/multisignal-epi-inference/issues/282)