### PR TITLE
Mark xfail for leaked tracer tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,28 @@ jobs:
     - name: Test x64
       run: |
         JAX_ENABLE_X64=1 pytest -vs test/test_distributions.py -k powerLaw
+    - name: Test tracer leak
+      if: matrix.python-version == '3.10'
+      env:
+        JAX_CHECK_TRACER_LEAKS: 1
+      run: |
+        pytest -vs test/contrib/einstein/test_steinvi.py::test_run_smoke -k ASVGD
+        pytest -vs test/contrib/stochastic_support/test_sdvi.py::test_elbos -k TraceEnum
+        pytest -vs test/contrib/test_enum_elbo.py
+        pytest -vs test/contrib/test_esc_proxies.py::test_haiku_compatiable
+        pytest -vs test/contrib/test_infer_discrete.py::test_scan_hmm_smoke
+        pytest -vs test/infer/test_autoguide.py::test_autosldais
+        pytest -vs test/infer/test_gradient.py
+        pytest -vs test/infer/test_hmc_gibbs.py
+        pytest -vs test/infer/test_mcmc.py::test_chain_inside_jit
+        pytest -vs test/infer/test_mcmc.py::test_chain_jit_args_smoke
+        pytest -vs test/infer/test_mcmc.py::test_reuse_mcmc_run
+        pytest -vs test/infer/test_mcmc.py::test_model_with_multiple_exec_paths
+        pytest -vs test/infer/test_svi.py::test_mutable_state
+        pytest -vs test/test_distributions.py::test_mean_var -k Gompertz
+        pytest -vs test/test_handlers.py::test_plate
+        pytest -vs test/test_pickle.py
+
     - name: Coveralls
       if: github.repository == 'pyro-ppl/numpyro' && matrix.python-version == '3.10'
       uses: coverallsapp/github-action@v2

--- a/test/contrib/einstein/test_steinvi.py
+++ b/test/contrib/einstein/test_steinvi.py
@@ -3,6 +3,7 @@
 
 from collections import namedtuple
 from functools import partial
+import os
 import string
 
 import numpy as np
@@ -119,6 +120,9 @@ def regression():
 @pytest.mark.parametrize("kernel", KERNELS)
 @pytest.mark.parametrize("problem", (uniform_normal, regression))
 @pytest.mark.parametrize("method", ("ASVGD", "SVGD", "SteinVI"))
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
+)
 def test_run_smoke(kernel, problem, method):
     true_coefs, data, model = problem()
     if method == "ASVGD":

--- a/test/contrib/stochastic_support/test_sdvi.py
+++ b/test/contrib/stochastic_support/test_sdvi.py
@@ -1,6 +1,8 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+
 import pytest
 
 from jax import random
@@ -91,6 +93,9 @@ def test_autoguides(auto_class):
     ],
 )
 @pytest.mark.parametrize("num_particles", [1, 4])
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
+)
 def test_elbos(elbo_class, num_particles):
     dim = 2
 

--- a/test/contrib/test_enum_elbo.py
+++ b/test/contrib/test_enum_elbo.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+import os
 
 import numpy as np
 import pytest
@@ -42,6 +43,9 @@ def xfail_param(*args, **kwargs):
 
 @pytest.mark.parametrize("inner_dim", [2])
 @pytest.mark.parametrize("outer_dim", [2])
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
+)
 def test_elbo_plate_plate(outer_dim, inner_dim):
     q = jnp.array([0.75, 0.25])
     p = 0.2693204236205713  # for which kl(Categorical(q), Categorical(p)) = 0.5
@@ -91,6 +95,9 @@ def test_elbo_plate_plate(outer_dim, inner_dim):
 
 
 @pytest.mark.parametrize("scale", [1, 10])
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
+)
 def test_elbo_enumerate_1(scale):
     params = {}
     params["guide_probs_x"] = jnp.array([0.1, 0.9])
@@ -138,6 +145,9 @@ def test_elbo_enumerate_1(scale):
 
 
 @pytest.mark.parametrize("scale", [1, 10])
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
+)
 def test_elbo_enumerate_2(scale):
     params = {}
     params["guide_probs_x"] = jnp.array([0.1, 0.9])
@@ -190,6 +200,9 @@ def test_elbo_enumerate_2(scale):
 
 
 @pytest.mark.parametrize("scale", [1, 10])
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
+)
 def test_elbo_enumerate_3(scale):
     params = {}
     params["guide_probs_x"] = jnp.array([0.1, 0.9])
