### PR TITLE
Fixing nested sampling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,9 @@ jobs:
     - name: Test custom prng
       run: |
         JAX_ENABLE_CUSTOM_PRNG=1 pytest -vs test/infer/test_mcmc.py
+    - name: Test nested sampling
+      run: |
+        JAX_ENABLE_X64=1 pytest -vs test/contrib/test_nested_sampling.py
 
 
   examples:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,8 +104,8 @@ jobs:
     - name: Test with pytest
       run: |
         pytest -vs --durations=20 test/infer/test_mcmc.py
-        pytest -vs --durations=20 test/infer --ignore=test/infer/test_mcmc.py
-        pytest -vs --durations=20 test/contrib --ignore=test/contrib/stochastic_support/test_dcc.py
+        pytest -vs --durations=20 test/infer --ignore=test/infer/test_mcmc.py --ignore=test/contrib/test_nested_sampling.py
+        pytest -vs --durations=20 test/contrib --ignore=test/contrib/stochastic_support/test_dcc.py --ignore=test/contrib/test_nested_sampling.py
     - name: Test x64
       run: |
         JAX_ENABLE_X64=1 pytest -vs test/infer/test_mcmc.py -k x64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
       run: |
         pytest -vs --durations=20 test/infer/test_mcmc.py
         pytest -vs --durations=20 test/infer --ignore=test/infer/test_mcmc.py --ignore=test/contrib/test_nested_sampling.py
-        pytest -vs --durations=20 test/contrib --ignore=test/contrib/stochastic_support/test_dcc.py --ignore=test/contrib/test_nested_sampling.py
+        pytest -vs --durations=20 test/contrib --ignore=test/contrib/stochastic_support/test_dcc.py
     - name: Test x64
       run: |
         JAX_ENABLE_X64=1 pytest -vs test/infer/test_mcmc.py -k x64

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,7 +4,7 @@ funsor
 ipython
 jax
 jaxlib
-jaxns==2.4.8
+jaxns==2.6.2
 Jinja2
 matplotlib
 multipledispatch

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,7 +4,7 @@ funsor
 ipython
 jax
 jaxlib
-jaxns==2.6.2
+jaxns==2.6.3
 Jinja2
 matplotlib
 multipledispatch

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -34,6 +34,8 @@ from numpyro.infer.hmc import hmc  # noqa: E402
 
 hmc(None, None)
 
+autodoc_mock_imports = ["jaxns"]
+
 # -- Project information -----------------------------------------------------
 
 project = "NumPyro"

--- a/examples/gaussian_shells.py
+++ b/examples/gaussian_shells.py
@@ -18,6 +18,8 @@ NUTS sampler.
        https://github.com/joshspeagle/dynesty/blob/master/demos/Examples%20--%20Gaussian%20Shells.ipynb
 """
 
+# ruff: noqa: E402
+
 import argparse
 
 import matplotlib.pyplot as plt
@@ -29,6 +31,9 @@ import numpyro
 from numpyro.contrib.nested_sampling import NestedSampler
 import numpyro.distributions as dist
 from numpyro.infer import MCMC, NUTS, DiscreteHMCGibbs
+
+numpyro.enable_x64()
+numpyro.set_host_device_count(2)
 
 
 class GaussianShell(dist.Distribution):

--- a/examples/gaussian_shells.py
+++ b/examples/gaussian_shells.py
@@ -32,9 +32,6 @@ from numpyro.contrib.nested_sampling import NestedSampler
 import numpyro.distributions as dist
 from numpyro.infer import MCMC, NUTS, DiscreteHMCGibbs
 
-numpyro.enable_x64()
-numpyro.set_host_device_count(2)
-
 
 class GaussianShell(dist.Distribution):
     support = dist.constraints.real_vector
@@ -126,6 +123,7 @@ def main(args):
 
 if __name__ == "__main__":
     assert numpyro.__version__.startswith("0.15.3")
+
     parser = argparse.ArgumentParser(description="Nested sampler for Gaussian shells")
     parser.add_argument("-n", "--num-samples", nargs="?", default=10000, type=int)
     parser.add_argument("--num-warmup", nargs="?", default=1000, type=int)
@@ -138,6 +136,7 @@ if __name__ == "__main__":
     parser.add_argument("--device", default="cpu", type=str, help='use "cpu" or "gpu".')
     args = parser.parse_args()
 
+    numpyro.enable_x64()
     numpyro.set_platform(args.device)
 
     main(args)

--- a/examples/gaussian_shells.py
+++ b/examples/gaussian_shells.py
@@ -18,8 +18,6 @@ NUTS sampler.
        https://github.com/joshspeagle/dynesty/blob/master/demos/Examples%20--%20Gaussian%20Shells.ipynb
 """
 
