### PR TITLE
Ensure BlockNeuralAutoregressiveTransform maps real->real

### DIFF
--- a/numpyro/nn/block_neural_arn.py
+++ b/numpyro/nn/block_neural_arn.py
@@ -114,7 +114,7 @@ def Tanh():
     return init_fun, apply_fun
 
 
-def LeakyTanh(min_grad: float = 0.001):
+def LeakyTanh(min_grad: float = 0.01):
     """
     Leaky Tanh nonlinearity :math:`y=Tanh(x) + cx` with its log-Jacobian.
 
@@ -204,6 +204,7 @@ def BlockNeuralAutoregressiveNN(
         input dimension. This corresponds to both :math:`a` and :math:`b` in reference [1].
         The elements of hidden_factors must be integers.
     :param str residual: Type of residual connections to use. One of `None`, `"normal"`, `"gated"`.
+    :param tuple activation: An (`init_fn`, `update_fn`) pair. Defaults to ``LeakyTanh``.
     :return: an (`init_fn`, `update_fn`) pair.
     """
     layers = []

--- a/numpyro/nn/block_neural_arn.py
+++ b/numpyro/nn/block_neural_arn.py
@@ -121,6 +121,7 @@ def LeakyTanh(min_grad: float = 0.01):
     This choice when used in ``BlockNeuralAutoregressiveNN`` ensures the image of the
     transformation is the set of real values (unlike ``Tanh``).
 
+    :param float min_grad: The minimum gradient value (:math:`c` above). Defaults to 0.01.
     :return: an (`init_fn`, `apply_fn`) pair.
     """
 

--- a/numpyro/nn/block_neural_arn.py
+++ b/numpyro/nn/block_neural_arn.py
@@ -116,7 +116,7 @@ def Tanh():
 
 def LeakyTanh(min_grad: float = 0.01):
     """
-    Leaky Tanh nonlinearity :math:`y=Tanh(x) + cx` with its log-Jacobian.
+    Leaky Tanh nonlinearity :math:`y=\text{tanh}(x) + cx` with its log-Jacobian.
 
     This choice when used in ``BlockNeuralAutoregressiveNN`` ensures the image of the
     transformation is the set of real values (unlike ``Tanh``).
@@ -192,8 +192,8 @@ def BlockNeuralAutoregressiveNN(
     An implementation of Block Neural Autoregressive neural network.
 
     In contrast to the original paper, by default, we use ``LeakyTanh`` as the
-    activation, defined as :math:`y=Tanh(x) + cx` with :math:`c` being a small constant,
-    to ensure the transform maps from real -> real.
+    activation, defined as :math:`y=Tanh(x) + cx` with :math:`c` being a small constant
+    (default to 0.01), which ensures the transform maps from real -> real.
 
     **References**
 

--- a/test/test_flows.py
+++ b/test/test_flows.py
@@ -16,6 +16,7 @@ from numpyro.distributions.flows import (
 )
 from numpyro.distributions.util import matrix_to_tril_vec
 from numpyro.nn import AutoregressiveNN, BlockNeuralAutoregressiveNN
+from numpyro.nn.block_neural_arn import Tanh, LeakyTanh
 
 
 def _make_iaf_args(input_dim, hidden_dims):
@@ -34,8 +35,12 @@ def _make_iaf_args(input_dim, hidden_dims):
     return (partial(arn, init_params),)
 
 
-def _make_bnaf_args(input_dim, hidden_factors):
-    arn_init, arn = BlockNeuralAutoregressiveNN(input_dim, hidden_factors)
+def _make_bnaf_args(input_dim, hidden_factors, activation):
+    arn_init, arn = BlockNeuralAutoregressiveNN(
+        input_dim,
+        hidden_factors,
+        activation=activation,
+    )
     _, rng_key_perm = random.split(random.PRNGKey(0))
     _, init_params = arn_init(random.PRNGKey(0), (input_dim,))
     return (partial(arn, init_params),)
@@ -46,10 +51,24 @@ def _make_bnaf_args(input_dim, hidden_factors):
     [
         (InverseAutoregressiveTransform, _make_iaf_args(5, hidden_dims=[10]), 5),
         (InverseAutoregressiveTransform, _make_iaf_args(7, hidden_dims=[8, 9]), 7),
-        (BlockNeuralAutoregressiveTransform, _make_bnaf_args(7, hidden_factors=[4]), 7),
         (
             BlockNeuralAutoregressiveTransform,
-            _make_bnaf_args(7, hidden_factors=[2, 3]),
+            _make_bnaf_args(7, hidden_factors=[4], activation=LeakyTanh()),
+            7,
+        ),
+        (
+            BlockNeuralAutoregressiveTransform,
+            _make_bnaf_args(7, hidden_factors=[2, 3], activation=LeakyTanh()),
+            7,
+        ),
+        (
+            BlockNeuralAutoregressiveTransform,
+            _make_bnaf_args(7, hidden_factors=[4], activation=Tanh()),
+            7,
+        ),
+        (
+            BlockNeuralAutoregressiveTransform,
+            _make_bnaf_args(7, hidden_factors=[2, 3], activation=Tanh()),
             7,
         ),
     ],

--- a/test/test_flows.py
+++ b/test/test_flows.py
@@ -9,14 +9,17 @@ import pytest
 
 from jax import jacfwd, random
 from jax.example_libraries import stax
+import jax.numpy as jnp
+import jax.random as jr
 
+from numpyro.distributions import Normal, TransformedDistribution
 from numpyro.distributions.flows import (
     BlockNeuralAutoregressiveTransform,
     InverseAutoregressiveTransform,
 )
 from numpyro.distributions.util import matrix_to_tril_vec
 from numpyro.nn import AutoregressiveNN, BlockNeuralAutoregressiveNN
-from numpyro.nn.block_neural_arn import Tanh, LeakyTanh
+from numpyro.nn.block_neural_arn import LeakyTanh, Tanh
 
 
 def _make_iaf_args(input_dim, hidden_dims):
@@ -110,3 +113,21 @@ def test_flows(flow_class, flow_args, input_dim, batch_shape):
 
         assert np.sum(np.abs(np.triu(jac, 1))) == 0.00
         assert np.all(np.abs(matrix_to_tril_vec(jac)) > 0)
+
+
+def test_bnaf_normalization():
+    dim = (1,)
+    x = jnp.linspace(-1000, 1000, 5000)[:, None]
+
+    init_fn, apply_fn = BlockNeuralAutoregressiveNN(dim[0], activation=LeakyTanh(0.1))
+    params = init_fn(jr.PRNGKey(0), (1,))[1]
+    arn = partial(apply_fn, params)
+    bnaf = BlockNeuralAutoregressiveTransform(arn)
+    dist = TransformedDistribution(Normal(jnp.zeros(dim), 0.5), bnaf.inv)
+    probs = jnp.exp(dist.log_prob(x))
+    probs, x = jnp.squeeze(probs), jnp.squeeze(x)
+
+    # Rough integral
+    integral = jnp.trapezoid(probs, x)
+    assert integral > 0.9
+    assert integral < 1.1


### PR DESCRIPTION
This fixes https://github.com/pyro-ppl/numpyro/issues/1655 by changing BNAF activation to $y=\text{tanh}(x) + cx$, by default (with c=0.01). This ensures the transform maps from real->real, which e.g. 

1) Means ``BlockNeuralAutoregressiveTransform`` will have the correct codomain (currently set as ``real_vector``)
2) Unbounded distributions transformed using the transform will remain unbounded
3) Transforming a distribution with the inverse transformation will now lead to properly normalised densities

Let me know if you think there are any problems with this solution.