@@ -243,6 +256,9 @@ def test_elbo_enumerate_3(scale):
 @pytest.mark.parametrize("scale", [1, 10])
 @pytest.mark.parametrize(
     "num_samples,num_masked", [(2, 2), (3, 2)], ids=["batch", "masked"]
+)
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
 )
 def test_elbo_enumerate_plate_1(num_samples, num_masked, scale):
     #              +---------+
@@ -314,6 +330,9 @@ def test_elbo_enumerate_plate_1(num_samples, num_masked, scale):
 @pytest.mark.parametrize("scale", [1, 10])
 @pytest.mark.parametrize(
     "num_samples,num_masked", [(2, 2), (3, 2)], ids=["batch", "masked"]
+)
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
 )
 def test_elbo_enumerate_plate_2(num_samples, num_masked, scale):
     #      +-----------------+
@@ -393,6 +412,9 @@ def test_elbo_enumerate_plate_2(num_samples, num_masked, scale):
 @pytest.mark.parametrize("scale", [1, 10])
 @pytest.mark.parametrize(
     "num_samples,num_masked", [(2, 2), (3, 2)], ids=["batch", "masked"]
+)
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
 )
 def test_elbo_enumerate_plate_3(num_samples, num_masked, scale):
     #  +-----------------------+
@@ -486,6 +508,9 @@ def test_elbo_enumerate_plate_3(num_samples, num_masked, scale):
 @pytest.mark.parametrize(
     "outer_obs,inner_obs", [(False, True), (True, False), (True, True)]
 )
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
+)
 def test_elbo_enumerate_plate_4(outer_obs, inner_obs, scale):
     #    a ---> outer_obs
     #      \
@@ -569,6 +594,9 @@ def test_elbo_enumerate_plate_4(outer_obs, inner_obs, scale):
     assert_equal(auto_grad, hand_grad, prec=1e-5)
 
 
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
+)
 def test_elbo_enumerate_plate_5():
     #        Guide   Model
     #                  a
@@ -657,6 +685,9 @@ def test_elbo_enumerate_plate_5():
 
 
 @pytest.mark.parametrize("enumerate1", ["parallel", "sequential"])
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
+)
 def test_elbo_enumerate_plate_6(enumerate1):
     #     Guide           Model
     #           +-------+
@@ -735,6 +766,9 @@ def test_elbo_enumerate_plate_6(enumerate1):
 
 
 @pytest.mark.parametrize("scale", [1, 10])
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
+)
 def test_elbo_enumerate_plate_7(scale):
     #  Guide    Model
     #    a -----> b
@@ -869,6 +903,9 @@ def test_elbo_enumerate_plate_7(scale):
 
 
 @pytest.mark.parametrize("scale", [1, 10])
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
+)
 def test_elbo_enumerate_plates_1(scale):
     #  +-----------------+
     #  | a ----> b   M=2 |
@@ -950,6 +987,9 @@ def test_elbo_enumerate_plates_1(scale):
 
 
 @pytest.mark.parametrize("scale", [1, 10])
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
+)
 def test_elbo_enumerate_plates_2(scale):
     #  +---------+       +---------+
     #  |     b <---- a ----> c     |
@@ -1019,6 +1059,9 @@ def test_elbo_enumerate_plates_2(scale):
 
 
 @pytest.mark.parametrize("scale", [1, 10])
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
+)
 def test_elbo_enumerate_plates_3(scale):
     #      +--------------------+
     #      |  +----------+      |
@@ -1081,6 +1124,9 @@ def test_elbo_enumerate_plates_3(scale):
 
 
 @pytest.mark.parametrize("scale", [1, 10])
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
+)
 def test_elbo_enumerate_plates_4(scale):
     #      +--------------------+
     #      |       +----------+ |
@@ -1151,6 +1197,9 @@ def test_elbo_enumerate_plates_4(scale):
 
 
 @pytest.mark.parametrize("scale", [1, 10])
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
+)
 def test_elbo_enumerate_plates_5(scale):
     #     a
     #     | \
@@ -1226,6 +1275,9 @@ def test_elbo_enumerate_plates_5(scale):
 
 
 @pytest.mark.parametrize("scale", [1, 10])
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
+)
 def test_elbo_enumerate_plates_6(scale):
     #         +----------+
     #         |      M=2 |