-# ruff: noqa: E402
-
 import argparse
 
 import matplotlib.pyplot as plt

--- a/numpyro/contrib/nested_sampling.py
+++ b/numpyro/contrib/nested_sampling.py
@@ -145,9 +145,7 @@ class NestedSampler:
     :param dict termination_kwargs: keyword arguments to terminate the sampler. Please
         refer to the upstream :meth:`jaxns.NestedSampler.__call__` method.
 
-    **Example**
-
-    .. doctest::
+    Example::
 
         >>> from jax import random
         >>> import jax.numpy as jnp

--- a/numpyro/contrib/nested_sampling.py
+++ b/numpyro/contrib/nested_sampling.py
@@ -3,12 +3,13 @@
 
 from functools import singledispatch
 
+import jax
 from jax import random
 import jax.numpy as jnp
 
 try:
+    import jaxns  # noqa: F401
     from jaxns import (
-        DefaultNestedSampler,
         Model,
         Prior,
         TerminationCondition,
@@ -17,11 +18,13 @@ try:
         resample,
         summary,
     )
+    from jaxns.public import DefaultNestedSampler
     from jaxns.utils import NestedSamplerResults
 
 except ImportError as e:
     raise ImportError(
-        "To use this module, please install `jaxns` package. It can be"
+        f"{e} \n "
+        f"To use this module, please install `jaxns>2.5` package. It can be"
         " installed with `pip install jaxns` with python>=3.8"
     ) from e
 
@@ -258,7 +261,7 @@ class NestedSampler:
 
         default_constructor_kwargs = dict(
             num_live_points=model.U_ndims * 25,
-            num_parallel_workers=1,
+            devices=jax.devices(),
             max_samples=1e4,
         )
         default_termination_kwargs = dict(dlogZ=1e-4)

--- a/numpyro/distributions/transforms.py
+++ b/numpyro/distributions/transforms.py
@@ -719,7 +719,7 @@ class LowerCholeskyAffine(Transform):
        >>> scale_tril = jnp.array([[0.3, 0.0], [1.0, 0.5]])
        >>> affine = LowerCholeskyAffine(loc=loc, scale_tril=scale_tril)
        >>> affine(base)
-       Array([0.3, 1.5], dtype=float64)
+       Array([0.3, 1.5], dtype=float32)
     """
 
     domain = constraints.real_vector

--- a/numpyro/distributions/transforms.py
+++ b/numpyro/distributions/transforms.py
@@ -714,9 +714,9 @@ class LowerCholeskyAffine(Transform):
 
        >>> import jax.numpy as jnp
        >>> from numpyro.distributions.transforms import LowerCholeskyAffine
-       >>> base = jnp.ones(2)
-       >>> loc = jnp.zeros(2)
-       >>> scale_tril = jnp.array([[0.3, 0.0], [1.0, 0.5]])
+       >>> base = jnp.ones(2, dtype=jnp.float32)
+       >>> loc = jnp.zeros(2, dtype=jnp.float32)
+       >>> scale_tril = jnp.array([[0.3, 0.0], [1.0, 0.5]], dtype=jnp.float32)
        >>> affine = LowerCholeskyAffine(loc=loc, scale_tril=scale_tril)
        >>> affine(base)
        Array([0.3, 1.5], dtype=float32)

--- a/numpyro/distributions/transforms.py
+++ b/numpyro/distributions/transforms.py
@@ -719,7 +719,7 @@ class LowerCholeskyAffine(Transform):
        >>> scale_tril = jnp.array([[0.3, 0.0], [1.0, 0.5]])
        >>> affine = LowerCholeskyAffine(loc=loc, scale_tril=scale_tril)
        >>> affine(base)
-       Array([0.3, 1.5], dtype=float32)
+       Array([0.3, 1.5], dtype=float64)
     """
 
     domain = constraints.real_vector

