### PR TITLE
Remove cached `plates` from `AutoGuide`.

### DIFF
--- a/numpyro/infer/autoguide.py
+++ b/numpyro/infer/autoguide.py
@@ -97,9 +97,9 @@ class AutoGuide(ABC):
         self._prototype_frames = {}
         self._prototype_frame_full_sizes = {}
 
-    def _create_plates(self, *args, **kwargs):
+    def _create_plates(self, *args, **kwargs) -> dict:
         if self.create_plates is None:
-            self.plates = {}
+            plates = {}
         else:
             plates = self.create_plates(*args, **kwargs)
             if isinstance(plates, numpyro.plate):
@@ -107,14 +107,14 @@ class AutoGuide(ABC):
             assert all(isinstance(p, numpyro.plate) for p in plates), (
                 "create_plates() returned a non-plate"
             )
-            self.plates = {p.name: p for p in plates}
+            plates = {p.name: p for p in plates}
         for name, frame in sorted(self._prototype_frames.items()):
-            if name not in self.plates:
+            if name not in plates:
                 full_size = self._prototype_frame_full_sizes[name]
-                self.plates[name] = numpyro.plate(
+                plates[name] = numpyro.plate(
                     name, full_size, dim=frame.dim, subsample_size=frame.size
                 )
-        return self.plates
+        return plates
 
     def __getstate__(self):
         state = self.__dict__.copy()


### PR DESCRIPTION
The `plate` primitive may leak tracers through its `_indices` attribute if created outside a pure function. The `AutoGuide` implementation caches plates in a `plates` attribute which results in a tracer leak when the guide is called (see example below).

This PR removes the caching such that calls to the guide are pure.


```python
>>> import jax
>>> import numpyro


>>> def model():
...     with numpyro.plate("n", 2):
...         numpyro.sample("x", numpyro.distributions.Normal())

>>> guide = numpyro.infer.autoguide.AutoDelta(model)

>>> numpyro.handlers.seed(guide, 9)()
>>> guide.plates["n"]._indices
Array([0, 1], dtype=int32)

>>> jax.jit(lambda: numpyro.handlers.seed(guide, 9)())()
>>> guide.plates["n"]._indices
Traced<ShapedArray(int32[2])>with<DynamicJaxprTrace>
```