### PR TITLE
Fetch `rng_key` using `prng_key` message in block handler.

### DIFF
--- a/numpyro/contrib/control_flow/scan.py
+++ b/numpyro/contrib/control_flow/scan.py
@@ -199,7 +199,9 @@ def scan_enum(
         return (i + 1, rng_key, new_carry), (PytreeTrace(trace), y)
 
     with (
-        handlers.block(hide_fn=lambda site: not site["name"].startswith("_PREV_")),
+        handlers.block(
+            hide_fn=lambda site: not site.get("name", "nameless").startswith("_PREV_")
+        ),
         enum(first_available_dim=first_available_dim),
     ):
         wrapped_carry = (0, rng_key, init)

--- a/numpyro/infer/autoguide.py
+++ b/numpyro/infer/autoguide.py
@@ -227,7 +227,7 @@ class AutoGuideList(AutoGuide):
         guide = AutoGuideList(my_model)
         guide.append(
             AutoNormal(
-                numpyro.handlers.block(numpyro.handlers.seed(model, rng_seed=0), hide=["coefs"])
+                numpyro.handlers.block(model, hide=["coefs"])
             )
         )
         guide.append(

--- a/numpyro/infer/autoguide.py
+++ b/numpyro/infer/autoguide.py
@@ -232,7 +232,7 @@ class AutoGuideList(AutoGuide):
         )
         guide.append(
             AutoDelta(
-                numpyro.handlers.block(numpyro.handlers.seed(model, rng_seed=1), expose=["coefs"])
+                numpyro.handlers.block(model, expose=["coefs"])
             )
         )
         svi = SVI(model, guide, optim, Trace_ELBO())
@@ -1403,7 +1403,7 @@ class AutoSemiDAIS(AutoGuide):
         self._local_plate = (plate_name, plate_full_size, plate_subsample_size)
 
         if self.global_guide is not None:
-            with handlers.block(), handlers.seed(rng_seed=0):
+            with handlers.block():
                 local_args = (self.global_guide.model(*args, **kwargs),)
                 local_kwargs = {}
         else:
@@ -1411,11 +1411,11 @@ class AutoSemiDAIS(AutoGuide):
             local_kwargs = kwargs.copy()
 
         if self.local_guide is not None:
-            with handlers.block(), handlers.trace() as tr, handlers.seed(rng_seed=0):
+            with handlers.block(), handlers.trace() as tr:
                 self.local_guide(*local_args, **local_kwargs)
             self.prototype_local_guide_trace = tr
 
-        with handlers.block(), handlers.trace() as tr, handlers.seed(rng_seed=0):
+        with handlers.block(), handlers.trace() as tr:
             self.local_model(*local_args, **local_kwargs)
         self.prototype_local_model_trace = tr
 
@@ -1462,12 +1462,7 @@ class AutoSemiDAIS(AutoGuide):
 
         if self.global_guide is not None:
             global_latents = self.global_guide(*args, **kwargs)
-            rng_key = numpyro.prng_key()
-            with (
-                handlers.block(),
-                handlers.seed(rng_seed=rng_key),
-                handlers.substitute(data=global_latents),
-            ):
+            with handlers.block(), handlers.substitute(data=global_latents):
                 global_outputs = self.global_guide.model(*args, **kwargs)
             local_args = (global_outputs,)
             local_kwargs = {}
@@ -1575,12 +1570,10 @@ class AutoSemiDAIS(AutoGuide):
 
             local_kwargs["_subsample_idx"] = {plate_name: idx}
             if self.local_guide is not None:
-                key = numpyro.prng_key()
                 subsample_guide = partial(_subsample_model, self.local_guide)
                 with (
                     handlers.block(),
                     handlers.trace() as tr,
-                    handlers.seed(rng_seed=key),
                     handlers.substitute(data=local_guide_params),
                 ):
                     with warnings.catch_warnings():

--- a/test/infer/test_autoguide.py
+++ b/test/infer/test_autoguide.py
@@ -1068,13 +1068,7 @@ def test_autoguidelist(auto_classes, Elbo):
             ValueError,
             match="AutoDAIS, AutoSemiDAIS, and AutoSurrogateLikelihoodDAIS are not supported.",
         ):
