### PR TITLE
Fix incorrect statement in GammaPoisson log_prob docstring

### DIFF
--- a/numpyro/distributions/conjugate.py
+++ b/numpyro/distributions/conjugate.py
@@ -383,7 +383,7 @@ class GammaPoisson(Distribution):
 
     @validate_sample
     def log_prob(self, value: ArrayLike) -> ArrayLike:
-        r"""If :math:`X \sim \mathrm{GammaPoisson}(\alpha, \lambda)`, then the log
+        r"""If :math:`X \sim \mathrm{GammaPoisson}(\alpha, \lambda)`, then the
         probability mass function is:
 
         .. math::


### PR DESCRIPTION
The mathematical expression is for the unlogged pmf, not the log pmf.