### PR TITLE
Fix GaussianStateSpace.variance shape when batch comes from initial_value

### DIFF
--- a/numpyro/distributions/continuous.py
+++ b/numpyro/distributions/continuous.py
@@ -1045,11 +1045,15 @@ class GaussianStateSpace(TransformedDistribution):
             self.scale_tril,
             jnp.arange(self.num_steps),
         )
-        return (
+        variance = (
             jnp.diagonal(scale_tril @ scale_tril.mT, axis1=-1, axis2=-2)
             .cumsum(axis=0)
             .swapaxes(0, -2)
         )
+        # The variance does not depend on the (deterministic) initial value, but the
+        # batch shape may be contributed by `initial_value`. Broadcast to the full
+        # `batch_shape + event_shape` so the moment shape matches the distribution.
+        return jnp.broadcast_to(variance, self.batch_shape + self.event_shape)
 
     @lazy_property
     def covariance_matrix(self):

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -2279,6 +2279,23 @@ def test_mean_var(jax_dist, sp_dist, params):
         else 200000
     )
     d_jax = jax_dist(*params)
+
+    # `mean` and `variance`, where implemented, must be arrays whose shape is exactly
+    # `batch_shape + event_shape` -- the same contract `test_dist_shape` enforces for
+    # samples. Checked uniformly here (not per scipy/family branch below) so every
+    # distribution is held to it. Distributions without a closed-form moment raise
+    # `NotImplementedError` and are skipped (e.g. CAR/Gompertz have no `variance`).
+    expected_moment_shape = d_jax.batch_shape + d_jax.event_shape
+    for moment in ("mean", "variance"):
+        try:
+            value = getattr(d_jax, moment)
+        except NotImplementedError:
+            continue
+        assert jnp.shape(value) == expected_moment_shape, (
+            f"{jax_dist.__name__}.{moment} has shape {jnp.shape(value)}, "
+            f"expected batch_shape + event_shape = {expected_moment_shape}"
+        )
+
     k = random.key(0)
     samples = d_jax.sample(k, sample_shape=(n,)).astype(np.float32)
     # check with suitable scipy implementation if available


### PR DESCRIPTION
## Problem

`GaussianStateSpace.variance` was computed from `scale_tril` alone, which drops any batch dimension contributed by `initial_value`. When the batch shape originates from `initial_value` (e.g. `scale_tril` of shape `(2, 2)` with `initial_value` of shape `(3, 2)`), `variance` came out as `(num_steps, state_dim)` instead of the required `batch_shape + event_shape`.

Concretely, for `num_steps=5`, transition `(2, 2)`, `scale_tril` `(2, 2)`, `initial_value` `(3, 2)`:
- `batch_shape = (3,)`, `event_shape = (5, 2)` → expected moment shape `(3, 5, 2)`
- `variance` returned `(5, 2)`

## Fix

Broadcast the variance to `batch_shape + event_shape`. The initial value is deterministic and does not affect the variance *values*, only the shape, so broadcasting is exact.

## Tests

Added a uniform moment-shape contract check in `test_mean_var` asserting that `mean`/`variance` (where implemented) have shape `batch_shape + event_shape` for every distribution. With the fix, the full `test_mean_var` suite passes (162 passed, 61 skipped, 3 xpassed, 0 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)