### PR TITLE
Remove uses of OrderedDict

### DIFF
--- a/numpyro/_typing.py
+++ b/numpyro/_typing.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from collections import OrderedDict
 from collections.abc import Callable
 from typing import Any, Protocol, runtime_checkable
 
@@ -15,7 +14,7 @@ P = ParamSpec("P")
 ModelT: TypeAlias = Callable[P, Any]
 
 Message: TypeAlias = dict[str, Any]
-TraceT: TypeAlias = OrderedDict[str, Message]
+TraceT: TypeAlias = dict[str, Message]
 
 
 @runtime_checkable

--- a/numpyro/contrib/control_flow/scan.py
+++ b/numpyro/contrib/control_flow/scan.py
@@ -1,7 +1,6 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
-from collections import OrderedDict
 from functools import partial
 from typing import Callable, Optional
 
@@ -493,9 +492,7 @@ def scan(
                 dim_to_name = msg["infer"].get("dim_to_name")
                 to_funsor(
                     msg["value"],
-                    dim_to_name=OrderedDict(
-                        [(k, dim_to_name[k]) for k in sorted(dim_to_name)]
-                    ),
+                    dim_to_name={k: dim_to_name[k] for k in sorted(dim_to_name)},
                 )
                 apply_stack(msg)
 

--- a/numpyro/contrib/funsor/discrete.py
+++ b/numpyro/contrib/funsor/discrete.py
@@ -1,7 +1,7 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
-from collections import OrderedDict, defaultdict
+from collections import defaultdict
 import functools
 
 from jax import random
@@ -35,7 +35,7 @@ def _get_support_value_contraction(funsor_dist, name, **kwargs):
 @_get_support_value.register(funsor.delta.Delta)
 def _get_support_value_delta(funsor_dist, name, **kwargs):
     assert name in funsor_dist.fresh
-    return OrderedDict(funsor_dist.terms)[name][0]
+    return dict(funsor_dist.terms)[name][0]
 
 
 def _sample_posterior(

--- a/numpyro/contrib/funsor/enum_messenger.py
+++ b/numpyro/contrib/funsor/enum_messenger.py
@@ -436,7 +436,7 @@ class BaseEnumMessenger(NamedMessenger):
     """
 
     def __init__(self, fn=None, first_available_dim=None):
-        assert first_available_dim is None or first_available_dim < 0), (
+        assert first_available_dim is None or first_available_dim < 0, (
             first_available_dim
         )
         self.first_available_dim = first_available_dim

--- a/numpyro/contrib/funsor/infer_util.py
+++ b/numpyro/contrib/funsor/infer_util.py
@@ -1,7 +1,7 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
-from collections import OrderedDict, defaultdict
+from collections import defaultdict
 from contextlib import contextmanager
 import functools
 import re
@@ -221,7 +221,7 @@ def _enum_log_density(model, model_args, model_kwargs, params, sum_op, prod_op):
 
             dim_to_name = site["infer"]["dim_to_name"]
 
-            if all(dim == 1 for dim in log_prob.shape) and dim_to_name == OrderedDict():
+            if all(dim == 1 for dim in log_prob.shape) and dim_to_name == {}:
                 log_prob = log_prob.squeeze()
 
             log_prob_factor = funsor.to_funsor(

--- a/numpyro/contrib/stochastic_support/sdvi.py
+++ b/numpyro/contrib/stochastic_support/sdvi.py
@@ -1,7 +1,7 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Callable, OrderedDict as OrderedDictType
+from typing import Any, Callable
 
 import jax
 import jax.numpy as jnp
@@ -98,7 +98,7 @@ class SDVI(StochasticSupportInference):
     def _run_inference(
         self,
         rng_key: jax.Array,
-        branching_trace: OrderedDictType,
+        branching_trace: dict,
         *args: Any,
         **kwargs: Any,
     ) -> RunInferenceResult:
@@ -121,7 +121,7 @@ class SDVI(StochasticSupportInference):
         self,
         rng_key: jax.Array,
         guides: dict[str, tuple[AutoGuide, dict[str, Any]]],
-        branching_traces: dict[str, OrderedDictType],
+        branching_traces: dict[str, dict],
         *args: Any,
         **kwargs: Any,
     ) -> SDVIResult:

--- a/numpyro/diagnostics.py
+++ b/numpyro/diagnostics.py
@@ -5,7 +5,6 @@
 This provides a small set of utilities in NumPyro that are used to diagnose posterior samples.
 """
 
-from collections import OrderedDict
 from itertools import product
 from typing import Union
 
@@ -271,17 +270,15 @@ def summary(
         r_hat = split_gelman_rubin(value)
         hpd_lower = "{:.1f}%".format(50 * (1 - prob))
         hpd_upper = "{:.1f}%".format(50 * (1 + prob))
-        summary_dict[name] = OrderedDict(
-            [
-                ("mean", mean),
-                ("std", std),
-                ("median", median),
-                (hpd_lower, hpd[0]),
-                (hpd_upper, hpd[1]),
-                ("n_eff", n_eff),
-                ("r_hat", r_hat),
-            ]
-        )
+        summary_dict[name] = {
+            "mean": mean,
+            "std": std,
+            "median": median,
+            hpd_lower: hpd[0],
+            hpd_upper: hpd[1],
+            "n_eff": n_eff,
+            "r_hat": r_hat,
+        }
     return summary_dict
 
 

--- a/numpyro/distributions/distribution.py
+++ b/numpyro/distributions/distribution.py
@@ -26,7 +26,6 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 
-from collections import OrderedDict
 from contextlib import contextmanager
 import functools
 import inspect
@@ -620,7 +619,7 @@ class ExpandedDistribution(Distribution):
     @staticmethod
     def _broadcast_shape(
         existing_shape: tuple[int, ...], new_shape: tuple[int, ...]
-    ) -> tuple[tuple[int, ...], OrderedDict, OrderedDict]:
+    ) -> tuple[tuple[int, ...], dict, dict]:
         if len(new_shape) < len(existing_shape):
             raise ValueError(
                 "Cannot broadcast distribution of shape {} to shape {}".format(
@@ -645,8 +644,8 @@ class ExpandedDistribution(Distribution):
                 )
         return (
             tuple(reversed(reversed_shape)),
-            OrderedDict(reversed(expanded_sizes)),
-            OrderedDict(interstitial_sizes),
+            dict(reversed(expanded_sizes)),
+            dict(interstitial_sizes),
         )
 
     @property

--- a/numpyro/handlers.py
+++ b/numpyro/handlers.py
@@ -93,7 +93,6 @@ results for all the data points, but does so by using JAX's auto-vectorize trans
 
 from __future__ import annotations
 
-from collections import OrderedDict
 from types import TracebackType
 from typing import Callable, Optional, Union
 import warnings
@@ -155,19 +154,19 @@ class trace(Messenger):
 
        >>> exec_trace = trace(seed(model, random.PRNGKey(0))).get_trace()
        >>> pp.pprint(exec_trace)  # doctest: +SKIP
-       OrderedDict([('a',
+       {'a':
                      {'args': (),
                       'fn': <numpyro.distributions.continuous.Normal object at 0x7f9e689b1eb8>,
                       'is_observed': False,
                       'kwargs': {'rng_key': Array([0, 0], dtype=uint32)},
                       'name': 'a',
                       'type': 'sample',
-                      'value': Array(-0.20584235, dtype=float32)})])
+                      'value': Array(-0.20584235, dtype=float32)}}
     """
 
     def __enter__(self) -> TraceT:  # type: ignore [override]
         super(trace, self).__enter__()
-        self.trace: TraceT = OrderedDict()
+        self.trace: TraceT = {}
         return self.trace
 
     def postprocess_message(self, msg: Message) -> None:
@@ -188,7 +187,7 @@ class trace(Messenger):
 
         :param `*args`: arguments to the callable.
         :param `**kwargs`: keyword arguments to the callable.
-        :return: `OrderedDict` containing the execution trace.
+        :return: `dict` containing the execution trace.
         """
         self(*args, **kwargs)
         return self.trace
@@ -201,7 +200,7 @@ class replay(Messenger):
     values from the corresponding site names in `trace`.
 
     :param fn: Python callable with NumPyro primitives.
-    :param trace: an OrderedDict containing execution metadata.
+    :param trace: dict containing execution metadata.
 
     **Example:**
 

--- a/numpyro/infer/elbo.py
+++ b/numpyro/infer/elbo.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from collections import OrderedDict, defaultdict
+from collections import defaultdict
 from collections.abc import Callable
 from functools import partial
 from typing import TYPE_CHECKING, Any, TypedDict, TypeVar
@@ -1025,9 +1025,7 @@ def _partition(
     model_sum_deps: dict[str, frozenset[str]], sum_vars: frozenset[str]
 ) -> list[tuple[frozenset[str], frozenset[str]]]:
     # Construct a bipartite graph between model_sum_deps and the sum_vars
-    neighbors: OrderedDict[str, list[str]] = OrderedDict(
-        [(t, []) for t in model_sum_deps.keys()]
-    )
+    neighbors: dict[str, list[str]] = {t: [] for t in model_sum_deps.keys()}
     for key, deps in model_sum_deps.items():
         for dim in deps:
             if dim in sum_vars:
@@ -1038,7 +1036,7 @@ def _partition(
     components = []
     while neighbors:
         v, pending = neighbors.popitem()
-        component = OrderedDict([(v, None)])  # used as an OrderedSet
+        component = {v: None}  # used as an OrderedSet
         for v in pending:
             component[v] = None
         while pending:

--- a/numpyro/infer/hmc.py
+++ b/numpyro/infer/hmc.py
@@ -1,7 +1,7 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
-from collections import OrderedDict, namedtuple
+from collections import defaultdict
 from functools import partial
 import math
 import os
@@ -94,7 +94,7 @@ def momentum_generator(prototype_r, mass_matrix_sqrt, rng_key):
         rng_keys = random.split(rng_key, len(mass_matrix_sqrt))
         r = {}
         for (site_names, mm_sqrt), rng_key in zip(mass_matrix_sqrt.items(), rng_keys):
-            r_block = OrderedDict([(k, prototype_r[k]) for k in site_names])
+            r_block = {k: prototype_r[k] for k in site_names}
             r.update(momentum_generator(r_block, mm_sqrt, rng_key))
         return r
 

--- a/numpyro/infer/hmc_util.py
+++ b/numpyro/infer/hmc_util.py
@@ -1,7 +1,7 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
-from collections import OrderedDict, namedtuple
+from collections import defaultdict
 
 import jax
 from jax import grad, jacfwd, random, value_and_grad, vmap
@@ -1204,7 +1204,7 @@ def _euclidean_kinetic_energy_grad(inverse_mass_matrix, r):
     if isinstance(inverse_mass_matrix, dict):
         r_grad = {}
         for site_names, inverse_mm in inverse_mass_matrix.items():
-            r_block = OrderedDict([(k, r[k]) for k in site_names])
+            r_block = {k: r[k] for k in site_names}
             r_grad.update(_euclidean_kinetic_energy_grad(inverse_mm, r_block))
         return r_grad
 

--- a/numpyro/util.py
+++ b/numpyro/util.py
@@ -1,7 +1,6 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
-from collections import OrderedDict
 from contextlib import contextmanager
 from functools import partial
 import inspect
@@ -174,7 +173,7 @@ def identity(x, *args, **kwargs):
 def cached_by(outer_fn, *keys):
     # Restrict cache size to prevent ref cycles.
     max_size = 8
-    outer_fn._cache = getattr(outer_fn, "_cache", OrderedDict())
+    outer_fn._cache = getattr(outer_fn, "_cache", {})
 
     def _wrapped(fn):
         fn_cache = outer_fn._cache

--- a/test/contrib/test_funsor.py
+++ b/test/contrib/test_funsor.py
@@ -1,7 +1,6 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
-from collections import OrderedDict
 from functools import partial
 
 import numpy as np
@@ -153,8 +152,8 @@ def test_gaussian_hmm():
 def test_iteration():
     def testing():
         for i in markov(range(5)):
-            v1 = to_data(Tensor(jnp.ones(2), OrderedDict([(str(i), Bint[2])]), "real"))
-            v2 = to_data(Tensor(jnp.zeros(2), OrderedDict([("a", Bint[2])]), "real"))
+            v1 = to_data(Tensor(jnp.ones(2), {str(i): Bint[2]}, "real"))
+            v2 = to_data(Tensor(jnp.zeros(2), {"a": Bint[2]}, "real"))
             fv1 = to_funsor(v1, Real)
             fv2 = to_funsor(v2, Real)
             print(i, v1.shape)  # shapes should alternate
@@ -174,25 +173,23 @@ def test_iteration():
 def test_nesting():
     def testing():
         with markov():
-            v1 = to_data(Tensor(jnp.ones(2), OrderedDict([("1", Bint[2])]), "real"))
+            v1 = to_data(Tensor(jnp.ones(2), {"1": Bint[2]}, "real"))
             print(1, v1.shape)  # shapes should alternate
             assert v1.shape == (2,)
 
             with markov():
-                v2 = to_data(Tensor(jnp.ones(2), OrderedDict([("2", Bint[2])]), "real"))
+                v2 = to_data(Tensor(jnp.ones(2), {"2": Bint[2]}, "real"))
                 print(2, v2.shape)  # shapes should alternate
                 assert v2.shape == (2, 1)
 
                 with markov():
-                    v3 = to_data(
-                        Tensor(jnp.ones(2), OrderedDict([("3", Bint[2])]), "real")
-                    )
+                    v3 = to_data(Tensor(jnp.ones(2), {"3": Bint[2]}, "real"))
                     print(3, v3.shape)  # shapes should alternate
                     assert v3.shape == (2,)
 
                     with markov():
                         v4 = to_data(
-                            Tensor(jnp.ones(2), OrderedDict([("4", Bint[2])]), "real")
+                            Tensor(jnp.ones(2), {"4": Bint[2]}, "real")
                         )
                         print(4, v4.shape)  # shapes should alternate
 
@@ -206,9 +203,7 @@ def test_staggered():
     def testing():
         for i in markov(range(12)):
             if i % 4 == 0:
-                v2 = to_data(
-                    Tensor(jnp.zeros(2), OrderedDict([("a", Bint[2])]), "real")
-                )
+                v2 = to_data(Tensor(jnp.zeros(2), {"a": Bint[2]}, "real"))
                 fv2 = to_funsor(v2, Real)
                 assert v2.shape == (2,)
                 print("a", v2.shape)


### PR DESCRIPTION
Since python 3.6 dict has the same behavior as OrderedDict. Numpyro requires python version >=3.9, so it should be fine to use dict instead of OrderedDict.