### PR TITLE
[Typo] Add missing plus sign circular GP notebook

### DIFF
--- a/notebooks/source/circulant_gp.ipynb
+++ b/notebooks/source/circulant_gp.ipynb
@@ -18,7 +18,7 @@
     "where $\\mathrm{expit}(z) = 1/\\left(1 + \\exp(-z)\\right)$ denotes the [logistic sigmoid](https://en.wikipedia.org/wiki/Sigmoid_function) and $K$ is the covariance matrix between elements of the Gaussian process evaluated on the grid. We use a [squared exponential kernel](https://www.cs.toronto.edu/~duvenaud/cookbook/) $k$ such that\n",
     "$$\\begin{aligned}\n",
     "K_{ij}&=k\\left(x_i,x_j\\right) + \\epsilon \\delta_{ij}\\\\\n",
-    "&=\\sigma^2\\exp\\left(-\\frac{d\\left(x_i, x_j\\right)}{2\\ell^2}\\right) \\epsilon \\delta_{ij},\n",
+    "&=\\sigma^2\\exp\\left(-\\frac{d\\left(x_i, x_j\\right)}{2\\ell^2}\\right) + \\epsilon \\delta_{ij},\n",
     "\\end{aligned}$$\n",
     "where $\\sigma$ is the marginal scale of the Gaussian process, $d\\left(x_i, x_j\\right)$ is the distance between $x_i$ and $x_j$, and $\\ell$ is the correlation length of the kernel. We add a so-called \"nugget variance\" $\\epsilon={10}^{-4}$ to the diagonal of the covariance matrix to ensure it is numerically positive definite.\n",
     "\n",


### PR DESCRIPTION
Add a missing plus sign in the circular GP notebook.