### PR TITLE
Bump CI to python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.10]
+        python-version: ["3.10"]
 
     steps:
     - uses: actions/checkout@v2
@@ -50,7 +50,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        python-version: [3.10]
+        python-version: ["3.10"]
 
     steps:
     - uses: actions/checkout@v2
@@ -83,7 +83,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        python-version: [3.10]
+        python-version: ["3.10"]
 
     steps:
     - uses: actions/checkout@v2
@@ -126,7 +126,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        python-version: [3.10]
+        python-version: ["3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: [3.10]
 
     steps:
     - uses: actions/checkout@v2
@@ -50,7 +50,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: [3.10]
 
     steps:
     - uses: actions/checkout@v2
@@ -83,7 +83,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: [3.10]
 
     steps:
     - uses: actions/checkout@v2
@@ -126,7 +126,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: [3.10]
 
     steps:
     - uses: actions/checkout@v2

--- a/numpyro/distributions/discrete.py
+++ b/numpyro/distributions/discrete.py
@@ -89,7 +89,8 @@ class BernoulliProbs(Distribution):
     @validate_sample
     def log_prob(self, value):
         ps_clamped = clamp_probs(self.probs)
-        return xlogy(value, ps_clamped) + xlog1py(1 - value, -ps_clamped)
+        value = jnp.array(value, jnp.result_type(float))
+        return xlogy(value, ps_clamped) + xlog1py(1.0 - value, -ps_clamped)
 
     @lazy_property
     def logits(self):
@@ -190,6 +191,7 @@ class BinomialProbs(Distribution):
 
     @validate_sample
     def log_prob(self, value):
+        value = jnp.array(value, jnp.result_type(float))
         log_factorial_n = gammaln(self.total_count + 1)
         log_factorial_k = gammaln(value + 1)
         log_factorial_nmk = gammaln(self.total_count - value + 1)
@@ -558,6 +560,7 @@ class MultinomialProbs(Distribution):
     def log_prob(self, value):
         if self._validate_args:
             self._validate_sample(value)
+        value = jnp.array(value, jnp.result_type(float))
         return gammaln(self.total_count + 1) + jnp.sum(
             xlogy(value, self.probs) - gammaln(value + 1), axis=-1
         )

--- a/numpyro/distributions/discrete.py
+++ b/numpyro/distributions/discrete.py
@@ -90,7 +90,7 @@ class BernoulliProbs(Distribution):
     def log_prob(self, value):
         ps_clamped = clamp_probs(self.probs)
         value = jnp.array(value, jnp.result_type(float))
-        return xlogy(value, ps_clamped) + xlog1py(1.0 - value, -ps_clamped)
+        return xlogy(value, ps_clamped) + xlog1py(1 - value, -ps_clamped)
 
     @lazy_property
     def logits(self):
@@ -263,12 +263,13 @@ class BinomialLogits(Distribution):
 
     @validate_sample
     def log_prob(self, value):
-        log_factorial_n = gammaln(self.total_count + 1)
+        total_count = jnp.array(self.total_count, dtype=jnp.result_type(float))
+        log_factorial_n = gammaln(total_count + 1)
         log_factorial_k = gammaln(value + 1)
-        log_factorial_nmk = gammaln(self.total_count - value + 1)
+        log_factorial_nmk = gammaln(total_count - value + 1)
         normalize_term = (
             self.total_count * jnp.clip(self.logits, 0)
-            + xlog1py(self.total_count, jnp.exp(-jnp.abs(self.logits)))
+            + xlog1py(total_count, jnp.exp(-jnp.abs(self.logits)))
             - log_factorial_n
         )
         return (
@@ -558,8 +559,6 @@ class MultinomialProbs(Distribution):
 
     @validate_sample
     def log_prob(self, value):
-        if self._validate_args:
-            self._validate_sample(value)
         value = jnp.array(value, jnp.result_type(float))
         return gammaln(self.total_count + 1) + jnp.sum(
             xlogy(value, self.probs) - gammaln(value + 1), axis=-1


### PR DESCRIPTION
Jax currently dropped support for Python 3.9, so our CI didn't catch the issues introduced in new jax versions.

Fixes #1876