### PR TITLE
Hm/all deterministic

### DIFF
--- a/numpyro/diagnostics.py
+++ b/numpyro/diagnostics.py
@@ -257,6 +257,8 @@ def summary(
 
     summary_dict = {}
     for name, value in samples.items():
+        if len(value) == 0:
+            continue
         value = device_get(value)
         value_flat = np.reshape(value, (-1,) + value.shape[2:])
         mean = value_flat.mean(axis=0)
@@ -307,6 +309,8 @@ def print_summary(
             "Param:{}".format(i): v for i, v in enumerate(jax.tree.flatten(samples)[0])
         }
     summary_dict = summary(samples, prob, group_by_chain=True)
+    if not summary_dict:
+        return
 
     row_names = {
         k: k + "[" + ",".join(map(lambda x: str(x - 1), v.shape[2:])) + "]"

--- a/test/infer/test_mcmc.py
+++ b/test/infer/test_mcmc.py
@@ -1208,3 +1208,29 @@ def test_extra_fields_include_unconstrained_samples():
     mcmc = MCMC(NUTS(model), num_warmup=10, num_samples=10)
     mcmc.run(random.PRNGKey(0), extra_fields=("z.x",))
     assert_allclose(mcmc.get_samples()["x"], jnp.exp(mcmc.get_extra_fields()["z.x"]))
+
+
+def test_all_deterministic():
+    def model1():
+        numpyro.deterministic("x", 1.0)
+
+    def model2():
+        numpyro.deterministic("x", jnp.array([1.0, 2.0]))
+
+    num_samples = 10
+    shapes = {model1: (), model2: (2,)}
+
+    for model, shape in shapes.items():
+        mcmc = MCMC(NUTS(model), num_warmup=10, num_samples=num_samples)
+        mcmc.run(random.PRNGKey(0))
+        assert mcmc.get_samples()["x"].shape == (num_samples,) + shape
+
+
+def test_empty_summary():
+    def model():
+        pass
+
+    mcmc = MCMC(NUTS(model), num_warmup=10, num_samples=10)
+    mcmc.run(random.PRNGKey(0))
+
+    mcmc.print_summary()


### PR DESCRIPTION
Current post-processing behaviour skips models with only deterministic variables. Applying this change will return consistent samples regardless of whether `sample` sites are present. Fixes #1911 