### PR TITLE
Unify constraint handling for `AutoContinuous`, `AutoDelta`, `AutoNormal`.

### DIFF
--- a/numpyro/infer/util.py
+++ b/numpyro/infer/util.py
@@ -668,12 +668,12 @@ def initialize_model(
         Defaults to True.
     :return: a namedtupe `ModelInfo` which contains the fields
         (`param_info`, `potential_fn`, `postprocess_fn`, `model_trace`), where
-        `param_info` is a namedtuple `ParamInfo` containing values from the prior
-        used to initiate MCMC, their corresponding potential energy, and their gradients;
-        `postprocess_fn` is a callable that uses inverse transforms
-        to convert unconstrained HMC samples to constrained values that
-        lie within the site's support, in addition to returning values
-        at `deterministic` sites in the model.
+        `param_info` is a namedtuple `ParamInfo` containing *unconstrained* values from
+        the prior used to initiate MCMC, their corresponding potential energy, and their
+        gradients; `postprocess_fn` is a callable that uses inverse transforms to
+        convert unconstrained HMC samples to constrained values that lie within the
+        site's support, in addition to returning values at `deterministic` sites in the
+        model.
     """
     model_kwargs = {} if model_kwargs is None else model_kwargs
     substituted_model = substitute(

--- a/test/infer/test_autoguide.py
+++ b/test/infer/test_autoguide.py
@@ -484,7 +484,7 @@ def test_module():
     lax.scan(lambda state, i: svi.update(state), svi_state, jnp.zeros(1000))
 
 
-@pytest.mark.parametrize("auto_class", [AutoNormal])
+@pytest.mark.parametrize("auto_class", [AutoNormal, AutoDelta])
 def test_subsample_guide(auto_class):
     # The model adapted from tutorial/source/easyguide.ipynb
     def model(batch, subsample, full_size):

--- a/test/infer/test_autoguide.py
+++ b/test/infer/test_autoguide.py
@@ -122,6 +122,14 @@ def test_beta_bernoulli(auto_class):
     predictive_samples = predictive(random.PRNGKey(1), None)
     assert predictive_samples["obs"].shape == (1000, N, 2)
 
+    # Check support of guide and model match.
+    model_trace = handlers.trace(handlers.seed(model, 0)).get_trace(data)
+    guide_trace = handlers.trace(handlers.seed(guide, 0)).get_trace(data)
+    for name, guide_site in guide_trace.items():
+        if guide_site["type"] == "sample" and name in model_trace:
+            model_site = model_trace[name]
+            assert guide_site["fn"].support == model_site["fn"].support
+
 
 @pytest.mark.parametrize(
     "auto_class",


### PR DESCRIPTION
This PR unifies constraint handling for several auto guides. In short, distributions for all variables in the guide are constructed in unconstrained space. If the variable has non-real support, the distribution is transformed.

The original motivation was to ensure that the support of random variables in the guide and model match. `AutoDelta` and `AutoContinuous` did not meet that requirement because they use `Delta` distributions in constrained space.