### PR TITLE
Reenable haiku tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,8 @@ setup(
             "scipy>=1.9",
         ],
         "dev": [
-            "dm-haiku",
+            "dm-haiku>=0.0.14; python_version >= '3.10'",
+            "dm-haiku<0.0.14; python_version < '3.10'",
             "equinox",
             "flax",
             "funsor>=0.4.1",

--- a/test/contrib/test_esc_proxies.py
+++ b/test/contrib/test_esc_proxies.py
@@ -35,7 +35,7 @@ def test_block_update_partitioning(num_blocks):
     assert gibbs_state == new_gibbs_state
 
 
-def test_haiku_compatiable():
+def test_haiku_compatible():
     try:
         import haiku as hk  # noqa: F401
 

--- a/test/contrib/test_esc_proxies.py
+++ b/test/contrib/test_esc_proxies.py
@@ -35,9 +35,6 @@ def test_block_update_partitioning(num_blocks):
     assert gibbs_state == new_gibbs_state
 
 
-@pytest.mark.xfail(
-    reason="Haiku module is deprecated and not supported on JAX >= 0.6.0"
-)
 def test_haiku_compatiable():
     try:
         import haiku as hk  # noqa: F401

--- a/test/contrib/test_module.py
+++ b/test/contrib/test_module.py
@@ -107,9 +107,6 @@ def test_flax_module():
     assert flax_tr["nn$params"]["value"]["bias"].shape == (100,)
 
 
-@pytest.mark.xfail(
-    reason="Haiku module is deprecated and not supported on JAX >= 0.6.0"
-)
 def test_haiku_module():
     W = np.arange(100).astype(np.float32)
     X = np.arange(100).astype(np.float32)
@@ -180,7 +177,6 @@ def test_random_module_mcmc(backend, init, callable_prior):
         random_module = random_flax_module
         kwargs_name = "inputs"
     elif backend == "haiku":
-        pytest.skip("Haiku module is deprecated and not supported on JAX >= 0.6.0")
         import haiku as hk
 
         linear_module = hk.transform(lambda x: hk.Linear(1)(x))
@@ -236,9 +232,6 @@ def test_random_module_mcmc(backend, init, callable_prior):
     )
 
 
-@pytest.mark.xfail(
-    reason="Haiku module is deprecated and not supported on JAX >= 0.6.0"
-)
 @pytest.mark.parametrize("dropout", [True, False])
 @pytest.mark.parametrize("batchnorm", [True, False])
 def test_haiku_state_dropout_smoke(dropout, batchnorm):


### PR DESCRIPTION
This PR reverts https://github.com/pyro-ppl/numpyro/pull/2018/commits/738e2e8f085c5f05521b1aeeffc2260766ef59fe as discussed in https://github.com/pyro-ppl/numpyro/issues/2019 and fixes a typo.