### PR TITLE
Fix compatibility `Predictive` and new random keys

### DIFF
--- a/numpyro/infer/util.py
+++ b/numpyro/infer/util.py
@@ -882,7 +882,10 @@ def _predictive(
     rng_key = rng_key.reshape(batch_shape + key_shape)
     chunk_size = num_samples if parallel else 1
     return soft_vmap(
-        single_prediction, (rng_key, posterior_samples), len(batch_shape), chunk_size
+        single_prediction,
+        (jax.random.key_data(rng_key), posterior_samples),
+        len(batch_shape),
+        chunk_size,
     )
 
 


### PR DESCRIPTION
Closes https://github.com/pyro-ppl/numpyro/issues/2071

I was able to reproduce.  I suggest a fix using the guidance from https://docs.jax.dev/en/latest/jep/9263-typed-keys.html#jep-9263