@@ -1400,6 +1452,9 @@ def test_elbo_enumerate_plates_6(scale):
 
 
 @pytest.mark.parametrize("scale", [1, 10])
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
+)
 def test_elbo_enumerate_plates_7(scale):
     #         +-------------+
     #         |         N=2 |
@@ -1593,6 +1648,9 @@ def test_elbo_enumerate_plates_7(scale):
 @pytest.mark.parametrize("model_scale", [1])
 @pytest.mark.parametrize("outer_vectorized", [False, True])
 @pytest.mark.parametrize("inner_vectorized", [False, True])
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
+)
 def test_elbo_enumerate_plates_8(
     model_scale, guide_scale, inner_vectorized, outer_vectorized
 ):
@@ -1770,6 +1828,9 @@ def test_elbo_enumerate_plates_8(
             assert_equal(actual_grad, expected_grad, prec=1e-4)
 
 
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
+)
 def test_elbo_enumerate_plate_9():
     #        Model   Guide
     #          a
@@ -1857,6 +1918,9 @@ def test_elbo_enumerate_plate_9():
     assert_equal(expected_grad, actual_grad, prec=1e-5)
 
 
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
+)
 def test_elbo_enumerate_plate_10():
     # Model
     # a -> [ [ bij -> cij ] ]
@@ -1945,6 +2009,9 @@ def test_elbo_enumerate_plate_10():
     assert_equal(expected_grad, actual_grad, prec=1e-5)
 
 
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
+)
 def test_elbo_enumerate_plate_11():
     # Model
     # [ ai -> [ bij -> cij ] ]
@@ -2033,6 +2100,9 @@ def test_elbo_enumerate_plate_11():
     assert_equal(expected_grad, actual_grad, prec=1e-5)
 
 
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
+)
 def test_elbo_enumerate_plate_12():
     # Model
     # a -> [ bi -> [ cij -> dij ] ]
@@ -2141,6 +2211,9 @@ def test_elbo_enumerate_plate_12():
     assert_equal(expected_grad, actual_grad, prec=1e-5)
 
 
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
+)
 def test_elbo_enumerate_plate_13():
     # Model
     # a -> [ cj -> [ dij ] ]
@@ -2256,6 +2329,9 @@ def test_elbo_enumerate_plate_13():
 
 
 @pytest.mark.parametrize("scale", [1, 10])
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
+)
 def test_model_enum_subsample_1(scale):
     # Enumerate: a
     # Subsample: b
@@ -2323,6 +2399,9 @@ def test_model_enum_subsample_1(scale):
 
 
 @pytest.mark.parametrize("scale", [1, 10])
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
+)
 def test_model_enum_subsample_2(scale):
     # Enumerate: a
     # Subsample: b, c
@@ -2398,6 +2477,9 @@ def test_model_enum_subsample_2(scale):
 
 
 @pytest.mark.parametrize("scale", [1, 10])
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
+)
 def test_model_enum_subsample_3(scale):
     # Enumerate: a
     # Subsample: a, b, c
@@ -2472,6 +2554,9 @@ def test_model_enum_subsample_3(scale):
         assert_equal(actual_grads, expected_grads, prec=1e-5)
 
 
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
+)
 def test_guide_plate_contraction():
     def model(params):
         with pyro.plate("a_axis", size=2):

--- a/test/contrib/test_esc_proxies.py
+++ b/test/contrib/test_esc_proxies.py
@@ -1,6 +1,8 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+
 import pytest
 
 from jax import numpy as jnp, random
@@ -35,6 +37,9 @@ def test_block_update_partitioning(num_blocks):
     assert gibbs_state == new_gibbs_state
 
 
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
+)
 def test_haiku_compatiable():
     try:
         import haiku as hk  # noqa: F401

--- a/test/contrib/test_infer_discrete.py
+++ b/test/contrib/test_infer_discrete.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+import os
 
 import numpy as np
 from numpy.testing import assert_allclose
@@ -95,6 +96,9 @@ def test_hmm_smoke(length, temperature):
     ],
 )
 @pytest.mark.parametrize("temperature", [0, 1])
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
+)
 def test_scan_hmm_smoke(length, temperature):
     # This should match the example in the infer_discrete docstring.
     def hmm(data, hidden_dim=10):

--- a/test/infer/test_autoguide.py
+++ b/test/infer/test_autoguide.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from functools import partial
+import os
 
 from numpy.random import RandomState
 from numpy.testing import assert_allclose
