### PR TITLE
Do not create plates for observed sites in `AutoGuide`.

### DIFF
--- a/numpyro/infer/autoguide.py
+++ b/numpyro/infer/autoguide.py
@@ -179,6 +179,10 @@ class AutoGuide(ABC):
                     # raise support errors early for discrete sites
                     with helpful_support_errors(site):
                         biject_to(site["fn"].support)
+                # Do not create plates for observed sites because they may be subsampled
+                # with a different size during prototype setup and training.
+                if site["is_observed"]:
+                    continue
                 for frame in site["cond_indep_stack"]:
                     if frame.name in self._prototype_frames:
                         assert frame == self._prototype_frames[frame.name], (


### PR DESCRIPTION
This PR updates `_setup_prototype` to only record plates for unobserved sites. I *think* this leaves the intended behavior unchanged because we only sample unobserved sites in the guide. Because plates for observed sites are not created, the subsample size can vary across different invocations of `svi.update` or between `svi.init` and `svi.update` (cf. #1739).