### PR TITLE
Refactor `validate_args` method on distributions (fixes #1865).

### DIFF
--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -3322,6 +3322,25 @@ def test_vmap_validate_args():
     assert not v_dist._validate_args
 
 
+def test_explicit_validate_args():
+    # Check validation passes for valid parameters.
+    d = dist.Normal(0, 1)
+    d.validate_args()
+
+    # Check validation fails for invalid parameters.
+    d = dist.Normal(0, -1)
+    with pytest.raises(ValueError, match="got invalid scale parameter"):
+        d.validate_args()
+
+    # Check validation is skipped for strict=False and raises an error for strict=True.
+    jitted = jax.jit(
+        lambda d, strict: d.validate_args(strict), static_argnames=["strict"]
+    )
+    jitted(d, False)
+    with pytest.raises(RuntimeError, match="Cannot validate arguments"):
+        jitted(d, True)
+
+
 def test_multinomial_abstract_total_count():
     probs = jnp.array([0.2, 0.5, 0.3])
     key = random.PRNGKey(0)


### PR DESCRIPTION
This PR moves argument validation into a separate method. I've added an argument `strict` to the method such that an error is raised if validation is requested inside jitted code. The constructor uses `strict = False` to maintain backwards compatibility.