@@ -918,6 +919,9 @@ def test_autosemidais_inadmissible_smoke():
         svi.run(random.PRNGKey(0), 10)
 
 
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
+)
 def test_autosldais(
     N=64, subsample_size=48, num_surrogate=32, D=3, num_steps=40000, num_samples=2000
 ):

--- a/test/infer/test_gradient.py
+++ b/test/infer/test_gradient.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+import os
 
 import numpy as np
 import pytest
@@ -102,6 +103,9 @@ params_2 = {
         (model_1, guide_1, params_1, jnp.array([-0.5, 2.0])),
         (model_2, guide_2, params_2, jnp.array([0, 1])),
     ],
+)
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
 )
 def test_gradient(model, guide, params, data):
     transform = dist.biject_to(dist.constraints.simplex)
@@ -304,6 +308,9 @@ def kl_model_7_z3(params):
         (kl_model_7_z3, set(["z3"]), True),
     ],
 )
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
+)
 def test_analytic_kl_1(model, kl_sites, valid_kl):
     @config_enumerate
     def guide(params):
@@ -367,6 +374,9 @@ def test_analytic_kl_1(model, kl_sites, valid_kl):
             assert_equal(actual_grads, expected_grads, prec=1e-5)
 
 
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
+)
 def test_analytic_kl_2():
     # Model with a mixture of enumerated, non-reparam, and reparam sites
     def model(params):
@@ -464,6 +474,9 @@ def test_analytic_kl_2():
     assert_equal(actual_grads, expected_grads, prec=0.005)
 
 
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
+)
 def test_analytic_kl_3():
     # Model with a mixture of enumerated, non-reparam, and reparam sites
     def model(params):
@@ -563,6 +576,9 @@ def test_analytic_kl_3():
 @pytest.mark.parametrize("scale2", [1, 10])
 @pytest.mark.parametrize("z1_dim", [2, 3])
 @pytest.mark.parametrize("z2_dim", [2, 3])
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
+)
 def test_analytic_kl_4(z1_dim, z2_dim, scale1, scale2):
     # Test handlers.scale and plate context manager for analytic kl
     @handlers.scale(scale=scale1)

--- a/test/infer/test_hmc_gibbs.py
+++ b/test/infer/test_hmc_gibbs.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from functools import partial
+import os
 
 import numpy as np
 from numpy.testing import assert_allclose
@@ -39,6 +40,9 @@ def _linear_regression_gibbs_fn(X, XX, XY, Y, rng_key, gibbs_sites, hmc_sites):
 
 
 @pytest.mark.parametrize("kernel_cls", [HMC, NUTS])
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
+)
 def test_linear_model_log_sigma(
     kernel_cls, N=100, P=50, sigma=0.11, num_warmup=500, num_samples=500
 ):
@@ -77,6 +81,9 @@ def test_linear_model_log_sigma(
 
 
 @pytest.mark.parametrize("kernel_cls", [HMC, NUTS])
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
+)
 def test_linear_model_sigma(
     kernel_cls, N=90, P=40, sigma=0.07, num_warmup=500, num_samples=500
 ):
@@ -113,6 +120,9 @@ def test_linear_model_sigma(
 
 
 @pytest.mark.parametrize("kernel_cls", [HMC, NUTS])
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
+)
 def test_gaussian_model(kernel_cls, D=2, num_warmup=5000, num_samples=5000):
     np.random.seed(0)
     cov = np.random.randn(4 * D * D).reshape((2 * D, 2 * D))
@@ -178,6 +188,9 @@ def test_gaussian_model(kernel_cls, D=2, num_warmup=5000, num_samples=5000):
 )
 @pytest.mark.parametrize("num_chains", [1, 2])
 @pytest.mark.filterwarnings("ignore:There are not enough devices:UserWarning")
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
+)
 def test_discrete_gibbs_multiple_sites_chain(kernel, inner_kernel, kwargs, num_chains):
     def model():
         numpyro.sample("x", dist.Bernoulli(0.7).expand([3]))
@@ -202,6 +215,9 @@ def test_discrete_gibbs_multiple_sites_chain(kernel, inner_kernel, kwargs, num_c
     "kernel, inner_kernel, kwargs",
     [(MixedHMC, HMC, {"num_discrete_updates": 6}), (DiscreteHMCGibbs, NUTS, {})],
 )
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
+)
 def test_discrete_gibbs_enum(kernel, inner_kernel, kwargs):
     def model():
         numpyro.sample("x", dist.Bernoulli(0.7), infer={"enumerate": "parallel"})