-            guide.append(
-                auto_classes[1](
-                    numpyro.handlers.block(
-                        numpyro.handlers.seed(model, rng_seed=1), hide=["a"]
-                    )
-                )
-            )
+            guide.append(auto_classes[1](numpyro.handlers.block(model, hide=["a"])))
         return
     if auto_classes[1] == AutoSemiDAIS:
         with pytest.raises(
@@ -1083,9 +1077,7 @@ def test_autoguidelist(auto_classes, Elbo):
         ):
             guide.append(
                 auto_classes[1](
-                    numpyro.handlers.block(
-                        numpyro.handlers.seed(model, rng_seed=1), hide=["a"]
-                    ),
+                    numpyro.handlers.block(model, hide=["a"]),
                     local_model=None,
                     global_guide=None,
                 )
@@ -1098,19 +1090,13 @@ def test_autoguidelist(auto_classes, Elbo):
         ):
             guide.append(
                 auto_classes[1](
-                    numpyro.handlers.block(
-                        numpyro.handlers.seed(model, rng_seed=1), hide=["a"]
-                    ),
+                    numpyro.handlers.block(model, hide=["a"]),
                     surrogate_model=None,
                 )
             )
         return
 
-    guide.append(
-        auto_classes[1](
-            numpyro.handlers.block(numpyro.handlers.seed(model, rng_seed=1), hide=["a"])
-        )
-    )
+    guide.append(auto_classes[1](numpyro.handlers.block(model, hide=["a"])))
 
     optimiser = numpyro.optim.Adam(step_size=0.1)
     svi = SVI(model, guide, optimiser, Elbo())
@@ -1195,7 +1181,7 @@ def test_autoguidelist_sample_posterior_with_sample_shape(
         numpyro.deterministic("x2", x**2)
 
     guide = AutoGuideList(model)
-    blocked_model = handlers.block(handlers.seed(model, 7), hide=["x2"])
+    blocked_model = handlers.block(model, hide=["x2"])
 
     # AutoGuideList does not support AutoDAIS, AutoSemiDAIS, or AutoSurrogateLikelihoodDAIS
     if auto_class == AutoDAIS:

--- a/test/infer/test_autoguide.py
+++ b/test/infer/test_autoguide.py
@@ -1055,13 +1055,7 @@ def test_autoguidelist(auto_classes, Elbo):
     y = a + x @ b + sigma * random.normal(random.PRNGKey(1), (N, 1))
 
     guide = AutoGuideList(model)
-    guide.append(
-        auto_classes[0](
-            numpyro.handlers.block(
-                numpyro.handlers.seed(model, rng_seed=0), expose=["a"]
-            )
-        )
-    )
+    guide.append(auto_classes[0](numpyro.handlers.block(model, expose=["a"])))
     # AutoGuideList does not support AutoDAIS, AutoSemiDAIS, or AutoSurrogateLikelihoodDAIS
     if auto_classes[1] == AutoDAIS:
         with pytest.raises(

--- a/test/test_handlers.py
+++ b/test/test_handlers.py
@@ -625,13 +625,7 @@ def test_block_expose():
         ({"expose_types": ["prng_key"]}, set()),
         ({"hide": ["n"]}, {"x", "y", "z", "cluster", "a", "b"}),
         ({"hide": ["cluster", "b"]}, {"x", "y", "z", "n", "a"}),
-        pytest.param(
-            {"expose": ["x", "z"]},
-            {"x", "z"},
-            marks=pytest.mark.xfail(
-                reason="Exposing by name blocks prng_key messages."
-            ),
-        ),
+        ({"expose": ["x", "z"]}, {"x", "z"}),
     ],
 )
 def test_block_seed(block_config: dict, expected_sites: set) -> None:

--- a/test/test_handlers.py
+++ b/test/test_handlers.py
@@ -16,6 +16,7 @@ except ImportError:
 
 import numpyro
 from numpyro import handlers
+from numpyro.contrib import control_flow
 import numpyro.distributions as dist
 from numpyro.distributions import constraints
 from numpyro.infer import MCMC, NUTS, SVI, Trace_ELBO
@@ -615,6 +616,61 @@ def test_block_expose():
                 sigma = numpyro.param("sigma", 1)
                 numpyro.sample("x", dist.Normal(mu, sigma))
     assert "x" in trace and "mu" not in trace and "sigma" in trace
