### PR TITLE
ci: prek for pre-commit hooks check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,20 +15,9 @@ jobs:
   prek:
 
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.11", "3.13"]
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install '.[test]'
       - name: prek check
         uses: j178/prek-action@v1
         with:


### PR DESCRIPTION
This PR adds pre-commit checks to the CI pipeline. Instead of the standard `pre-commit` framework, it uses [prek](https://github.com/j178/prek), a faster Rust-based alternative.