### PR TITLE
Disable masking when running Predictive with infer_discrete=True

### DIFF
--- a/numpyro/infer/util.py
+++ b/numpyro/infer/util.py
@@ -813,7 +813,8 @@ def _predictive(
     model_args=(),
     model_kwargs={},
 ):
-    masked_model = numpyro.handlers.mask(model, mask=False)
+    # When enumerating discrete sites, we need true log probabilities.
+    masked_model = numpyro.handlers.mask(model, mask=infer_discrete)
     if infer_discrete:
         # inspect the model to get some structure
         rng_key, subkey = random.split(rng_key)


### PR DESCRIPTION
Fixes the issue in https://forum.pyro.ai/t/recover-discrete-latent-states-after-enumerate-scan/9018/8

We need log probabilities to infer the probabilities at discrete sites, so we can draw samples from.