### PR TITLE
Expose `ZeroInflatedLogits` and `ZeroInflatedProbs` from top-level distributions module

### DIFF
--- a/numpyro/distributions/__init__.py
+++ b/numpyro/distributions/__init__.py
@@ -91,7 +91,9 @@ from numpyro.distributions.discrete import (
     OrderedLogistic,
     Poisson,
     ZeroInflatedDistribution,
+    ZeroInflatedLogits,
     ZeroInflatedPoisson,
+    ZeroInflatedProbs,
 )
 from numpyro.distributions.distribution import (
     Delta,
@@ -227,7 +229,9 @@ __all__ = [
     "Wishart",
     "WishartCholesky",
     "ZeroInflatedDistribution",
+    "ZeroInflatedLogits",
     "ZeroInflatedNegativeBinomial2",
     "ZeroInflatedPoisson",
+    "ZeroInflatedProbs",
     "ZeroSumNormal",
 ]


### PR DESCRIPTION
After #2196, I checked each file in `numpyro/distributions/` and found `ZeroInflatedLogits` and `ZeroInflatedProbs` not exposed at top-level.