### PR TITLE
dev: pre-commit hook to standardize toml format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,3 +50,8 @@ repos:
     hooks:
       - id: yamlfmt
         args: [-formatter, retain_line_breaks=true]
+
+  - repo: https://github.com/tombi-toml/tombi-pre-commit
+    rev: v0.10.6
+    hooks:
+      - id: tombi-format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,14 +11,14 @@ classifiers = [
     "Intended Audience :: Education",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: Apache Software License",
-    "Operating System :: POSIX :: Linux",
     "Operating System :: MacOS :: MacOS X",
+    "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
 ]
-keywords = ["probabilistic", "machine learning", "bayesian", "statistics"]
+keywords = ["bayesian", "machine learning", "probabilistic", "statistics"]
 dependencies = [
     "jax>=0.7.0",
     "jaxlib>=0.7.0",
@@ -47,11 +47,6 @@ requires = ["setuptools>=61", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [dependency-groups]
-ci = [
-    "coverage>=7.13.5",
-    "coveralls>=4.1.0",
-    "funsor",
-]
 dev = [
     "equinox",
     "flax",
@@ -61,19 +56,24 @@ dev = [
     "jaxns>=2.6.3,<=2.6.9",
     "matplotlib",
     "optax>=0.0.6",
-    "pylab-sdk",            # jaxns dependency
+    "pylab-sdk",                         # jaxns dependency
     "pytest-cov",
-    "pyyaml",               # flax dependency
-    "requests",             # pylab dependency
+    "pyyaml",                            # flax dependency
+    "requests",                          # pylab dependency
     "tfp-nightly",
 ]
+ci = [
+    "coverage>=7.13.5",
+    "coveralls>=4.1.0",
+    "funsor",
+]
 docs = [
-    "ipython",                          # sphinx needs this to render codes
+    "ipython",                           # sphinx needs this to render codes
     "nbsphinx>=0.8.9",
     "readthedocs-sphinx-search>=0.3.2",
-    "sphinx-rtd-theme",
-    "sphinx-gallery",
     "sphinx>=5",
+    "sphinx-gallery",
+    "sphinx-rtd-theme",
 ]
 examples = [
     "arviz",
@@ -142,10 +142,10 @@ extend-include = ["*.ipynb"]
 [tool.ruff.lint]
 select = ["ANN", "E", "F", "I", "W"]
 ignore = [
-    "ANN002", # missing args type annotation
-    "ANN003", # missing kwargs type annotation
-    "ANN204", # missing type annotation for __call__
-    "ANN401", # function arguments are annotated with a more specific type than Any.
+    "ANN002",                         # missing args type annotation
+    "ANN003",                         # missing kwargs type annotation
+    "ANN204",                         # missing type annotation for __call__
+    "ANN401",                         # function arguments are annotated with a more specific type than Any.
     "E203",
 ]
 
@@ -175,7 +175,7 @@ line-ending = "auto"
 [tool.ruff.lint.per-file-ignores]
 "!numpyro/{diagnostics.py,handlers.py,optim.py,patch.py,primitives.py,infer/elbo.py,distributions/distribution.py}" = [
     "ANN",
-] # require type annotations in typed modules
+]                                                                                                                        # require type annotations in typed modules
 
 [tool.ruff.lint.extend-per-file-ignores]
 "numpyro/contrib/tfp/distributions.py" = ["F811"]
@@ -197,7 +197,6 @@ section-order = [
 
 [tool.ruff.lint.isort.sections]
 known-jax = ["flax", "jax", "optax", "tensorflow_probability"]
-
 
 [tool.pytest.ini_options]
 addopts = ["-v", "--color=yes"]
@@ -225,8 +224,8 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 module = [
     "examples.datasets",
-    "numpyro.contrib.control_flow.*",       # types missing
-    "numpyro.contrib.funsor.*",             # types missing
+    "numpyro.contrib.control_flow.*",        # types missing
+    "numpyro.contrib.funsor.*",              # types missing
     "numpyro.contrib.hsgp.*",
     "numpyro.contrib.stochastic_support.*",
     "numpyro.diagnostics.*",

--- a/tombi.toml
+++ b/tombi.toml
@@ -1,0 +1,42 @@
+toml-version = "v1.0.0"
+
+[files]
+include = ["**/*.toml"]
+exclude = [".cache/**/*.toml"]
+
+[format]
+[format.rules]
+array-bracket-space-width = 0
+array-comma-space-width = 1
+date-time-delimiter = "T"
+indent-style = "space"
+indent-sub-tables = false
+indent-table-key-value-pairs = false
+indent-width = 4
+inline-table-brace-space-width = 1
+inline-table-comma-space-width = 1
+key-value-equals-sign-alignment = false
+key-value-equals-sign-space-width = 1
+line-ending = "lf"
+line-width = 80
+string-quote-style = "double"
+trailing-comment-alignment = true
+trailing-comment-space-width = 2
+
+[lint]
+[lint.rules]
+dotted-keys-out-of-order = "warn"
+key-empty = "warn"
+tables-out-of-order = "off"
+
+[lsp]
+code-action.enabled = true
+completion.enabled = true
+diagnostic.enabled = true
+document-link.enabled = true
+formatting.enabled = true
+goto-declaration.enabled = true
+goto-definition.enabled = true
+goto-type-definition.enabled = true
+hover.enabled = true
+workspace-diagnostic.enabled = true

--- a/ty.toml
+++ b/ty.toml
@@ -6,20 +6,20 @@ python-version = "3.13"
 # To match mypy's "passing" behavior, we disable ty's stricter rules that mypy doesn't catch.
 [rules]
 unresolved-import = "ignore"
-unused-ignore-comment = "ignore"    # Needed for mypy compatibility
+unused-ignore-comment = "ignore"          # Needed for mypy compatibility
 # Rules that ty catches but mypy doesn't (needed to match mypy's passing behavior)
-invalid-type-form = "ignore"        # ParamSpec usage patterns
-not-subscriptable = "ignore"        # ModelT[P] subscripting
-invalid-assignment = "ignore"       # Implicit shadowing
-possibly-missing-attribute = "warn" # Nullable attribute access
-not-iterable = "ignore"             # Iterator type inference
-invalid-argument-type = "ignore"    # Stricter arg type checking
-no-matching-overload = "ignore"     # Overload resolution
-invalid-return-type = "ignore"      # Return type mismatches
-unresolved-attribute = "ignore"     # Attribute resolution
-invalid-method-override = "ignore"  # Liskov substitution violations
-call-non-callable = "ignore"        # Callable type inference
-unsupported-operator = "ignore"     # Operator type checking
+invalid-type-form = "ignore"              # ParamSpec usage patterns
+not-subscriptable = "ignore"              # ModelT[P] subscripting
+invalid-assignment = "ignore"             # Implicit shadowing
+possibly-missing-attribute = "warn"       # Nullable attribute access
+not-iterable = "ignore"                   # Iterator type inference
+invalid-argument-type = "ignore"          # Stricter arg type checking
+no-matching-overload = "ignore"           # Overload resolution
+invalid-return-type = "ignore"            # Return type mismatches
+unresolved-attribute = "ignore"           # Attribute resolution
+invalid-method-override = "ignore"        # Liskov substitution violations
+call-non-callable = "ignore"              # Callable type inference
+unsupported-operator = "ignore"           # Operator type checking
 too-many-positional-arguments = "ignore"  # Argument count checking
 
 # Check the same modules mypy checks (ignore_errors = false in pyproject.toml)


### PR DESCRIPTION
This PR introduces a pre-commit hook of [tombi](https://github.com/tombi-toml/tombi) to standardize the toml format.