### PR TITLE
Make seed handler stateless by default

### DIFF
--- a/numpyro/handlers.py
+++ b/numpyro/handlers.py
@@ -800,6 +800,8 @@ class seed(Messenger):
        >>> assert x == y
     """
 
+    stateful = False
+
     def __init__(
         self,
         fn: Optional[Callable] = None,
@@ -834,6 +836,15 @@ class seed(Messenger):
         if self.rng_key is not None:
             self.rng_key, rng_key_sample = random.split(self.rng_key)
             msg["kwargs"]["rng_key"] = rng_key_sample
+
+    def __call__(self, *args, **kwargs):
+        if self.fn is not None and not self.stateful:
+            cloned_seeded_fn = seed(
+                self.fn, rng_seed=self.rng_key, hide_types=self.hide_types
+            )
+            cloned_seeded_fn.stateful = True
+            return cloned_seeded_fn.__call__(*args, **kwargs)
+        return super().__call__(*args, **kwargs)
 
 
 class substitute(Messenger):

--- a/test/test_handlers.py
+++ b/test/test_handlers.py
@@ -340,9 +340,12 @@ def model_subsample_2():
         model_subsample_2,
     ],
 )
-def test_plate(model):
+def test_trace_jit(model):
     trace = handlers.trace(handlers.seed(model, random.PRNGKey(1))).get_trace()
-    jit_trace = handlers.trace(jit(handlers.seed(model, random.PRNGKey(1)))).get_trace()
+    with jax.check_tracer_leaks(False):
+        jit_trace = handlers.trace(
+            jit(handlers.seed(model, random.PRNGKey(1)))
+        ).get_trace()
     assert "z" in trace
     for name, site in trace.items():
         if site["type"] == "sample":


### PR DESCRIPTION
This addresses some tracer leaks reported in https://github.com/pyro-ppl/numpyro/issues/1981

Test: `JAX_CHECK_TRACER_LEAKS=1 test/contrib/test_enum_elbo.py` passes after this change