### PR TITLE
Fix binominal distribution

### DIFF
--- a/numpyro/distributions/util.py
+++ b/numpyro/distributions/util.py
@@ -157,7 +157,7 @@ def _binomial_dispatch(key, p, n):
     def dispatch(key, p, n):
         is_le_mid = p <= 0.5
         #Make sure p=0 is never taken into account as a fix for possible zeros in p.
-        p = jnp.sum(jnp.stack((p, jnp.ones(p.shape)*0.001)), where = (p == 0))
+        p = jnp.clip(p, jnp.finfo(jnp.float32).tiny)
         pq = jnp.where(is_le_mid, p, 1 - p)
         mu = n * pq
         k = lax.cond(

--- a/numpyro/distributions/util.py
+++ b/numpyro/distributions/util.py
@@ -156,7 +156,7 @@ def _binomial_inversion(key, p, n):
 def _binomial_dispatch(key, p, n):
     def dispatch(key, p, n):
         is_le_mid = p <= 0.5
-        #Make sure p=0 is never taken into account as a fix for possible zeros in p.
+        # Make sure p=0 is never taken into account as a fix for possible zeros in p.
         p = jnp.clip(p, jnp.finfo(jnp.float32).tiny)
         pq = jnp.where(is_le_mid, p, 1 - p)
         mu = n * pq

--- a/numpyro/distributions/util.py
+++ b/numpyro/distributions/util.py
@@ -149,6 +149,8 @@ def _binomial_inversion(key, p, n):
         return cond_exclude_large_mu & (geom_acc <= n)
 
     log1_p = jnp.log1p(-p)
+    # Make sure p=0 is never taken into account as a fix for possible zeros in p.
+    log1_p = jnp.where(log1_p == 0, -jnp.finfo(log1_p.dtype).tiny, log1_p)
     ret = lax.while_loop(_binom_inv_cond_fn, _binom_inv_body_fn, (-1, key, 0.0))
     return ret[0]
 
@@ -156,8 +158,6 @@ def _binomial_inversion(key, p, n):
 def _binomial_dispatch(key, p, n):
     def dispatch(key, p, n):
         is_le_mid = p <= 0.5
-        # Make sure p=0 is never taken into account as a fix for possible zeros in p.
-        p = jnp.clip(p, jnp.finfo(jnp.float32).tiny)
         pq = jnp.where(is_le_mid, p, 1 - p)
         mu = n * pq
         k = lax.cond(


### PR DESCRIPTION
Hi, Pull Request #1807 ends in an infinite loop while running the test setup for the distributions, causing the tests to end until the time limit is reached. 

The misbehavior can be tested just by running the test_distributions setup or only especially the 
**test_vmapped_binominal_p0** function solely with the following code included directly after the imports in **test_distributions.py**:
```
# Enable 64bit support for higher accuracy
if sys.maxsize > 2**32:
    jax.config.update("jax_enable_x64", True)
```

While I can't 100% say why this endless loop only occurs when increasing the numeric accuracy to 64 bits, I'm sure to have a suitable solution for the behavior (which also seems faulty at 32 bits).

The problem stems from the **_binomial_dispatch** function in **util.py** (see the description commit). In short, zero values for the probability p are also passed to the dispatch function, even if filtered out afterward via _lax.cond_.  Therefore, the underlying while_loop in the **_binomial_inversion** function runs infinitely.

This merge request solves this issue by ensuring that no p values equal to zero are passed to the underlying functions. As _lax.cond_ is still filtering out the results of the zero-corrected values, there's no change for instances using the mentioned methods.
