### PR TITLE
remove depreciated line from docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -7,7 +7,6 @@ import shutil
 import sys
 
 import nbsphinx
-import sphinx_rtd_theme
 
 # import pkg_resources
 
@@ -227,7 +226,6 @@ html_favicon = "_static/img/favicon/favicon.ico"
 # a list of builtin themes.
 #
 html_theme = "sphinx_rtd_theme"
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
Trying to solve the error in https://github.com/pyro-ppl/numpyro/actions/runs/11218235719/job/31185189614?pr=1880

```python
phinx.errors.SphinxWarning: Calling get_html_theme_path is deprecated. If you are calling it to define html_theme_path, you are safe to remove that code.
```

So that is what I did (works locally)