### PR TITLE
Use tfp-nightly for tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(
             "pytest-cov",
             "pyyaml",  # flax dependency
             "requests",  # pylab dependency
-            "tensorflow_probability>=0.18.0",
+            "tfp-nightly",
         ],
         "examples": [
             "arviz",


### PR DESCRIPTION
Motivated by https://github.com/pyro-ppl/numpyro/pull/2052#issuecomment-3109050581 and in view of the comment https://github.com/tensorflow/probability/issues/1994#issuecomment-3129033043

> For TFP on JAX I would strongly advise using tfp-nightly. It's tested continuously against the latest JAX, and you can pin to a particular date's release if you need your dependencies to remain fixed.

(also by the fact that the last stable release of `tensorflow-probability` was like 9 months ago), I suggest using `tfp-nightly` in our test suite :) 

It seems this one depends on https://github.com/pyro-ppl/numpyro/pull/2052 (but maybe it's easier if this change is added there directly)

```python
ImportError: cannot import name 'pjit_p' from 'jax.experimental.pjit'
```