### PR TITLE
feat(gh-2142): add VSBC diagnostic

### DIFF
--- a/numpyro/infer/__init__.py
+++ b/numpyro/infer/__init__.py
@@ -3,6 +3,7 @@
 
 
 from numpyro.infer.barker import BarkerMH
+from numpyro.infer.calibration import vsbc_diagnostic
 from numpyro.infer.elbo import (
     ELBO,
     RenyiELBO,
@@ -41,6 +42,7 @@ __all__ = [
     "init_to_value",
     "log_likelihood",
     "reparam",
+    "vsbc_diagnostic",
     "BarkerMH",
     "DiscreteHMCGibbs",
     "ELBO",

--- a/numpyro/infer/__init__.py
+++ b/numpyro/infer/__init__.py
@@ -3,7 +3,6 @@
 
 
 from numpyro.infer.barker import BarkerMH
-from numpyro.infer.calibration import vsbc_diagnostic
 from numpyro.infer.elbo import (
     ELBO,
     RenyiELBO,
@@ -29,11 +28,12 @@ from numpyro.infer.sa import SA
 from numpyro.infer.svi import SVI
 from numpyro.infer.util import Predictive, log_likelihood
 
-from . import autoguide, reparam
+from . import autoguide, calibration, reparam
 
 __all__ = [
     "AIES",
     "autoguide",
+    "calibration",
     "init_to_feasible",
     "init_to_mean",
     "init_to_median",
@@ -42,7 +42,6 @@ __all__ = [
     "init_to_value",
     "log_likelihood",
     "reparam",
-    "vsbc_diagnostic",
     "BarkerMH",
     "DiscreteHMCGibbs",
     "ELBO",

--- a/numpyro/infer/calibration.py
+++ b/numpyro/infer/calibration.py
@@ -119,9 +119,7 @@ def _resolve_observed_sites(model_trace, observed_sites):
 
 def _validate_latent_sites(model_trace, latent_names):
     discrete_latents = [
-        name
-        for name in latent_names
-        if model_trace[name]["fn"].support.is_discrete
+        name for name in latent_names if model_trace[name]["fn"].support.is_discrete
     ]
     if discrete_latents:
         raise ValueError(
@@ -158,7 +156,11 @@ def _get_observed_arg_injector(fn, observed_names, args, kwargs):
             ):
                 continue
             current = bound.arguments.get(name, _MISSING)
-            if current is not _MISSING and current is not None and param.default is None:
+            if (
+                current is not _MISSING
+                and current is not None
+                and param.default is None
+            ):
                 bound_conflicts.append(name)
             if current is None or (current is _MISSING and param.default is None):
                 candidate_params.append(name)
@@ -400,7 +402,9 @@ def vsbc_diagnostic(
 
     if observed_sites is None:
         model_trace = trace(seed(model, key_discover)).get_trace(*args, **kwargs)
-        observed_names, latent_names = _resolve_observed_sites(model_trace, observed_sites)
+        observed_names, latent_names = _resolve_observed_sites(
+            model_trace, observed_sites
+        )
         simulated_data_injector = _get_simulated_data_injector(
             model, observed_names, args, kwargs, simulated_data_to_args
         )
@@ -416,7 +420,9 @@ def vsbc_diagnostic(
         model_trace = trace(seed(model, key_discover)).get_trace(
             *cleared_args, **cleared_kwargs
         )
-        observed_names, latent_names = _resolve_observed_sites(model_trace, observed_sites)
+        observed_names, latent_names = _resolve_observed_sites(
+            model_trace, observed_sites
+        )
         simulated_data_injector = _get_simulated_data_injector(
             model, observed_names, args, kwargs, simulated_data_to_args
         )

--- a/numpyro/infer/calibration.py
+++ b/numpyro/infer/calibration.py
@@ -1,0 +1,549 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Variational Simulation-Based Calibration (VSBC) diagnostic.
+
+Implements the calibration diagnostic from:
+    Yao, Y., Vehtari, A., Simpson, D., and Gelman, A. (2018).
+    Yes, but Did It Work?: Evaluating Variational Inference.
+    International Conference on Machine Learning.
+"""
+
+from __future__ import annotations
+
+from collections import namedtuple
+from collections.abc import Mapping
+import inspect
+import warnings
+
+import numpy as np
+
+import jax
+from jax import pmap, random, vmap
+import jax.numpy as jnp
+
+from numpyro.handlers import condition, seed, trace
+from numpyro.infer.svi import SVI
+from numpyro.infer.util import Predictive
+
+__all__ = ["vsbc_diagnostic"]
+
+
+VSBCResult = namedtuple(
+    "VSBCResult",
+    ["probabilities", "ks_stats", "ks_pvalues", "ranks", "param_names"],
+)
+r"""
+A :func:`~collections.namedtuple` with fields:
+ - **probabilities** - dict mapping parameter names to arrays of
+   calibration probability estimates, each of shape
+   ``(num_simulations, *site_shape)``. These are Monte Carlo estimates of
+   :math:`p_{ij} = \Pr_q(\theta_i < \theta_i^*)`, computed as the
+   proportion of posterior guide draws strictly less than the true latent
+   value.
+ - **ks_stats** - dict mapping parameter names to KS test statistics,
+   each of shape ``site_shape``.
+ - **ks_pvalues** - dict mapping parameter names to KS test p-values,
+   each of shape ``site_shape``.
+ - **ranks** - dict mapping parameter names to arrays of rank statistics,
+   each of shape ``(num_simulations, *site_shape)``. This is retained as
+   a secondary diagnostic and as the Monte Carlo support statistic for
+   ``probabilities``.
+ - **param_names** - tuple of parameter names.
+"""
+
+
+_MISSING = object()
+_SUPPORTED_ARG_KINDS = (
+    inspect.Parameter.POSITIONAL_ONLY,
+    inspect.Parameter.POSITIONAL_OR_KEYWORD,
+    inspect.Parameter.KEYWORD_ONLY,
+)
+_INFER_ARGS_ERROR = (
+    "Unable to infer how simulated observations should be passed to model "
+    "arguments. Use argument names matching observed_sites, leave direct "
+    "observed-data arguments unset/None, or pass simulated_data_to_args "
+    "explicitly."
+)
+
+
+def _prior_predictive_sample(rng_key, model, *args, **kwargs):
+    """Draw a single joint sample from the prior predictive distribution.
+
+    Returns dict mapping all sample site names to their values.
+    """
+    model_trace = trace(seed(model, rng_key)).get_trace(*args, **kwargs)
+    return {
+        name: site["value"]
+        for name, site in model_trace.items()
+        if site["type"] == "sample"
+    }
+
+
+def _resolve_observed_sites(model_trace, observed_sites):
+    sample_names = [
+        name for name, site in model_trace.items() if site["type"] == "sample"
+    ]
+    sample_name_set = set(sample_names)
+
+    if observed_sites is None:
+        observed_names = [
+            name
+            for name, site in model_trace.items()
+            if site["type"] == "sample" and site.get("is_observed", False)
+        ]
+        if not observed_names:
+            raise ValueError(
+                "Unable to infer observed sites from a generative model trace. "
+                "Please specify observed_sites explicitly."
+            )
+    else:
+        observed_names = list(dict.fromkeys(observed_sites))
+        unknown_sites = [name for name in observed_names if name not in sample_name_set]
+        if unknown_sites:
+            raise ValueError(
+                f"Unknown observed sites: {unknown_sites}. Expected a subset of "
+                f"{sample_names}."
+            )
+
+    if not observed_names:
+        raise ValueError("observed_sites must contain at least one sample site.")
+
+    latent_names = sorted(set(sample_names) - set(observed_names))
+    if not latent_names:
+        raise ValueError("No latent parameters found. All sample sites are observed.")
+
+    return observed_names, latent_names
+
+
+def _validate_latent_sites(model_trace, latent_names):
+    discrete_latents = [
+        name
+        for name in latent_names
+        if model_trace[name]["fn"].support.is_discrete
+    ]
+    if discrete_latents:
+        raise ValueError(
+            "vsbc_diagnostic currently supports only continuous latent sample "
+            f"sites. Found discrete latents: {discrete_latents}."
+        )
+
+
+def _get_observed_arg_injector(fn, observed_names, args, kwargs):
+    signature = inspect.signature(fn)
+    bound = signature.bind_partial(*args, **kwargs)
+
+    assignments = []
+
+    for site_name in observed_names:
+        param = signature.parameters.get(site_name)
+        current = bound.arguments.get(site_name, _MISSING)
+        if (
+            param is not None
+            and param.kind in _SUPPORTED_ARG_KINDS
+            and (current is _MISSING or current is None)
+        ):
+            assignments.append((site_name, site_name))
+    remaining_sites = [name for name in observed_names if name not in dict(assignments)]
+
+    if remaining_sites:
+        candidate_params = []
+        bound_conflicts = []
+        for name, param in signature.parameters.items():
+            if (
+                name in dict(assignments)
+                or param.kind not in _SUPPORTED_ARG_KINDS
+                or name in observed_names
+            ):
+                continue
+            current = bound.arguments.get(name, _MISSING)
+            if current is not _MISSING and current is not None and param.default is None:
+                bound_conflicts.append(name)
+            if current is None or (current is _MISSING and param.default is None):
+                candidate_params.append(name)
+
+        if bound_conflicts:
+            raise ValueError(
+                f"{_INFER_ARGS_ERROR} Conflicting bound arguments: {bound_conflicts}."
+            )
+
+        if len(remaining_sites) == 1 and len(candidate_params) == 1:
+            assignments.append((candidate_params[0], remaining_sites[0]))
+        else:
+            raise ValueError(_INFER_ARGS_ERROR)
+
+    def inject(sim_data):
+        if not assignments:
+            return args, kwargs
+        call_bound = signature.bind_partial(*args, **kwargs)
+        for param_name, site_name in assignments:
+            if site_name in sim_data:
+                call_bound.arguments[param_name] = sim_data[site_name]
+        return call_bound.args, call_bound.kwargs
+
+    return inject
+
+
+def _get_simulated_data_injector(
+    model, observed_names, args, kwargs, simulated_data_to_args
+):
+    if simulated_data_to_args is None:
+        return _get_observed_arg_injector(model, observed_names, args, kwargs)
+
+    if not callable(simulated_data_to_args):
+        raise ValueError("simulated_data_to_args must be callable.")
+
+    def inject(sim_data):
+        injected = simulated_data_to_args(sim_data, *args, **kwargs)
+        if not isinstance(injected, tuple) or len(injected) != 2:
+            raise ValueError(
+                "simulated_data_to_args must return a pair (args, kwargs)."
+            )
+
+        sim_args, sim_kwargs = injected
+        if not isinstance(sim_args, (tuple, list)):
+            raise ValueError(
+                "simulated_data_to_args must return a tuple or list for args."
+            )
+        if not isinstance(sim_kwargs, Mapping):
+            raise ValueError("simulated_data_to_args must return a mapping for kwargs.")
+
+        return tuple(sim_args), dict(sim_kwargs)
+
+    return inject
+
+
+def _warmup_guide(
+    model,
+    guide,
+    optim,
+    loss,
+    observed_names,
+    simulated_data_injector,
+    *args,
+    **kwargs,
+):
+    """Run one SVI init to populate the guide's prototype trace.
+
+    This must happen before ``jax.lax.map`` because auto-guide prototype
+    setup uses ``while_loop`` which leaks tracers inside ``lax.map``.
+    """
+    dummy_data = {}
+    model_trace = trace(seed(model, random.PRNGKey(0))).get_trace(*args, **kwargs)
+    for name in observed_names:
+        if name in model_trace and model_trace[name]["type"] == "sample":
+            dummy_data[name] = model_trace[name]["value"]
+
+    dummy_model = condition(model, dummy_data)
+    warmup_args, warmup_kwargs = simulated_data_injector(dummy_data)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message="Found non-auxiliary vars")
+        svi = SVI(dummy_model, guide, optim, loss)
+        svi.init(random.PRNGKey(0), *warmup_args, **warmup_kwargs)
+
+
+def vsbc_diagnostic(
+    rng_key,
+    model,
+    guide,
+    optim,
+    loss,
+    *args,
+    observed_sites=None,
+    simulated_data_to_args=None,
+    num_simulations=100,
+    num_svi_steps=1000,
+    num_samples=1000,
+    chain_method="sequential",
+    **kwargs,
+):
+    r"""Compute the VSBC diagnostic for a model/guide pair.
+
+    Variational Simulation-Based Calibration checks whether a variational
+    approximation produces unbiased marginal point estimates on average
+    across simulated datasets. This implementation estimates the
+    calibration probabilities
+    :math:`p_{ij} = \Pr_q(\theta_i < \theta_i^*)` from posterior guide
+    draws and applies a two-sample Kolmogorov-Smirnov test to compare
+    :math:`p_{i:}` with :math:`1 - p_{i:}`. For a VSBC-calibrated
+    approximation, those marginal probabilities should be symmetric
+    around ``0.5``.
+
+    For tensor-valued latent sites, calibration probabilities, ranks, and
+    KS tests are computed component-wise. No multiple-comparison correction
+    is applied across components. Because the Monte Carlo probabilities lie
+    on a discrete grid with denominator ``num_samples``, the symmetry test
+    uses the asymptotic two-sample KS approximation.
+
+    The model must be generative when observed data is cleared: it should
+    sample both latent parameters and data from the prior predictive
+    distribution. The current implementation supports only continuous
+    latent sample sites.
+
+    Independent SVI fits are dispatched according to ``chain_method``
+    (following the same convention as :class:`~numpyro.infer.MCMC`):
+
+    - ``"sequential"`` (default): :func:`jax.lax.map` — JIT-compiled loop,
+      one simulation at a time. Memory-efficient; best for CPU.
+    - ``"vectorized"``: :func:`jax.vmap` — all simulations batched on one
+      device. Higher throughput on GPU but requires M× memory.
+    - ``"parallel"``: :func:`jax.pmap` — one simulation per device.
+      Requires ``num_simulations`` devices; falls back to ``"sequential"``
+      if insufficient devices are available.
+
+    **Example**::
+
+        >>> from jax import random
+        >>> import numpyro
+        >>> import numpyro.distributions as dist
+        >>> from numpyro.infer import Trace_ELBO
+        >>> from numpyro.infer.autoguide import AutoNormal
+        >>> from numpyro.infer.calibration import vsbc_diagnostic
+
+        >>> def model(obs=None):
+        ...     loc = numpyro.sample("loc", dist.Normal(0.0, 1.0))
+        ...     numpyro.sample("obs", dist.Normal(loc, 1.0), obs=obs)
+
+        >>> guide = AutoNormal(model)
+        >>> result = vsbc_diagnostic(
+        ...     random.PRNGKey(0), model, guide,
+        ...     numpyro.optim.Adam(0.01), Trace_ELBO(),
+        ...     observed_sites=["obs"],
+        ...     num_simulations=50, num_svi_steps=500, num_samples=500,
+        ... )
+
+    This diagnostic is computationally expensive because it runs
+    ``num_simulations`` independent SVI fits.
+
+    :param jax.random.PRNGKey rng_key: random number generator key.
+    :param Callable model: NumPyro model. Must be generative: when called
+        without observed data, it samples from the prior predictive.
+    :param Callable guide: NumPyro guide (unfitted). Will be re-initialized
+        for each simulation.
+    :param optim: a NumPyro optimizer (e.g. ``numpyro.optim.Adam``).
+    :param loss: an ELBO loss instance (e.g. ``Trace_ELBO()``).
+    :param args: positional arguments to model and guide. For direct
+        observed-data arguments, leave them unset or pass ``None`` so they
+        can be filled from ``observed_sites``. Passing concrete observed
+        data through direct arguments during VSBC is unsupported unless
+        ``simulated_data_to_args`` rewrites those arguments explicitly. If
+        observed-site names do not match argument names, automatic alias
+        inference is only supported when there is exactly one unset direct
+        observed-data argument.
+    :param list observed_sites: names of observed (data) sample sites in
+        the model. If None, observed sites are auto-detected from the
+        initial model trace when possible; otherwise a ``ValueError`` is
+        raised and sites must be provided explicitly.
+    :param callable simulated_data_to_args: optional callback to map a
+        simulated observation dict into model/guide call arguments. It is
+        called as ``simulated_data_to_args(sim_data, *args, **kwargs)``
+        and must return ``(sim_args, sim_kwargs)``. This is required when
+        observed data is passed through a container-style argument such as
+        ``data={"y": obs}`` rather than direct ``obs=...`` parameters.
+        Because it is executed inside the mapped simulation loop, this
+        callback should be a pure structural rewrite that is compatible
+        with JAX transformations such as ``lax.map``, ``vmap``, and
+        ``pmap``. If observed data is already bound in ``args`` or
+        ``kwargs``, the same callback is also used to clear those values
+        during discovery and prior-predictive simulation.
+    :param int num_simulations: number of prior predictive simulations (M
+        in Algorithm 2). Default 100.
+    :param int num_svi_steps: number of SVI optimization steps per
+        simulation. Default 1000.
+    :param int num_samples: number of posterior samples (L) to draw from
+        the fitted guide for Monte Carlo estimation of calibration
+        probabilities. Default 1000.
+    :param str chain_method: a callable JAX transform like :func:`jax.vmap`
+        or one of ``"sequential"`` (default), ``"vectorized"``, or
+        ``"parallel"``. See above for details.
+    :param kwargs: keyword arguments to model and guide.
+    :return: a :data:`VSBCResult` namedtuple containing calibration
+        probability estimates, symmetry-test results, and raw ranks.
+    :rtype: VSBCResult
+
+    **References**
+
+    - Yao, Y., Vehtari, A., Simpson, D., and Gelman, A. (2018).
+      *Yes, but Did It Work?: Evaluating Variational Inference.*
+    - Talts, S., Betancourt, M., Simpson, D., Vehtari, A., and Gelman, A.
+      (2018). *Validating Bayesian Inference Algorithms with
+      Simulation-Based Calibration.*
+    """
+    if num_simulations < 2:
+        raise ValueError("num_simulations must be at least 2.")
+    if num_svi_steps < 1:
+        raise ValueError("num_svi_steps must be at least 1.")
+    if num_samples < 2:
+        raise ValueError("num_samples must be at least 2.")
+    if not callable(chain_method) and chain_method not in (
+        "sequential",
+        "vectorized",
+        "parallel",
+    ):
+        raise ValueError(
+            "Only supporting the following methods to dispatch simulations:"
+            ' "sequential", "parallel", or "vectorized"'
+        )
+
+    if chain_method == "parallel" and jax.local_device_count() < num_simulations:
+        chain_method = "sequential"
+        warnings.warn(
+            f"Not enough devices for parallel execution: expected "
+            f"{num_simulations} but got {jax.local_device_count()}."
+            f" Falling back to sequential. If running on CPU, consider"
+            f" using numpyro.set_host_device_count({num_simulations}).",
+            stacklevel=2,
+        )
+
+    rng_key, key_discover = random.split(rng_key)
+
+    if observed_sites is None:
+        model_trace = trace(seed(model, key_discover)).get_trace(*args, **kwargs)
+        observed_names, latent_names = _resolve_observed_sites(model_trace, observed_sites)
+        simulated_data_injector = _get_simulated_data_injector(
+            model, observed_names, args, kwargs, simulated_data_to_args
+        )
+        cleared_args, cleared_kwargs = args, kwargs
+    else:
+        observed_names = list(dict.fromkeys(observed_sites))
+        simulated_data_injector = _get_simulated_data_injector(
+            model, observed_names, args, kwargs, simulated_data_to_args
+        )
+        cleared_args, cleared_kwargs = simulated_data_injector(
+            {name: None for name in observed_names}
+        )
+        model_trace = trace(seed(model, key_discover)).get_trace(
+            *cleared_args, **cleared_kwargs
+        )
+        observed_names, latent_names = _resolve_observed_sites(model_trace, observed_sites)
+        simulated_data_injector = _get_simulated_data_injector(
+            model, observed_names, args, kwargs, simulated_data_to_args
+        )
+
+    _validate_latent_sites(model_trace, latent_names)
+
+    _warmup_guide(
+        model,
+        guide,
+        optim,
+        loss,
+        observed_names,
+        simulated_data_injector,
+        *args,
+        **kwargs,
+    )
+
+    # Draw prior predictive samples (Python loop — model tracing cannot
+    # be JIT-compiled, but this is fast relative to the SVI fits below).
+    rng_key, key_prior = random.split(rng_key)
+    prior_keys = random.split(key_prior, num_simulations)
+    prior_latents = []
+    sim_data = []
+    for i in range(num_simulations):
+        samples = _prior_predictive_sample(
+            prior_keys[i], model, *cleared_args, **cleared_kwargs
+        )
+        prior_latents.append({n: samples[n] for n in latent_names if n in samples})
+        sim_data.append({n: samples[n] for n in observed_names if n in samples})
+
+    sim_data_stacked = {
+        n: jnp.stack([sim_data[i][n] for i in range(num_simulations)])
+        for n in observed_names
+    }
+    theta_true_stacked = {
+        n: jnp.stack([prior_latents[i][n] for i in range(num_simulations)])
+        for n in latent_names
+    }
+
+    # Run M independent SVI fits. Handlers (condition, seed) are applied
+    # inside the mapped function so each iteration gets fresh state.
+    rng_key, key_sim = random.split(rng_key)
+    sim_keys = random.split(key_sim, num_simulations * 2).reshape(
+        num_simulations, 2, -1
+    )
+
+    def _single_simulation(carry):
+        key_svi, key_post, sim_data, theta_true = carry
+        conditioned_model = condition(model, sim_data)
+        sim_args, sim_kwargs = simulated_data_injector(sim_data)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message="Found non-auxiliary vars")
+            svi = SVI(conditioned_model, guide, optim, loss)
+            svi_state = svi.init(key_svi, *sim_args, **sim_kwargs)
+
+            def body_fn(svi_state, _):
+                svi_state, svi_loss = svi.update(svi_state, *sim_args, **sim_kwargs)
+                return svi_state, svi_loss
+
+            svi_state, _ = jax.lax.scan(body_fn, svi_state, None, length=num_svi_steps)
+            params = svi.get_params(svi_state)
+
+        predictive = Predictive(guide, params=params, num_samples=num_samples)
+        posterior_samples = predictive(key_post, *sim_args, **sim_kwargs)
+
+        rank_dict = {
+            name: jnp.sum(posterior_samples[name] < theta_true[name], axis=0)
+            for name in latent_names
+        }
+        return rank_dict
+
+    map_args = (
+        sim_keys[:, 0],
+        sim_keys[:, 1],
+        sim_data_stacked,
+        theta_true_stacked,
+    )
+
+    if chain_method == "sequential":
+        rank_results = jax.lax.map(_single_simulation, map_args)
+    elif chain_method == "parallel":
+        rank_results = pmap(_single_simulation)(map_args)
+    elif callable(chain_method):
+        rank_results = chain_method(_single_simulation)(map_args)
+    else:
+        assert chain_method == "vectorized"
+        rank_results = vmap(_single_simulation)(map_args)
+
+    all_ranks = {
+        name: np.asarray(jax.device_get(rank_results[name])) for name in latent_names
+    }
+
+    from scipy.stats import ks_2samp
+
+    probabilities = {}
+    ranks = {}
+    ks_stats = {}
+    ks_pvalues = {}
+    param_names = tuple(sorted(all_ranks.keys()))
+
+    for name in param_names:
+        ranks[name] = all_ranks[name]
+        probabilities[name] = np.asarray(all_ranks[name] / num_samples)
+        flat_probabilities = probabilities[name].reshape((num_simulations, -1))
+        flat_stats = np.empty(flat_probabilities.shape[1], dtype=float)
+        flat_pvalues = np.empty(flat_probabilities.shape[1], dtype=float)
+        for i in range(flat_probabilities.shape[1]):
+            ks_stat, ks_pvalue = ks_2samp(
+                flat_probabilities[:, i],
+                1.0 - flat_probabilities[:, i],
+                method="asymp",
+            )
+            flat_stats[i] = ks_stat
+            flat_pvalues[i] = ks_pvalue
+
+        site_shape = probabilities[name].shape[1:]
+        if site_shape:
+            ks_stats[name] = flat_stats.reshape(site_shape)
+            ks_pvalues[name] = flat_pvalues.reshape(site_shape)
+        else:
+            ks_stats[name] = float(flat_stats[0])
+            ks_pvalues[name] = float(flat_pvalues[0])
+
+    return VSBCResult(
+        probabilities=probabilities,
+        ks_stats=ks_stats,
+        ks_pvalues=ks_pvalues,
+        ranks=ranks,
+        param_names=param_names,
+    )

--- a/test/infer/test_calibration.py
+++ b/test/infer/test_calibration.py
@@ -1,0 +1,614 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for the VSBC diagnostic (numpyro.infer.calibration).
+
+These tests exercise the probability-based VSBC implementation against
+known Gaussian cases, regression scenarios, and API edge cases.
+"""
+
+import numpy as np
+import pytest
+from scipy import stats
+
+from jax import random
+
+import numpyro
+import numpyro.distributions as dist
+from numpyro.infer import Predictive, Trace_ELBO
+from numpyro.infer.autoguide import AutoNormal
+from numpyro.infer.calibration import vsbc_diagnostic
+
+
+def _normal_model(x=None):
+    loc = numpyro.sample("loc", dist.Normal(0.0, 1.0))
+    numpyro.sample("obs", dist.Normal(loc, 1.0), obs=x)
+
+
+def _fixed_unbiased_guide(x=None):
+    numpyro.sample("loc", dist.Normal(0.0, 1.0))
+
+
+def _fixed_underdispersed_guide(x=None):
+    numpyro.sample("loc", dist.Normal(0.0, 0.1))
+
+
+def _fixed_biased_guide(x=None):
+    numpyro.sample("loc", dist.Normal(1.0, 1.0))
+
+
+def _vector_obs_model(x=None):
+    loc = numpyro.sample("loc", dist.Normal(0.0, 1.0))
+    numpyro.sample("obs", dist.Normal(loc, 1.0).expand([3]), obs=x)
+
+
+def _data_dependent_guide(x=None):
+    if x is None:
+        raise RuntimeError("guide received x=None")
+    loc_mean = numpyro.param("loc_mean", 0.0)
+    numpyro.sample("loc", dist.Normal(loc_mean + x.mean(), 1.0))
+
+
+def _fixed_data_dependent_guide(x=None):
+    if x is None:
+        raise RuntimeError("guide received x=None")
+    numpyro.sample("loc", dist.Normal(x.mean(), 0.2))
+
+
+def _misrouting_model(x=None, mask=None):
+    loc = numpyro.sample("loc", dist.Normal(0.0, 1.0))
+    numpyro.sample("obs", dist.Normal(loc, 1.0), obs=x)
+
+
+def _misrouting_guide(x=None, mask=None):
+    if mask is not None:
+        raise RuntimeError("mask was injected")
+    if x is None:
+        raise RuntimeError("guide received x=None")
+    numpyro.sample("loc", dist.Normal(x.mean(), 1.0))
+
+
+def _scaled_obs_model(x=None, scale=2.0):
+    loc = numpyro.sample("loc", dist.Normal(0.0, 1.0))
+    numpyro.sample("obs", dist.Normal(loc, scale), obs=x)
+
+
+def _scaled_data_guide(x=None, scale=2.0):
+    if x is None:
+        raise RuntimeError("guide received x=None")
+    numpyro.sample("loc", dist.Normal(x.mean() / scale, 1.0))
+
+
+def _container_model(data=None):
+    loc = numpyro.sample("loc", dist.Normal(0.0, 1.0))
+    scale = numpyro.sample("scale", dist.LogNormal(0.0, 0.3))
+    obs_loc = None if data is None else data["obs_loc"]
+    obs_scale = None if data is None else data["obs_scale"]
+    numpyro.sample("obs_loc", dist.Normal(loc, 1.0), obs=obs_loc)
+    numpyro.sample("obs_scale", dist.Normal(scale, 0.5), obs=obs_scale)
+
+
+def _container_data_guide(data=None):
+    if data is None:
+        raise RuntimeError("guide received data=None")
+    numpyro.sample("loc", dist.Normal(data["obs_loc"], 1.0))
+    numpyro.sample("scale", dist.LogNormal(data["obs_scale"], 0.2))
+
+
+def _simulated_data_to_container_args(sim_data, *args, **kwargs):
+    sim_kwargs = dict(kwargs)
+    sim_kwargs["data"] = sim_data
+    return args, sim_kwargs
+
+
+def _simulated_data_to_x_args(sim_data, *args, **kwargs):
+    return (sim_data["obs"],), kwargs
+
+
+def _single_obs_container_model(data=None):
+    loc = numpyro.sample("loc", dist.Normal(0.0, 1.0))
+    obs = None if data is None else data["obs"]
+    numpyro.sample("obs", dist.Normal(loc, 1.0), obs=obs)
+
+
+def _single_obs_container_guide(data=None):
+    if data is None:
+        raise RuntimeError("guide received data=None")
+    numpyro.sample("loc", dist.Normal(data["obs"], 0.2))
+
+
+def _simulated_data_to_single_obs_container_args(sim_data, *args, **kwargs):
+    sim_kwargs = dict(kwargs)
+    sim_kwargs["data"] = {"obs": sim_data["obs"]}
+    return args, sim_kwargs
+
+
+def _discrete_model(x=None):
+    z = numpyro.sample("z", dist.Bernoulli(0.5))
+    numpyro.sample("obs", dist.Normal(z, 1.0), obs=x)
+
+
+def _discrete_guide(x=None):
+    numpyro.sample("z", dist.Bernoulli(0.5))
+
+
+class TestVSBCDiagnostic:
+    """End-to-end tests for vsbc_diagnostic."""
+
+    def test_output_structure(self):
+        """Return value has correct shape, bounds, and param names."""
+        guide = AutoNormal(_normal_model)
+        num_samples = 100
+        result = vsbc_diagnostic(
+            random.PRNGKey(0),
+            _normal_model,
+            guide,
+            numpyro.optim.Adam(0.01),
+            Trace_ELBO(),
+            observed_sites=["obs"],
+            num_simulations=5,
+            num_svi_steps=100,
+            num_samples=num_samples,
+        )
+        assert result.param_names == ("loc",)
+        assert "obs" not in result.param_names
+        assert result.probabilities["loc"].shape == (5,)
+        assert np.all(result.probabilities["loc"] >= 0)
+        assert np.all(result.probabilities["loc"] <= 1)
+        assert result.ranks["loc"].shape == (5,)
+        assert np.all(result.ranks["loc"] >= 0)
+        assert np.all(result.ranks["loc"] <= num_samples)
+        assert 0 <= result.ks_stats["loc"] <= 1
+        assert 0 <= result.ks_pvalues["loc"] <= 1
+
+    def test_probabilities_match_analytic_gaussian_cdf(self):
+        """Monte Carlo probabilities should match the guide CDF in a Gaussian case."""
+        rng_key = random.PRNGKey(0)
+        num_simulations = 6
+        result = vsbc_diagnostic(
+            rng_key,
+            _normal_model,
+            _fixed_unbiased_guide,
+            numpyro.optim.Adam(0.01),
+            Trace_ELBO(),
+            observed_sites=["obs"],
+            num_simulations=num_simulations,
+            num_svi_steps=5,
+            num_samples=4000,
+        )
+        rng_key, _ = random.split(rng_key)
+        _, key_prior = random.split(rng_key)
+        theta_true = np.array(
+            Predictive(_normal_model, num_samples=num_simulations)(key_prior)["loc"]
+        )
+        expected = stats.norm.cdf(theta_true, loc=0.0, scale=1.0)
+        np.testing.assert_allclose(result.probabilities["loc"], expected, atol=0.03)
+
+    def test_underdispersed_but_unbiased_guide_passes_symmetry_test(self):
+        """VSBC should track symmetry, not uniformity, for unbiased point estimates."""
+        result = vsbc_diagnostic(
+            random.PRNGKey(42),
+            _normal_model,
+            _fixed_underdispersed_guide,
+            numpyro.optim.Adam(0.01),
+            Trace_ELBO(),
+            observed_sites=["obs"],
+            num_simulations=150,
+            num_svi_steps=5,
+            num_samples=2000,
+        )
+        assert result.ks_pvalues["loc"] > 0.05
+        assert stats.kstest(result.probabilities["loc"], "uniform").pvalue < 1e-6
+
+    def test_biased_guide_fails_symmetry_test(self):
+        """A biased variational center should fail the VSBC symmetry check."""
+        result = vsbc_diagnostic(
+            random.PRNGKey(123),
+            _normal_model,
+            _fixed_biased_guide,
+            numpyro.optim.Adam(0.01),
+            Trace_ELBO(),
+            observed_sites=["obs"],
+            num_simulations=150,
+            num_svi_steps=5,
+            num_samples=2000,
+        )
+        assert result.ks_pvalues["loc"] < 0.05
+
+    def test_multiple_latent_parameters(self):
+        """Each latent parameter gets its own probabilities, ranks, and KS test."""
+
+        def multi_model(x=None):
+            loc = numpyro.sample("loc", dist.Normal(0.0, 1.0))
+            scale = numpyro.sample("scale", dist.HalfNormal(1.0))
+            numpyro.sample("obs", dist.Normal(loc, scale), obs=x)
+
+        guide = AutoNormal(multi_model)
+        result = vsbc_diagnostic(
+            random.PRNGKey(0),
+            multi_model,
+            guide,
+            numpyro.optim.Adam(0.01),
+            Trace_ELBO(),
+            observed_sites=["obs"],
+            num_simulations=5,
+            num_svi_steps=100,
+            num_samples=100,
+        )
+        assert result.param_names == ("loc", "scale")
+        assert result.probabilities["loc"].shape == (5,)
+        assert result.probabilities["scale"].shape == (5,)
+        assert result.ranks["loc"].shape == (5,)
+        assert result.ranks["scale"].shape == (5,)
+
+    def test_data_dependent_guide_uses_simulated_observations(self):
+        """Direct observed-data args should receive the simulated observations."""
+        rng_key = random.PRNGKey(0)
+        num_simulations = 4
+        result = vsbc_diagnostic(
+            rng_key,
+            _vector_obs_model,
+            _fixed_data_dependent_guide,
+            numpyro.optim.Adam(0.01),
+            Trace_ELBO(),
+            observed_sites=["obs"],
+            num_simulations=num_simulations,
+            num_svi_steps=5,
+            num_samples=4000,
+        )
+        rng_key, _ = random.split(rng_key)
+        _, key_prior = random.split(rng_key)
+        prior_samples = Predictive(_vector_obs_model, num_samples=num_simulations)(key_prior)
+        expected = stats.norm.cdf(
+            np.array(prior_samples["loc"]),
+            loc=np.array(prior_samples["obs"]).mean(axis=-1),
+            scale=0.2,
+        )
+        np.testing.assert_allclose(result.probabilities["loc"], expected, atol=0.03)
+
+    def test_bound_direct_observed_args_require_explicit_mapper(self):
+        """Bound direct observed args should fail fast instead of misrouting."""
+        with pytest.raises(ValueError, match="Conflicting bound arguments"):
+            vsbc_diagnostic(
+                random.PRNGKey(0),
+                _misrouting_model,
+                _misrouting_guide,
+                numpyro.optim.Adam(0.01),
+                Trace_ELBO(),
+                np.ones(3),
+                observed_sites=["obs"],
+                num_simulations=2,
+                num_svi_steps=5,
+                num_samples=10,
+            )
+
+    def test_alias_observed_arg_allows_other_fixed_hyperparameters(self):
+        """Alias-style observed args should still work with fixed non-data kwargs."""
+        result = vsbc_diagnostic(
+            random.PRNGKey(0),
+            _scaled_obs_model,
+            _scaled_data_guide,
+            numpyro.optim.Adam(0.01),
+            Trace_ELBO(),
+            observed_sites=["obs"],
+            scale=2.0,
+            num_simulations=4,
+            num_svi_steps=10,
+            num_samples=20,
+        )
+        assert result.param_names == ("loc",)
+        assert result.probabilities["loc"].shape == (4,)
+
+    def test_bound_direct_observed_data_is_cleared_with_explicit_mapper(self):
+        """Bound direct observed data should be cleared when a mapper is supplied."""
+        baseline = vsbc_diagnostic(
+            random.PRNGKey(0),
+            _vector_obs_model,
+            _fixed_data_dependent_guide,
+            numpyro.optim.Adam(0.01),
+            Trace_ELBO(),
+            observed_sites=["obs"],
+            simulated_data_to_args=_simulated_data_to_x_args,
+            num_simulations=4,
+            num_svi_steps=5,
+            num_samples=4000,
+        )
+        reused_data = vsbc_diagnostic(
+            random.PRNGKey(0),
+            _vector_obs_model,
+            _fixed_data_dependent_guide,
+            numpyro.optim.Adam(0.01),
+            Trace_ELBO(),
+            np.full(3, 10.0),
+            observed_sites=["obs"],
+            simulated_data_to_args=_simulated_data_to_x_args,
+            num_simulations=4,
+            num_svi_steps=5,
+            num_samples=4000,
+        )
+        np.testing.assert_allclose(
+            reused_data.probabilities["loc"], baseline.probabilities["loc"]
+        )
+
+    def test_bound_container_observed_data_is_cleared_for_prior_predictive(self):
+        """Bound container data should not affect simulated datasets."""
+        baseline = vsbc_diagnostic(
+            random.PRNGKey(0),
+            _single_obs_container_model,
+            _single_obs_container_guide,
+            numpyro.optim.Adam(0.01),
+            Trace_ELBO(),
+            observed_sites=["obs"],
+            simulated_data_to_args=_simulated_data_to_single_obs_container_args,
+            num_simulations=4,
+            num_svi_steps=5,
+            num_samples=4000,
+        )
+        reused_data = vsbc_diagnostic(
+            random.PRNGKey(0),
+            _single_obs_container_model,
+            _single_obs_container_guide,
+            numpyro.optim.Adam(0.01),
+            Trace_ELBO(),
+            observed_sites=["obs"],
+            simulated_data_to_args=_simulated_data_to_single_obs_container_args,
+            data={"obs": 10.0},
+            num_simulations=4,
+            num_svi_steps=5,
+            num_samples=4000,
+        )
+        np.testing.assert_allclose(
+            reused_data.probabilities["loc"], baseline.probabilities["loc"]
+        )
+
+    def test_container_observed_data_requires_explicit_mapper(self):
+        """Container-style observed data should require simulated_data_to_args."""
+        with pytest.raises(ValueError, match="simulated_data_to_args"):
+            vsbc_diagnostic(
+                random.PRNGKey(0),
+                _container_model,
+                _container_data_guide,
+                numpyro.optim.Adam(0.01),
+                Trace_ELBO(),
+                observed_sites=["obs_loc", "obs_scale"],
+                num_simulations=2,
+                num_svi_steps=5,
+                num_samples=10,
+            )
+
+    def test_container_observed_data_mapper_threads_multiple_sites(self):
+        """Container mappers should route the intended simulated observations."""
+        rng_key = random.PRNGKey(0)
+        num_simulations = 4
+        result = vsbc_diagnostic(
+            rng_key,
+            _container_model,
+            _container_data_guide,
+            numpyro.optim.Adam(0.01),
+            Trace_ELBO(),
+            observed_sites=["obs_loc", "obs_scale"],
+            simulated_data_to_args=_simulated_data_to_container_args,
+            num_simulations=num_simulations,
+            num_svi_steps=5,
+            num_samples=4000,
+        )
+        rng_key, _ = random.split(rng_key)
+        _, key_prior = random.split(rng_key)
+        prior_samples = Predictive(_container_model, num_samples=num_simulations)(key_prior)
+        expected_loc = stats.norm.cdf(
+            np.array(prior_samples["loc"]),
+            loc=np.array(prior_samples["obs_loc"]),
+            scale=1.0,
+        )
+        expected_scale = stats.lognorm.cdf(
+            np.array(prior_samples["scale"]),
+            s=0.2,
+            scale=np.exp(np.array(prior_samples["obs_scale"])),
+        )
+        np.testing.assert_allclose(result.probabilities["loc"], expected_loc, atol=0.03)
+        np.testing.assert_allclose(
+            result.probabilities["scale"], expected_scale, atol=0.03
+        )
+
+    def test_container_observed_data_mapper_supports_vectorized_dispatch(self):
+        """Vectorized dispatch should preserve container-mapper behavior."""
+        sequential = vsbc_diagnostic(
+            random.PRNGKey(0),
+            _container_model,
+            _container_data_guide,
+            numpyro.optim.Adam(0.01),
+            Trace_ELBO(),
+            observed_sites=["obs_loc", "obs_scale"],
+            simulated_data_to_args=_simulated_data_to_container_args,
+            num_simulations=4,
+            num_svi_steps=20,
+            num_samples=20,
+        )
+        vectorized = vsbc_diagnostic(
+            random.PRNGKey(0),
+            _container_model,
+            _container_data_guide,
+            numpyro.optim.Adam(0.01),
+            Trace_ELBO(),
+            observed_sites=["obs_loc", "obs_scale"],
+            simulated_data_to_args=_simulated_data_to_container_args,
+            num_simulations=4,
+            num_svi_steps=20,
+            num_samples=20,
+            chain_method="vectorized",
+        )
+        assert vectorized.param_names == sequential.param_names
+        np.testing.assert_allclose(
+            vectorized.probabilities["loc"], sequential.probabilities["loc"]
+        )
+        np.testing.assert_allclose(
+            vectorized.probabilities["scale"], sequential.probabilities["scale"]
+        )
+        np.testing.assert_array_equal(vectorized.ranks["loc"], sequential.ranks["loc"])
+        np.testing.assert_array_equal(
+            vectorized.ranks["scale"], sequential.ranks["scale"]
+        )
+
+    @pytest.mark.parametrize(
+        "simulated_data_to_args, match",
+        [
+            (0, "must be callable"),
+            (lambda sim_data, *args, **kwargs: sim_data, "must return a pair"),
+            (
+                lambda sim_data, *args, **kwargs: (sim_data["obs_loc"], {}),
+                "must return a tuple or list for args",
+            ),
+            (
+                lambda sim_data, *args, **kwargs: (args, sim_data["obs_loc"]),
+                "must return a mapping for kwargs",
+            ),
+        ],
+    )
+    def test_container_observed_data_mapper_validation(
+        self, simulated_data_to_args, match
+    ):
+        """Container mappers should fail fast on invalid callback contracts."""
+        with pytest.raises(ValueError, match=match):
+            vsbc_diagnostic(
+                random.PRNGKey(0),
+                _container_model,
+                _container_data_guide,
+                numpyro.optim.Adam(0.01),
+                Trace_ELBO(),
+                observed_sites=["obs_loc", "obs_scale"],
+                simulated_data_to_args=simulated_data_to_args,
+                num_simulations=2,
+                num_svi_steps=5,
+                num_samples=10,
+            )
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        dict(num_simulations=1),
+        dict(num_svi_steps=0),
+        dict(num_samples=1),
+        dict(observed_sites=["missing"]),
+        dict(observed_sites=["loc", "obs"]),
+        dict(chain_method="invalid"),
+    ],
+)
+def test_input_validation(kwargs):
+    """Invalid inputs should raise ValueError."""
+    defaults = dict(observed_sites=["obs"], num_simulations=2)
+    defaults.update(kwargs)
+    guide = AutoNormal(_normal_model)
+    with pytest.raises(ValueError):
+        vsbc_diagnostic(
+            random.PRNGKey(0),
+            _normal_model,
+            guide,
+            numpyro.optim.Adam(0.01),
+            Trace_ELBO(),
+            **defaults,
+        )
+
+
+def test_observed_sites_auto_detection_requires_explicit_sites_for_generative_models():
+    """Generative models with obs=None should request observed_sites explicitly."""
+    guide = AutoNormal(_normal_model)
+    with pytest.raises(ValueError, match="Unable to infer observed sites"):
+        vsbc_diagnostic(
+            random.PRNGKey(0),
+            _normal_model,
+            guide,
+            numpyro.optim.Adam(0.01),
+            Trace_ELBO(),
+            num_simulations=2,
+            num_svi_steps=10,
+            num_samples=10,
+        )
+
+
+def test_discrete_latents_raise_value_error():
+    """VSBC currently supports only continuous latent sample sites."""
+    with pytest.raises(ValueError, match="supports only continuous latent"):
+        vsbc_diagnostic(
+            random.PRNGKey(0),
+            _discrete_model,
+            _discrete_guide,
+            numpyro.optim.Adam(0.01),
+            Trace_ELBO(),
+            observed_sites=["obs"],
+            num_simulations=2,
+            num_svi_steps=5,
+            num_samples=10,
+        )
+
+
+@pytest.mark.parametrize("chain_method", ["sequential", "vectorized"])
+def test_chain_methods(chain_method):
+    """Both sequential and vectorized dispatch produce valid VSBC outputs."""
+    guide = AutoNormal(_normal_model)
+    num_samples = 100
+    result = vsbc_diagnostic(
+        random.PRNGKey(42),
+        _normal_model,
+        guide,
+        numpyro.optim.Adam(0.01),
+        Trace_ELBO(),
+        observed_sites=["obs"],
+        num_simulations=5,
+        num_svi_steps=200,
+        num_samples=num_samples,
+        chain_method=chain_method,
+    )
+    assert result.probabilities["loc"].shape == (5,)
+    assert np.all(result.probabilities["loc"] >= 0)
+    assert np.all(result.probabilities["loc"] <= 1)
+    assert result.ranks["loc"].shape == (5,)
+    assert np.all(result.ranks["loc"] >= 0)
+    assert np.all(result.ranks["loc"] <= num_samples)
+
+
+def test_vector_latent_sites_return_marginal_probabilities():
+    """Vector-valued latents should return per-component VSBC diagnostics."""
+
+    def vector_latent_model(x=None):
+        z = numpyro.sample("z", dist.Normal(0.0, 1.0).expand([2]))
+        numpyro.sample("obs", dist.Normal(z.sum(), 1.0), obs=x)
+
+    def vector_guide(x=None):
+        numpyro.sample("z", dist.Normal(0.0, 1.0).expand([2]))
+
+    result = vsbc_diagnostic(
+        random.PRNGKey(0),
+        vector_latent_model,
+        vector_guide,
+        numpyro.optim.Adam(0.01),
+        Trace_ELBO(),
+        observed_sites=["obs"],
+        num_simulations=5,
+        num_svi_steps=5,
+        num_samples=200,
+    )
+    assert result.probabilities["z"].shape == (5, 2)
+    assert result.ranks["z"].shape == (5, 2)
+    assert result.ks_stats["z"].shape == (2,)
+    assert result.ks_pvalues["z"].shape == (2,)
+
+
+def test_parallel_fallback():
+    """parallel falls back to sequential with a warning when not enough devices."""
+    guide = AutoNormal(_normal_model)
+    with pytest.warns(UserWarning, match="Not enough devices"):
+        result = vsbc_diagnostic(
+            random.PRNGKey(0),
+            _normal_model,
+            guide,
+            numpyro.optim.Adam(0.01),
+            Trace_ELBO(),
+            observed_sites=["obs"],
+            num_simulations=5,
+            num_svi_steps=100,
+            num_samples=50,
+            chain_method="parallel",
+        )
+    assert result.ranks["loc"].shape == (5,)

--- a/test/infer/test_calibration.py
+++ b/test/infer/test_calibration.py
@@ -259,7 +259,9 @@ class TestVSBCDiagnostic:
         )
         rng_key, _ = random.split(rng_key)
         _, key_prior = random.split(rng_key)
-        prior_samples = Predictive(_vector_obs_model, num_samples=num_simulations)(key_prior)
+        prior_samples = Predictive(_vector_obs_model, num_samples=num_simulations)(
+            key_prior
+        )
         expected = stats.norm.cdf(
             np.array(prior_samples["loc"]),
             loc=np.array(prior_samples["obs"]).mean(axis=-1),
@@ -395,7 +397,9 @@ class TestVSBCDiagnostic:
         )
         rng_key, _ = random.split(rng_key)
         _, key_prior = random.split(rng_key)
-        prior_samples = Predictive(_container_model, num_samples=num_simulations)(key_prior)
+        prior_samples = Predictive(_container_model, num_samples=num_simulations)(
+            key_prior
+        )
         expected_loc = stats.norm.cdf(
             np.array(prior_samples["loc"]),
             loc=np.array(prior_samples["obs_loc"]),


### PR DESCRIPTION
## Summary

Implements the VSBC diagnostic requested in #2142.

This follows Yao et al. (2018), Section 3 / Algorithm 2: simulate datasets from the prior predictive, fit a variational approximation for each dataset, estimate marginal calibration probabilities, and test symmetry of `p` vs `1 - p` with a two-sample KS test.

## Changes

- add `vsbc_diagnostic` in `numpyro/infer/calibration.py`
- export `vsbc_diagnostic` from `numpyro.infer`
- add end-to-end tests in `test/infer/test_calibration.py`
- support sequential / vectorized / parallel dispatch
- validate observed-site plumbing and `simulated_data_to_args`
- reject discrete latent sample sites explicitly

## References
- Yao, Y., Vehtari, A., Simpson, D., and Gelman, A. (2018). *Yes, but Did It Work?: Evaluating Variational Inference.*
- Talts, S., Betancourt, M., Simpson, D., Vehtari, A., and Gelman, A. (2018). *Validating Bayesian Inference Algorithms with Simulation-Based Calibration.*

Fixes #2142