### PR TITLE
Fix NumPy 2.4 deprecation warning when loading JSB Chorales dataset

### DIFF
--- a/numpyro/examples/datasets.py
+++ b/numpyro/examples/datasets.py
@@ -279,7 +279,14 @@ def _load_jsb_chorales():
 
     file_path = os.path.join(DATA_DIR, "jsb_chorales.pickle")
     with open(file_path, "rb") as f:
-        data = pickle.load(f)
+        # Filter numpy deprecation warning from loading legacy pickle file
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message="dtype.*align should be passed as Python or NumPy boolean",
+                category=np.exceptions.VisibleDeprecationWarning,
+            )
+            data = pickle.load(f)
 
     # XXX: we might expose those in `load_dataset` keywords
     min_note = 21


### PR DESCRIPTION
## Problem

The test `test/test_example_utils.py::test_jsb_chorales` was failing with:

```python
numpy.exceptions.VisibleDeprecationWarning: dtype(): align should be passed as Python or NumPy boolean but got `align=0`. Did you mean to pass a tuple to create a subarray type? (Deprecated NumPy 2.4)
```

See [here](https://github.com/pyro-ppl/numpyro/actions/runs/20407154203/job/58638654215)

This error occurs when loading the `jsb_chorales.pickle` file, which was serialized with an older version of NumPy. The pickled data contains dtype objects with align=0, but NumPy 2.4 now requires align to be a Python or NumPy boolean.
Since pytest is configured with filterwarnings = ["error", ...] in pyproject.toml, this deprecation warning is treated as an error, causing the test to fail.

## Solution

Wrapped the `pickle.load()` call in `_load_jsb_chorales()` with a warning filter that specifically ignores this NumPy deprecation warning.