### PR TITLE
Fix test for new NNX 0.12.0

### DIFF
--- a/test/contrib/test_module.py
+++ b/test/contrib/test_module.py
@@ -514,7 +514,7 @@ def test_random_nnx_module_mcmc_sequence_params(scope_divider: str):
     class MLP(nnx.Module):
         def __init__(self, din, dout, hidden_layers, *, rngs, activation=jax.nn.relu):
             self.activation = activation
-            self.layers = []
+            self.layers = nnx.List([])
             layer_dims = [din] + hidden_layers + [dout]
             for in_dim, out_dim in zip(layer_dims[:-1], layer_dims[1:]):
                 self.layers.append(nnx.Linear(in_dim, out_dim, rngs=rngs))


### PR DESCRIPTION
See https://github.com/google/flax/releases/tag/v0.12.0

The tests were failing in https://github.com/pyro-ppl/numpyro/pull/2074