### PR TITLE
Make `Delta.log_prob` jit-able on metal and raise explicit error for `Delta` sampling site during initialization.

### DIFF
--- a/numpyro/distributions/distribution.py
+++ b/numpyro/distributions/distribution.py
@@ -1250,7 +1250,7 @@ class Delta(Distribution):
 
     @validate_sample
     def log_prob(self, value):
-        log_prob = jnp.log(value == self.v)
+        log_prob = jnp.where(value == self.v, 0, -jnp.inf)
         log_prob = sum_rightmost(log_prob, len(self.event_shape))
         return log_prob + self.log_density
 


### PR DESCRIPTION
Two `Delta` distribution related changes.

1. The current implementation uses `jnp.log(value == self.v)`, where `self.v` is the value of the `Delta` distribution. This is not jit-able on metal (cf. jax-ml/jax#25935). The updated implementation uses `jnp.where(value == self.v, 0, -jnp.inf)` which is equivalent but jit-able.
2. `Delta` sampling sites lead to a non-specific error message `RuntimeError: Cannot find valid initial parameters. Please check your model again.`. This change adds a line to check for unobserved `Delta` sites in a model and raises a more explicit error.