### PR TITLE
Add initial value to Gaussian state space distribution (fixes #2098).

### DIFF
--- a/numpyro/distributions/constraints.py
+++ b/numpyro/distributions/constraints.py
@@ -45,6 +45,7 @@ __all__ = [
     "multinomial",
     "nonnegative",
     "nonnegative_integer",
+    "ordered_vector",
     "positive",
     "positive_definite",
     "positive_definite_circulant_vector",

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -631,6 +631,33 @@ CONTINUOUS = [
         np.array([[0.8, 0.2], [-0.1, 1.1]]),
         np.array([0.1, 0.3, 0.25])[:, None, None] * np.array([[0.8, 0.2], [0.2, 0.7]]),
     ),
+    T(
+        dist.GaussianStateSpace,
+        5,
+        np.array([[0.8, 0.1], [-0.1, 0.9]]),
+        None,
+        None,
+        np.array([[0.5, 0.0], [0.0, 0.5]]),
+        np.array([1.0, 2.0]),
+    ),
+    T(
+        dist.GaussianStateSpace,
+        5,
+        np.array([[0.8, 0.1], [-0.1, 0.9]]),
+        None,
+        None,
+        np.array([[0.5, 0.0], [0.0, 0.5]]),
+        np.array([[1.0, 2.0], [0.5, 1.5], [-1.0, 0.0]]),
+    ),
+    T(
+        dist.GaussianStateSpace,
+        4,
+        np.array([[0.9, 0.0], [0.0, 0.9]]),
+        None,
+        None,
+        np.array([[0.3, 0.0], [0.0, 0.3]]),
+        np.array([[[1.0, 0.0]], [[0.0, 1.0]]]),
+    ),
     pytest.param(
         *T(
             dist.GaussianCopulaBeta,


### PR DESCRIPTION
This PR adds an `initial_value` argument to the `GaussianStateSpace` distribution as suggested in #2098.

As part of this change, I added an `optional` constraint. I'm a bit torn on whether that's the right choice, and we could instead promote 0 to the right shape. However, that would make evaluating the `mean` of the distribution relatively inefficient when there is no initial value: We'd still `scan` over the sequence even though we should really just return zeros (although maybe `jax.jit` amortizes that?). Open to suggestions.