@@ -224,6 +240,9 @@ def test_discrete_gibbs_enum(kernel, inner_kernel, kwargs):
         (DiscreteHMCGibbs, NUTS, {"modified": False}),
     ],
 )
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
+)
 def test_discrete_gibbs_bernoulli(random_walk, kernel, inner_kernel, kwargs):
     def model():
         numpyro.sample("c", dist.Bernoulli(0.8))
@@ -235,6 +254,9 @@ def test_discrete_gibbs_bernoulli(random_walk, kernel, inner_kernel, kwargs):
     assert_allclose(jnp.mean(samples), 0.8, atol=0.05)
 
 
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
+)
 def test_improper_uniform():
     def model():
         numpyro.sample("c", dist.Bernoulli(0.8))
@@ -251,6 +273,9 @@ def test_improper_uniform():
 @pytest.mark.parametrize(
     "kernel, inner_kernel, kwargs",
     [(MixedHMC, HMC, {"num_discrete_updates": 20}), (DiscreteHMCGibbs, NUTS, {})],
+)
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
 )
 def test_discrete_gibbs_gmm_1d(modified, kernel, inner_kernel, kwargs):
     def model(probs, locs):
@@ -271,6 +296,9 @@ def test_discrete_gibbs_gmm_1d(modified, kernel, inner_kernel, kwargs):
     assert_allclose(jnp.var(samples["c"]), 1.03, atol=0.1)
 
 
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
+)
 def test_enum_subsample_smoke():
     def model(data):
         x = numpyro.sample("x", dist.Bernoulli(0.5), infer={"enumerate": "parallel"})
@@ -284,6 +312,9 @@ def test_enum_subsample_smoke():
     mcmc.run(random.PRNGKey(0), data)
 
 
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
+)
 def test_enum_subsample_error():
     def model(data):
         x = numpyro.sample("x", dist.Bernoulli(0.5), infer={"enumerate": "parallel"})
@@ -302,6 +333,9 @@ def test_enum_subsample_error():
 @pytest.mark.parametrize("num_block", [1, 2, 50])
 @pytest.mark.parametrize("subsample_size", [50, 150])
 @pytest.mark.parametrize("degree", [1, 2])
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
+)
 def test_hmcecs_normal_normal(kernel_cls, num_block, subsample_size, degree):
     true_loc = jnp.array([0.3, 0.1, 0.9])
     num_warmup, num_samples = 200, 200
@@ -332,6 +366,9 @@ def test_hmcecs_normal_normal(kernel_cls, num_block, subsample_size, degree):
 
 
 @pytest.mark.parametrize("subsample_size", [5, 10, 15])
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
+)
 def test_taylor_proxy_norm(subsample_size):
     data_key, tr_key, rng_key = random.split(random.PRNGKey(0), 3)
     ref_params = jnp.array([0.1, 0.5, -0.2])
@@ -405,6 +442,9 @@ def test_taylor_proxy_norm(subsample_size):
 
 @pytest.mark.filterwarnings("ignore::UserWarning")
 @pytest.mark.parametrize("kernel_cls", [HMC, NUTS])
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
+)
 def test_estimate_likelihood(kernel_cls):
     ref_params = jnp.array([0.1, 0.5, -0.2])
     sigma = 0.1
@@ -440,6 +480,9 @@ def test_estimate_likelihood(kernel_cls):
     assert jnp.var(jnp.exp(-pes - pes_full)) < 1.0
 
 
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
+)
 def test_hmcecs_multiple_plates():
     true_loc = jnp.array([0.3, 0.1, 0.9])
     num_warmup, num_samples = 2, 2
@@ -464,6 +507,9 @@ def test_hmcecs_multiple_plates():
     mcmc.run(random.PRNGKey(0), data)
 
 
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
+)
 def test_callable_chain_method():
     def model():
         x = numpyro.sample("x", dist.Normal(0.0, 2.0))

--- a/test/infer/test_mcmc.py
+++ b/test/infer/test_mcmc.py
@@ -607,6 +607,9 @@ def test_chain(use_init_params, chain_method):
 @pytest.mark.skipif(
     "CI" in os.environ, reason="Compiling time the whole sampling process is slow."
 )
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
+)
 def test_chain_inside_jit(kernel_cls, chain_method):
     # NB: this feature is useful for consensus MC.
     # Caution: compiling time will be slow (~ 90s)