+
+
+@pytest.mark.parametrize(
+    "block_config, expected_sites",
+    [
+        ({"hide": ["y"]}, {"x", "z", "n", "cluster", "a", "b"}),
+        ({"expose_types": ["prng_key"]}, set()),
+        ({"hide": ["n"]}, {"x", "y", "z", "cluster", "a", "b"}),
+        ({"hide": ["cluster", "b"]}, {"x", "y", "z", "n", "a"}),
+        pytest.param(
+            {"expose": ["x", "z"]},
+            {"x", "z"},
+            marks=pytest.mark.xfail(
+                reason="Exposing by name blocks prng_key messages."
+            ),
+        ),
+    ],
+)
+def test_block_seed(block_config: dict, expected_sites: set) -> None:
+    def fn():
+        sample = {}
+        sample["x"] = numpyro.sample("x", dist.Normal())
+        sample["y"] = numpyro.sample("y", dist.Normal(sample["x"]))
+        with numpyro.plate("n", 10, subsample_size=7) as sample["idx"]:
+            sample["z"] = numpyro.sample("z", dist.Normal(sample["y"]))
+
+        def true_fun(_):
+            a = numpyro.sample("a", dist.Normal(4.0))
+            b = numpyro.deterministic("b", a - 2.0)
+            return a, b
+
+        def false_fun(_):
+            a = numpyro.sample("a", dist.Normal(0.0))
+            b = numpyro.deterministic("b", a)
+            return a, b
+
+        sample["cluster"] = numpyro.sample("cluster", dist.Normal())
+        sample["a"], sample["b"] = control_flow.cond(
+            sample["cluster"] > 0, true_fun, false_fun, None
+        )
+        return sample
+
+    blocked_seeded = handlers.block(handlers.seed(fn, rng_seed=17), **block_config)
+    with handlers.trace() as trace1:
+        sample1 = blocked_seeded()
+    assert set(trace1) == expected_sites
+
+    seeded_blocked = handlers.seed(handlers.block(fn, **block_config), rng_seed=17)
+    with handlers.trace() as trace2:
+        sample2 = seeded_blocked()
+    assert set(trace2) == expected_sites
+
+    # Verify that the sample values are identical.
+    for key, value in sample1.items():
+        assert jnp.allclose(value, sample2[key])
 
 
 def test_scope():


### PR DESCRIPTION
This PR seeks to address #1657 by fetching a `rng_key` after setting `msg["stop"] = True` in the block handler. This approach ensures that the values obtained from `sample` statements are always the same as if no `block` had been added to the stack.

We can simplify a number of `block(seed(model, rng_seed=dummy_seed), ...)` to `block(model, ...)` statements for blocked auto guides because the `rng_key`s now propagate.

Caveat: This currently only works for `block(hide=...)` because `block(expose=...)` blocks everything but the specified site, including `prng_key` messages. Not sure this is the *right* solution, but maybe a starting point.

# Illustration

```python
import numpyro
from numpyro.handlers import block, seed
import subprocess
import traceback


print("commit hash", subprocess.check_output(["git", "rev-parse", "HEAD"], text=True))


def model(prefix):
    try:
        samples = (
            numpyro.sample("x", numpyro.distributions.Normal(0, 1)),
            numpyro.sample("y", numpyro.distributions.Normal(0, 1)),
            numpyro.sample("z", numpyro.distributions.Normal(0, 1)),
        )
        print(f"{prefix}:\n{', '.join(f'{x:.2f}' for x in samples)}")
    except Exception:
        print(f"{prefix}: ERROR\n{traceback.format_exc()}")
    print()


# This always works.
with seed(rng_seed=0):
    model("seed 0")

# Re-seeding using the parent `seed` handler leads to different samples because
# `numpyro.prng_key` is executed at the time of handler construction instead of
# during model execution.
with seed(rng_seed=0), block(hide=["y"]), seed(rng_seed=numpyro.prng_key()):
    model("seed 0, block y, seed with `prng_key`")

# This fails on `master`.
with seed(rng_seed=0), block(hide=["y"]):
    model("seed 0, block y")
```

## Results on `master` Branch

```
commit hash 4704656886185fe3ba2df2f25af5910b5441255e

seed 0:
-1.25, -0.59, 0.49

seed 0, block y, seed with `prng_key`:
1.28, 2.13, -0.44

seed 0, block y: ERROR
Traceback (most recent call last):
  File "/Users/till/git/numpyro/playground/issue_1657.py", line 14, in model
    numpyro.sample("y", numpyro.distributions.Normal(0, 1)),
  File "/Users/till/git/numpyro/numpyro/primitives.py", line 250, in sample
    msg = apply_stack(initial_msg)
  File "/Users/till/git/numpyro/numpyro/primitives.py", line 61, in apply_stack
    default_process_message(msg)
  File "/Users/till/git/numpyro/numpyro/primitives.py", line 32, in default_process_message
    msg["value"], msg["intermediates"] = msg["fn"](
  File "/Users/till/git/numpyro/numpyro/distributions/distribution.py", line 393, in __call__
    return self.sample_with_intermediates(key, *args, **kwargs)
  File "/Users/till/git/numpyro/numpyro/distributions/distribution.py", line 351, in sample_with_intermediates
    return self.sample(key, sample_shape=sample_shape), []
  File "/Users/till/git/numpyro/numpyro/distributions/continuous.py", line 2190, in sample
    assert is_prng_key(key)
AssertionError
```

## Results on `seed-block` Branch

```
commit hash 102e08e6a6a4d24bc1e15fd7179ab07827173bf9

seed 0:
-1.25, -0.59, 0.49

seed 0, block y, seed with `prng_key`:
1.28, 2.13, -0.44

seed 0, block y:
-1.25, -0.59, 0.49
```