### PR TITLE
Ensure compatibility NNX 0.11.2

### DIFF
--- a/numpyro/contrib/module.py
+++ b/numpyro/contrib/module.py
@@ -498,7 +498,7 @@ def nnx_module(name, nn_module):
         if mutable_holder:
             nnx.replace_by_pure_dict(mutable_state, mutable_holder["state"])
 
-        model = nnx.merge(graph_def, params_state, mutable_state)
+        model = nnx.merge(graph_def, params_state, mutable_state, copy=True)
 
         model_call = model(*call_args, **call_kwargs)
 

--- a/test/contrib/test_module.py
+++ b/test/contrib/test_module.py
@@ -385,9 +385,6 @@ def test_nnx_module():
 @pytest.mark.parametrize(
     argnames="batchnorm", argvalues=[True, False], ids=["batchnorm", "no_batchnorm"]
 )
-@pytest.mark.xfail(
-    reason="Temporary marking to pass CI. Bug fixed in https://github.com/pyro-ppl/numpyro/pull/2067"
-)
 def test_nnx_state_dropout_smoke(dropout, batchnorm):
     from flax import nnx
 


### PR DESCRIPTION
Ensures compatibility with https://github.com/google/flax/releases/tag/v0.11.2

The tests were failing in https://github.com/pyro-ppl/numpyro/actions/runs/17463007632/job/49592472608

```python
FAILED test/contrib/test_module.py::test_nnx_state_dropout_smoke[batchnorm-dropout] - flax.errors.TraceContextError: Cannot mutate BatchStat from a different trace level (https://flax.readthedocs.io/en/latest/api_reference/flax.errors.html#flax.errors.TraceContextError)
--------------------
For simplicity, JAX has removed its internal frames from the traceback of the following exception. Set JAX_TRACEBACK_FILTERING=off to include these.
FAILED test/contrib/test_module.py::test_nnx_state_dropout_smoke[batchnorm-no_dropout] - flax.errors.TraceContextError: Cannot mutate BatchStat from a different trace level (https://flax.readthedocs.io/en/latest/api_reference/flax.errors.html#flax.errors.TraceContextError)
--------------------
For simplicity, JAX has removed its internal frames from the traceback of the following exception. Set JAX_TRACEBACK_FILTERING=off to include these.
= 2 failed, 506 passed, 66 skipped, 4 xfailed, 36 warnings in 654.96s (0:10:54)
```