### PR TITLE
Add `ComplexTransform` and update `biject_to` registry.

### DIFF
--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -910,6 +910,14 @@ CholeskyTransform
     :show-inheritance:
     :member-order: bysource
 
+ComplexTransform
+^^^^^^^^^^^^^^^^
+.. autoclass:: numpyro.distributions.transforms.ComplexTransform
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :member-order: bysource
+
 ComposeTransform
 ^^^^^^^^^^^^^^^^
 .. autoclass:: numpyro.distributions.transforms.ComposeTransform

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -21,6 +21,7 @@ from numpyro.distributions.transforms import (
     AbsTransform,
     AffineTransform,
     CholeskyTransform,
+    ComplexTransform,
     ComposeTransform,
     CorrCholeskyTransform,
     CorrMatrixCholeskyTransform,
@@ -105,6 +106,7 @@ TRANSFORMS = {
     # unparametrized transforms
     "abs": T(AbsTransform, (), dict()),
     "cholesky": T(CholeskyTransform, (), dict()),
+    "complex": T(ComplexTransform, (), dict()),
     "corr_chol": T(CorrCholeskyTransform, (), dict()),
     "corr_matrix_chol": T(CorrMatrixCholeskyTransform, (), dict()),
     "exp": T(ExpTransform, (), dict()),
@@ -270,6 +272,7 @@ def test_real_fast_fourier_transform(input_shape, shape, ndims):
     [
         (AffineTransform(3, 2.5), ()),
         (CholeskyTransform(), (10,)),
+        (ComplexTransform(), (2,)),
         (ComposeTransform([SoftplusTransform(), SigmoidTransform()]), ()),
         (CorrCholeskyTransform(), (15,)),
         (CorrMatrixCholeskyTransform(), (15,)),
@@ -361,7 +364,7 @@ def test_batched_recursive_linear_transform():
     "constraint, shape",
     [
         (constraints.circular, (3,)),
-        (constraints.complex, (3,)),
+        (constraints.complex, (3, 2)),
         (constraints.corr_cholesky, (10, 10)),
         (constraints.corr_matrix, (15,)),
         (constraints.greater_than(3), ()),


### PR DESCRIPTION
I added a `complex` constraint in #1762 with `biject_to` using the identity function as shown below. This makes inference challenging in practice because we end up with a mix of real and complex parameters.

https://github.com/pyro-ppl/numpyro/blob/93e11c2e43a99a450b2d857ff1f0a84ac1057f9e/numpyro/distributions/transforms.py#L1650-L1654

This PR adds a `ComplexTransform` which turns a real tensor of shape `(..., 2)` into a complex tensor of shape `(...)`. It also updates the `biject_to` registry such that complex variables can be integrated into models (e.g., for FFTs) while ensuring that the unconstrained space is real.