@@ -662,6 +665,9 @@ def test_chain_inside_jit(kernel_cls, chain_method):
 @pytest.mark.parametrize("compile_args", [False, True])
 @pytest.mark.skipif(
     "CI" in os.environ, reason="Compiling time the whole sampling process is slow."
+)
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
 )
 def test_chain_jit_args_smoke(chain_method, compile_args):
     def model(data):
@@ -780,6 +786,9 @@ def test_functional_map(algo, map_fn):
 
 @pytest.mark.parametrize("jit_args", [False, True])
 @pytest.mark.parametrize("shape", [50, 100])
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
+)
 def test_reuse_mcmc_run(jit_args, shape):
     y1 = np.random.normal(3, 0.1, (100,))
     y2 = np.random.normal(-3, 0.1, (shape,))
@@ -800,6 +809,9 @@ def test_reuse_mcmc_run(jit_args, shape):
 
 
 @pytest.mark.parametrize("jit_args", [False, True])
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
+)
 def test_model_with_multiple_exec_paths(jit_args):
     def model(a=None, b=None, z=None):
         int_term = numpyro.sample("a", dist.Normal(0.0, 0.2))

--- a/test/infer/test_svi.py
+++ b/test/infer/test_svi.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from functools import partial
+import os
 
 import numpy as np
 from numpy.testing import assert_allclose
@@ -519,6 +520,9 @@ def test_elbo_by_site(loss_cls, sum_sites, num_particles, with_mutable):
 @pytest.mark.parametrize("stable_update", [True, False])
 @pytest.mark.parametrize("num_particles", [1, 10])
 @pytest.mark.parametrize("elbo", [Trace_ELBO, TraceMeanField_ELBO])
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
+)
 def test_mutable_state(stable_update, num_particles, elbo):
     def model():
         x = numpyro.sample("x", dist.Normal(-1, 1))

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -1881,6 +1881,9 @@ def test_log_prob_gradient(jax_dist, sp_dist, params):
 @pytest.mark.parametrize(
     "jax_dist, sp_dist, params", CONTINUOUS + DISCRETE + DIRECTIONAL
 )
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
+)
 def test_mean_var(jax_dist, sp_dist, params):
     if jax_dist is _ImproperWrapper:
         pytest.skip("Improper distribution does not has mean/var implemented")

--- a/test/test_handlers.py
+++ b/test/test_handlers.py
@@ -1,6 +1,8 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+
 import numpy as np
 from numpy.testing import assert_allclose, assert_raises
 import pytest
@@ -339,6 +341,9 @@ def model_subsample_2():
         model_subsample_1,
         model_subsample_2,
     ],
+)
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
 )
 def test_trace_jit(model):
     trace = handlers.trace(handlers.seed(model, random.PRNGKey(1))).get_trace()

--- a/test/test_pickle.py
+++ b/test/test_pickle.py
@@ -1,6 +1,7 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 import pickle
 
 import numpy as np
@@ -116,6 +117,9 @@ def test_pickle_hmc_enumeration(kernel):
 
 
 @pytest.mark.parametrize("kernel", [DiscreteHMCGibbs, MixedHMC])
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
+)
 def test_pickle_discrete_hmc(kernel):
     mcmc = MCMC(kernel(HMC(bernoulli_model)), num_warmup=10, num_samples=10)
     mcmc.run(random.PRNGKey(0))
@@ -125,6 +129,9 @@ def test_pickle_discrete_hmc(kernel):
     )
 
 
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
+)
 def test_pickle_hmcecs():
     mcmc = MCMC(HMCECS(NUTS(logistic_regression)), num_warmup=10, num_samples=10)
     mcmc.run(random.PRNGKey(0))
@@ -226,6 +233,9 @@ def bernoulli_regression(data):
         numpyro.sample("obs", dist.Bernoulli(f), obs=data)
 
 
+@pytest.mark.xfail(
+    os.getenv("JAX_CHECK_TRACER_LEAKS") == "1", reason="Expected tracer leak"
+)
 def test_beta_bernoulli():
     data = jnp.array([1.0] * 8 + [0.0] * 2)
 


### PR DESCRIPTION
This PR adds an entry in github action to track leaked tracer failing tests reported in https://github.com/pyro-ppl/numpyro/issues/1981. I found the behaviors under JAX_CHECK_TRACER_LEAKS is a bit different from the normal behaviors so just want to perform a subset of tests.