### PR TITLE
Mark haiku and flax dropout tests as `xfail`.

### DIFF
--- a/test/contrib/test_module.py
+++ b/test/contrib/test_module.py
@@ -224,6 +224,7 @@ def test_random_module_mcmc(backend, init, callable_prior):
     )
 
 
+@pytest.mark.xfail(reason="fails due to upgrade from jax 0.4.35 to 0.4.36")
 @pytest.mark.parametrize("dropout", [True, False])
 @pytest.mark.parametrize("batchnorm", [True, False])
 def test_haiku_state_dropout_smoke(dropout, batchnorm):
@@ -263,6 +264,7 @@ def test_haiku_state_dropout_smoke(dropout, batchnorm):
     svi.run(random.PRNGKey(100), 10)
 
 
+@pytest.mark.xfail(reason="fails due to upgrade from jax 0.4.35 to 0.4.36")
 @pytest.mark.parametrize("dropout", [True, False])
 @pytest.mark.parametrize("batchnorm", [True, False])
 def test_flax_state_dropout_smoke(dropout, batchnorm):


### PR DESCRIPTION
As discussed in #1932.