### PR TITLE
fix(tests): fix for failing nested sampling unit tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
             "flax",
             "funsor>=0.4.1",
             "graphviz",
-            "jaxns==2.6.3",
+            "jaxns>=2.6.3,<=2.6.8",
             "matplotlib",
             "optax>=0.0.6",
             "pylab-sdk",  # jaxns dependency

--- a/test/contrib/test_nested_sampling.py
+++ b/test/contrib/test_nested_sampling.py
@@ -86,7 +86,6 @@ def test_log_normal(batch_shape, base_batch_shape, event_shape):
     assert_allclose(actual_moments, expected_moments, atol=0.05, rtol=0.01)
 
 
-@pytest.mark.xfail(reason="Compiling with JAX >= 0.6.0 fails")
 @pytest.mark.parametrize("rho", [-0.7, 0.8])
 def test_dense_mass(rho):
     true_cov = jnp.array([[10.0, rho], [rho, 0.1]])


### PR DESCRIPTION
The failure of the unit tests of Nested Sampling for `jax>=0.6.0` is due to the [deprecation of all APIs in `jax.lib.xla_extension`](https://docs.jax.dev/en/latest/changelog.html#jax-0-6-0-april-16-2025), which were internally [used in `jaxns==2.6.3`](https://github.com/Joshuaalbert/jaxns/blob/e3c2a8f8d2ea4329509fc4232076973a1dd107cf/src/jaxns/internals/maps.py#L11) (because the version was pinned in the numpyro setup.py). The issue was [reported](https://github.com/Joshuaalbert/jaxns/issues/221) and has been [solved](https://github.com/Joshuaalbert/jaxns/issues/221#issuecomment-2928127572) in `jaxns==2.6.8`.

This PR updates the version dependency to account the changes in `jax>=0.6.0` and `jax<=0.5.3` by introducing a range-based constraint on `jaxns` version. The dependency solver will choose an appropriate version of `jaxns` depending on the `jax` version. I have also removed the `pytest.mark.xfail` from `test/infer/test_nested_sampling::test_dense_mass` because it is passing.