### PR TITLE
use biased autocorrelation estimate by default (resolves #1785)

### DIFF
--- a/numpyro/diagnostics.py
+++ b/numpyro/diagnostics.py
@@ -96,12 +96,13 @@ def _fft_next_fast_len(target):
         target += 1
 
 
-def autocorrelation(x, axis=0):
+def autocorrelation(x, axis=0, unbiased=False):
     """
     Computes the autocorrelation of samples at dimension ``axis``.
 
     :param numpy.ndarray x: the input array.
     :param int axis: the dimension to calculate autocorrelation.
+    :param unbiased: use an unbiased estimator of the autocorrelation.
     :return: autocorrelation of ``x``.
     :rtype: numpy.ndarray
     """
@@ -127,7 +128,13 @@ def autocorrelation(x, axis=0):
 
     # truncate and normalize the result, then transpose back to original shape
     autocorr = autocorr[..., :N]
-    autocorr = autocorr / np.arange(N, 0.0, -1)
+
+    # the unbiased estimator is known to have "wild" tails, due to few samples at longer lags.
+    # see Geyer (1992) and Priestley (1981) for a discussion. also note that it is only strictly
+    # unbiased when the mean is known, whereas we it estimate from samples here.
+    if unbiased:
+        autocorr = autocorr / np.arange(N, 0.0, -1)
+
     with np.errstate(invalid="ignore", divide="ignore"):
         autocorr = autocorr / autocorr[..., :1]
     return np.swapaxes(autocorr, axis, -1)

--- a/test/test_diagnostics.py
+++ b/test/test_diagnostics.py
@@ -71,7 +71,7 @@ def test_autocorrelation():
     # the unbiased estimator has variance O(1) at large lags
     x = np.random.normal(size=20000)
     ac = autocorrelation(x, unbiased=True)
-    assert_(np.any(np.abs(ac[-100:]) > 0.01))
+    assert_(np.any(np.abs(ac[-100:]) > .1))
 
     ac = autocorrelation(x, unbiased=False)
     assert_allclose(np.abs(ac[-100:]), 0.0, atol=0.01)

--- a/test/test_diagnostics.py
+++ b/test/test_diagnostics.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np
-from numpy.testing import assert_allclose
+from numpy.testing import assert_, assert_allclose
 import pytest
 from scipy.fftpack import next_fast_len
 
@@ -60,9 +60,21 @@ def test_hpdi():
 
 def test_autocorrelation():
     x = np.arange(10.0)
-    actual = autocorrelation(x)
+    actual = autocorrelation(x, unbiased=True)
     expected = np.array([1, 0.78, 0.52, 0.21, -0.13, -0.52, -0.94, -1.4, -1.91, -2.45])
     assert_allclose(actual, expected, atol=0.01)
+
+    actual = autocorrelation(x, unbiased=False)
+    expected = expected * np.arange(len(x), 0.0, -1) / len(x)
+    assert_allclose(actual, expected, atol=0.01)
+
+    # the unbiased estimator has variance O(1) at large lags
+    x = np.random.normal(size=20000)
+    ac = autocorrelation(x, unbiased=True)
+    assert_(np.any(np.abs(ac[-100:]) > 0.01))
+
+    ac = autocorrelation(x, unbiased=False)
+    assert_allclose(np.abs(ac[-100:]), 0.0, atol=0.01)
 
 
 def test_autocovariance():

--- a/test/test_diagnostics.py
+++ b/test/test_diagnostics.py
@@ -60,26 +60,26 @@ def test_hpdi():
 
 def test_autocorrelation():
     x = np.arange(10.0)
-    actual = autocorrelation(x, unbiased=True)
+    actual = autocorrelation(x, bias=False)
     expected = np.array([1, 0.78, 0.52, 0.21, -0.13, -0.52, -0.94, -1.4, -1.91, -2.45])
     assert_allclose(actual, expected, atol=0.01)
 
-    actual = autocorrelation(x, unbiased=False)
+    actual = autocorrelation(x, bias=True)
     expected = expected * np.arange(len(x), 0.0, -1) / len(x)
     assert_allclose(actual, expected, atol=0.01)
 
     # the unbiased estimator has variance O(1) at large lags
     x = np.random.normal(size=20000)
-    ac = autocorrelation(x, unbiased=True)
-    assert_(np.any(np.abs(ac[-100:]) > .1))
+    ac = autocorrelation(x, bias=False)
+    assert_(np.any(np.abs(ac[-100:]) > 0.1))
 
-    ac = autocorrelation(x, unbiased=False)
+    ac = autocorrelation(x, bias=True)
     assert_allclose(np.abs(ac[-100:]), 0.0, atol=0.01)
 
 
 def test_autocovariance():
     x = np.arange(10.0)
-    actual = autocovariance(x)
+    actual = autocovariance(x, bias=False)
     expected = np.array(
         [8.25, 6.42, 4.25, 1.75, -1.08, -4.25, -7.75, -11.58, -15.75, -20.25]
     )
@@ -105,4 +105,4 @@ def test_split_gelman_rubin_agree_with_gelman_rubin():
 
 def test_effective_sample_size():
     x = np.arange(1000.0).reshape(100, 10)
-    assert_allclose(effective_sample_size(x), 52.64, atol=0.01)
+    assert_allclose(effective_sample_size(x, bias=False), 52.64, atol=0.01)


### PR DESCRIPTION
This changes the autocorrelation function to use the same (biased) estimate as Stan by default. The unbiased estimate is known to have "wild" tails, with variance that is O(1) at longer lags regardless of the length of the chain. See Priestley (1981, Section 5.3) for a discussion of the properties of these estimators. Note that the old (unbiased) estimator is only strictly unbiased when the mean is known, but I have followed Priestley (1981) in referring to it as unbiased.

I have added two checks to ``test_autocorrelation`` that highlight the difference in the tail behaviour.