### PR TITLE
feat(distributions.conjugate): support total_count_max in DirichletMultinomial distribution

### DIFF
--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -3416,6 +3416,23 @@ def test_multinomial_abstract_total_count():
     assert_allclose(x, y, rtol=1e-6)
 
 
+def test_dirichlet_multinomial_abstract_total_count():
+    probs = jnp.array([0.2, 0.5, 0.3])
+    key = random.PRNGKey(0)
+
+    def f(x):
+        total_count = x.sum(-1)
+        return dist.DirichletMultinomial(
+            concentration=probs,
+            total_count=total_count,
+            total_count_max=10,  # fails on 0.18.0
+        ).sample(key)
+
+    x = dist.DirichletMultinomial(concentration=probs, total_count=10).sample(key)
+    y = jax.jit(f)(x)
+    assert_allclose(x, y, rtol=1e-6)
+
+
 def test_normal_log_cdf():
     # test if log_cdf method agrees with jax.scipy.stats.norm.logcdf
     # and if exp(log_cdf) agrees with cdf


### PR DESCRIPTION
Follow on to #1557 for the `DirichletMultinomial` case. 

Prior to this change, users may encounter the error `ValueError("Please specify total_count_max in Multinomial distribution.")` (see [`multinomial`](https://github.com/pyro-ppl/numpyro/blob/ab1f0dc6e954ef7d54724386667e33010b2cfc8b/numpyro/distributions/util.py#L273) in `distributions.util` when using the distribution inside of traced environments.