### PR TITLE
feat: add support for CUDA 12 and CUDA 13

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,21 +232,29 @@ See the [docs](https://num.pyro.ai/en/latest/contrib.html#stein-variational-infe
 
 To install NumPyro with the latest CPU version of JAX, you can use pip:
 
-```
+```bash
 pip install numpyro
 ```
 
 In case of compatibility issues arise during execution of the above command, you can instead force the installation of a known
 compatible CPU version of JAX with
 
-```
+```bash
 pip install 'numpyro[cpu]'
 ```
 
-To use **NumPyro on the GPU**, you need to install CUDA first and then use the following pip command:
+To use **NumPyro on the GPU**, you need to install CUDA first, and based on your CUDA version, you can use the following pip command:
 
+For **CUDA 12.x.y**:
+
+```bash
+pip install 'numpyro[cuda12]' -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
 ```
-pip install 'numpyro[cuda]' -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
+
+For **CUDA 13.x.y**:
+
+```bash
+pip install 'numpyro[cuda13]' -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
 ```
 
 If you need further guidance, please have a look at the [JAX GPU installation instructions](https://github.com/jax-ml/jax#pip-installation-gpu-cuda).
@@ -261,7 +269,7 @@ you can install NumPyro using the `pip install numpyro` command.
 
 You can also install NumPyro from source:
 
-```
+```bash
 git clone https://github.com/pyro-ppl/numpyro.git
 cd numpyro
 # install jax/jaxlib first for CUDA support
@@ -270,7 +278,7 @@ pip install -e '.[dev]'  # contains additional dependencies for NumPyro developm
 
 You can also install NumPyro with conda:
 
-```
+```bash
 conda install -c conda-forge numpyro
 ```
 

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,8 @@ setup(
         # TPU and CUDA installations, currently require to add package repository URL, i.e.,
         # pip install 'numpyro[cuda]' -f https://storage.googleapis.com/jax-releases/jax_releases.html
         "tpu": f"jax[tpu]{_jax_version_constraints}",
-        "cuda": f"jax[cuda]{_jax_version_constraints}",
+        "cuda12": f"jax[cuda12]{_jax_version_constraints}",
+        "cuda13": f"jax[cuda13]{_jax_version_constraints}",
     },
     python_requires=">=3.9",
     long_description=long_description,


### PR DESCRIPTION
Current installation instructions to install numpyro on GPU is not supported for CUDA 13.

```bash
uv pip install --upgrade numpyro[cuda] --dry-run -f https://storage.googleapis.com/jax-releases/jax_releases.html
```

```
Resolved 23 packages in 1.67s
Would download 23 packages
Would install 23 packages
 + jax==0.8.0
 + jax-cuda12-pjrt==0.8.0
 + jax-cuda12-plugin==0.8.0
 + jaxlib==0.8.0
 + ml-dtypes==0.5.3
 + multipledispatch==1.0.0
 + numpy==2.3.4
 + numpyro==0.19.0
 + nvidia-cublas-cu12==12.9.1.4
 + nvidia-cuda-cupti-cu12==12.9.79
 + nvidia-cuda-nvcc-cu12==12.9.86
 + nvidia-cuda-nvrtc-cu12==12.9.86
 + nvidia-cuda-runtime-cu12==12.9.79
 + nvidia-cudnn-cu12==9.15.0.57
 + nvidia-cufft-cu12==11.4.1.4
 + nvidia-cusolver-cu12==11.7.5.82
 + nvidia-cusparse-cu12==12.5.10.65
 + nvidia-nccl-cu12==2.28.7
 + nvidia-nvjitlink-cu12==12.9.86
 + nvidia-nvshmem-cu12==3.4.5
 + opt-einsum==3.4.0
 + scipy==1.16.3
 + tqdm==4.67.1
```

This PR updates the `setup.py` along with relevant documentation to install NumPyro for both CUDA 12 and CUDA 13.