### PR TITLE
Fix `typing_extensions` import issue

### DIFF
--- a/numpyro/_typing.py
+++ b/numpyro/_typing.py
@@ -6,7 +6,10 @@ from collections import OrderedDict
 from collections.abc import Callable
 from typing import Any, Protocol, runtime_checkable
 
-from typing_extensions import ParamSpec, TypeAlias
+try:
+    from typing import ParamSpec, TypeAlias
+except ImportError:
+    from typing_extensions import ParamSpec, TypeAlias
 
 import jax
 from jax.typing import ArrayLike

--- a/numpyro/infer/elbo.py
+++ b/numpyro/infer/elbo.py
@@ -9,7 +9,10 @@ from functools import partial
 from typing import TYPE_CHECKING, Any, TypedDict, TypeVar
 import warnings
 
-from typing_extensions import TypeAlias
+try:
+    from typing import TypeAlias
+except ImportError:
+    from typing_extensions import TypeAlias
 
 import jax
 from jax import eval_shape, random, vmap

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
         "multipledispatch",
         "numpy",
         "tqdm",
+        "typing_extensions; python_version < '3.10'",
     ],
     extras_require={
         "doc": [


### PR DESCRIPTION
This PR aims to address https://github.com/pyro-ppl/numpyro/issues/2053.