### PR TITLE
Generic `cdf` and `icdf` implementation for scalar `TransformedDistribution`s.

### DIFF
--- a/numpyro/distributions/continuous.py
+++ b/numpyro/distributions/continuous.py
@@ -698,9 +698,6 @@ class InverseGamma(TransformedDistribution):
         a = (self.rate / (self.concentration - 1)) ** 2 / (self.concentration - 2)
         return jnp.where(self.concentration <= 2, jnp.inf, a)
 
-    def cdf(self, x):
-        return 1 - self.base_dist.cdf(1 / x)
-
     def entropy(self):
         return (
             self.concentration
@@ -1205,9 +1202,6 @@ class LogNormal(TransformedDistribution):
     def variance(self):
         return (jnp.exp(self.scale**2) - 1) * jnp.exp(2 * self.loc + self.scale**2)
 
-    def cdf(self, x):
-        return self.base_dist.cdf(jnp.log(x))
-
     def entropy(self):
         return (1 + jnp.log(2 * jnp.pi)) / 2 + self.loc + jnp.log(self.scale)
 
@@ -1282,9 +1276,6 @@ class LogUniform(TransformedDistribution):
             0.5 * (self.high**2 - self.low**2) / jnp.log(self.high / self.low)
             - self.mean**2
         )
-
-    def cdf(self, x):
-        return self.base_dist.cdf(jnp.log(x))
 
     def entropy(self):
         log_low = jnp.log(self.low)
@@ -2161,12 +2152,6 @@ class Pareto(TransformedDistribution):
     @constraints.dependent_property(is_discrete=False, event_dim=0)
     def support(self):
         return constraints.greater_than(self.scale)
-
-    def cdf(self, value):
-        return 1 - jnp.power(self.scale / value, self.alpha)
-
-    def icdf(self, q):
-        return self.scale / jnp.power(1 - q, 1 / self.alpha)
 
     def entropy(self):
         return jnp.log(self.scale / self.alpha) + 1 + 1 / self.alpha

--- a/numpyro/distributions/distribution.py
+++ b/numpyro/distributions/distribution.py
@@ -1105,6 +1105,24 @@ class TransformedDistribution(Distribution):
     def variance(self):
         raise NotImplementedError
 
+    def cdf(self, value):
+        sign = 1
+        for transform in reversed(self.transforms):
+            sign *= transform.sign
+            value = transform.inv(value)
+        q = self.base_dist.cdf(value)
+        return jnp.where(sign < 0, 1 - q, q)
+
+    def icdf(self, q):
+        sign = 1
+        for transform in self.transforms:
+            sign *= transform.sign
+        q = jnp.where(sign < 0, 1 - q, q)
+        value = self.base_dist.icdf(q)
+        for transform in self.transforms:
+            value = transform(value)
+        return value
+
 
 class FoldedDistribution(TransformedDistribution):
     """

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -540,6 +540,7 @@ CONTINUOUS = [
     T(dist.HalfNormal, 1.0),
     T(dist.HalfNormal, np.array([1.0, 2.0])),
     T(_ImproperWrapper, constraints.positive, (), (3,)),
+    T(dist.InverseGamma, np.array([3.1]), np.array([[2.0], [3.0]])),
     T(dist.InverseGamma, np.array([1.7]), np.array([[2.0], [3.0]])),
     T(dist.InverseGamma, np.array([0.5, 1.3]), np.array([[1.0], [3.0]])),
     T(dist.Kumaraswamy, 10.0, np.array([2.0, 3.0])),
@@ -1568,7 +1569,7 @@ def test_cdf_and_icdf(jax_dist, sp_dist, params):
     samples = d.sample(key=random.PRNGKey(0), sample_shape=(100,))
     quantiles = random.uniform(random.PRNGKey(1), (100,) + d.shape())
     try:
-        rtol = 2e-3 if jax_dist in (dist.Gamma, dist.StudentT) else 1e-5
+        rtol = 2e-3 if jax_dist in (dist.Gamma, dist.LogNormal, dist.StudentT) else 1e-5
         if d.shape() == () and not d.is_discrete:
             assert_allclose(
                 jax.vmap(jax.grad(d.cdf))(samples),
@@ -1585,7 +1586,7 @@ def test_cdf_and_icdf(jax_dist, sp_dist, params):
         assert_allclose(d.cdf(d.icdf(quantiles)), quantiles, atol=1e-5, rtol=1e-5)
         assert_allclose(d.icdf(d.cdf(samples)), samples, atol=1e-5, rtol=rtol)
     except NotImplementedError:
-        pass
+        pytest.skip("cdf/icdf not implemented")
 
     # test against scipy
     if not sp_dist:
@@ -1599,7 +1600,7 @@ def test_cdf_and_icdf(jax_dist, sp_dist, params):
         expected_icdf = sp_dist.ppf(quantiles)
         assert_allclose(actual_icdf, expected_icdf, atol=1e-4, rtol=1e-4)
     except NotImplementedError:
-        pass
+        pytest.skip("cdf/icdf not implemented")
 
 
 @pytest.mark.parametrize("jax_dist, sp_dist, params", CONTINUOUS + DIRECTIONAL)

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -341,6 +341,9 @@ def test_bijective_transforms(transform, shape):
         )
         slogdet = jnp.linalg.slogdet(jac)
         assert jnp.allclose(log_abs_det_jacobian, slogdet.logabsdet, atol=atol)
+        assert transform.domain.event_dim or jnp.allclose(
+            jnp.sign(jnp.diagonal(jac, axis1=-1, axis2=-2)), transform.sign
+        )
 
 
 def test_batched_recursive_linear_transform():


### PR DESCRIPTION
This PR

- Adds a `sign` attribute to `Transform` which is the sign of the derivative for bijective scalar transforms. This matches the `sign` attribute of transforms in Pyro.
- Implements `cdf` for `TransformedDistribution` by transforming from the domain of the transformed distribution to the domain of the base distribution and evaluating the cdf.
- Implements `icdf` for `TransformedDistribution` by calling `icdf` of the base distribution and applying the transforms.

This means cdfs for `LogNormal`, `InverseGamma`, `LogUniform`, and `Pareto` do not require a custom implementation. As a side effect, this PR adds `icdf` support for `LogNormal`, `InverseGamma`, and `LogUniform`; it also adds `cdf` and `icdf` support for `RelaxedBernoulliLogits`.