--- a/numpyro/distributions/transforms.py
+++ b/numpyro/distributions/transforms.py
@@ -714,9 +714,9 @@ class LowerCholeskyAffine(Transform):
 
        >>> import jax.numpy as jnp
        >>> from numpyro.distributions.transforms import LowerCholeskyAffine
-       >>> base = jnp.ones(2, dtype=jnp.float32)
-       >>> loc = jnp.zeros(2, dtype=jnp.float32)
-       >>> scale_tril = jnp.array([[0.3, 0.0], [1.0, 0.5]], dtype=jnp.float32)
+       >>> base = jnp.ones(2)
+       >>> loc = jnp.zeros(2)
+       >>> scale_tril = jnp.array([[0.3, 0.0], [1.0, 0.5]])
        >>> affine = LowerCholeskyAffine(loc=loc, scale_tril=scale_tril)
        >>> affine(base)
        Array([0.3, 1.5], dtype=float32)

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
             "flax",
             "funsor>=0.4.1",
             "graphviz",
-            "jaxns==2.6.2",
+            "jaxns==2.6.3",
             "matplotlib",
             "optax>=0.0.6",
             "pylab-sdk",  # jaxns dependency

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
             "flax",
             "funsor>=0.4.1",
             "graphviz",
-            "jaxns==2.4.8",
+            "jaxns==2.6.2",
             "matplotlib",
             "optax>=0.0.6",
             "pylab-sdk",  # jaxns dependency

--- a/test/contrib/test_nested_sampling.py
+++ b/test/contrib/test_nested_sampling.py
@@ -13,15 +13,18 @@ import jax.numpy as jnp
 import numpyro
 
 try:
-    from numpyro.contrib.nested_sampling import NestedSampler, UniformReparam
+    if os.environ.get("JAX_ENABLE_X64"):
+        from numpyro.contrib.nested_sampling import NestedSampler, UniformReparam
+
 except ImportError:
     pytestmark = pytest.mark.skip(reason="jaxns is not installed")
+
 import numpyro.distributions as dist
 from numpyro.distributions.transforms import AffineTransform, ExpTransform
 
 pytestmark = [
     pytest.mark.filterwarnings("ignore:jax.tree_.+ is deprecated:FutureWarning"),
-    pytest.mark.filterwarnings("ignore:JAX x64 is not enabled. Setting it now. Check for errors.:UserWarning"),
+    pytest.mark.filterwarnings("ignore:JAX x64"),
     pytest.mark.skipif(
         not os.environ.get("JAX_ENABLE_X64"),
         reason="test suite for jaxns requires double precision",

--- a/test/contrib/test_nested_sampling.py
+++ b/test/contrib/test_nested_sampling.py
@@ -1,6 +1,8 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+
 import numpy as np
 from numpy.testing import assert_allclose
 import pytest
@@ -17,9 +19,13 @@ except ImportError:
 import numpyro.distributions as dist
 from numpyro.distributions.transforms import AffineTransform, ExpTransform
 
-pytestmark = pytest.mark.filterwarnings(
-    "ignore:jax.tree_.+ is deprecated:FutureWarning"
-)
+pytestmark = [
+    pytest.mark.filterwarnings("ignore:jax.tree_.+ is deprecated:FutureWarning"),
+    pytest.mark.skipif(
+        not os.environ.get("JAX_ENABLE_X64"),
+        reason="test suite for jaxns requires double precision",
+    ),
+]
 
 
 # Test helper to extract a few central moments from samples.

--- a/test/contrib/test_nested_sampling.py
+++ b/test/contrib/test_nested_sampling.py
@@ -21,6 +21,7 @@ from numpyro.distributions.transforms import AffineTransform, ExpTransform
 
 pytestmark = [
     pytest.mark.filterwarnings("ignore:jax.tree_.+ is deprecated:FutureWarning"),
+    pytest.mark.filterwarnings("ignore:JAX x64 is not enabled. Setting it now. Check for errors.:UserWarning"),
     pytest.mark.skipif(
         not os.environ.get("JAX_ENABLE_X64"),
         reason="test suite for jaxns requires double precision",


### PR DESCRIPTION
There are some import discrepancies between `jaxns<2.6` and `jaxns 2.6.*`. This small fix seems to do the trick!