### PR TITLE
Fix handling of event dimensions in `ComposeTransform` (fixes #1893).

### DIFF
--- a/numpyro/distributions/transforms.py
+++ b/numpyro/distributions/transforms.py
@@ -282,7 +282,7 @@ class AffineTransform(Transform):
 
 def _get_compose_transform_input_event_dim(parts):
     input_event_dim = parts[-1].domain.event_dim
-    for part in parts[len(parts) - 1 :: -1]:
+    for part in parts[:-1][::-1]:
         input_event_dim = part.domain.event_dim + max(
             input_event_dim - part.codomain.event_dim, 0
         )

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -397,3 +397,16 @@ def test_biject_to(constraint, shape):
     expected_shape = constrained.shape[: constrained.ndim - constraint.event_dim]
     assert passed.shape == expected_shape
     assert jnp.all(passed)
+
+
+@pytest.mark.parametrize(
+    "transform",
+    [
+        CorrCholeskyTransform(),
+        CorrCholeskyTransform().inv,
+    ],
+)
+def test_compose_domain_codomain(transform):
+    composed = ComposeTransform([transform])
+    assert transform.domain.event_dim == composed.domain.event_dim
+    assert transform.codomain.event_dim == composed.codomain.event_dim


### PR DESCRIPTION
This PR fixes #1893, I think. It looks like the implicit end in the slice caused some trouble if there's only one transform.