### PR TITLE
Ensure distribution moments/samples are jax arrays

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
         files: "(.py$)|(.*.ipynb$)"
 
   - repo: https://github.com/astral-sh/ty-pre-commit
-    rev: v0.0.57
+    rev: v0.0.75
     hooks:
       - id: ty
 

--- a/numpyro/distributions/batch_util.py
+++ b/numpyro/distributions/batch_util.py
@@ -3,7 +3,7 @@
 
 import copy
 from functools import singledispatch
-from typing import Union
+from typing import Any, Union
 
 import jax
 import jax.numpy as jnp
@@ -77,7 +77,7 @@ def vmap_over(d: Union[Distribution, Transform, Constraint], **kwargs):
 def _vmap_over_affine_transform(
     dist: AffineTransform, loc=None, scale=None, domain=None
 ):
-    dist_axes = copy.copy(dist)
+    dist_axes: Any = copy.copy(dist)
     dist_axes.loc = loc
     dist_axes.scale = scale
     dist_axes._domain = domain
@@ -86,14 +86,14 @@ def _vmap_over_affine_transform(
 
 @vmap_over.register
 def _vmap_over_greater_than(dist: constraints._GreaterThan, lower_bound=None):
-    axes = copy.copy(dist)
+    axes: Any = copy.copy(dist)
     axes.lower_bound = lower_bound
     return axes
 
 
 @vmap_over.register
 def _vmap_over_less_than(dist: constraints._LessThan, upper_bound=None):
-    axes = copy.copy(dist)
+    axes: Any = copy.copy(dist)
     axes.upper_bound = upper_bound
     return axes
 
@@ -102,7 +102,7 @@ def _vmap_over_less_than(dist: constraints._LessThan, upper_bound=None):
 def _vmap_over_interval(
     dist: constraints._Interval, lower_bound=None, upper_bound=None
 ):
-    axes = copy.copy(dist)
+    axes: Any = copy.copy(dist)
     axes.lower_bound = lower_bound
     axes.upper_bound = upper_bound
     return axes
@@ -112,7 +112,7 @@ def _vmap_over_interval(
 def _vmap_over_integer_interval(
     dist: constraints._IntegerInterval, lower_bound=None, upper_bound=None
 ):
-    dist_axes = copy.copy(dist)
+    dist_axes: Any = copy.copy(dist)
     dist_axes.lower_bound = lower_bound
     dist_axes.upper_bound = upper_bound
     return dist_axes
@@ -125,7 +125,7 @@ def _vmap_over_corr_cholesky_transform(dist: CorrCholeskyTransform):
 
 @vmap_over.register
 def _vmap_over_power_transform(dist: PowerTransform, exponent=None):
-    axes = copy.copy(dist)
+    axes: Any = copy.copy(dist)
     axes.exponent = exponent
     return axes
 

--- a/numpyro/distributions/censored.py
+++ b/numpyro/distributions/censored.py
@@ -8,7 +8,7 @@ import warnings
 import numpy as np
 
 import jax
-from jax import lax
+from jax import Array, lax
 import jax.numpy as jnp
 from jax.typing import ArrayLike
 
@@ -112,7 +112,7 @@ class LeftCensoredDistribution(Distribution):
 
     def sample(
         self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
-    ) -> ArrayLike:
+    ) -> Array:
         return self.base_dist.expand(self.batch_shape).sample(key, sample_shape)
 
     @constraints.dependent_property(is_discrete=False, event_dim=0)
@@ -120,7 +120,7 @@ class LeftCensoredDistribution(Distribution):
         return self._support
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         dtype = jnp.result_type(value, float)
         minval = 100.0 * jnp.finfo(dtype).tiny
 
@@ -228,7 +228,7 @@ class RightCensoredDistribution(Distribution):
 
     def sample(
         self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
-    ) -> ArrayLike:
+    ) -> Array:
         return self.base_dist.expand(self.batch_shape).sample(key, sample_shape)
 
     @constraints.dependent_property(is_discrete=False, event_dim=0)
@@ -236,7 +236,7 @@ class RightCensoredDistribution(Distribution):
         return self._support
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         dtype = jnp.result_type(value, float)
         eps = jnp.finfo(dtype).eps
 
@@ -363,7 +363,7 @@ class IntervalCensoredDistribution(Distribution):
 
     def sample(
         self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
-    ) -> ArrayLike:
+    ) -> Array:
         return self.base_dist.expand(self.batch_shape).sample(key, sample_shape)
 
     @constraints.dependent_property(is_discrete=False, event_dim=1)

--- a/numpyro/distributions/censored.py
+++ b/numpyro/distributions/censored.py
@@ -385,7 +385,7 @@ class IntervalCensoredDistribution(Distribution):
         return m_left, m_right, m_int, m_double, m_point
 
     @validate_sample
-    def log_prob(self, value):
+    def log_prob(self, value) -> Array:
         dtype = jnp.result_type(value, float)
         minval = 100.0 * jnp.finfo(dtype).tiny  # for values close to 0
         eps = jnp.finfo(dtype).eps  # otherwise
@@ -441,7 +441,7 @@ class IntervalCensoredDistribution(Distribution):
         logp = jnp.where(m_double, lp_double, logp)
         return logp
 
-    def _validate_sample(self, value: ArrayLike) -> None:
+    def _validate_sample(self, value: ArrayLike) -> Array:
         if value.shape[-1] != 2:
             raise ValueError(
                 f"Expected last dimension of `value` to be 2 (lower, upper), but got shape {value.shape}"

--- a/numpyro/distributions/censored.py
+++ b/numpyro/distributions/censored.py
@@ -94,6 +94,7 @@ class LeftCensoredDistribution(Distribution):
         # Optionally test that cdf actually works (in validate_args mode)
         if validate_args:
             try:
+                assert base_dist.support is not None
                 test_val = base_dist.support.feasible_like(jnp.array(0.0))
                 _ = base_dist.cdf(test_val)
             except (NotImplementedError, AttributeError) as e:
@@ -117,6 +118,7 @@ class LeftCensoredDistribution(Distribution):
 
     @constraints.dependent_property(is_discrete=False, event_dim=0)
     def support(self) -> Constraint:
+        assert self._support is not None
         return self._support
 
     @validate_sample
@@ -210,6 +212,7 @@ class RightCensoredDistribution(Distribution):
         # Optionally test that cdf actually works (in validate_args mode)
         if validate_args:
             try:
+                assert base_dist.support is not None
                 test_val = base_dist.support.feasible_like(jnp.array(0.0))
                 _ = base_dist.cdf(test_val)
             except (NotImplementedError, AttributeError) as e:
@@ -233,6 +236,7 @@ class RightCensoredDistribution(Distribution):
 
     @constraints.dependent_property(is_discrete=False, event_dim=0)
     def support(self) -> Constraint:
+        assert self._support is not None
         return self._support
 
     @validate_sample
@@ -340,6 +344,7 @@ class IntervalCensoredDistribution(Distribution):
         # Optionally test that cdf actually works (in validate_args mode)
         if validate_args:
             try:
+                assert base_dist.support is not None
                 test_val = base_dist.support.feasible_like(jnp.array(0.0))
                 _ = base_dist.cdf(test_val)
             except (NotImplementedError, AttributeError) as e:
@@ -368,6 +373,7 @@ class IntervalCensoredDistribution(Distribution):
 
     @constraints.dependent_property(is_discrete=False, event_dim=1)
     def support(self) -> Constraint:
+        assert self._support is not None
         return self._support
 
     def _get_censoring_masks(self, value):
@@ -442,9 +448,9 @@ class IntervalCensoredDistribution(Distribution):
         return logp
 
     def _validate_sample(self, value: ArrayLike) -> Array:
-        if value.shape[-1] != 2:
+        if jnp.shape(value)[-1] != 2:
             raise ValueError(
-                f"Expected last dimension of `value` to be 2 (lower, upper), but got shape {value.shape}"
+                f"Expected last dimension of `value` to be 2 (lower, upper), but got shape {jnp.shape(value)}"
             )
         x1 = jnp.take(value, 0, axis=-1)  # left bound
         x2 = jnp.take(value, 1, axis=-1)  # right bound

--- a/numpyro/distributions/conjugate.py
+++ b/numpyro/distributions/conjugate.py
@@ -399,13 +399,13 @@ class GammaPoisson(Distribution):
         )
 
     @property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         r"""If :math:`X \sim \mathrm{GammaPoisson}(\alpha, \lambda)`, then the mean is:
 
         .. math::
             \mathbb{E}[X] = \frac{\alpha}{\lambda}
         """
-        return self.concentration / self.rate
+        return jnp.asarray(self.concentration / self.rate)
 
     @property
     def variance(self) -> Array:
@@ -416,7 +416,7 @@ class GammaPoisson(Distribution):
         """
         return self.concentration / jnp.square(self.rate) * (1 + self.rate)
 
-    def cdf(self, value: ArrayLike) -> ArrayLike:
+    def cdf(self, value: ArrayLike) -> Array:
         r"""If :math:`X \sim \mathrm{GammaPoisson}(\alpha, \lambda)`, then the cumulative
         distribution function is:
 

--- a/numpyro/distributions/conjugate.py
+++ b/numpyro/distributions/conjugate.py
@@ -5,7 +5,7 @@
 from typing import Optional
 
 import jax
-from jax import lax, nn, random
+from jax import Array, lax, nn, random
 import jax.numpy as jnp
 from jax.scipy.special import betainc, betaln, gammaln
 from jax.typing import ArrayLike
@@ -72,7 +72,7 @@ class BetaBinomial(Distribution):
         self._beta = Beta(concentration1, concentration0)
         super(BetaBinomial, self).__init__(batch_shape, validate_args=validate_args)
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
         assert is_prng_key(key)
         key_beta, key_binom = random.split(key)
         probs = self._beta.sample(key_beta, sample_shape)
@@ -81,7 +81,7 @@ class BetaBinomial(Distribution):
         )
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         return (
             -_log_beta_1(self.total_count - value + 1, value)
             + betaln(
@@ -92,11 +92,11 @@ class BetaBinomial(Distribution):
         )
 
     @property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         return self._beta.mean * self.total_count
 
     @property
-    def variance(self) -> ArrayLike:
+    def variance(self) -> Array:
         return (
             self._beta.variance
             * self.total_count
@@ -161,7 +161,7 @@ class BetaNegativeBinomial(Distribution):
             batch_shape, validate_args=validate_args
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
         r"""If :math:`X \sim \mathrm{BetaNegativeBinomial}(\alpha, \beta, n)`, then the sampling
         procedure is:
 
@@ -182,7 +182,7 @@ class BetaNegativeBinomial(Distribution):
         return NegativeBinomialProbs(total_count=self.n, probs=probs).sample(key_nb)
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         r"""If :math:`X \sim \mathrm{BetaNegativeBinomial}(\alpha, \beta, n)`, then the log
         probability mass function is:
 
@@ -201,7 +201,7 @@ class BetaNegativeBinomial(Distribution):
         )
 
     @property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         r"""If :math:`X \sim \mathrm{BetaNegativeBinomial}(\alpha, \beta, n)` and
         :math:`\beta > 1`, then the mean is:
 
@@ -217,7 +217,7 @@ class BetaNegativeBinomial(Distribution):
         )
 
     @property
-    def variance(self) -> ArrayLike:
+    def variance(self) -> Array:
         r"""If :math:`X \sim \mathrm{BetaNegativeBinomial}(\alpha, \beta, n)` and
         :math:`\beta > 2`, then the variance is:
 
@@ -289,7 +289,7 @@ class DirichletMultinomial(Distribution):
             validate_args=validate_args,
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
         assert is_prng_key(key)
         key_dirichlet, key_multinom = random.split(key)
         probs = self._dirichlet.sample(key_dirichlet, sample_shape)
@@ -300,18 +300,18 @@ class DirichletMultinomial(Distribution):
         ).sample(key_multinom)
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         alpha = self.concentration
         return _log_beta_1(alpha.sum(-1), value.sum(-1)) - _log_beta_1(
             alpha, value
         ).sum(-1)
 
     @property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         return self._dirichlet.mean * jnp.expand_dims(self.total_count, -1)
 
     @property
-    def variance(self) -> ArrayLike:
+    def variance(self) -> Array:
         n = jnp.expand_dims(self.total_count, -1)
         alpha = self.concentration
         alpha_sum = self.concentration.sum(-1, keepdims=True)
@@ -362,7 +362,7 @@ class GammaPoisson(Distribution):
             self._gamma.batch_shape, validate_args=validate_args
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
         r"""If :math:`X \sim \mathrm{GammaPoisson}(\alpha, \lambda)`, then the sampling
         procedure is:
 
@@ -383,7 +383,7 @@ class GammaPoisson(Distribution):
         return Poisson(rate).sample(key_poisson)
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         r"""If :math:`X \sim \mathrm{GammaPoisson}(\alpha, \lambda)`, then the
         probability mass function is:
 
@@ -408,7 +408,7 @@ class GammaPoisson(Distribution):
         return self.concentration / self.rate
 
     @property
-    def variance(self) -> ArrayLike:
+    def variance(self) -> Array:
         r"""If :math:`X \sim \mathrm{GammaPoisson}(\alpha, \lambda)`, then the variance is:
 
         .. math::
@@ -514,7 +514,7 @@ class NegativeBinomialLogits(GammaPoisson):
         super().__init__(concentration, rate, validate_args=validate_args)
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         r"""If :math:`X \sim \mathrm{NegativeBinomial}(r, \mathrm{logits}(p))`, then the log
         probability mass function is:
 

--- a/numpyro/distributions/conjugate.py
+++ b/numpyro/distributions/conjugate.py
@@ -72,7 +72,10 @@ class BetaBinomial(Distribution):
         self._beta = Beta(concentration1, concentration0)
         super(BetaBinomial, self).__init__(batch_shape, validate_args=validate_args)
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> Array:
+        assert key is not None
         assert is_prng_key(key)
         key_beta, key_binom = random.split(key)
         probs = self._beta.sample(key_beta, sample_shape)
@@ -161,7 +164,9 @@ class BetaNegativeBinomial(Distribution):
             batch_shape, validate_args=validate_args
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> Array:
         r"""If :math:`X \sim \mathrm{BetaNegativeBinomial}(\alpha, \beta, n)`, then the sampling
         procedure is:
 
@@ -176,6 +181,7 @@ class BetaNegativeBinomial(Distribution):
         :class:`~numpyro.distributions.discrete.NegativeBinomialProbs` to generate samples
         from the Negative Binomial distribution.
         """
+        assert key is not None
         assert is_prng_key(key)
         key_beta, key_nb = random.split(key)
         probs = self._beta.sample(key_beta, sample_shape)
@@ -289,7 +295,10 @@ class DirichletMultinomial(Distribution):
             validate_args=validate_args,
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> Array:
+        assert key is not None
         assert is_prng_key(key)
         key_dirichlet, key_multinom = random.split(key)
         probs = self._dirichlet.sample(key_dirichlet, sample_shape)
@@ -302,9 +311,9 @@ class DirichletMultinomial(Distribution):
     @validate_sample
     def log_prob(self, value: ArrayLike) -> Array:
         alpha = self.concentration
-        return _log_beta_1(alpha.sum(-1), value.sum(-1)) - _log_beta_1(
-            alpha, value
-        ).sum(-1)
+        return _log_beta_1(jnp.sum(alpha, -1), jnp.sum(value, -1)) - jnp.sum(
+            _log_beta_1(alpha, value), -1
+        )
 
     @property
     def mean(self) -> Array:
@@ -322,9 +331,9 @@ class DirichletMultinomial(Distribution):
     def support(self) -> Constraint:
         return constraints.multinomial(self.total_count)
 
-    @staticmethod
+    @classmethod
     def infer_shapes(
-        concentration: ArrayLike, total_count=()
+        cls, concentration: tuple[int, ...], total_count: tuple[int, ...] = ()
     ) -> tuple[tuple[int, ...], tuple[int, ...]]:
         batch_shape = lax.broadcast_shapes(concentration[:-1], total_count)
         event_shape = concentration[-1:]
@@ -362,7 +371,9 @@ class GammaPoisson(Distribution):
             self._gamma.batch_shape, validate_args=validate_args
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> Array:
         r"""If :math:`X \sim \mathrm{GammaPoisson}(\alpha, \lambda)`, then the sampling
         procedure is:
 
@@ -377,6 +388,7 @@ class GammaPoisson(Distribution):
         :class:`~numpyro.distributions.continuous.Poisson` to generate samples from the
         Poisson distribution.
         """
+        assert key is not None
         assert is_prng_key(key)
         key_gamma, key_poisson = random.split(key)
         rate = self._gamma.sample(key_gamma, sample_shape)
@@ -510,7 +522,7 @@ class NegativeBinomialLogits(GammaPoisson):
     ):
         self.total_count, self.logits = promote_shapes(total_count, logits)
         concentration = total_count
-        rate = jnp.exp(-logits)
+        rate = jnp.exp(jnp.negative(logits))
         super().__init__(concentration, rate, validate_args=validate_args)
 
     @validate_sample

--- a/numpyro/distributions/constraints.py
+++ b/numpyro/distributions/constraints.py
@@ -70,6 +70,7 @@ from typing import ClassVar, Generic, Optional, cast
 import numpy as np
 
 import jax
+from jax import Array
 import jax.numpy as jnp
 from jax.tree_util import register_pytree_node
 from jax.typing import ArrayLike
@@ -96,13 +97,13 @@ class Constraint(Generic[NumLikeT]):
     def tree_flatten(self):
         raise NotImplementedError
 
-    def __call__(self, x: NumLikeT) -> ArrayLike:
+    def __call__(self, x: NumLikeT) -> Array:
         raise NotImplementedError
 
     def __repr__(self) -> str:
         return self.__class__.__name__[1:] + "()"
 
-    def check(self, value: NumLikeT) -> ArrayLike:
+    def check(self, value: NumLikeT) -> Array:
         """
         Returns a byte tensor of `sample_shape + batch_shape` indicating
         whether each event in value satisfies this constraint.
@@ -115,7 +116,7 @@ class Constraint(Generic[NumLikeT]):
         """
         raise NotImplementedError
 
-    def eq(self, other: object, static: bool = False) -> ArrayLike:
+    def eq(self, other: object, static: bool = False) -> bool:
         return self is other
 
     def __eq__(self, other: object) -> bool:
@@ -137,7 +138,7 @@ class ParameterFreeConstraint(Constraint[NumLikeT]):
     def tree_flatten(self):
         return (), ((), dict())
 
-    def eq(self, other: object, static: bool = False) -> ArrayLike:
+    def eq(self, other: object, static: bool = False) -> bool:
         return isinstance(other, type(self))
 
 
@@ -159,7 +160,7 @@ class _SingletonConstraint(ParameterFreeConstraint[NumLikeT]):
 class _Boolean(_SingletonConstraint[NumLike]):
     is_discrete = True
 
-    def __call__(self, x: NumLike) -> ArrayLike:
+    def __call__(self, x: NumLike) -> Array:
         xp = jnp if isinstance(x, jax.Array) else np
         return xp.equal(x, 0) | xp.equal(x, 1)
 
@@ -170,7 +171,7 @@ class _Boolean(_SingletonConstraint[NumLike]):
 class _CorrCholesky(_SingletonConstraint[NonScalarArray]):
     event_dim = 2
 
-    def __call__(self, x: NonScalarArray) -> ArrayLike:
+    def __call__(self, x: NonScalarArray) -> Array:
         xp = np if isinstance(x, (np.ndarray, np.generic)) else jnp
         tril = xp.tril(x)
         lower_triangular = xp.all(xp.reshape(tril == x, x.shape[:-2] + (-1,)), axis=-1)
@@ -187,7 +188,7 @@ class _CorrCholesky(_SingletonConstraint[NonScalarArray]):
 class _CorrMatrix(_SingletonConstraint[NonScalarArray]):
     event_dim = 2
 
-    def __call__(self, x: NonScalarArray) -> ArrayLike:
+    def __call__(self, x: NonScalarArray) -> Array:
         xp = np if isinstance(x, (np.ndarray, np.generic)) else jnp
         # check for symmetric
         symmetric = xp.all(xp.isclose(x, xp.swapaxes(x, -2, -1)), axis=(-2, -1))
@@ -256,7 +257,7 @@ class _Dependent(Constraint[NumLike]):
             event_dim = self._event_dim
         return _Dependent(is_discrete=is_discrete, event_dim=event_dim)
 
-    def eq(self, other: object, static: bool = False) -> ArrayLike:
+    def eq(self, other: object, static: bool = False) -> bool:
         if not isinstance(other, _Dependent):
             return False
         return (
@@ -302,9 +303,9 @@ class _GreaterThan(Constraint[NumLike]):
     def __init__(self, lower_bound: NumLike) -> None:
         self.lower_bound = lower_bound
 
-    def __call__(self, x: NumLike) -> ArrayLike:
+    def __call__(self, x: NumLike) -> Array:
         xp = jnp if isinstance(x, jax.Array) else np
-        return xp.greater(x, self.lower_bound)
+        return xp.greater(x, self.lower_bound)  # type: ignore
 
     def __repr__(self) -> str:
         fmt_string = self.__class__.__name__[1:]
@@ -317,18 +318,18 @@ class _GreaterThan(Constraint[NumLike]):
     def tree_flatten(self):
         return (self.lower_bound,), (("lower_bound",), dict())
 
-    def eq(self, other: object, static: bool = False) -> ArrayLike:
+    def eq(self, other: object, static: bool = False) -> bool:
         if not isinstance(other, _GreaterThan):
             return False
         return array_equiv(self.lower_bound, other.lower_bound, static=static)
 
 
 class _GreaterThanEq(_GreaterThan):
-    def __call__(self, x: NumLike) -> ArrayLike:
+    def __call__(self, x: NumLike) -> Array:
         xp = jnp if isinstance(x, jax.Array) else np
-        return xp.greater_equal(x, self.lower_bound)
+        return xp.greater_equal(x, self.lower_bound)  # type: ignore
 
-    def eq(self, other: object, static: bool = False) -> ArrayLike:
+    def eq(self, other: object, static: bool = False) -> bool:
         if not isinstance(other, _GreaterThanEq):
             return False
         return array_equiv(self.lower_bound, other.lower_bound, static=static)
@@ -341,7 +342,7 @@ class _Positive(_GreaterThan, _SingletonConstraint[NumLike]):
     def tree_flatten(self):
         return (), ((), dict())
 
-    def eq(self, other: object, static: bool = False) -> ArrayLike:
+    def eq(self, other: object, static: bool = False) -> bool:
         return _GreaterThan.eq(self, other, static=static)
 
 
@@ -352,7 +353,7 @@ class _Nonnegative(_GreaterThanEq, _SingletonConstraint[NumLike]):
     def tree_flatten(self):
         return (), ((), dict())
 
-    def eq(self, other: object, static: bool = False) -> ArrayLike:
+    def eq(self, other: object, static: bool = False) -> bool:
         return _GreaterThanEq.eq(self, other, static=static)
 
 
@@ -386,7 +387,7 @@ class _IndependentConstraint(Constraint[NumLikeT]):
     def event_dim(self) -> int:
         return self.base_constraint.event_dim + self.reinterpreted_batch_ndims
 
-    def __call__(self, x: NumLikeT) -> ArrayLike:
+    def __call__(self, x: NumLikeT) -> Array:
         result = self.base_constraint(x)
         if self.reinterpreted_batch_ndims == 0:
             return result
@@ -419,7 +420,7 @@ class _IndependentConstraint(Constraint[NumLikeT]):
             {"reinterpreted_batch_ndims": self.reinterpreted_batch_ndims},
         )
 
-    def eq(self, other: object, static: bool = False) -> ArrayLike:
+    def eq(self, other: object, static: bool = False) -> bool:
         if not isinstance(other, _IndependentConstraint):
             return False
         if self.reinterpreted_batch_ndims != other.reinterpreted_batch_ndims:
@@ -445,9 +446,9 @@ class _LessThan(Constraint[NumLike]):
     def __init__(self, upper_bound: NumLike) -> None:
         self.upper_bound = upper_bound
 
-    def __call__(self, x: NumLike) -> ArrayLike:
+    def __call__(self, x: NumLike) -> Array:
         xp = jnp if isinstance(x, jax.Array) else np
-        return xp.less(x, self.upper_bound)
+        return xp.less(x, self.upper_bound)  # type: ignore
 
     def __repr__(self) -> str:
         fmt_string = self.__class__.__name__[1:]
@@ -460,18 +461,18 @@ class _LessThan(Constraint[NumLike]):
     def tree_flatten(self):
         return (self.upper_bound,), (("upper_bound",), dict())
 
-    def eq(self, other: object, static: bool = False) -> ArrayLike:
+    def eq(self, other: object, static: bool = False) -> bool:
         if not isinstance(other, _LessThan):
             return False
         return array_equiv(self.upper_bound, other.upper_bound, static=static)
 
 
 class _LessThanEq(_LessThan):
-    def __call__(self, x: NumLike) -> ArrayLike:
+    def __call__(self, x: NumLike) -> Array:
         xp = jnp if isinstance(x, jax.Array) else np
-        return xp.less_equal(x, self.upper_bound)
+        return xp.less_equal(x, self.upper_bound)  # type: ignore
 
-    def eq(self, other: object, static: bool = False) -> ArrayLike:
+    def eq(self, other: object, static: bool = False) -> bool:
         if not isinstance(other, _LessThanEq):
             return False
         return array_equiv(self.upper_bound, other.upper_bound, static=static)
@@ -484,7 +485,7 @@ class _IntegerInterval(Constraint[NumLike]):
         self.lower_bound = lower_bound
         self.upper_bound = upper_bound
 
-    def __call__(self, x: NumLike) -> ArrayLike:
+    def __call__(self, x: NumLike) -> Array:
         xp = jnp if isinstance(x, jax.Array) else np
         return (
             xp.greater_equal(x, self.lower_bound)
@@ -508,7 +509,7 @@ class _IntegerInterval(Constraint[NumLike]):
             dict(),
         )
 
-    def eq(self, other: object, static: bool = False) -> ArrayLike:
+    def eq(self, other: object, static: bool = False) -> bool:
         if not isinstance(other, _IntegerInterval):
             return False
         return array_equiv(
@@ -522,7 +523,7 @@ class _IntegerGreaterThan(Constraint[NumLike]):
     def __init__(self, lower_bound: NumLike) -> None:
         self.lower_bound = lower_bound
 
-    def __call__(self, x: NumLike) -> ArrayLike:
+    def __call__(self, x: NumLike) -> Array:
         xp = jnp if isinstance(x, jax.Array) else np
         return (xp.mod(x, 1) == 0) & xp.greater_equal(x, self.lower_bound)
 
@@ -537,7 +538,7 @@ class _IntegerGreaterThan(Constraint[NumLike]):
     def tree_flatten(self):
         return (self.lower_bound,), (("lower_bound",), dict())
 
-    def eq(self, other: object, static: bool = False) -> ArrayLike:
+    def eq(self, other: object, static: bool = False) -> bool:
         if not isinstance(other, _IntegerGreaterThan):
             return False
         return array_equiv(self.lower_bound, other.lower_bound, static=static)
@@ -550,7 +551,7 @@ class _IntegerPositive(_IntegerGreaterThan, _SingletonConstraint[NumLike]):
     def tree_flatten(self):
         return (), ((), dict())
 
-    def eq(self, other: object, static: bool = False) -> ArrayLike:
+    def eq(self, other: object, static: bool = False) -> bool:
         return _IntegerGreaterThan.eq(self, other, static=static)
 
 
@@ -561,7 +562,7 @@ class _IntegerNonnegative(_IntegerGreaterThan, _SingletonConstraint[NumLike]):
     def tree_flatten(self):
         return (), ((), dict())
 
-    def eq(self, other: object, static: bool = False) -> ArrayLike:
+    def eq(self, other: object, static: bool = False) -> bool:
         return _IntegerGreaterThan.eq(self, other, static=static)
 
 
@@ -570,7 +571,7 @@ class _Interval(Constraint[NumLike]):
         self.lower_bound = lower_bound
         self.upper_bound = upper_bound
 
-    def __call__(self, x: NumLike) -> ArrayLike:
+    def __call__(self, x: NumLike) -> Array:
         xp = jnp if isinstance(x, jax.Array) else np
         return xp.greater_equal(x, self.lower_bound) & xp.less_equal(
             x, self.upper_bound
@@ -588,7 +589,7 @@ class _Interval(Constraint[NumLike]):
             (self.lower_bound + self.upper_bound) / 2, jnp.shape(prototype)
         )
 
-    def eq(self, other: object, static: bool = False) -> ArrayLike:
+    def eq(self, other: object, static: bool = False) -> bool:
         if not isinstance(other, _Interval):
             return False
         return array_equiv(
@@ -609,7 +610,7 @@ class _Circular(_Interval, _SingletonConstraint[NumLike]):
     def tree_flatten(self):
         return (), ((), dict())
 
-    def eq(self, other: object, static: bool = False) -> ArrayLike:
+    def eq(self, other: object, static: bool = False) -> bool:
         return _Interval.eq(self, other, static=static)
 
 
@@ -620,12 +621,12 @@ class _UnitInterval(_Interval, _SingletonConstraint[NumLike]):
     def tree_flatten(self):
         return (), ((), dict())
 
-    def eq(self, other: object, static: bool = False) -> ArrayLike:
+    def eq(self, other: object, static: bool = False) -> bool:
         return _Interval.eq(self, other, static=static)
 
 
 class _OpenInterval(_Interval):
-    def __call__(self, x: NumLike) -> ArrayLike:
+    def __call__(self, x: NumLike) -> Array:
         xp = jnp if isinstance(x, jax.Array) else np
         return xp.greater(x, self.lower_bound) & xp.less(x, self.upper_bound)
 
@@ -640,7 +641,7 @@ class _OpenInterval(_Interval):
 class _LowerCholesky(_SingletonConstraint[NonScalarArray]):
     event_dim = 2
 
-    def __call__(self, x: NonScalarArray) -> ArrayLike:
+    def __call__(self, x: NonScalarArray) -> Array:
         xp = np if isinstance(x, (np.ndarray, np.generic)) else jnp
         tril = xp.tril(x)
         lower_triangular = xp.all(xp.reshape(tril == x, x.shape[:-2] + (-1,)), axis=-1)
@@ -658,9 +659,9 @@ class _Multinomial(Constraint[NonScalarArray]):
     def __init__(self, upper_bound: ArrayLike) -> None:
         self.upper_bound = upper_bound
 
-    def __call__(self, x: NonScalarArray) -> ArrayLike:
+    def __call__(self, x: NonScalarArray) -> Array:
         xp = jnp if isinstance(x, jax.Array) else np
-        return (x >= 0).all(axis=-1) & xp.equal(x.sum(axis=-1), self.upper_bound)
+        return (x >= 0).all(axis=-1) & xp.equal(x.sum(axis=-1), self.upper_bound)  # type: ignore
 
     def feasible_like(self, prototype: NonScalarArray) -> NonScalarArray:
         pad_width = ((0, 0),) * jnp.ndim(self.upper_bound) + (
@@ -672,7 +673,7 @@ class _Multinomial(Constraint[NonScalarArray]):
     def tree_flatten(self):
         return (self.upper_bound,), (("upper_bound",), dict())
 
-    def eq(self, other: object, static: bool = False) -> ArrayLike:
+    def eq(self, other: object, static: bool = False) -> bool:
         if not isinstance(other, _Multinomial):
             return False
         return array_equiv(self.upper_bound, other.upper_bound, static=static)
@@ -686,7 +687,7 @@ class _L1Ball(_SingletonConstraint[NumLike]):
     event_dim = 1
     reltol = 10.0  # Relative to finfo.eps.
 
-    def __call__(self, x: NumLike) -> ArrayLike:
+    def __call__(self, x: NumLike) -> Array:
         xp = np if isinstance(x, (np.ndarray, np.generic)) else jnp
         dtype = x.dtype if isinstance(x, xp.ndarray) else type(x)
         eps = jnp.finfo(dtype).eps
@@ -699,8 +700,8 @@ class _L1Ball(_SingletonConstraint[NumLike]):
 class _OrderedVector(_SingletonConstraint[NonScalarArray]):
     event_dim = 1
 
-    def __call__(self, x: NonScalarArray) -> ArrayLike:
-        return (x[..., 1:] > x[..., :-1]).all(axis=-1)
+    def __call__(self, x: NonScalarArray) -> Array:
+        return (x[..., 1:] > x[..., :-1]).all(axis=-1)  # type: ignore
 
     def feasible_like(self, prototype: NonScalarArray) -> NonScalarArray:
         return jnp.broadcast_to(jnp.arange(float(prototype.shape[-1])), prototype.shape)
@@ -709,7 +710,7 @@ class _OrderedVector(_SingletonConstraint[NonScalarArray]):
 class _PositiveDefinite(_SingletonConstraint[NonScalarArray]):
     event_dim = 2
 
-    def __call__(self, x: NonScalarArray) -> ArrayLike:
+    def __call__(self, x: NonScalarArray) -> Array:
         xp = np if isinstance(x, (np.ndarray, np.generic)) else jnp
         # check for symmetric
         symmetric = xp.all(xp.isclose(x, xp.swapaxes(x, -2, -1)), axis=(-2, -1))
@@ -724,11 +725,11 @@ class _PositiveDefinite(_SingletonConstraint[NonScalarArray]):
 class _PositiveDefiniteCirculantVector(_SingletonConstraint[NonScalarArray]):
     event_dim = 1
 
-    def __call__(self, x: NonScalarArray) -> ArrayLike:
+    def __call__(self, x: NonScalarArray) -> Array:
         xp = np if isinstance(x, (np.ndarray, np.generic)) else jnp
         tol = 10 * xp.finfo(x.dtype).eps
         rfft = xp.fft.rfft(x)
-        return (xp.abs(rfft.imag) < tol) & (rfft.real > -tol)
+        return (xp.abs(rfft.imag) < tol) & (rfft.real > -tol)  # type: ignore
 
     def feasible_like(self, prototype: NonScalarArray) -> NonScalarArray:
         return jnp.zeros_like(prototype).at[..., 0].set(1.0)
@@ -737,7 +738,7 @@ class _PositiveDefiniteCirculantVector(_SingletonConstraint[NonScalarArray]):
 class _PositiveSemiDefinite(_SingletonConstraint[NonScalarArray]):
     event_dim = 2
 
-    def __call__(self, x: NonScalarArray) -> ArrayLike:
+    def __call__(self, x: NonScalarArray) -> Array:
         xp = np if isinstance(x, (np.ndarray, np.generic)) else jnp
         # check for symmetric
         symmetric = xp.all(xp.isclose(x, xp.swapaxes(x, -2, -1)), axis=(-2, -1))
@@ -757,7 +758,7 @@ class _PositiveOrderedVector(_SingletonConstraint[NonScalarArray]):
 
     event_dim = 1
 
-    def __call__(self, x: NonScalarArray) -> ArrayLike:
+    def __call__(self, x: NonScalarArray) -> Array:
         return jnp.logical_and(
             ordered_vector.check(x), jnp.all(positive.check(x), axis=-1)
         )
@@ -769,7 +770,7 @@ class _PositiveOrderedVector(_SingletonConstraint[NonScalarArray]):
 
 
 class _Complex(_SingletonConstraint[NumLike]):
-    def __call__(self, x: NumLike) -> ArrayLike:
+    def __call__(self, x: NumLike) -> Array:
         # XXX: consider to relax this condition to [-inf, inf] interval
         xp = jnp if isinstance(x, jax.Array) else np
         return (
@@ -783,9 +784,9 @@ class _Complex(_SingletonConstraint[NumLike]):
 
 
 class _Real(_SingletonConstraint[NumLike]):
-    def __call__(self, x: NumLike) -> ArrayLike:
+    def __call__(self, x: NumLike) -> Array:
         # XXX: consider to relax this condition to [-inf, inf] interval
-        return (x == x) & (x != float("inf")) & (x != float("-inf"))
+        return (x == x) & (x != float("inf")) & (x != float("-inf"))  # type: ignore
 
     def feasible_like(self, prototype: NumLike) -> NumLike:
         return jnp.zeros_like(prototype)
@@ -794,9 +795,9 @@ class _Real(_SingletonConstraint[NumLike]):
 class _Simplex(_SingletonConstraint[NonScalarArray]):
     event_dim = 1
 
-    def __call__(self, x: NonScalarArray) -> ArrayLike:
+    def __call__(self, x: NonScalarArray) -> Array:
         x_sum = x.sum(axis=-1)
-        return (x >= 0).all(axis=-1) & (x_sum < 1 + 1e-6) & (x_sum > 1 - 1e-6)
+        return (x >= 0).all(axis=-1) & (x_sum < 1 + 1e-6) & (x_sum > 1 - 1e-6)  # type: ignore
 
     def feasible_like(self, prototype: NonScalarArray) -> NonScalarArray:
         return jnp.full_like(prototype, 1 / prototype.shape[-1])
@@ -829,7 +830,7 @@ class _Sphere(_SingletonConstraint[NonScalarArray]):
     event_dim = 1
     reltol = 10.0  # Relative to finfo.eps.
 
-    def __call__(self, x: NonScalarArray) -> ArrayLike:
+    def __call__(self, x: NonScalarArray) -> Array:
         xp = np if isinstance(x, (np.ndarray, np.generic)) else jnp
         eps = xp.finfo(x.dtype).eps
         norm = xp.linalg.norm(x, axis=-1)
@@ -849,15 +850,16 @@ class _ZeroSum(Constraint[NonScalarArray]):
     def event_dim(self) -> int:
         return self._event_dim
 
-    def __call__(self, x: NonScalarArray) -> ArrayLike:
+    def __call__(self, x: NonScalarArray) -> Array:
         xp = np if isinstance(x, (np.ndarray, np.generic)) else jnp
         tol = xp.finfo(x.dtype).eps * x.shape[-1] * 10
         zerosum_true = True
         for dim in range(-self.event_dim, 0):
             zerosum_true = zerosum_true & xp.allclose(x.sum(dim), 0, atol=tol)
-        return zerosum_true
+        # FIXME: shape must match batch shape of `x`, not be a literal boolean.
+        return zerosum_true  # type: ignore
 
-    def eq(self, other: object, static: bool = False) -> ArrayLike:
+    def eq(self, other: object, static: bool = False) -> bool:
         if not isinstance(other, _ZeroSum):
             return False
         return self.event_dim == other.event_dim

--- a/numpyro/distributions/constraints.py
+++ b/numpyro/distributions/constraints.py
@@ -97,13 +97,13 @@ class Constraint(Generic[NumLikeT]):
     def tree_flatten(self):
         raise NotImplementedError
 
-    def __call__(self, x: NumLikeT) -> Array:
+    def __call__(self, x: NumLikeT) -> ArrayLike:
         raise NotImplementedError
 
     def __repr__(self) -> str:
         return self.__class__.__name__[1:] + "()"
 
-    def check(self, value: NumLikeT) -> Array:
+    def check(self, value: NumLikeT) -> ArrayLike:
         """
         Returns a byte tensor of `sample_shape + batch_shape` indicating
         whether each event in value satisfies this constraint.
@@ -116,7 +116,7 @@ class Constraint(Generic[NumLikeT]):
         """
         raise NotImplementedError
 
-    def eq(self, other: object, static: bool = False) -> bool:
+    def eq(self, other: object, static: bool = False) -> ArrayLike:
         return self is other
 
     def __eq__(self, other: object) -> bool:
@@ -138,7 +138,7 @@ class ParameterFreeConstraint(Constraint[NumLikeT]):
     def tree_flatten(self):
         return (), ((), dict())
 
-    def eq(self, other: object, static: bool = False) -> bool:
+    def eq(self, other: object, static: bool = False) -> ArrayLike:
         return isinstance(other, type(self))
 
 
@@ -160,7 +160,7 @@ class _SingletonConstraint(ParameterFreeConstraint[NumLikeT]):
 class _Boolean(_SingletonConstraint[NumLike]):
     is_discrete = True
 
-    def __call__(self, x: NumLike) -> Array:
+    def __call__(self, x: NumLike) -> ArrayLike:
         xp = jnp if isinstance(x, jax.Array) else np
         return xp.equal(x, 0) | xp.equal(x, 1)
 
@@ -171,7 +171,7 @@ class _Boolean(_SingletonConstraint[NumLike]):
 class _CorrCholesky(_SingletonConstraint[NonScalarArray]):
     event_dim = 2
 
-    def __call__(self, x: NonScalarArray) -> Array:
+    def __call__(self, x: NonScalarArray) -> ArrayLike:
         xp = np if isinstance(x, (np.ndarray, np.generic)) else jnp
         tril = xp.tril(x)
         lower_triangular = xp.all(xp.reshape(tril == x, x.shape[:-2] + (-1,)), axis=-1)
@@ -188,7 +188,7 @@ class _CorrCholesky(_SingletonConstraint[NonScalarArray]):
 class _CorrMatrix(_SingletonConstraint[NonScalarArray]):
     event_dim = 2
 
-    def __call__(self, x: NonScalarArray) -> Array:
+    def __call__(self, x: NonScalarArray) -> ArrayLike:
         xp = np if isinstance(x, (np.ndarray, np.generic)) else jnp
         # check for symmetric
         symmetric = xp.all(xp.isclose(x, xp.swapaxes(x, -2, -1)), axis=(-2, -1))
@@ -257,7 +257,7 @@ class _Dependent(Constraint[NumLike]):
             event_dim = self._event_dim
         return _Dependent(is_discrete=is_discrete, event_dim=event_dim)
 
-    def eq(self, other: object, static: bool = False) -> bool:
+    def eq(self, other: object, static: bool = False) -> ArrayLike:
         if not isinstance(other, _Dependent):
             return False
         return (
@@ -303,9 +303,9 @@ class _GreaterThan(Constraint[NumLike]):
     def __init__(self, lower_bound: NumLike) -> None:
         self.lower_bound = lower_bound
 
-    def __call__(self, x: NumLike) -> Array:
+    def __call__(self, x: NumLike) -> ArrayLike:
         xp = jnp if isinstance(x, jax.Array) else np
-        return xp.greater(x, self.lower_bound)  # type: ignore
+        return xp.greater(x, self.lower_bound)
 
     def __repr__(self) -> str:
         fmt_string = self.__class__.__name__[1:]
@@ -318,18 +318,18 @@ class _GreaterThan(Constraint[NumLike]):
     def tree_flatten(self):
         return (self.lower_bound,), (("lower_bound",), dict())
 
-    def eq(self, other: object, static: bool = False) -> bool:
+    def eq(self, other: object, static: bool = False) -> ArrayLike:
         if not isinstance(other, _GreaterThan):
             return False
         return array_equiv(self.lower_bound, other.lower_bound, static=static)
 
 
 class _GreaterThanEq(_GreaterThan):
-    def __call__(self, x: NumLike) -> Array:
+    def __call__(self, x: NumLike) -> ArrayLike:
         xp = jnp if isinstance(x, jax.Array) else np
-        return xp.greater_equal(x, self.lower_bound)  # type: ignore
+        return xp.greater_equal(x, self.lower_bound)
 
-    def eq(self, other: object, static: bool = False) -> bool:
+    def eq(self, other: object, static: bool = False) -> ArrayLike:
         if not isinstance(other, _GreaterThanEq):
             return False
         return array_equiv(self.lower_bound, other.lower_bound, static=static)
@@ -342,7 +342,7 @@ class _Positive(_GreaterThan, _SingletonConstraint[NumLike]):
     def tree_flatten(self):
         return (), ((), dict())
 
-    def eq(self, other: object, static: bool = False) -> bool:
+    def eq(self, other: object, static: bool = False) -> ArrayLike:
         return _GreaterThan.eq(self, other, static=static)
 
 
@@ -353,7 +353,7 @@ class _Nonnegative(_GreaterThanEq, _SingletonConstraint[NumLike]):
     def tree_flatten(self):
         return (), ((), dict())
 
-    def eq(self, other: object, static: bool = False) -> bool:
+    def eq(self, other: object, static: bool = False) -> ArrayLike:
         return _GreaterThanEq.eq(self, other, static=static)
 
 
@@ -387,7 +387,7 @@ class _IndependentConstraint(Constraint[NumLikeT]):
     def event_dim(self) -> int:
         return self.base_constraint.event_dim + self.reinterpreted_batch_ndims
 
-    def __call__(self, x: NumLikeT) -> Array:
+    def __call__(self, x: NumLikeT) -> ArrayLike:
         result = self.base_constraint(x)
         if self.reinterpreted_batch_ndims == 0:
             return result
@@ -420,7 +420,7 @@ class _IndependentConstraint(Constraint[NumLikeT]):
             {"reinterpreted_batch_ndims": self.reinterpreted_batch_ndims},
         )
 
-    def eq(self, other: object, static: bool = False) -> bool:
+    def eq(self, other: object, static: bool = False) -> ArrayLike:
         if not isinstance(other, _IndependentConstraint):
             return False
         if self.reinterpreted_batch_ndims != other.reinterpreted_batch_ndims:
@@ -446,9 +446,9 @@ class _LessThan(Constraint[NumLike]):
     def __init__(self, upper_bound: NumLike) -> None:
         self.upper_bound = upper_bound
 
-    def __call__(self, x: NumLike) -> Array:
+    def __call__(self, x: NumLike) -> ArrayLike:
         xp = jnp if isinstance(x, jax.Array) else np
-        return xp.less(x, self.upper_bound)  # type: ignore
+        return xp.less(x, self.upper_bound)
 
     def __repr__(self) -> str:
         fmt_string = self.__class__.__name__[1:]
@@ -461,18 +461,18 @@ class _LessThan(Constraint[NumLike]):
     def tree_flatten(self):
         return (self.upper_bound,), (("upper_bound",), dict())
 
-    def eq(self, other: object, static: bool = False) -> bool:
+    def eq(self, other: object, static: bool = False) -> ArrayLike:
         if not isinstance(other, _LessThan):
             return False
         return array_equiv(self.upper_bound, other.upper_bound, static=static)
 
 
 class _LessThanEq(_LessThan):
-    def __call__(self, x: NumLike) -> Array:
+    def __call__(self, x: NumLike) -> ArrayLike:
         xp = jnp if isinstance(x, jax.Array) else np
-        return xp.less_equal(x, self.upper_bound)  # type: ignore
+        return xp.less_equal(x, self.upper_bound)
 
-    def eq(self, other: object, static: bool = False) -> bool:
+    def eq(self, other: object, static: bool = False) -> ArrayLike:
         if not isinstance(other, _LessThanEq):
             return False
         return array_equiv(self.upper_bound, other.upper_bound, static=static)
@@ -485,7 +485,7 @@ class _IntegerInterval(Constraint[NumLike]):
         self.lower_bound = lower_bound
         self.upper_bound = upper_bound
 
-    def __call__(self, x: NumLike) -> Array:
+    def __call__(self, x: NumLike) -> ArrayLike:
         xp = jnp if isinstance(x, jax.Array) else np
         return (
             xp.greater_equal(x, self.lower_bound)
@@ -509,7 +509,7 @@ class _IntegerInterval(Constraint[NumLike]):
             dict(),
         )
 
-    def eq(self, other: object, static: bool = False) -> bool:
+    def eq(self, other: object, static: bool = False) -> ArrayLike:
         if not isinstance(other, _IntegerInterval):
             return False
         return array_equiv(
@@ -523,7 +523,7 @@ class _IntegerGreaterThan(Constraint[NumLike]):
     def __init__(self, lower_bound: NumLike) -> None:
         self.lower_bound = lower_bound
 
-    def __call__(self, x: NumLike) -> Array:
+    def __call__(self, x: NumLike) -> ArrayLike:
         xp = jnp if isinstance(x, jax.Array) else np
         return (xp.mod(x, 1) == 0) & xp.greater_equal(x, self.lower_bound)
 
@@ -538,7 +538,7 @@ class _IntegerGreaterThan(Constraint[NumLike]):
     def tree_flatten(self):
         return (self.lower_bound,), (("lower_bound",), dict())
 
-    def eq(self, other: object, static: bool = False) -> bool:
+    def eq(self, other: object, static: bool = False) -> ArrayLike:
         if not isinstance(other, _IntegerGreaterThan):
             return False
         return array_equiv(self.lower_bound, other.lower_bound, static=static)
@@ -551,7 +551,7 @@ class _IntegerPositive(_IntegerGreaterThan, _SingletonConstraint[NumLike]):
     def tree_flatten(self):
         return (), ((), dict())
 
-    def eq(self, other: object, static: bool = False) -> bool:
+    def eq(self, other: object, static: bool = False) -> ArrayLike:
         return _IntegerGreaterThan.eq(self, other, static=static)
 
 
@@ -562,7 +562,7 @@ class _IntegerNonnegative(_IntegerGreaterThan, _SingletonConstraint[NumLike]):
     def tree_flatten(self):
         return (), ((), dict())
 
-    def eq(self, other: object, static: bool = False) -> bool:
+    def eq(self, other: object, static: bool = False) -> ArrayLike:
         return _IntegerGreaterThan.eq(self, other, static=static)
 
 
@@ -571,7 +571,7 @@ class _Interval(Constraint[NumLike]):
         self.lower_bound = lower_bound
         self.upper_bound = upper_bound
 
-    def __call__(self, x: NumLike) -> Array:
+    def __call__(self, x: NumLike) -> ArrayLike:
         xp = jnp if isinstance(x, jax.Array) else np
         return xp.greater_equal(x, self.lower_bound) & xp.less_equal(
             x, self.upper_bound
@@ -589,7 +589,7 @@ class _Interval(Constraint[NumLike]):
             (self.lower_bound + self.upper_bound) / 2, jnp.shape(prototype)
         )
 
-    def eq(self, other: object, static: bool = False) -> bool:
+    def eq(self, other: object, static: bool = False) -> ArrayLike:
         if not isinstance(other, _Interval):
             return False
         return array_equiv(
@@ -610,7 +610,7 @@ class _Circular(_Interval, _SingletonConstraint[NumLike]):
     def tree_flatten(self):
         return (), ((), dict())
 
-    def eq(self, other: object, static: bool = False) -> bool:
+    def eq(self, other: object, static: bool = False) -> ArrayLike:
         return _Interval.eq(self, other, static=static)
 
 
@@ -621,12 +621,12 @@ class _UnitInterval(_Interval, _SingletonConstraint[NumLike]):
     def tree_flatten(self):
         return (), ((), dict())
 
-    def eq(self, other: object, static: bool = False) -> bool:
+    def eq(self, other: object, static: bool = False) -> ArrayLike:
         return _Interval.eq(self, other, static=static)
 
 
 class _OpenInterval(_Interval):
-    def __call__(self, x: NumLike) -> Array:
+    def __call__(self, x: NumLike) -> ArrayLike:
         xp = jnp if isinstance(x, jax.Array) else np
         return xp.greater(x, self.lower_bound) & xp.less(x, self.upper_bound)
 
@@ -641,7 +641,7 @@ class _OpenInterval(_Interval):
 class _LowerCholesky(_SingletonConstraint[NonScalarArray]):
     event_dim = 2
 
-    def __call__(self, x: NonScalarArray) -> Array:
+    def __call__(self, x: NonScalarArray) -> ArrayLike:
         xp = np if isinstance(x, (np.ndarray, np.generic)) else jnp
         tril = xp.tril(x)
         lower_triangular = xp.all(xp.reshape(tril == x, x.shape[:-2] + (-1,)), axis=-1)
@@ -659,9 +659,9 @@ class _Multinomial(Constraint[NonScalarArray]):
     def __init__(self, upper_bound: ArrayLike) -> None:
         self.upper_bound = upper_bound
 
-    def __call__(self, x: NonScalarArray) -> Array:
+    def __call__(self, x: NonScalarArray) -> ArrayLike:
         xp = jnp if isinstance(x, jax.Array) else np
-        return (x >= 0).all(axis=-1) & xp.equal(x.sum(axis=-1), self.upper_bound)  # type: ignore
+        return (x >= 0).all(axis=-1) & xp.equal(x.sum(axis=-1), self.upper_bound)
 
     def feasible_like(self, prototype: NonScalarArray) -> NonScalarArray:
         pad_width = ((0, 0),) * jnp.ndim(self.upper_bound) + (
@@ -673,7 +673,7 @@ class _Multinomial(Constraint[NonScalarArray]):
     def tree_flatten(self):
         return (self.upper_bound,), (("upper_bound",), dict())
 
-    def eq(self, other: object, static: bool = False) -> bool:
+    def eq(self, other: object, static: bool = False) -> ArrayLike:
         if not isinstance(other, _Multinomial):
             return False
         return array_equiv(self.upper_bound, other.upper_bound, static=static)
@@ -687,7 +687,7 @@ class _L1Ball(_SingletonConstraint[NumLike]):
     event_dim = 1
     reltol = 10.0  # Relative to finfo.eps.
 
-    def __call__(self, x: NumLike) -> Array:
+    def __call__(self, x: NumLike) -> ArrayLike:
         xp = np if isinstance(x, (np.ndarray, np.generic)) else jnp
         dtype = x.dtype if isinstance(x, xp.ndarray) else type(x)
         eps = jnp.finfo(dtype).eps
@@ -710,7 +710,7 @@ class _OrderedVector(_SingletonConstraint[NonScalarArray]):
 class _PositiveDefinite(_SingletonConstraint[NonScalarArray]):
     event_dim = 2
 
-    def __call__(self, x: NonScalarArray) -> Array:
+    def __call__(self, x: NonScalarArray) -> ArrayLike:
         xp = np if isinstance(x, (np.ndarray, np.generic)) else jnp
         # check for symmetric
         symmetric = xp.all(xp.isclose(x, xp.swapaxes(x, -2, -1)), axis=(-2, -1))
@@ -725,11 +725,11 @@ class _PositiveDefinite(_SingletonConstraint[NonScalarArray]):
 class _PositiveDefiniteCirculantVector(_SingletonConstraint[NonScalarArray]):
     event_dim = 1
 
-    def __call__(self, x: NonScalarArray) -> Array:
+    def __call__(self, x: NonScalarArray) -> ArrayLike:
         xp = np if isinstance(x, (np.ndarray, np.generic)) else jnp
         tol = 10 * xp.finfo(x.dtype).eps
         rfft = xp.fft.rfft(x)
-        return (xp.abs(rfft.imag) < tol) & (rfft.real > -tol)  # type: ignore
+        return (xp.abs(rfft.imag) < tol) & (rfft.real > -tol)
 
     def feasible_like(self, prototype: NonScalarArray) -> NonScalarArray:
         return jnp.zeros_like(prototype).at[..., 0].set(1.0)
@@ -738,7 +738,7 @@ class _PositiveDefiniteCirculantVector(_SingletonConstraint[NonScalarArray]):
 class _PositiveSemiDefinite(_SingletonConstraint[NonScalarArray]):
     event_dim = 2
 
-    def __call__(self, x: NonScalarArray) -> Array:
+    def __call__(self, x: NonScalarArray) -> ArrayLike:
         xp = np if isinstance(x, (np.ndarray, np.generic)) else jnp
         # check for symmetric
         symmetric = xp.all(xp.isclose(x, xp.swapaxes(x, -2, -1)), axis=(-2, -1))
@@ -770,7 +770,7 @@ class _PositiveOrderedVector(_SingletonConstraint[NonScalarArray]):
 
 
 class _Complex(_SingletonConstraint[NumLike]):
-    def __call__(self, x: NumLike) -> Array:
+    def __call__(self, x: NumLike) -> ArrayLike:
         # XXX: consider to relax this condition to [-inf, inf] interval
         xp = jnp if isinstance(x, jax.Array) else np
         return (
@@ -830,7 +830,7 @@ class _Sphere(_SingletonConstraint[NonScalarArray]):
     event_dim = 1
     reltol = 10.0  # Relative to finfo.eps.
 
-    def __call__(self, x: NonScalarArray) -> Array:
+    def __call__(self, x: NonScalarArray) -> ArrayLike:
         xp = np if isinstance(x, (np.ndarray, np.generic)) else jnp
         eps = xp.finfo(x.dtype).eps
         norm = xp.linalg.norm(x, axis=-1)
@@ -850,16 +850,16 @@ class _ZeroSum(Constraint[NonScalarArray]):
     def event_dim(self) -> int:
         return self._event_dim
 
-    def __call__(self, x: NonScalarArray) -> Array:
+    def __call__(self, x: NonScalarArray) -> ArrayLike:
         xp = np if isinstance(x, (np.ndarray, np.generic)) else jnp
         tol = xp.finfo(x.dtype).eps * x.shape[-1] * 10
         zerosum_true = True
         for dim in range(-self.event_dim, 0):
             zerosum_true = zerosum_true & xp.allclose(x.sum(dim), 0, atol=tol)
         # FIXME: shape must match batch shape of `x`, not be a literal boolean.
-        return zerosum_true  # type: ignore
+        return zerosum_true
 
-    def eq(self, other: object, static: bool = False) -> bool:
+    def eq(self, other: object, static: bool = False) -> ArrayLike:
         if not isinstance(other, _ZeroSum):
             return False
         return self.event_dim == other.event_dim

--- a/numpyro/distributions/constraints.py
+++ b/numpyro/distributions/constraints.py
@@ -950,11 +950,15 @@ class _ZeroSum(Constraint[NonScalarArray]):
         return self._event_dim
 
     def __call__(self, x: NonScalarArray) -> ArrayLike:
+        """Return a boolean mask of shape ``x.shape[:-event_dim]`` that is true where
+        ``x`` sums to zero along each of the last ``event_dim`` axes."""
         xp = np if isinstance(x, (np.ndarray, np.generic)) else jnp
         tol = xp.finfo(x.dtype).eps * x.shape[-1] * 10
+        event_axes = tuple(range(-self.event_dim, 0))
         zerosum_true = True
-        for dim in range(-self.event_dim, 0):
-            zerosum_true = zerosum_true & xp.allclose(x.sum(dim), 0, atol=tol)
+        for dim in event_axes:
+            is_zero = xp.isclose(x.sum(dim, keepdims=True), 0, atol=tol)
+            zerosum_true = zerosum_true & xp.all(is_zero, axis=event_axes)
         return zerosum_true
 
     def eq(self, other: object, static: bool = False) -> ArrayLike:

--- a/numpyro/distributions/constraints.py
+++ b/numpyro/distributions/constraints.py
@@ -953,10 +953,11 @@ class _ZeroSum(Constraint[NonScalarArray]):
         """Return a boolean mask of shape ``x.shape[:-event_dim]`` that is true where
         ``x`` sums to zero along each of the last ``event_dim`` axes."""
         xp = np if isinstance(x, (np.ndarray, np.generic)) else jnp
-        tol = xp.finfo(x.dtype).eps * x.shape[-1] * 10
         event_axes = tuple(range(-self.event_dim, 0))
+        scale = xp.maximum(xp.max(xp.abs(x), axis=event_axes, keepdims=True), 1.0)
         zerosum_true = True
         for dim in event_axes:
+            tol = xp.finfo(x.dtype).eps * 10 * x.shape[dim] * scale
             is_zero = xp.isclose(x.sum(dim, keepdims=True), 0, atol=tol)
             zerosum_true = zerosum_true & xp.all(is_zero, axis=event_axes)
         return zerosum_true

--- a/numpyro/distributions/continuous.py
+++ b/numpyro/distributions/continuous.py
@@ -157,7 +157,7 @@ class AsymmetricLaplace(Distribution):
         variance = p * left**2 + q * right**2 + p * q * total**2
         return jnp.broadcast_to(variance, self.batch_shape)
 
-    def cdf(self, value: ArrayLike) -> ArrayLike:
+    def cdf(self, value: ArrayLike) -> Array:
         z = value - self.loc
         k = self.asymmetry
         return jnp.where(
@@ -166,7 +166,7 @@ class AsymmetricLaplace(Distribution):
             k**2 / (1 + k**2) * jnp.exp(-jnp.abs(z) / self.left_scale),
         )
 
-    def icdf(self, value: ArrayLike) -> ArrayLike:
+    def icdf(self, value: ArrayLike) -> Array:
         k = self.asymmetry
         temp = k**2 / (1 + k**2)
         return jnp.where(
@@ -281,23 +281,27 @@ class Beta(Distribution):
         )
 
     @property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         r"""Calculates the analytical mean.
 
         .. math:: E[X] = \frac{\alpha}{\alpha + \beta}
         """
-        return self.concentration1 / (self.concentration1 + self.concentration0)
+        return jnp.asarray(
+            self.concentration1 / (self.concentration1 + self.concentration0)
+        )
 
     @property
-    def variance(self) -> ArrayLike:
+    def variance(self) -> Array:
         r"""Calculates the analytical variance.
 
         .. math:: Var(X) = \frac{\alpha \beta}{(\alpha + \beta)^2 (\alpha + \beta + 1)}
         """
         total = self.concentration1 + self.concentration0
-        return self.concentration1 * self.concentration0 / (total**2 * (total + 1))
+        return jnp.asarray(
+            self.concentration1 * self.concentration0 / (total**2 * (total + 1))
+        )
 
-    def cdf(self, value: ArrayLike) -> ArrayLike:
+    def cdf(self, value: ArrayLike) -> Array:
         r"""Cumulative distribution function using the regularized incomplete beta function.
 
         .. math:: I_x(\alpha, \beta) = \frac{\text{B}(x; \alpha, \beta)}{\text{B}(\alpha, \beta)}
@@ -307,7 +311,7 @@ class Beta(Distribution):
         """
         return betainc(self.concentration1, self.concentration0, value)
 
-    def icdf(self, q: ArrayLike) -> ArrayLike:
+    def icdf(self, q: ArrayLike) -> Array:
         r"""Inverse cumulative distribution function (Quantile function).
 
         :param q: Probability value in :math:`[0,1]`.
@@ -421,7 +425,7 @@ class Cauchy(Distribution):
         """
         return jnp.full(self.batch_shape, jnp.nan)
 
-    def cdf(self, value: ArrayLike) -> ArrayLike:
+    def cdf(self, value: ArrayLike) -> Array:
         r"""Cumulative distribution function.
 
         .. math::
@@ -434,7 +438,7 @@ class Cauchy(Distribution):
         scaled = (value - self.loc) / self.scale
         return jnp.arctan(scaled) / jnp.pi + 0.5
 
-    def icdf(self, q: ArrayLike) -> ArrayLike:
+    def icdf(self, q: ArrayLike) -> Array:
         r"""Inverse cumulative distribution function (Quantile function).
 
         .. math::
@@ -741,7 +745,7 @@ class Exponential(Distribution):
         """
         return jnp.reciprocal(self.rate**2)
 
-    def cdf(self, value: ArrayLike) -> ArrayLike:
+    def cdf(self, value: ArrayLike) -> Array:
         r"""Cumulative distribution function.
 
         .. math::
@@ -752,7 +756,7 @@ class Exponential(Distribution):
         """
         return -jnp.expm1(-self.rate * value)
 
-    def icdf(self, q: ArrayLike) -> ArrayLike:
+    def icdf(self, q: ArrayLike) -> Array:
         r"""Inverse cumulative distribution function (Quantile function).
 
         .. math::
@@ -832,13 +836,13 @@ class Gamma(Distribution):
         )
 
     @property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         r"""If :math:`X \sim \mathrm{Gamma}(\alpha, \lambda)`, then
 
         .. math::
             \mathbb{E}[X] = \frac{\alpha}{\lambda}
         """
-        return self.concentration / self.rate
+        return jnp.asarray(self.concentration / self.rate)
 
     @property
     def variance(self) -> Array:
@@ -849,7 +853,7 @@ class Gamma(Distribution):
         """
         return self.concentration / jnp.power(self.rate, 2)
 
-    def cdf(self, x):
+    def cdf(self, x) -> Array:
         r"""If :math:`X \sim \mathrm{Gamma}(\alpha, \lambda)`, then
 
         .. math::
@@ -862,7 +866,7 @@ class Gamma(Distribution):
         """
         return gammainc(self.concentration, self.rate * x)
 
-    def icdf(self, q: ArrayLike) -> ArrayLike:
+    def icdf(self, q: ArrayLike) -> Array:
         r"""If :math:`X \sim \mathrm{Gamma}(\alpha, \lambda)`, then
 
         .. math::
@@ -1149,10 +1153,10 @@ class HalfCauchy(Distribution):
     def log_prob(self, value: ArrayLike) -> Array:
         return self._cauchy.log_prob(value) + jnp.log(2)
 
-    def cdf(self, value: ArrayLike) -> ArrayLike:
+    def cdf(self, value: ArrayLike) -> Array:
         return self._cauchy.cdf(value) * 2 - 1
 
-    def icdf(self, q: ArrayLike) -> ArrayLike:
+    def icdf(self, q: ArrayLike) -> Array:
         return self._cauchy.icdf((q + 1) / 2)
 
     @property
@@ -1190,10 +1194,10 @@ class HalfNormal(Distribution):
     def log_prob(self, value: ArrayLike) -> Array:
         return self._normal.log_prob(value) + jnp.log(2)
 
-    def cdf(self, value: ArrayLike) -> ArrayLike:
+    def cdf(self, value: ArrayLike) -> Array:
         return self._normal.cdf(value) * 2 - 1
 
-    def icdf(self, q: ArrayLike) -> ArrayLike:
+    def icdf(self, q: ArrayLike) -> Array:
         return self._normal.icdf((q + 1) / 2)
 
     @property
@@ -1201,8 +1205,8 @@ class HalfNormal(Distribution):
         return jnp.sqrt(2 / jnp.pi) * self.scale
 
     @property
-    def variance(self) -> ArrayLike:
-        return (1 - 2 / jnp.pi) * self.scale**2
+    def variance(self) -> Array:
+        return jnp.asarray((1 - 2 / jnp.pi) * self.scale**2)
 
 
 class InverseGamma(TransformedDistribution):
@@ -1306,10 +1310,10 @@ class Gompertz(Distribution):
             - self.concentration * jnp.expm1(scaled_value)
         )
 
-    def cdf(self, value: ArrayLike) -> ArrayLike:
+    def cdf(self, value: ArrayLike) -> Array:
         return -jnp.expm1(-self.concentration * jnp.expm1(value * self.rate))
 
-    def icdf(self, q: ArrayLike) -> ArrayLike:
+    def icdf(self, q: ArrayLike) -> Array:
         return jnp.log1p(-jnp.log1p(-q) / self.concentration) / self.rate
 
     @property
@@ -1411,7 +1415,7 @@ class Gumbel(Distribution):
         """
         return jnp.broadcast_to(jnp.pi**2 / 6.0 * self.scale**2, self.batch_shape)
 
-    def cdf(self, value: ArrayLike) -> ArrayLike:
+    def cdf(self, value: ArrayLike) -> Array:
         r"""Cumulative Distribution Function (CDF) of the Gumbel distribution:
 
         .. math::
@@ -1422,7 +1426,7 @@ class Gumbel(Distribution):
         """
         return jnp.exp(-jnp.exp((self.loc - value) / self.scale))
 
-    def icdf(self, q: ArrayLike) -> ArrayLike:
+    def icdf(self, q: ArrayLike) -> Array:
         r"""Inverse CDF (quantile function) of the Gumbel distribution:
 
         .. math::
@@ -1582,7 +1586,7 @@ class Laplace(Distribution):
         """
         return jnp.broadcast_to(2 * self.scale**2, self.batch_shape)
 
-    def cdf(self, value: ArrayLike) -> ArrayLike:
+    def cdf(self, value: ArrayLike) -> Array:
         r"""Cumulative Distribution Function (CDF) of the Laplace distribution.
         Letting :math:`z = (x - \mu)/b`,
 
@@ -1599,7 +1603,7 @@ class Laplace(Distribution):
         scaled = (value - self.loc) / self.scale
         return 0.5 - 0.5 * jnp.sign(scaled) * jnp.expm1(-jnp.abs(scaled))
 
-    def icdf(self, q: ArrayLike) -> ArrayLike:
+    def icdf(self, q: ArrayLike) -> Array:
         r"""Inverse CDF (quantile function) of the Laplace distribution:
 
         .. math::
@@ -2032,7 +2036,7 @@ class Logistic(Distribution):
         var = (self.scale**2) * (jnp.pi**2) / 3
         return jnp.broadcast_to(var, self.batch_shape)
 
-    def cdf(self, value: ArrayLike) -> ArrayLike:
+    def cdf(self, value: ArrayLike) -> Array:
         r"""Cumulative Distribution Function (CDF) of the Logistic distribution.
         Letting :math:`z = (x - \mu)/s`,
 
@@ -2048,7 +2052,7 @@ class Logistic(Distribution):
         scaled = (value - self.loc) / self.scale
         return expit(scaled)
 
-    def icdf(self, q: ArrayLike) -> ArrayLike:
+    def icdf(self, q: ArrayLike) -> Array:
         r"""Inverse CDF (quantile function) of the Logistic distribution:
 
         .. math::
@@ -2230,7 +2234,7 @@ class MatrixNormal(Distribution):
         return samples
 
     @validate_sample
-    def log_prob(self, values):
+    def log_prob(self, values) -> Array:
         n, p = self.event_shape
 
         row_log_det = tri_logabsdet(self.scale_tril_row)
@@ -2836,7 +2840,7 @@ class LowRankMultivariateNormal(Distribution):
 
     @property
     def mean(self) -> Array:
-        return self.loc
+        return jnp.asarray(self.loc)
 
     @lazy_property
     def variance(self) -> Array:
@@ -2988,7 +2992,7 @@ class Normal(Distribution):
         value_scaled = (value - self.loc) / self.scale
         return -0.5 * value_scaled**2 - normalize_term
 
-    def cdf(self, value: ArrayLike) -> ArrayLike:
+    def cdf(self, value: ArrayLike) -> Array:
         r"""Cumulative distribution function.
 
         .. math::
@@ -3004,7 +3008,7 @@ class Normal(Distribution):
         scaled = (value - self.loc) / self.scale
         return ndtr(scaled)
 
-    def log_cdf(self, value: ArrayLike) -> ArrayLike:
+    def log_cdf(self, value: ArrayLike) -> Array:
         r"""Log of the cumulative distribution function. Implementation
         calls :func:`jax.scipy.stats.norm.logcdf`.
 
@@ -3013,7 +3017,7 @@ class Normal(Distribution):
         """
         return jax_norm.logcdf(value, loc=self.loc, scale=self.scale)
 
-    def icdf(self, q: ArrayLike) -> ArrayLike:
+    def icdf(self, q: ArrayLike) -> Array:
         r"""Inverse cumulative distribution function (Quantile function).
 
         .. math::
@@ -3173,20 +3177,20 @@ class SoftLaplace(Distribution):
         return self.icdf(u)
 
     # TODO: refactor validate_sample to only does validation check and use it here
-    def cdf(self, value: ArrayLike) -> ArrayLike:
+    def cdf(self, value: ArrayLike) -> Array:
         z = (value - self.loc) / self.scale
         return jnp.arctan(jnp.exp(z)) * (2 / jnp.pi)
 
-    def icdf(self, value: ArrayLike) -> ArrayLike:
+    def icdf(self, value: ArrayLike) -> Array:
         return jnp.log(jnp.tan(value * (jnp.pi / 2))) * self.scale + self.loc
 
     @property
-    def mean(self) -> ArrayLike:
-        return self.loc
+    def mean(self) -> Array:
+        return jnp.asarray(self.loc)
 
     @property
-    def variance(self) -> ArrayLike:
-        return (jnp.pi / 2 * self.scale) ** 2
+    def variance(self) -> Array:
+        return jnp.asarray((jnp.pi / 2 * self.scale) ** 2)
 
 
 class StudentT(Distribution):
@@ -3252,7 +3256,7 @@ class StudentT(Distribution):
         var = jnp.where(self.df <= 1, jnp.nan, var)
         return jnp.broadcast_to(var, self.batch_shape)
 
-    def cdf(self, value: ArrayLike) -> ArrayLike:
+    def cdf(self, value: ArrayLike) -> Array:
         # Ref: https://en.wikipedia.org/wiki/Student's_t-distribution#Related_distributions
         # X^2 ~ F(1, df) -> df / (df + X^2) ~ Beta(df/2, 0.5)
         scaled = (value - self.loc) / self.scale
@@ -3267,7 +3271,7 @@ class StudentT(Distribution):
             - jnp.sign(scaled) * betainc(0.5 * self.df, 0.5, beta_value)
         )
 
-    def icdf(self, q: ArrayLike) -> ArrayLike:
+    def icdf(self, q: ArrayLike) -> Array:
         beta_value = betaincinv(0.5 * self.df, 0.5, 1 - jnp.abs(1 - 2 * q))
         scaled_squared = self.df * (1 / beta_value - 1)
         scaled = jnp.sign(q - 0.5) * jnp.sqrt(scaled_squared)
@@ -3316,20 +3320,20 @@ class Uniform(Distribution):
         shape = lax.broadcast_shapes(jnp.shape(value), self.batch_shape)
         return -jnp.broadcast_to(jnp.log(self.high - self.low), shape)
 
-    def cdf(self, value: ArrayLike) -> ArrayLike:
+    def cdf(self, value: ArrayLike) -> Array:
         cdf = (value - self.low) / (self.high - self.low)
         return jnp.clip(cdf, 0.0, 1.0)
 
-    def icdf(self, value: ArrayLike) -> ArrayLike:
-        return self.low + value * (self.high - self.low)
+    def icdf(self, value: ArrayLike) -> Array:
+        return jnp.asarray(self.low + value * (self.high - self.low))
 
     @property
-    def mean(self) -> ArrayLike:
-        return self.low + (self.high - self.low) / 2.0
+    def mean(self) -> Array:
+        return jnp.asarray(self.low + (self.high - self.low) / 2.0)
 
     @property
-    def variance(self) -> ArrayLike:
-        return (self.high - self.low) ** 2 / 12.0
+    def variance(self) -> Array:
+        return jnp.asarray((self.high - self.low) ** 2 / 12.0)
 
     @staticmethod
     def infer_shapes(
@@ -3379,7 +3383,7 @@ class Weibull(Distribution):
         ll -= self.concentration * jnp.log(self.scale)
         return ll
 
-    def cdf(self, value: ArrayLike) -> ArrayLike:
+    def cdf(self, value: ArrayLike) -> Array:
         return 1 - jnp.exp(-((value / self.scale) ** self.concentration))
 
     @property
@@ -3517,10 +3521,10 @@ class AsymmetricLaplaceQuantile(Distribution):
     def variance(self) -> Array:
         return self._ald.variance
 
-    def cdf(self, value: ArrayLike) -> ArrayLike:
+    def cdf(self, value: ArrayLike) -> Array:
         return self._ald.cdf(value)
 
-    def icdf(self, value: ArrayLike) -> ArrayLike:
+    def icdf(self, value: ArrayLike) -> Array:
         return self._ald.icdf(value)
 
 
@@ -3980,7 +3984,7 @@ class InverseWishart(TransformedDistribution):
         )
 
     @lazy_property
-    def mode(self) -> ArrayLike:
+    def mode(self) -> Array:
         p = self.scale_matrix.shape[-1]
         return self.scale_matrix / (self.concentration[..., None, None] + p + 1)
 
@@ -4236,7 +4240,7 @@ class Levy(Distribution):
         u = random.uniform(key, shape=sample_shape + self.batch_shape)
         return self.icdf(u)
 
-    def icdf(self, q: ArrayLike) -> ArrayLike:
+    def icdf(self, q: ArrayLike) -> Array:
         r"""
         The inverse cumulative distribution function of Lévy distribution is given by,
 
@@ -4250,7 +4254,7 @@ class Levy(Distribution):
         """
         return self.loc + self.scale * jnp.power(ndtri(1 - 0.5 * q), -2)
 
-    def cdf(self, value: ArrayLike) -> ArrayLike:
+    def cdf(self, value: ArrayLike) -> Array:
         r"""The cumulative distribution function of Lévy distribution is given by,
 
         .. math::
@@ -4389,11 +4393,11 @@ class CirculantNormal(TransformedDistribution):
         return jnp.broadcast_to(self.loc, self.shape())
 
     @lazy_property
-    def covariance_row(self) -> ArrayLike:
+    def covariance_row(self) -> Array:
         return jnp.fft.irfft(self.covariance_rfft, n=self.event_shape[-1])
 
     @lazy_property
-    def covariance_matrix(self) -> ArrayLike:
+    def covariance_matrix(self) -> Array:
         *leading_shape, n = self.covariance_row.shape
         if leading_shape:
             # `toeplitz` flattens the input, and we need to broadcast manually.
@@ -4478,7 +4482,7 @@ class Dagum(Distribution):
             - (self.concentration + 1.0) * nn.softplus(a_ln_x_m_ln_b)
         )
 
-    def cdf(self, value: ArrayLike) -> ArrayLike:
+    def cdf(self, value: ArrayLike) -> Array:
         return jnp.exp(
             -self.concentration
             * nn.softplus(
@@ -4486,7 +4490,7 @@ class Dagum(Distribution):
             )
         )
 
-    def icdf(self, q: ArrayLike) -> ArrayLike:
+    def icdf(self, q: ArrayLike) -> Array:
         q_root_p = jnp.power(q, -jnp.reciprocal(self.concentration))
         return self.scale * jnp.power(q_root_p - 1.0, -jnp.reciprocal(self.sharpness))
 

--- a/numpyro/distributions/continuous.py
+++ b/numpyro/distributions/continuous.py
@@ -128,27 +128,27 @@ class AsymmetricLaplace(Distribution):
     def right_scale(self):
         return self.scale / self.asymmetry
 
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         if self._validate_args:
             self._validate_sample(value)
         z = value - self.loc
         z = -jnp.abs(z) / jnp.where(z < 0, self.left_scale, self.right_scale)
         return z - jnp.log(self.left_scale + self.right_scale)
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
         assert is_prng_key(key)
         shape = (2,) + sample_shape + self.batch_shape + self.event_shape
         u, v = random.exponential(key, shape=shape)
         return self.loc - self.left_scale * u + self.right_scale * v
 
     @property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         total_scale = self.left_scale + self.right_scale
         mean = self.loc + (self.right_scale**2 - self.left_scale**2) / total_scale
         return jnp.broadcast_to(mean, self.batch_shape)
 
     @property
-    def variance(self) -> ArrayLike:
+    def variance(self) -> Array:
         left = self.left_scale
         right = self.right_scale
         total = left + right
@@ -224,7 +224,7 @@ class Beta(Distribution):
             jnp.stack([concentration1, concentration0], axis=-1)
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
         r"""Generates samples from the distribution using the underlying Dirichlet implementation.
 
         Since a :math:`\mathrm{Beta}(\alpha, \beta)` distribution is equivalent to a
@@ -242,7 +242,7 @@ class Beta(Distribution):
         return self._dirichlet.sample(key, sample_shape)[..., 0]
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         r"""Calculates the log of the probability density function.
 
         To avoid `NaN` gradients at the boundaries :math:`x=0` or :math:`x=1`, this
@@ -315,7 +315,7 @@ class Beta(Distribution):
         """
         return betaincinv(self.concentration1, self.concentration0, q)
 
-    def entropy(self) -> ArrayLike:
+    def entropy(self) -> Array:
         r"""Entropy of the Beta distribution.
 
         .. math::
@@ -372,7 +372,7 @@ class Cauchy(Distribution):
             batch_shape=batch_shape, validate_args=validate_args
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
         r"""Generates samples using the inverse CDF method via :func:`~jax.random.cauchy`.
 
         :param key: JAX PRNGKey for reproducibility.
@@ -387,7 +387,7 @@ class Cauchy(Distribution):
         return self.loc + eps * self.scale
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         r"""Calculates the log of the probability density function.
 
         .. math::
@@ -406,7 +406,7 @@ class Cauchy(Distribution):
         )
 
     @property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         r"""The mean of the Cauchy distribution is undefined.
 
         Returns ``NaN`` for all batch elements.
@@ -414,7 +414,7 @@ class Cauchy(Distribution):
         return jnp.full(self.batch_shape, jnp.nan)
 
     @property
-    def variance(self) -> ArrayLike:
+    def variance(self) -> Array:
         r"""The variance of the Cauchy distribution is undefined.
 
         Returns ``NaN`` for all batch elements.
@@ -446,7 +446,7 @@ class Cauchy(Distribution):
         """
         return self.loc + self.scale * jnp.tan(jnp.pi * (q - 0.5))
 
-    def entropy(self) -> ArrayLike:
+    def entropy(self) -> Array:
         r"""Entropy of the Cauchy distribution.
 
         .. math::
@@ -480,7 +480,7 @@ class Dirichlet(Distribution):
             validate_args=validate_args,
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
         assert is_prng_key(key)
         shape = sample_shape + self.batch_shape
         samples = random.dirichlet(key, self.concentration, shape=shape)
@@ -489,7 +489,7 @@ class Dirichlet(Distribution):
         )
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         normalize_term = jnp.sum(gammaln(self.concentration), axis=-1) - gammaln(
             jnp.sum(self.concentration, axis=-1)
         )
@@ -499,11 +499,11 @@ class Dirichlet(Distribution):
         )
 
     @property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         return self.concentration / jnp.sum(self.concentration, axis=-1, keepdims=True)
 
     @property
-    def variance(self) -> ArrayLike:
+    def variance(self) -> Array:
         con0 = jnp.sum(self.concentration, axis=-1, keepdims=True)
         return self.concentration * (con0 - self.concentration) / (con0**2 * (con0 + 1))
 
@@ -513,7 +513,7 @@ class Dirichlet(Distribution):
         event_shape = concentration[-1:]
         return batch_shape, event_shape
 
-    def entropy(self) -> ArrayLike:
+    def entropy(self) -> Array:
         (n,) = self.event_shape
         total = self.concentration.sum(axis=-1)
         return (
@@ -569,7 +569,7 @@ class EulerMaruyama(Distribution):
     def support(self) -> constraints.Constraint:
         return constraints.independent(constraints.real, self.event_dim)
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
         assert is_prng_key(key)
         batch_shape = sample_shape + self.batch_shape
 
@@ -609,7 +609,7 @@ class EulerMaruyama(Distribution):
         return sde_out
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         sample_shape = lax.broadcast_shapes(
             value.shape[: -self.event_dim], self.batch_shape
         )
@@ -695,7 +695,7 @@ class Exponential(Distribution):
             batch_shape=jnp.shape(rate), validate_args=validate_args
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
         r"""Generates samples by scaling standard exponential draws by the
         inverse rate: :math:`X = E / \lambda`, where :math:`E \sim \mathrm{Exp}(1)`.
 
@@ -712,7 +712,7 @@ class Exponential(Distribution):
         )
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         r"""Calculates the log of the probability density function.
 
         .. math::
@@ -726,7 +726,7 @@ class Exponential(Distribution):
         return jnp.log(self.rate) - self.rate * value
 
     @property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         r"""Calculates the analytical mean.
 
         .. math:: E[X] = \frac{1}{\lambda}
@@ -734,7 +734,7 @@ class Exponential(Distribution):
         return jnp.reciprocal(self.rate)
 
     @property
-    def variance(self) -> ArrayLike:
+    def variance(self) -> Array:
         r"""Calculates the analytical variance.
 
         .. math:: \mathrm{Var}(X) = \frac{1}{\lambda^2}
@@ -763,7 +763,7 @@ class Exponential(Distribution):
         """
         return -jnp.log1p(-q) / self.rate
 
-    def entropy(self) -> ArrayLike:
+    def entropy(self) -> Array:
         r"""Entropy of the Exponential distribution.
 
         .. math::
@@ -801,7 +801,7 @@ class Gamma(Distribution):
             batch_shape=batch_shape, validate_args=validate_args
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
         r"""Method to generate samples :math:`X \sim \mathrm{Gamma}(\alpha, \lambda)`.
         It uses :func:`~jax.random.gamma` under the hood to generate samples.
         """
@@ -810,7 +810,7 @@ class Gamma(Distribution):
         return random.gamma(key, self.concentration, shape=shape) / self.rate
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         r"""If :math:`X \sim \mathrm{Gamma}(\alpha, \lambda)`, then
 
         .. math::
@@ -841,7 +841,7 @@ class Gamma(Distribution):
         return self.concentration / self.rate
 
     @property
-    def variance(self) -> ArrayLike:
+    def variance(self) -> Array:
         r"""If :math:`X \sim \mathrm{Gamma}(\alpha, \lambda)`, then
 
         .. math::
@@ -875,7 +875,7 @@ class Gamma(Distribution):
         """
         return gammaincinv(self.concentration, q) / self.rate
 
-    def entropy(self) -> ArrayLike:
+    def entropy(self) -> Array:
         r"""If :math:`X \sim \mathrm{Gamma}(\alpha, \lambda)`, then
 
         .. math::
@@ -1018,7 +1018,7 @@ class GaussianStateSpace(TransformedDistribution):
         return self._initial_value
 
     @property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         # If there's no initial value, the mean is zero (base distribution mean).
         if self._initial_value is None:
             return self.base_dist.mean
@@ -1035,7 +1035,7 @@ class GaussianStateSpace(TransformedDistribution):
         return jnp.moveaxis(means, 0, -2)
 
     @property
-    def variance(self) -> ArrayLike:
+    def variance(self) -> Array:
         # Given z_t = z_0 + \sum_{k=1}^t A^{t-k} \epsilon_t, the covariance of the state
         # vector at step t is E[z_t transpose(z_t)] = \sum_{k,k'}^t A^{t-k}
         # E[\epsilon_k transpose(\epsilon_{k'})] transpose(A^{t-k'}). We only have
@@ -1094,14 +1094,14 @@ class GaussianRandomWalk(Distribution):
             batch_shape, event_shape, validate_args=validate_args
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
         assert is_prng_key(key)
         shape = sample_shape + self.batch_shape + self.event_shape
         walks = random.normal(key, shape=shape)
         return jnp.cumsum(walks, axis=-1) * jnp.expand_dims(self.scale, axis=-1)
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         init_prob = Normal(0.0, self.scale).log_prob(value[..., 0])
         scale = jnp.expand_dims(self.scale, -1)
         # Normal is location-invariant, so evaluate the increments under a
@@ -1112,11 +1112,11 @@ class GaussianRandomWalk(Distribution):
         return init_prob + jnp.sum(step_probs, axis=-1)
 
     @property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         return jnp.zeros(self.batch_shape + self.event_shape)
 
     @property
-    def variance(self) -> ArrayLike:
+    def variance(self) -> Array:
         return jnp.broadcast_to(
             jnp.expand_dims(self.scale, -1) ** 2 * jnp.arange(1, self.num_steps + 1),
             self.batch_shape + self.event_shape,
@@ -1141,12 +1141,12 @@ class HalfCauchy(Distribution):
             batch_shape=jnp.shape(scale), validate_args=validate_args
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
         assert is_prng_key(key)
         return jnp.abs(self._cauchy.sample(key, sample_shape))
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         return self._cauchy.log_prob(value) + jnp.log(2)
 
     def cdf(self, value: ArrayLike) -> ArrayLike:
@@ -1156,11 +1156,11 @@ class HalfCauchy(Distribution):
         return self._cauchy.icdf((q + 1) / 2)
 
     @property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         return jnp.full(self.batch_shape, jnp.inf)
 
     @property
-    def variance(self) -> ArrayLike:
+    def variance(self) -> Array:
         return jnp.full(self.batch_shape, jnp.inf)
 
 
@@ -1187,7 +1187,7 @@ class HalfNormal(Distribution):
         return jnp.abs(self._normal.sample(key, sample_shape))
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         return self._normal.log_prob(value) + jnp.log(2)
 
     def cdf(self, value: ArrayLike) -> ArrayLike:
@@ -1197,7 +1197,7 @@ class HalfNormal(Distribution):
         return self._normal.icdf((q + 1) / 2)
 
     @property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         return jnp.sqrt(2 / jnp.pi) * self.scale
 
     @property
@@ -1234,18 +1234,18 @@ class InverseGamma(TransformedDistribution):
         )
 
     @property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         # mean is inf for alpha <= 1
         a = self.rate / (self.concentration - 1)
         return jnp.where(self.concentration <= 1, jnp.inf, a)
 
     @property
-    def variance(self) -> ArrayLike:
+    def variance(self) -> Array:
         # var is inf for alpha <= 2
         a = (self.rate / (self.concentration - 1)) ** 2 / (self.concentration - 2)
         return jnp.where(self.concentration <= 2, jnp.inf, a)
 
-    def entropy(self) -> ArrayLike:
+    def entropy(self) -> Array:
         return (
             self.concentration
             + jnp.log(self.rate)
@@ -1290,14 +1290,14 @@ class Gompertz(Distribution):
             validate_args=validate_args,
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
         assert is_prng_key(key)
         random_shape = sample_shape + self.batch_shape + self.event_shape
         unifs = random.uniform(key, shape=random_shape)
         return self.icdf(unifs)
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         scaled_value = value * self.rate
         return (
             jnp.log(self.concentration)
@@ -1313,7 +1313,7 @@ class Gompertz(Distribution):
         return jnp.log1p(-jnp.log1p(-q) / self.concentration) / self.rate
 
     @property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         return -jnp.exp(self.concentration) * expi(-self.concentration) / self.rate
 
 
@@ -1357,7 +1357,7 @@ class Gumbel(Distribution):
             batch_shape=batch_shape, validate_args=validate_args
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
         r"""Draw samples from the Gumbel distribution via the location-scale
         transform :math:`X = \mu + \beta Z`, where
         :math:`Z \sim \mathrm{Gumbel}(0, 1)` is drawn from
@@ -1374,7 +1374,7 @@ class Gumbel(Distribution):
         return self.loc + self.scale * standard_gumbel_sample
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         r"""Evaluate the log probability density function at ``value``.
 
         Letting :math:`z = (x - \mu)/\beta`,
@@ -1389,7 +1389,7 @@ class Gumbel(Distribution):
         return -(z + jnp.exp(-z)) - jnp.log(self.scale)
 
     @property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         r"""Mean of the Gumbel distribution:
 
         .. math::
@@ -1403,7 +1403,7 @@ class Gumbel(Distribution):
         )
 
     @property
-    def variance(self) -> ArrayLike:
+    def variance(self) -> Array:
         r"""Variance of the Gumbel distribution:
 
         .. math::
@@ -1464,7 +1464,7 @@ class Kumaraswamy(Distribution):
         )
         super().__init__(batch_shape=batch_shape, validate_args=validate_args)
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
         assert is_prng_key(key)
         finfo = jnp.finfo(jnp.result_type(float))
         u = random.uniform(
@@ -1475,7 +1475,7 @@ class Kumaraswamy(Distribution):
         return jnp.clip(jnp.exp(log_sample), finfo.tiny, 1 - finfo.eps)
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         finfo = jnp.finfo(jnp.result_type(float))
         normalize_term = jnp.log(self.concentration0) + jnp.log(self.concentration1)
         value_con1 = jnp.clip(value**self.concentration1, None, 1 - finfo.eps)
@@ -1486,12 +1486,12 @@ class Kumaraswamy(Distribution):
         )
 
     @property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         log_beta = betaln(1 + 1 / self.concentration1, self.concentration0)
         return self.concentration0 * jnp.exp(log_beta)
 
     @property
-    def variance(self) -> ArrayLike:
+    def variance(self) -> Array:
         log_beta = betaln(1 + 2 / self.concentration1, self.concentration0)
         return self.concentration0 * jnp.exp(log_beta) - jnp.square(self.mean)
 
@@ -1535,7 +1535,7 @@ class Laplace(Distribution):
             batch_shape=batch_shape, validate_args=validate_args
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
         r"""Draw samples via the location-scale transform
         :math:`X = \mu + b Z`, where :math:`Z \sim \mathrm{Laplace}(0, 1)` is
         drawn from :func:`~jax.random.laplace`.
@@ -1551,7 +1551,7 @@ class Laplace(Distribution):
         return self.loc + eps * self.scale
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         r"""Evaluate the log probability density function at ``value``:
 
         .. math::
@@ -1565,7 +1565,7 @@ class Laplace(Distribution):
         return -value_scaled - normalize_term
 
     @property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         r"""Mean of the Laplace distribution:
 
         .. math::
@@ -1574,7 +1574,7 @@ class Laplace(Distribution):
         return jnp.broadcast_to(self.loc, self.batch_shape)
 
     @property
-    def variance(self) -> ArrayLike:
+    def variance(self) -> Array:
         r"""Variance of the Laplace distribution:
 
         .. math::
@@ -1613,7 +1613,7 @@ class Laplace(Distribution):
         a = q - 0.5
         return self.loc - self.scale * jnp.sign(a) * jnp.log1p(-2 * jnp.abs(a))
 
-    def entropy(self) -> ArrayLike:
+    def entropy(self) -> Array:
         r"""Differential entropy of the Laplace distribution:
 
         .. math::
@@ -1693,7 +1693,7 @@ class LKJ(TransformedDistribution):
         )
 
     @property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         return jnp.broadcast_to(
             jnp.identity(self.dimension),
             self.batch_shape + (self.dimension, self.dimension),
@@ -1855,7 +1855,7 @@ class LKJCholesky(Distribution):
         diag = jnp.ones(cholesky.shape[:-1]).at[..., 1:].set(jnp.sqrt(1 - beta_sample))
         return add_diag(cholesky, diag)
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
         assert is_prng_key(key)
         if self.sample_method == "onion":
             return self._onion(key, sample_shape)
@@ -1863,7 +1863,7 @@ class LKJCholesky(Distribution):
             return self._cvine(key, sample_shape)
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         # Note about computing Jacobian of the transformation from Cholesky factor to
         # correlation matrix:
         #
@@ -1927,14 +1927,14 @@ class LogNormal(TransformedDistribution):
         )
 
     @property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         return jnp.exp(self.loc + self.scale**2 / 2)
 
     @property
-    def variance(self) -> ArrayLike:
+    def variance(self) -> Array:
         return (jnp.exp(self.scale**2) - 1) * jnp.exp(2 * self.loc + self.scale**2)
 
-    def entropy(self) -> ArrayLike:
+    def entropy(self) -> Array:
         return (1 + jnp.log(2 * jnp.pi)) / 2 + self.loc + jnp.log(self.scale)
 
 
@@ -1978,7 +1978,7 @@ class Logistic(Distribution):
         batch_shape = lax.broadcast_shapes(jnp.shape(loc), jnp.shape(scale))
         super(Logistic, self).__init__(batch_shape, validate_args=validate_args)
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
         r"""Draw samples via the location-scale transform
         :math:`X = \mu + s Z`, where :math:`Z \sim \mathrm{Logistic}(0, 1)` is
         drawn from :func:`~jax.random.logistic`.
@@ -1994,7 +1994,7 @@ class Logistic(Distribution):
         return self.loc + z * self.scale
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         r"""Evaluate the log probability density function at ``value``.
 
         Letting :math:`u = (\mu - x)/s`, the log PDF is
@@ -2014,7 +2014,7 @@ class Logistic(Distribution):
         return log_exponent - log_denominator
 
     @property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         r"""Mean of the Logistic distribution:
 
         .. math::
@@ -2023,7 +2023,7 @@ class Logistic(Distribution):
         return jnp.broadcast_to(self.loc, self.batch_shape)
 
     @property
-    def variance(self) -> ArrayLike:
+    def variance(self) -> Array:
         r"""Variance of the Logistic distribution:
 
         .. math::
@@ -2062,7 +2062,7 @@ class Logistic(Distribution):
         """
         return self.loc + self.scale * logit(q)
 
-    def entropy(self) -> ArrayLike:
+    def entropy(self) -> Array:
         r"""Differential entropy of the Logistic distribution:
 
         .. math::
@@ -2095,17 +2095,17 @@ class LogUniform(TransformedDistribution):
         return self._support
 
     @property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         return (self.high - self.low) / jnp.log(self.high / self.low)
 
     @property
-    def variance(self) -> ArrayLike:
+    def variance(self) -> Array:
         return (
             0.5 * (self.high**2 - self.low**2) / jnp.log(self.high / self.low)
             - self.mean**2
         )
 
-    def entropy(self) -> ArrayLike:
+    def entropy(self) -> Array:
         log_low = jnp.log(self.low)
         log_high = jnp.log(self.high)
         return (log_low + log_high) / 2 + jnp.log(log_high - log_low)
@@ -2216,10 +2216,10 @@ class MatrixNormal(Distribution):
         )
 
     @property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         return jnp.broadcast_to(self.loc, self.shape())
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
         eps = random.normal(
             key, shape=sample_shape + self.batch_shape + self.event_shape
         )
@@ -2350,7 +2350,7 @@ class MultivariateNormal(Distribution):
             validate_args=validate_args,
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
         assert is_prng_key(key)
         eps = random.normal(
             key, shape=sample_shape + self.batch_shape + self.event_shape
@@ -2360,7 +2360,7 @@ class MultivariateNormal(Distribution):
         )
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         M = _batch_mahalanobis(self.scale_tril, value - self.loc)
         half_log_det = tri_logabsdet(self.scale_tril)
         normalize_term = half_log_det + 0.5 * self.scale_tril.shape[-1] * jnp.log(
@@ -2380,11 +2380,11 @@ class MultivariateNormal(Distribution):
         return cho_solve((self.scale_tril, True), identity)
 
     @property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         return jnp.broadcast_to(self.loc, self.shape())
 
     @property
-    def variance(self) -> ArrayLike:
+    def variance(self) -> Array:
         return jnp.broadcast_to(
             jnp.sum(self.scale_tril**2, axis=-1), self.batch_shape + self.event_shape
         )
@@ -2405,7 +2405,7 @@ class MultivariateNormal(Distribution):
                 event_shape = lax.broadcast_shapes(event_shape, matrix[-1:])
                 return batch_shape, event_shape
 
-    def entropy(self) -> ArrayLike:
+    def entropy(self) -> Array:
         (n,) = self.event_shape
         half_log_det = tri_logabsdet(self.scale_tril)
         return n * (jnp.log(2 * np.pi) + 1) / 2 + half_log_det
@@ -2528,13 +2528,13 @@ class CAR(Distribution):
                     self.adj_matrix, np.swapaxes(self.adj_matrix, -2, -1)
                 ), "adjacency matrix must be symmetric"
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
         # TODO: look into a sparse sampling method
         mvn = MultivariateNormal(self.mean, precision_matrix=self.precision_matrix)
         return mvn.sample(key, sample_shape=sample_shape)
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         phi = value - self.loc
         adj_matrix = self.adj_matrix
 
@@ -2581,7 +2581,7 @@ class CAR(Distribution):
         return 0.5 * (-n * jnp.log(2 * jnp.pi) + logprec + logdet - logquad)
 
     @property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         return jnp.broadcast_to(self.loc, self.shape())
 
     @lazy_property
@@ -2667,7 +2667,7 @@ class MultivariateStudentT(Distribution):
             validate_args=validate_args,
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
         assert is_prng_key(key)
         key_normal, key_chi2 = random.split(key)
         std_normal = random.normal(
@@ -2681,7 +2681,7 @@ class MultivariateStudentT(Distribution):
         )
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         n = self.scale_tril.shape[-1]
         Z = (
             tri_logabsdet(self.scale_tril)
@@ -2707,7 +2707,7 @@ class MultivariateStudentT(Distribution):
         return cho_solve((self.scale_tril, True), identity)
 
     @property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         # for df <= 1. should be jnp.nan (keeping jnp.inf for consistency with scipy)
         return jnp.broadcast_to(
             jnp.where(jnp.expand_dims(self.df, -1) <= 1, jnp.inf, self.loc),
@@ -2715,7 +2715,7 @@ class MultivariateStudentT(Distribution):
         )
 
     @property
-    def variance(self) -> ArrayLike:
+    def variance(self) -> Array:
         df = jnp.expand_dims(self.df, -1)
         var = jnp.power(self.scale_tril, 2).sum(-1) * (df / (df - 2))
         var = jnp.where(df > 2, var, jnp.inf)
@@ -2877,7 +2877,7 @@ class LowRankMultivariateNormal(Distribution):
         inverse_cov_diag = jnp.reciprocal(self.cov_diag)
         return add_diag(-jnp.matmul(jnp.swapaxes(A, -1, -2), A), inverse_cov_diag)
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
         assert is_prng_key(key)
         key_W, key_D = random.split(key)
         batch_shape = sample_shape + self.batch_shape
@@ -2892,7 +2892,7 @@ class LowRankMultivariateNormal(Distribution):
         )
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         diff = value - self.loc
         M = _batch_lowrank_mahalanobis(
             self.cov_factor, self.cov_diag, diff, self._capacitance_tril
@@ -2902,7 +2902,7 @@ class LowRankMultivariateNormal(Distribution):
         )
         return -0.5 * (self.loc.shape[-1] * jnp.log(2 * jnp.pi) + log_det + M)
 
-    def entropy(self) -> ArrayLike:
+    def entropy(self) -> Array:
         log_det = _batch_lowrank_logdet(
             self.cov_factor, self.cov_diag, self._capacitance_tril
         )
@@ -2954,7 +2954,7 @@ class Normal(Distribution):
             batch_shape=batch_shape, validate_args=validate_args
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
         r"""Generates samples via the reparameterization trick:
         :math:`X = \mu + \sigma \epsilon`, where :math:`\epsilon \sim \mathcal{N}(0,1)`.
 
@@ -2972,7 +2972,7 @@ class Normal(Distribution):
         return self.loc + eps * self.scale
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         r"""Calculates the log of the probability density function.
 
         .. math::
@@ -3029,7 +3029,7 @@ class Normal(Distribution):
         return self.loc + self.scale * ndtri(q)
 
     @property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         r"""Calculates the analytical mean.
 
         .. math:: E[X] = \mu
@@ -3037,14 +3037,14 @@ class Normal(Distribution):
         return jnp.broadcast_to(self.loc, self.batch_shape)
 
     @property
-    def variance(self) -> ArrayLike:
+    def variance(self) -> Array:
         r"""Calculates the analytical variance.
 
         .. math:: \mathrm{Var}(X) = \sigma^2
         """
         return jnp.broadcast_to(self.scale**2, self.batch_shape)
 
-    def entropy(self) -> ArrayLike:
+    def entropy(self) -> Array:
         r"""Entropy of the Normal distribution.
 
         .. math::
@@ -3077,13 +3077,13 @@ class Pareto(TransformedDistribution):
         super(Pareto, self).__init__(base_dist, transforms, validate_args=validate_args)
 
     @property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         # mean is inf for alpha <= 1
         a = jnp.divide(self.alpha * self.scale, (self.alpha - 1))
         return jnp.where(self.alpha <= 1, jnp.inf, a)
 
     @property
-    def variance(self) -> ArrayLike:
+    def variance(self) -> Array:
         # var is inf for alpha <= 2
         a = jnp.divide(
             (self.scale**2) * self.alpha, (self.alpha - 1) ** 2 * (self.alpha - 2)
@@ -3095,7 +3095,7 @@ class Pareto(TransformedDistribution):
     def support(self) -> constraints.Constraint:
         return constraints.greater_than(self.scale)
 
-    def entropy(self) -> ArrayLike:
+    def entropy(self) -> Array:
         return jnp.log(self.scale / self.alpha) + 1 + 1 / self.alpha
 
 
@@ -3160,11 +3160,11 @@ class SoftLaplace(Distribution):
         super().__init__(batch_shape=batch_shape, validate_args=validate_args)
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         z = (value - self.loc) / self.scale
         return jnp.log(2 / jnp.pi) - jnp.log(self.scale) - jnp.logaddexp(z, -z)
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
         assert is_prng_key(key)
         dtype = jnp.result_type(float)
         finfo = jnp.finfo(dtype)
@@ -3217,7 +3217,7 @@ class StudentT(Distribution):
         self._chi2 = Chi2(df)
         super(StudentT, self).__init__(batch_shape, validate_args=validate_args)
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
         assert is_prng_key(key)
         key_normal, key_chi2 = random.split(key)
         std_normal = random.normal(key_normal, shape=sample_shape + self.batch_shape)
@@ -3226,7 +3226,7 @@ class StudentT(Distribution):
         return self.loc + self.scale * y
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         y = (value - self.loc) / self.scale
         z = (
             jnp.log(self.scale)
@@ -3238,14 +3238,14 @@ class StudentT(Distribution):
         return -0.5 * (self.df + 1.0) * jnp.log1p(y**2.0 / self.df) - z
 
     @property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         # for df <= 1. should be jnp.nan (keeping jnp.inf for consistency with scipy)
         return jnp.broadcast_to(
             jnp.where(self.df <= 1, jnp.inf, self.loc), self.batch_shape
         )
 
     @property
-    def variance(self) -> ArrayLike:
+    def variance(self) -> Array:
         var = jnp.where(
             self.df > 2, jnp.divide(self.scale**2 * self.df, self.df - 2.0), jnp.inf
         )
@@ -3273,7 +3273,7 @@ class StudentT(Distribution):
         scaled = jnp.sign(q - 0.5) * jnp.sqrt(scaled_squared)
         return scaled * self.scale + self.loc
 
-    def entropy(self) -> ArrayLike:
+    def entropy(self) -> Array:
         return jnp.broadcast_to(
             (self.df + 1) / 2 * (digamma((self.df + 1) / 2) - digamma(self.df / 2))
             + jnp.log(self.df) / 2
@@ -3307,12 +3307,12 @@ class Uniform(Distribution):
     def support(self) -> constraints.Constraint:
         return self._support
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
         shape = sample_shape + self.batch_shape
         return random.uniform(key, shape=shape, minval=self.low, maxval=self.high)
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         shape = lax.broadcast_shapes(jnp.shape(value), self.batch_shape)
         return -jnp.broadcast_to(jnp.log(self.high - self.low), shape)
 
@@ -3339,7 +3339,7 @@ class Uniform(Distribution):
         event_shape: tuple[int, ...] = ()
         return batch_shape, event_shape
 
-    def entropy(self) -> ArrayLike:
+    def entropy(self) -> Array:
         return jnp.log(self.high - self.low)
 
 
@@ -3362,7 +3362,7 @@ class Weibull(Distribution):
         batch_shape = lax.broadcast_shapes(jnp.shape(concentration), jnp.shape(scale))
         super().__init__(batch_shape=batch_shape, validate_args=validate_args)
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
         assert is_prng_key(key)
         return random.weibull_min(
             key,
@@ -3372,7 +3372,7 @@ class Weibull(Distribution):
         )
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         ll = -jnp.power(value / self.scale, self.concentration)
         ll += jnp.log(self.concentration)
         ll += (self.concentration - 1.0) * jnp.log(value)
@@ -3383,17 +3383,17 @@ class Weibull(Distribution):
         return 1 - jnp.exp(-((value / self.scale) ** self.concentration))
 
     @property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         return self.scale * jnp.exp(gammaln(1.0 + 1.0 / self.concentration))
 
     @property
-    def variance(self) -> ArrayLike:
+    def variance(self) -> Array:
         return self.scale**2 * (
             jnp.exp(gammaln(1.0 + 2.0 / self.concentration))
             - jnp.exp(gammaln(1.0 + 1.0 / self.concentration)) ** 2
         )
 
-    def entropy(self) -> ArrayLike:
+    def entropy(self) -> Array:
         return (
             jnp.euler_gamma * (1 - 1 / self.concentration)
             + jnp.log(self.scale / self.concentration)
@@ -3501,20 +3501,20 @@ class AsymmetricLaplaceQuantile(Distribution):
         scale_classic = scale * asymmetry / quantile
         self._ald = AsymmetricLaplace(loc=loc, scale=scale_classic, asymmetry=asymmetry)
 
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         if self._validate_args:
             self._validate_sample(value)
         return self._ald.log_prob(value)
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
         return self._ald.sample(key, sample_shape=sample_shape)
 
     @property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         return self._ald.mean
 
     @property
-    def variance(self) -> ArrayLike:
+    def variance(self) -> Array:
         return self._ald.variance
 
     def cdf(self, value: ArrayLike) -> ArrayLike:
@@ -3610,11 +3610,11 @@ class ZeroSumNormal(TransformedDistribution):
         return constraints.zero_sum(len(self.event_shape))
 
     @property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         return jnp.zeros(self.batch_shape + self.event_shape)
 
     @property
-    def variance(self) -> ArrayLike:
+    def variance(self) -> Array:
         event_ndim = len(self.event_shape)
         zero_sum_axes = tuple(range(-event_ndim, 0))
         theoretical_var = jnp.square(self.scale)
@@ -3688,11 +3688,11 @@ class Wishart(TransformedDistribution):
         return self.base_dist.scale_tril
 
     @lazy_property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         return self.concentration[..., None, None] * self.scale_matrix
 
     @lazy_property
-    def variance(self) -> ArrayLike:
+    def variance(self) -> Array:
         diag = jnp.diagonal(self.scale_matrix, axis1=-1, axis2=-2)
         return self.concentration[..., None, None] * (
             self.scale_matrix**2 + diag[..., :, None] * diag[..., None, :]
@@ -3706,7 +3706,7 @@ class Wishart(TransformedDistribution):
             concentration, scale_matrix, rate_matrix, scale_tril
         )
 
-    def entropy(self) -> ArrayLike:
+    def entropy(self) -> Array:
         p = self.event_shape[-1]
         return (
             (p + 1) * tri_logabsdet(self.scale_tril)
@@ -3783,7 +3783,7 @@ class WishartCholesky(Distribution):
         )
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         # The log density of the Wishart distribution includes a term
         # t = trace(rate_matrix @ cov). Here, value = cholesky(cov) such that
         # t = trace(value.T @ rate_matrix @ value) by the cyclical property of the
@@ -3820,7 +3820,7 @@ class WishartCholesky(Distribution):
         )
         return cho_solve((self.scale_tril, True), identity)
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
         assert is_prng_key(key)
         # Sample using the Bartlett decomposition
         # (https://en.wikipedia.org/wiki/Wishart_distribution#Bartlett_decomposition).
@@ -3843,7 +3843,7 @@ class WishartCholesky(Distribution):
         return jnp.matmul(*jnp.broadcast_arrays(self.scale_tril, latent))
 
     @lazy_property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         # The mean follows from the Bartlett decomposition sampling. All off-diagonal
         # elements of the latent variable have zero expectation. The diagonal are the
         # expected square roots of chi^2 variables which can be expressed in terms of
@@ -3854,7 +3854,7 @@ class WishartCholesky(Distribution):
         return self.scale_tril * sqrtchi2[..., None, :]
 
     @lazy_property
-    def variance(self) -> ArrayLike:
+    def variance(self) -> Array:
         # We have the same as for the mean except now the lower off-diagonals are one
         # due to the standard normal noise, and the diagonals are equal to the dof of
         # the chi^2 variables.
@@ -3970,7 +3970,7 @@ class InverseWishart(TransformedDistribution):
         return self.base_dist.scale_tril
 
     @lazy_property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         # Mean exists only when concentration > p + 1
         p = self.scale_matrix.shape[-1]
         return jnp.where(
@@ -3985,7 +3985,7 @@ class InverseWishart(TransformedDistribution):
         return self.scale_matrix / (self.concentration[..., None, None] + p + 1)
 
     @lazy_property
-    def variance(self) -> ArrayLike:
+    def variance(self) -> Array:
         # Variance of entry (i,j) for nu > p + 3
         # Var(X_ij) = (Psi_ij^2 + Psi_ii * Psi_jj) / ((nu - p - 1)^2 * (nu - p - 3))
         p = self.scale_matrix.shape[-1]
@@ -4078,7 +4078,7 @@ class InverseWishartCholesky(Distribution):
         )
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         # L = value (Cholesky factor), X = L @ L^T ~ InverseWishart(Psi, nu)
         # log p(X) = (nu/2) log|Psi| - (nu*p/2) log(2) - log Gamma_p(nu/2)
         #            - ((nu+p+1)/2) log|X| - tr(Psi @ X^{-1}) / 2
@@ -4110,7 +4110,7 @@ class InverseWishartCholesky(Distribution):
         )
         return cho_solve((self.scale_tril, True), identity)
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
         assert is_prng_key(key)
         # Sample from standard InverseWishartCholesky using Bartlett decomposition
         # Ref: https://nbviewer.org/gist/fehiepsi/5ef8e09e61604f10607380467eb82006#Precision-to-scale_tril
@@ -4140,7 +4140,7 @@ class InverseWishartCholesky(Distribution):
         return jnp.matmul(self.scale_tril, L_inv_std)
 
     @lazy_property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         # Approximate: chol(E[X]) where E[X] = Psi / (nu - p - 1) for nu > p + 1
         p = self.scale_tril.shape[-1]
         mean_x = jnp.where(
@@ -4157,7 +4157,7 @@ class InverseWishartCholesky(Distribution):
         )
 
     @lazy_property
-    def variance(self) -> ArrayLike:
+    def variance(self) -> Array:
         # Variance of Cholesky factor is complex; return NaN for now
         return jnp.full(self.batch_shape + self.event_shape, jnp.nan)
 
@@ -4215,7 +4215,7 @@ class Levy(Distribution):
         return self._support
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         r"""Compute the log probability density function of the Lévy distribution.
 
         .. math::
@@ -4231,7 +4231,7 @@ class Levy(Distribution):
             jnp.log(2.0 * jnp.pi) - jnp.log(self.scale) + self.scale / shifted_value
         ) - 1.5 * jnp.log(shifted_value)
 
-    def sample(self, key: ArrayLike, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+    def sample(self, key: ArrayLike, sample_shape: tuple[int, ...] = ()) -> Array:
         assert is_prng_key(key)
         u = random.uniform(key, shape=sample_shape + self.batch_shape)
         return self.icdf(u)
@@ -4265,14 +4265,14 @@ class Levy(Distribution):
         return 2.0 - 2.0 * ndtr(jnp.sqrt(inv_standardized))
 
     @property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         return jnp.broadcast_to(jnp.inf, self.batch_shape)
 
     @property
-    def variance(self) -> ArrayLike:
+    def variance(self) -> Array:
         return jnp.broadcast_to(jnp.inf, self.batch_shape)
 
-    def entropy(self) -> ArrayLike:
+    def entropy(self) -> Array:
         r"""If :math:`X \sim \text{Levy}(\mu, c)`, then the entropy of :math:`X` is given by,
 
         .. math::
@@ -4385,7 +4385,7 @@ class CirculantNormal(TransformedDistribution):
         )
 
     @property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         return jnp.broadcast_to(self.loc, self.shape())
 
     @lazy_property
@@ -4405,7 +4405,7 @@ class CirculantNormal(TransformedDistribution):
             return toeplitz(self.covariance_row)
 
     @lazy_property
-    def variance(self) -> ArrayLike:
+    def variance(self) -> Array:
         return jnp.broadcast_to(self.covariance_row[..., 0, None], self.shape())
 
     @staticmethod
@@ -4421,7 +4421,7 @@ class CirculantNormal(TransformedDistribution):
                 event_shape = loc[-1:]
                 return batch_shape, event_shape
 
-    def entropy(self) -> ArrayLike:
+    def entropy(self) -> Array:
         (n,) = self.event_shape
         log_abs_det_jacobian = 2 * jnp.log(2) * ((n - 1) // 2) - jnp.log(n) * n
         return self.base_dist.entropy() + log_abs_det_jacobian / 2
@@ -4468,7 +4468,7 @@ class Dagum(Distribution):
         super().__init__(batch_shape=batch_shape, validate_args=validate_args)
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         a_ln_x_m_ln_b = xlogy(self.sharpness, value) - xlogy(self.sharpness, self.scale)
         return (
             jnp.log(self.sharpness)
@@ -4495,7 +4495,7 @@ class Dagum(Distribution):
         return self.icdf(random.uniform(key, shape=self.shape(sample_shape)))
 
     @property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         safe_a = jnp.where(self.sharpness > 1.0, self.sharpness, 2.0)
         return jnp.where(
             self.sharpness > 1.0,
@@ -4505,7 +4505,7 @@ class Dagum(Distribution):
         )
 
     @property
-    def variance(self) -> ArrayLike:
+    def variance(self) -> Array:
         safe_a = jnp.where(self.sharpness > 2.0, self.sharpness, 3.0)
         return jnp.where(
             self.sharpness > 2.0,

--- a/numpyro/distributions/continuous.py
+++ b/numpyro/distributions/continuous.py
@@ -26,7 +26,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 
-from typing import Callable, Literal, Optional
+from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, Union, cast
 
 import numpy as np
 
@@ -55,6 +55,7 @@ from jax.scipy.special import (
 from jax.scipy.stats import norm as jax_norm
 from jax.typing import ArrayLike
 
+from numpyro._typing import NonScalarArray, NumLike
 from numpyro.distributions import constraints
 from numpyro.distributions.discrete import HurdleProbs, _to_logits_bernoulli
 from numpyro.distributions.distribution import (
@@ -71,6 +72,7 @@ from numpyro.distributions.transforms import (
     RealFastFourierTransform,
     RecursiveLinearTransform,
     SigmoidTransform,
+    Transform,
     ZeroSumTransform,
 )
 from numpyro.distributions.util import (
@@ -91,6 +93,9 @@ from numpyro.distributions.util import (
     vec_to_tril_matrix,
 )
 from numpyro.util import is_prng_key
+
+if TYPE_CHECKING:
+    import scipy.sparse
 
 
 class AsymmetricLaplace(Distribution):
@@ -128,15 +133,20 @@ class AsymmetricLaplace(Distribution):
     def right_scale(self):
         return self.scale / self.asymmetry
 
-    def log_prob(self, value: ArrayLike) -> Array:
+    def log_prob(
+        self, value: ArrayLike, intermediates: Optional[list[Any]] = None
+    ) -> Array:
         if self._validate_args:
             self._validate_sample(value)
         z = value - self.loc
         z = -jnp.abs(z) / jnp.where(z < 0, self.left_scale, self.right_scale)
         return z - jnp.log(self.left_scale + self.right_scale)
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> Array:
         assert is_prng_key(key)
+        assert key is not None
         shape = (2,) + sample_shape + self.batch_shape + self.event_shape
         u, v = random.exponential(key, shape=shape)
         return self.loc - self.left_scale * u + self.right_scale * v
@@ -166,13 +176,13 @@ class AsymmetricLaplace(Distribution):
             k**2 / (1 + k**2) * jnp.exp(-jnp.abs(z) / self.left_scale),
         )
 
-    def icdf(self, value: ArrayLike) -> Array:
+    def icdf(self, q: ArrayLike) -> Array:
         k = self.asymmetry
         temp = k**2 / (1 + k**2)
         return jnp.where(
-            value <= temp,
-            self.loc + self.left_scale * jnp.log(value / temp),
-            self.loc - self.right_scale * jnp.log((1 + k**2) * (1 - value)),
+            q <= temp,
+            self.loc + self.left_scale * jnp.log(q / temp),
+            self.loc - self.right_scale * jnp.log((1 + k**2) * (1 - q)),
         )
 
 
@@ -224,7 +234,9 @@ class Beta(Distribution):
             jnp.stack([concentration1, concentration0], axis=-1)
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> Array:
         r"""Generates samples from the distribution using the underlying Dirichlet implementation.
 
         Since a :math:`\mathrm{Beta}(\alpha, \beta)` distribution is equivalent to a
@@ -236,7 +248,7 @@ class Beta(Distribution):
         :param sample_shape: The shape of the samples to be generated.
         :type sample_shape: tuple[int, ...]
         :return: Samples from the Beta distribution of shape ``sample_shape + batch_shape``.
-        :rtype: ArrayLike
+        :rtype: jax.Array
         """
         assert is_prng_key(key)
         return self._dirichlet.sample(key, sample_shape)[..., 0]
@@ -253,7 +265,7 @@ class Beta(Distribution):
         :param value: Values at which to evaluate the log density.
         :type value: ArrayLike
         :return: Log probability density.
-        :rtype: ArrayLike
+        :rtype: jax.Array
         """
         # Use double-where trick to avoid NaN gradients at boundary conditions
         # Reference: https://github.com/tensorflow/probability/blob/main/discussion/where-nan.pdf
@@ -376,7 +388,9 @@ class Cauchy(Distribution):
             batch_shape=batch_shape, validate_args=validate_args
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> Array:
         r"""Generates samples using the inverse CDF method via :func:`~jax.random.cauchy`.
 
         :param key: JAX PRNGKey for reproducibility.
@@ -384,9 +398,10 @@ class Cauchy(Distribution):
         :param sample_shape: The shape of the samples to be generated.
         :type sample_shape: tuple[int, ...]
         :return: Samples from the Cauchy distribution of shape ``sample_shape + batch_shape``.
-        :rtype: ArrayLike
+        :rtype: jax.Array
         """
         assert is_prng_key(key)
+        assert key is not None
         eps = random.cauchy(key, shape=sample_shape + self.batch_shape)
         return self.loc + eps * self.scale
 
@@ -401,7 +416,7 @@ class Cauchy(Distribution):
         :param value: Values at which to evaluate the log density.
         :type value: ArrayLike
         :return: Log probability density.
-        :rtype: ArrayLike
+        :rtype: jax.Array
         """
         return (
             -jnp.log(jnp.pi)
@@ -492,7 +507,7 @@ class Dirichlet(Distribution):
 
     def __init__(
         self,
-        concentration: Array,
+        concentration: ArrayLike,
         *,
         validate_args: Optional[bool] = None,
     ) -> None:
@@ -501,14 +516,19 @@ class Dirichlet(Distribution):
                 "`concentration` parameter must be at least one-dimensional."
             )
         self.concentration = concentration
-        batch_shape, event_shape = concentration.shape[:-1], concentration.shape[-1:]
+        batch_shape, event_shape = (
+            jnp.shape(concentration)[:-1],
+            jnp.shape(concentration)[-1:],
+        )
         super(Dirichlet, self).__init__(
             batch_shape=batch_shape,
             event_shape=event_shape,
             validate_args=validate_args,
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> Array:
         r"""Generates samples using :func:`~jax.random.dirichlet`.
 
         :param key: JAX PRNGKey for reproducibility.
@@ -516,9 +536,10 @@ class Dirichlet(Distribution):
         :param sample_shape: The shape of the samples to be generated.
         :type sample_shape: tuple[int, ...]
         :return: Samples from the Dirichlet distribution of shape ``sample_shape + batch_shape + event_shape``.
-        :rtype: ArrayLike
+        :rtype: jax.Array
         """
         assert is_prng_key(key)
+        assert key is not None
         shape = sample_shape + self.batch_shape
         samples = random.dirichlet(key, self.concentration, shape=shape)
         return jnp.clip(
@@ -537,7 +558,7 @@ class Dirichlet(Distribution):
         :param value: Values at which to evaluate the log density.
         :type value: ArrayLike
         :return: Log probability density.
-        :rtype: ArrayLike
+        :rtype: jax.Array
         """
         normalize_term = jnp.sum(gammaln(self.concentration), axis=-1) - gammaln(
             jnp.sum(self.concentration, axis=-1)
@@ -571,8 +592,8 @@ class Dirichlet(Distribution):
         con0 = jnp.sum(self.concentration, axis=-1, keepdims=True)
         return self.concentration * (con0 - self.concentration) / (con0**2 * (con0 + 1))
 
-    @staticmethod
-    def infer_shapes(concentration):
+    @classmethod
+    def infer_shapes(cls, concentration):
         batch_shape = concentration[:-1]
         event_shape = concentration[-1:]
         return batch_shape, event_shape
@@ -591,7 +612,7 @@ class Dirichlet(Distribution):
         :math:`\psi` is the digamma function.
         """
         (n,) = self.event_shape
-        total = self.concentration.sum(axis=-1)
+        total = jnp.sum(self.concentration, axis=-1)
         return (
             gammaln(self.concentration).sum(axis=-1)
             - gammaln(total)
@@ -620,7 +641,7 @@ class EulerMaruyama(Distribution):
 
     def __init__(
         self,
-        t: Array,
+        t: ArrayLike,
         sde_fn: Callable[[Array, Array], tuple[Array, Array]],
         init_dist: Distribution,
         *,
@@ -645,8 +666,11 @@ class EulerMaruyama(Distribution):
     def support(self) -> constraints.Constraint:
         return constraints.independent(constraints.real, self.event_dim)
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> Array:
         assert is_prng_key(key)
+        assert key is not None
         batch_shape = sample_shape + self.batch_shape
 
         def step(y_curr, xs):
@@ -669,7 +693,7 @@ class EulerMaruyama(Distribution):
 
         batch_dim = len(batch_shape)
         if batch_dim:
-            inits = inits.reshape((-1,) + inits.shape[batch_dim:])
+            inits = jnp.reshape(inits, (-1,) + jnp.shape(inits)[batch_dim:])
             noises = noises.reshape((-1,) + noises.shape[batch_dim:])
             t = jnp.broadcast_to(self.t, batch_shape + (self.event_shape[0],))
             t = t.reshape((-1,) + t.shape[batch_dim:])
@@ -679,15 +703,15 @@ class EulerMaruyama(Distribution):
             sde_out = jnp.reshape(sde_out, batch_shape + self.event_shape)
         else:
             dt = jnp.diff(self.t, axis=-1)
-            _, sde_out = scan_fn(inits, noises, self.t[:-1], dt)
-            sde_out = jnp.concatenate([inits[None], sde_out], axis=0)
+            _, sde_out = scan_fn(inits, noises, jnp.asarray(self.t)[:-1], dt)
+            sde_out = jnp.concatenate([jnp.expand_dims(inits, 0), sde_out], axis=0)
 
         return sde_out
 
     @validate_sample
     def log_prob(self, value: ArrayLike) -> Array:
         sample_shape = lax.broadcast_shapes(
-            value.shape[: -self.event_dim], self.batch_shape
+            jnp.shape(value)[: -self.event_dim], self.batch_shape
         )
         value = jnp.broadcast_to(value, sample_shape + self.event_shape)
 
@@ -710,7 +734,7 @@ class EulerMaruyama(Distribution):
             xtm1, xt = value[:-1], value[1:]
             value0 = value[0]
 
-            f, g = vmap(self.sde_fn)(xtm1, self.t[:-1])
+            f, g = vmap(self.sde_fn)(xtm1, jnp.asarray(self.t)[:-1])
 
         # add missing event dimensions
         batch_dim = len(sample_shape)
@@ -771,7 +795,9 @@ class Exponential(Distribution):
             batch_shape=jnp.shape(rate), validate_args=validate_args
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> Array:
         r"""Generates samples by scaling standard exponential draws by the
         inverse rate: :math:`X = E / \lambda`, where :math:`E \sim \mathrm{Exp}(1)`.
 
@@ -780,9 +806,10 @@ class Exponential(Distribution):
         :param sample_shape: The shape of the samples to be generated.
         :type sample_shape: tuple[int, ...]
         :return: Samples from the Exponential distribution of shape ``sample_shape + batch_shape``.
-        :rtype: ArrayLike
+        :rtype: jax.Array
         """
         assert is_prng_key(key)
+        assert key is not None
         return (
             random.exponential(key, shape=sample_shape + self.batch_shape) / self.rate
         )
@@ -797,7 +824,7 @@ class Exponential(Distribution):
         :param value: Values at which to evaluate the log density.
         :type value: ArrayLike
         :return: Log probability density.
-        :rtype: ArrayLike
+        :rtype: jax.Array
         """
         return jnp.log(self.rate) - self.rate * value
 
@@ -826,7 +853,7 @@ class Exponential(Distribution):
         :param value: Value to evaluate.
         :type value: ArrayLike
         """
-        return -jnp.expm1(-self.rate * value)
+        return -jnp.expm1(jnp.negative(self.rate) * value)
 
     def icdf(self, q: ArrayLike) -> Array:
         r"""Inverse cumulative distribution function (Quantile function).
@@ -837,7 +864,7 @@ class Exponential(Distribution):
         :param q: Probability value in :math:`[0,1]`.
         :type q: ArrayLike
         """
-        return -jnp.log1p(-q) / self.rate
+        return -jnp.log1p(jnp.negative(q)) / self.rate
 
     def entropy(self) -> Array:
         r"""Entropy of the Exponential distribution.
@@ -877,11 +904,14 @@ class Gamma(Distribution):
             batch_shape=batch_shape, validate_args=validate_args
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> Array:
         r"""Method to generate samples :math:`X \sim \mathrm{Gamma}(\alpha, \lambda)`.
         It uses :func:`~jax.random.gamma` under the hood to generate samples.
         """
         assert is_prng_key(key)
+        assert key is not None
         shape = sample_shape + self.batch_shape + self.event_shape
         return random.gamma(key, self.concentration, shape=shape) / self.rate
 
@@ -925,7 +955,7 @@ class Gamma(Distribution):
         """
         return self.concentration / jnp.power(self.rate, 2)
 
-    def cdf(self, x) -> Array:
+    def cdf(self, value: ArrayLike) -> Array:
         r"""If :math:`X \sim \mathrm{Gamma}(\alpha, \lambda)`, then
 
         .. math::
@@ -936,7 +966,7 @@ class Gamma(Distribution):
         This method uses regularized incomplete gamma function,
         which is implemented as :func:`~jax.scipy.special.gammainc`.
         """
-        return gammainc(self.concentration, self.rate * x)
+        return gammainc(self.concentration, self.rate * value)
 
     def icdf(self, q: ArrayLike) -> Array:
         r"""If :math:`X \sim \mathrm{Gamma}(\alpha, \lambda)`, then
@@ -1044,11 +1074,11 @@ class GaussianStateSpace(TransformedDistribution):
     def __init__(
         self,
         num_steps: int,
-        transition_matrix: Array,
+        transition_matrix: NonScalarArray,
         covariance_matrix: Optional[Array] = None,
         precision_matrix: Optional[Array] = None,
         scale_tril: Optional[Array] = None,
-        initial_value: Optional[Array] = None,
+        initial_value: Optional[NonScalarArray] = None,
         *,
         validate_args: Optional[bool] = None,
     ) -> None:
@@ -1056,7 +1086,7 @@ class GaussianStateSpace(TransformedDistribution):
             "`num_steps` argument should be a positive integer."
         )
         self.num_steps = num_steps
-        assert transition_matrix.ndim == 2, (
+        assert jnp.ndim(transition_matrix) == 2, (
             "`transition_matrix` argument should be a square matrix"
         )
         self.transition_matrix = transition_matrix
@@ -1079,19 +1109,20 @@ class GaussianStateSpace(TransformedDistribution):
         # The base distribution must have at least the same batch shape as the initial
         # value.
         if initial_value is not None:
-            batch_shape = initial_value.shape[:-1]
+            batch_shape = jnp.shape(initial_value)[:-1]
             base_distribution = base_distribution.expand(batch_shape)
 
         transform = RecursiveLinearTransform(
-            transition_matrix, initial_value=initial_value
+            transition_matrix,
+            initial_value=initial_value,
         )
         super().__init__(base_distribution, transform, validate_args=validate_args)
 
     @property
     def initial_value(self) -> Array:
         if self._initial_value is None:
-            return jnp.zeros(self.transition_matrix.shape[-1:])
-        return self._initial_value
+            return jnp.zeros(jnp.shape(self.transition_matrix)[-1:])
+        return jnp.asarray(self._initial_value)
 
     @property
     def mean(self) -> Array:
@@ -1170,14 +1201,18 @@ class GaussianRandomWalk(Distribution):
             batch_shape, event_shape, validate_args=validate_args
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> Array:
         assert is_prng_key(key)
+        assert key is not None
         shape = sample_shape + self.batch_shape + self.event_shape
         walks = random.normal(key, shape=shape)
         return jnp.cumsum(walks, axis=-1) * jnp.expand_dims(self.scale, axis=-1)
 
     @validate_sample
     def log_prob(self, value: ArrayLike) -> Array:
+        value = jnp.asarray(value)
         init_prob = Normal(0.0, self.scale).log_prob(value[..., 0])
         scale = jnp.expand_dims(self.scale, -1)
         # Normal is location-invariant, so evaluate the increments under a
@@ -1217,7 +1252,9 @@ class HalfCauchy(Distribution):
             batch_shape=jnp.shape(scale), validate_args=validate_args
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> Array:
         assert is_prng_key(key)
         return jnp.abs(self._cauchy.sample(key, sample_shape))
 
@@ -1258,7 +1295,9 @@ class HalfNormal(Distribution):
             batch_shape=jnp.shape(scale), validate_args=validate_args
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> Array:
         assert is_prng_key(key)
         return jnp.abs(self._normal.sample(key, sample_shape))
 
@@ -1366,8 +1405,11 @@ class Gompertz(Distribution):
             validate_args=validate_args,
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> Array:
         assert is_prng_key(key)
+        assert key is not None
         random_shape = sample_shape + self.batch_shape + self.event_shape
         unifs = random.uniform(key, shape=random_shape)
         return self.icdf(unifs)
@@ -1386,7 +1428,7 @@ class Gompertz(Distribution):
         return -jnp.expm1(-self.concentration * jnp.expm1(value * self.rate))
 
     def icdf(self, q: ArrayLike) -> Array:
-        return jnp.log1p(-jnp.log1p(-q) / self.concentration) / self.rate
+        return jnp.log1p(-jnp.log1p(jnp.negative(q)) / self.concentration) / self.rate
 
     @property
     def mean(self) -> Array:
@@ -1433,7 +1475,9 @@ class Gumbel(Distribution):
             batch_shape=batch_shape, validate_args=validate_args
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> Array:
         r"""Draw samples from the Gumbel distribution via the location-scale
         transform :math:`X = \mu + \beta Z`, where
         :math:`Z \sim \mathrm{Gumbel}(0, 1)` is drawn from
@@ -1444,6 +1488,7 @@ class Gumbel(Distribution):
         :return: Real-valued samples from the Gumbel distribution.
         """
         assert is_prng_key(key)
+        assert key is not None
         standard_gumbel_sample = random.gumbel(
             key, shape=sample_shape + self.batch_shape + self.event_shape
         )
@@ -1540,8 +1585,11 @@ class Kumaraswamy(Distribution):
         )
         super().__init__(batch_shape=batch_shape, validate_args=validate_args)
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> Array:
         assert is_prng_key(key)
+        assert key is not None
         finfo = jnp.finfo(jnp.result_type(float))
         u = random.uniform(
             key, shape=sample_shape + self.batch_shape, minval=finfo.tiny
@@ -1611,7 +1659,9 @@ class Laplace(Distribution):
             batch_shape=batch_shape, validate_args=validate_args
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> Array:
         r"""Draw samples via the location-scale transform
         :math:`X = \mu + b Z`, where :math:`Z \sim \mathrm{Laplace}(0, 1)` is
         drawn from :func:`~jax.random.laplace`.
@@ -1621,6 +1671,7 @@ class Laplace(Distribution):
         :return: Real-valued samples from the Laplace distribution.
         """
         assert is_prng_key(key)
+        assert key is not None
         eps = random.laplace(
             key, shape=sample_shape + self.batch_shape + self.event_shape
         )
@@ -1931,8 +1982,11 @@ class LKJCholesky(Distribution):
         diag = jnp.ones(cholesky.shape[:-1]).at[..., 1:].set(jnp.sqrt(1 - beta_sample))
         return add_diag(cholesky, diag)
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> Array:
         assert is_prng_key(key)
+        assert key is not None
         if self.sample_method == "onion":
             return self._onion(key, sample_shape)
         else:
@@ -2054,7 +2108,9 @@ class Logistic(Distribution):
         batch_shape = lax.broadcast_shapes(jnp.shape(loc), jnp.shape(scale))
         super(Logistic, self).__init__(batch_shape, validate_args=validate_args)
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> Array:
         r"""Draw samples via the location-scale transform
         :math:`X = \mu + s Z`, where :math:`Z \sim \mathrm{Logistic}(0, 1)` is
         drawn from :func:`~jax.random.logistic`.
@@ -2064,6 +2120,7 @@ class Logistic(Distribution):
         :return: Real-valued samples from the Logistic distribution.
         """
         assert is_prng_key(key)
+        assert key is not None
         z = random.logistic(
             key, shape=sample_shape + self.batch_shape + self.event_shape
         )
@@ -2151,6 +2208,7 @@ class LogUniform(TransformedDistribution):
     arg_constraints = {"low": constraints.positive, "high": constraints.positive}
     reparametrized_params = ["low", "high"]
     pytree_data_fields = ("low", "high", "_support")
+    _support: constraints.Constraint
 
     def __init__(
         self,
@@ -2266,24 +2324,24 @@ class MatrixNormal(Distribution):
 
     def __init__(
         self,
-        loc: Array,
-        scale_tril_row: Array,
-        scale_tril_column: Array,
+        loc: ArrayLike,
+        scale_tril_row: ArrayLike,
+        scale_tril_column: ArrayLike,
         *,
         validate_args: Optional[bool] = None,
     ) -> None:
-        event_shape = loc.shape[-2:]
+        event_shape = jnp.shape(loc)[-2:]
         batch_shape = lax.broadcast_shapes(
             jnp.shape(loc)[:-2],
             jnp.shape(scale_tril_row)[:-2],
             jnp.shape(scale_tril_column)[:-2],
         )
-        (self.loc,) = promote_shapes(loc, shape=batch_shape + loc.shape[-2:])
+        (self.loc,) = promote_shapes(loc, shape=batch_shape + jnp.shape(loc)[-2:])
         (self.scale_tril_row,) = promote_shapes(
-            scale_tril_row, shape=batch_shape + scale_tril_row.shape[-2:]
+            scale_tril_row, shape=batch_shape + jnp.shape(scale_tril_row)[-2:]
         )
         (self.scale_tril_column,) = promote_shapes(
-            scale_tril_column, shape=batch_shape + scale_tril_column.shape[-2:]
+            scale_tril_column, shape=batch_shape + jnp.shape(scale_tril_column)[-2:]
         )
         super(MatrixNormal, self).__init__(
             batch_shape=batch_shape,
@@ -2295,7 +2353,10 @@ class MatrixNormal(Distribution):
     def mean(self) -> Array:
         return jnp.broadcast_to(self.loc, self.shape())
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> Array:
+        assert key is not None
         eps = random.normal(
             key, shape=sample_shape + self.batch_shape + self.event_shape
         )
@@ -2406,7 +2467,7 @@ class MultivariateNormal(Distribution):
         if jnp.ndim(loc) == 0:
             (loc,) = promote_shapes(loc, shape=(1,))
         # temporary append a new axis to loc
-        loc = loc[..., jnp.newaxis]
+        loc = jnp.expand_dims(loc, -1)
         if covariance_matrix is not None:
             loc, self.covariance_matrix = promote_shapes(loc, covariance_matrix)
             self.scale_tril = jnp.linalg.cholesky(self.covariance_matrix)
@@ -2426,8 +2487,11 @@ class MultivariateNormal(Distribution):
             validate_args=validate_args,
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> Array:
         assert is_prng_key(key)
+        assert key is not None
         eps = random.normal(
             key, shape=sample_shape + self.batch_shape + self.event_shape
         )
@@ -2465,9 +2529,9 @@ class MultivariateNormal(Distribution):
             jnp.sum(self.scale_tril**2, axis=-1), self.batch_shape + self.event_shape
         )
 
-    @staticmethod
+    @classmethod
     def infer_shapes(
-        loc=(), covariance_matrix=None, precision_matrix=None, scale_tril=None
+        cls, loc=(), covariance_matrix=None, precision_matrix=None, scale_tril=None
     ):
         assert_one_of(
             covariance_matrix=covariance_matrix,
@@ -2537,9 +2601,9 @@ class CAR(Distribution):
     def __init__(
         self,
         loc: ArrayLike,
-        correlation: Array,
-        conditional_precision: Array,
-        adj_matrix: Array,
+        correlation: ArrayLike,
+        conditional_precision: ArrayLike,
+        adj_matrix: Union[ArrayLike, "scipy.sparse.spmatrix"],
         *,
         is_sparse: bool = False,
         validate_args: Optional[bool] = None,
@@ -2557,7 +2621,7 @@ class CAR(Distribution):
         )
 
         if self.is_sparse:
-            if adj_matrix.ndim != 2:
+            if len(jnp.shape(adj_matrix)) != 2:
                 raise ValueError(
                     "Currently, we only support 2-dimensional adj_matrix. Please make a feature request",
                     " if you need higher dimensional adj_matrix.",
@@ -2575,7 +2639,7 @@ class CAR(Distribution):
             )
             # TODO: look into static jax ndarray representation
             (self.adj_matrix,) = promote_shapes(
-                adj_matrix, shape=batch_shape + adj_matrix.shape[-2:]
+                adj_matrix, shape=batch_shape + jnp.shape(adj_matrix)[-2:]
             )
 
         event_shape = jnp.shape(self.adj_matrix)[-1:]
@@ -2604,7 +2668,9 @@ class CAR(Distribution):
                     self.adj_matrix, np.swapaxes(self.adj_matrix, -2, -1)
                 ), "adjacency matrix must be symmetric"
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> Array:
         # TODO: look into a sparse sampling method
         mvn = MultivariateNormal(self.mean, precision_matrix=self.precision_matrix)
         return mvn.sample(key, sample_shape=sample_shape)
@@ -2672,8 +2738,8 @@ class CAR(Distribution):
         correlation = jnp.expand_dims(self.correlation, (-2, -1))
         return conditional_precision * (D - correlation * adj_matrix)
 
-    @staticmethod
-    def infer_shapes(loc, correlation, conditional_precision, adj_matrix):
+    @classmethod
+    def infer_shapes(cls, loc, correlation, conditional_precision, adj_matrix):
         event_shape = adj_matrix[-1:]
         batch_shape = lax.broadcast_shapes(
             loc[:-1], correlation, conditional_precision, adj_matrix[:-2]
@@ -2697,7 +2763,7 @@ class CAR(Distribution):
 
     @classmethod
     def tree_unflatten(cls, aux_data, params):
-        d = super().tree_unflatten(aux_data, params)
+        d = cast(CAR, super().tree_unflatten(aux_data, params))
         if not d.is_sparse:
             adj_matrix_data_idx = cls.gather_pytree_data_fields().index("adj_matrix")
             setattr(d, "adj_matrix", params[adj_matrix_data_idx])
@@ -2725,15 +2791,16 @@ class MultivariateStudentT(Distribution):
         *,
         validate_args: Optional[bool] = None,
     ) -> None:
+        assert scale_tril is not None
         if jnp.ndim(loc) == 0:
             (loc,) = promote_shapes(loc, shape=(1,))
         batch_shape = lax.broadcast_shapes(
             jnp.shape(df), jnp.shape(loc)[:-1], jnp.shape(scale_tril)[:-2]
         )
         (self.df,) = promote_shapes(df, shape=batch_shape)
-        (self.loc,) = promote_shapes(loc, shape=batch_shape + loc.shape[-1:])
+        (self.loc,) = promote_shapes(loc, shape=batch_shape + jnp.shape(loc)[-1:])
         (self.scale_tril,) = promote_shapes(
-            scale_tril, shape=batch_shape + scale_tril.shape[-2:]
+            scale_tril, shape=batch_shape + jnp.shape(scale_tril)[-2:]
         )
         event_shape = jnp.shape(self.scale_tril)[-1:]
         self._chi2 = Chi2(self.df)
@@ -2743,8 +2810,11 @@ class MultivariateStudentT(Distribution):
             validate_args=validate_args,
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> Array:
         assert is_prng_key(key)
+        assert key is not None
         key_normal, key_chi2 = random.split(key)
         std_normal = random.normal(
             key_normal,
@@ -2798,8 +2868,8 @@ class MultivariateStudentT(Distribution):
         var = jnp.where(df <= 1, jnp.nan, var)
         return jnp.broadcast_to(var, self.batch_shape + self.event_shape)
 
-    @staticmethod
-    def infer_shapes(df, loc, scale_tril):
+    @classmethod
+    def infer_shapes(cls, df, loc, scale_tril):
         event_shape = (scale_tril[-1],)
         batch_shape = lax.broadcast_shapes(df, loc[:-1], scale_tril[:-2])
         return batch_shape, event_shape
@@ -2866,9 +2936,9 @@ class LowRankMultivariateNormal(Distribution):
 
     def __init__(
         self,
-        loc: Array,
-        cov_factor: Array,
-        cov_diag: Array,
+        loc: ArrayLike,
+        cov_factor: ArrayLike,
+        cov_diag: ArrayLike,
         *,
         validate_args: Optional[bool] = None,
     ) -> None:
@@ -2894,7 +2964,7 @@ class LowRankMultivariateNormal(Distribution):
             )
 
         loc, cov_factor, cov_diag = promote_shapes(
-            loc[..., jnp.newaxis], cov_factor, cov_diag[..., jnp.newaxis]
+            jnp.expand_dims(loc, -1), cov_factor, jnp.expand_dims(cov_diag, -1)
         )
         batch_shape = lax.broadcast_shapes(
             jnp.shape(loc), jnp.shape(cov_factor), jnp.shape(cov_diag)
@@ -2953,8 +3023,11 @@ class LowRankMultivariateNormal(Distribution):
         inverse_cov_diag = jnp.reciprocal(self.cov_diag)
         return add_diag(-jnp.matmul(jnp.swapaxes(A, -1, -2), A), inverse_cov_diag)
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> Array:
         assert is_prng_key(key)
+        assert key is not None
         key_W, key_D = random.split(key)
         batch_shape = sample_shape + self.batch_shape
         W_shape = batch_shape + self.cov_factor.shape[-1:]
@@ -2985,8 +3058,8 @@ class LowRankMultivariateNormal(Distribution):
         H = 0.5 * (self.loc.shape[-1] * (1.0 + jnp.log(2 * jnp.pi)) + log_det)
         return jnp.broadcast_to(H, self.batch_shape)
 
-    @staticmethod
-    def infer_shapes(loc, cov_factor, cov_diag):
+    @classmethod
+    def infer_shapes(cls, loc, cov_factor, cov_diag):
         event_shape = loc[-1:]
         batch_shape = lax.broadcast_shapes(loc[:-1], cov_factor[:-2], cov_diag[:-1])
         return batch_shape, event_shape
@@ -3030,7 +3103,9 @@ class Normal(Distribution):
             batch_shape=batch_shape, validate_args=validate_args
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> Array:
         r"""Generates samples via the reparameterization trick:
         :math:`X = \mu + \sigma \epsilon`, where :math:`\epsilon \sim \mathcal{N}(0,1)`.
 
@@ -3039,9 +3114,10 @@ class Normal(Distribution):
         :param sample_shape: The shape of the samples to be generated.
         :type sample_shape: tuple[int, ...]
         :return: Samples from the Normal distribution of shape ``sample_shape + batch_shape``.
-        :rtype: ArrayLike
+        :rtype: jax.Array
         """
         assert is_prng_key(key)
+        assert key is not None
         eps = random.normal(
             key, shape=sample_shape + self.batch_shape + self.event_shape
         )
@@ -3058,7 +3134,7 @@ class Normal(Distribution):
         :param value: Values at which to evaluate the log density.
         :type value: ArrayLike
         :return: Log probability density.
-        :rtype: ArrayLike
+        :rtype: jax.Array
         """
         normalize_term = jnp.log(jnp.sqrt(2 * jnp.pi) * self.scale)
         value_scaled = (value - self.loc) / self.scale
@@ -3149,7 +3225,10 @@ class Pareto(TransformedDistribution):
             jnp.broadcast_to(alpha, batch_shape),
         )
         base_dist = Exponential(alpha)
-        transforms = [ExpTransform(), AffineTransform(loc=0, scale=scale)]
+        transforms: list[Transform] = [
+            ExpTransform(),
+            AffineTransform(loc=0, scale=scale),
+        ]
         super(Pareto, self).__init__(base_dist, transforms, validate_args=validate_args)
 
     @property
@@ -3188,7 +3267,7 @@ class RelaxedBernoulliLogits(TransformedDistribution):
     ) -> None:
         self.temperature, self.logits = promote_shapes(temperature, logits)
         base_dist = Logistic(logits / temperature, 1 / temperature)
-        transforms = [SigmoidTransform()]
+        transforms: list[Transform] = [SigmoidTransform()]
         super().__init__(base_dist, transforms, validate_args=validate_args)
 
 
@@ -3240,8 +3319,11 @@ class SoftLaplace(Distribution):
         z = (value - self.loc) / self.scale
         return jnp.log(2 / jnp.pi) - jnp.log(self.scale) - jnp.logaddexp(z, -z)
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> Array:
         assert is_prng_key(key)
+        assert key is not None
         dtype = jnp.result_type(float)
         finfo = jnp.finfo(dtype)
         minval = finfo.tiny
@@ -3253,8 +3335,8 @@ class SoftLaplace(Distribution):
         z = (value - self.loc) / self.scale
         return jnp.arctan(jnp.exp(z)) * (2 / jnp.pi)
 
-    def icdf(self, value: ArrayLike) -> Array:
-        return jnp.log(jnp.tan(value * (jnp.pi / 2))) * self.scale + self.loc
+    def icdf(self, q: ArrayLike) -> Array:
+        return jnp.log(jnp.tan(q * (jnp.pi / 2))) * self.scale + self.loc
 
     @property
     def mean(self) -> Array:
@@ -3293,8 +3375,11 @@ class StudentT(Distribution):
         self._chi2 = Chi2(df)
         super(StudentT, self).__init__(batch_shape, validate_args=validate_args)
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> Array:
         assert is_prng_key(key)
+        assert key is not None
         key_normal, key_chi2 = random.split(key)
         std_normal = random.normal(key_normal, shape=sample_shape + self.batch_shape)
         z = self._chi2.sample(key_chi2, sample_shape)
@@ -3366,6 +3451,7 @@ class Uniform(Distribution):
     }
     reparametrized_params = ["low", "high"]
     pytree_data_fields = ("low", "high", "_support")
+    _support: constraints.Constraint
 
     def __init__(
         self,
@@ -3376,14 +3462,17 @@ class Uniform(Distribution):
     ) -> None:
         self.low, self.high = promote_shapes(low, high)
         batch_shape = lax.broadcast_shapes(jnp.shape(low), jnp.shape(high))
-        self._support = constraints.interval(low, high)
+        self._support = constraints.interval(cast(NumLike, low), cast(NumLike, high))
         super().__init__(batch_shape, validate_args=validate_args)
 
     @constraints.dependent_property(is_discrete=False, event_dim=0)
     def support(self) -> constraints.Constraint:
         return self._support
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> Array:
+        assert key is not None
         shape = sample_shape + self.batch_shape
         return random.uniform(key, shape=shape, minval=self.low, maxval=self.high)
 
@@ -3396,8 +3485,8 @@ class Uniform(Distribution):
         cdf = (value - self.low) / (self.high - self.low)
         return jnp.clip(cdf, 0.0, 1.0)
 
-    def icdf(self, value: ArrayLike) -> Array:
-        return jnp.asarray(self.low + value * (self.high - self.low))
+    def icdf(self, q: ArrayLike) -> Array:
+        return jnp.asarray(self.low + q * (self.high - self.low))
 
     @property
     def mean(self) -> Array:
@@ -3407,9 +3496,9 @@ class Uniform(Distribution):
     def variance(self) -> Array:
         return jnp.asarray((self.high - self.low) ** 2 / 12.0)
 
-    @staticmethod
+    @classmethod
     def infer_shapes(
-        low: tuple[int, ...] = (), high: tuple[int, ...] = ()
+        cls, low: tuple[int, ...] = (), high: tuple[int, ...] = ()
     ) -> tuple[tuple[int, ...], tuple[int, ...]]:
         batch_shape = lax.broadcast_shapes(low, high)
         event_shape: tuple[int, ...] = ()
@@ -3438,8 +3527,11 @@ class Weibull(Distribution):
         batch_shape = lax.broadcast_shapes(jnp.shape(concentration), jnp.shape(scale))
         super().__init__(batch_shape=batch_shape, validate_args=validate_args)
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> Array:
         assert is_prng_key(key)
+        assert key is not None
         return random.weibull_min(
             key,
             scale=self.scale,
@@ -3577,12 +3669,16 @@ class AsymmetricLaplaceQuantile(Distribution):
         scale_classic = scale * asymmetry / quantile
         self._ald = AsymmetricLaplace(loc=loc, scale=scale_classic, asymmetry=asymmetry)
 
-    def log_prob(self, value: ArrayLike) -> Array:
+    def log_prob(
+        self, value: ArrayLike, intermediates: Optional[list[Any]] = None
+    ) -> Array:
         if self._validate_args:
             self._validate_sample(value)
         return self._ald.log_prob(value)
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> Array:
         return self._ald.sample(key, sample_shape=sample_shape)
 
     @property
@@ -3596,8 +3692,8 @@ class AsymmetricLaplaceQuantile(Distribution):
     def cdf(self, value: ArrayLike) -> Array:
         return self._ald.cdf(value)
 
-    def icdf(self, value: ArrayLike) -> Array:
-        return self._ald.icdf(value)
+    def icdf(self, q: ArrayLike) -> Array:
+        return self._ald.icdf(q)
 
 
 class ZeroSumNormal(TransformedDistribution):
@@ -3726,6 +3822,7 @@ class Wishart(TransformedDistribution):
         "rate_matrix",
         "scale_tril",
     ]
+    base_dist: "WishartCholesky"
 
     def __init__(
         self,
@@ -3774,9 +3871,9 @@ class Wishart(TransformedDistribution):
             self.scale_matrix**2 + diag[..., :, None] * diag[..., None, :]
         )
 
-    @staticmethod
+    @classmethod
     def infer_shapes(
-        concentration=(), scale_matrix=None, rate_matrix=None, scale_tril=None
+        cls, concentration=(), scale_matrix=None, rate_matrix=None, scale_tril=None
     ):
         return WishartCholesky.infer_shapes(
             concentration, scale_matrix, rate_matrix, scale_tril
@@ -3869,9 +3966,10 @@ class WishartCholesky(Distribution):
         # rewrite as t = trace(x.T @ x) for x = inv(scale_tril) @ value which we can
         # obtain easily by solving a triangular system. x is again triangular such that
         # trace(x @ x.T) is equal to the sum of squares of elements.
-        x = solve_triangular(*jnp.broadcast_arrays(self.scale_tril, value), lower=True)
+        scale_tril, x = jnp.broadcast_arrays(self.scale_tril, value)
+        x = solve_triangular(scale_tril, x, lower=True)
         trace = jnp.square(x).sum(axis=(-1, -2))
-        p = value.shape[-1]
+        p = jnp.shape(value)[-1]
         return (
             (self.concentration - p - 1) * tri_logabsdet(value)
             - trace / 2
@@ -3896,8 +3994,11 @@ class WishartCholesky(Distribution):
         )
         return cho_solve((self.scale_tril, True), identity)
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> Array:
         assert is_prng_key(key)
+        assert key is not None
         # Sample using the Bartlett decomposition
         # (https://en.wikipedia.org/wiki/Wishart_distribution#Bartlett_decomposition).
         rng_diag, rng_offdiag = random.split(key)
@@ -3941,8 +4042,9 @@ class WishartCholesky(Distribution):
         )
         return jnp.square(self.scale_tril) @ latent - jnp.square(self.mean)
 
-    @staticmethod
+    @classmethod
     def infer_shapes(
+        cls,
         concentration: tuple[int, ...] = (),
         scale_matrix: Optional[tuple[int, ...]] = None,
         rate_matrix: Optional[tuple[int, ...]] = None,
@@ -4008,6 +4110,7 @@ class InverseWishart(TransformedDistribution):
         "rate_matrix",
         "scale_tril",
     ]
+    base_dist: "InverseWishartCholesky"
 
     def __init__(
         self,
@@ -4073,9 +4176,9 @@ class InverseWishart(TransformedDistribution):
         var = (psi**2 + psi_ii * psi_jj) / denom
         return jnp.where(nu > p + 3, var, jnp.full_like(var, jnp.nan))
 
-    @staticmethod
+    @classmethod
     def infer_shapes(
-        concentration=(), scale_matrix=None, rate_matrix=None, scale_tril=None
+        cls, concentration=(), scale_matrix=None, rate_matrix=None, scale_tril=None
     ):
         return InverseWishartCholesky.infer_shapes(
             concentration, scale_matrix, rate_matrix, scale_tril
@@ -4159,10 +4262,11 @@ class InverseWishartCholesky(Distribution):
         # log p(X) = (nu/2) log|Psi| - (nu*p/2) log(2) - log Gamma_p(nu/2)
         #            - ((nu+p+1)/2) log|X| - tr(Psi @ X^{-1}) / 2
         # Trace trick: tr(Psi @ X^{-1}) = ||L^{-1} @ scale_tril||_F^2
-        x = solve_triangular(*jnp.broadcast_arrays(value, self.scale_tril), lower=True)
+        x, scale_tril = jnp.broadcast_arrays(value, self.scale_tril)
+        x = solve_triangular(x, scale_tril, lower=True)
         trace = jnp.square(x).sum(axis=(-1, -2))
 
-        p = value.shape[-1]
+        p = jnp.shape(value)[-1]
         log_diag = jnp.log(jnp.diagonal(value, axis1=-2, axis2=-1))
         return (
             self.concentration * tri_logabsdet(self.scale_tril)  # (nu/2) log|Psi|
@@ -4186,8 +4290,11 @@ class InverseWishartCholesky(Distribution):
         )
         return cho_solve((self.scale_tril, True), identity)
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> Array:
         assert is_prng_key(key)
+        assert key is not None
         # Sample from standard InverseWishartCholesky using Bartlett decomposition
         # Ref: https://nbviewer.org/gist/fehiepsi/5ef8e09e61604f10607380467eb82006#Precision-to-scale_tril
         rng_diag, rng_offdiag = random.split(key)
@@ -4222,7 +4329,7 @@ class InverseWishartCholesky(Distribution):
         mean_x = jnp.where(
             self.concentration[..., None, None] > p + 1,
             self.scale_matrix / (self.concentration[..., None, None] - p - 1),
-            jnp.full_like(self.scale_matrix, jnp.nan),
+            jnp.full_like(jnp.asarray(self.scale_matrix), jnp.nan),
         )
         return jnp.linalg.cholesky(
             jnp.where(jnp.isnan(mean_x), jnp.eye(p), mean_x)
@@ -4237,8 +4344,9 @@ class InverseWishartCholesky(Distribution):
         # Variance of Cholesky factor is complex; return NaN for now
         return jnp.full(self.batch_shape + self.event_shape, jnp.nan)
 
-    @staticmethod
+    @classmethod
     def infer_shapes(
+        cls,
         concentration: tuple[int, ...] = (),
         scale_matrix: Optional[tuple[int, ...]] = None,
         rate_matrix: Optional[tuple[int, ...]] = None,
@@ -4273,6 +4381,7 @@ class Levy(Distribution):
         "loc": constraints.real,
         "scale": constraints.positive,
     }
+    _support: constraints.Constraint
 
     def __init__(
         self,
@@ -4283,7 +4392,7 @@ class Levy(Distribution):
     ) -> None:
         self.loc, self.scale = promote_shapes(loc, scale)
         batch_shape = lax.broadcast_shapes(jnp.shape(loc), jnp.shape(scale))
-        self._support = constraints.greater_than(loc)
+        self._support = constraints.greater_than(cast(NumLike, loc))
         super(Levy, self).__init__(batch_shape, validate_args=validate_args)
 
     @constraints.dependent_property(is_discrete=False)
@@ -4307,8 +4416,11 @@ class Levy(Distribution):
             jnp.log(2.0 * jnp.pi) - jnp.log(self.scale) + self.scale / shifted_value
         ) - 1.5 * jnp.log(shifted_value)
 
-    def sample(self, key: ArrayLike, sample_shape: tuple[int, ...] = ()) -> Array:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> Array:
         assert is_prng_key(key)
+        assert key is not None
         u = random.uniform(key, shape=sample_shape + self.batch_shape)
         return self.icdf(u)
 
@@ -4421,7 +4533,8 @@ class CirculantNormal(TransformedDistribution):
 
         if covariance_rfft is None:
             # Evaluate `covariance_rfft` if not provided and validate.
-            assert covariance_row.shape[-1] == n
+            assert covariance_row is not None
+            assert jnp.shape(covariance_row)[-1] == n
             loc, covariance_row = promote_shapes(loc, covariance_row)
             covariance_rfft = jnp.fft.rfft(covariance_row).real
             self.covariance_row = covariance_row
@@ -4430,7 +4543,9 @@ class CirculantNormal(TransformedDistribution):
             # dimension does not match. We manually retrieve the shapes and then
             # promote.
             loc_shape, covariance_rfft_shape = promote_shapes(
-                loc[..., 0], covariance_rfft[..., 0], return_shapes=True
+                jnp.asarray(loc)[..., 0],
+                jnp.asarray(covariance_rfft)[..., 0],
+                return_shapes=True,
             )
             loc = _reshape(loc, loc_shape + (n,))
             covariance_rfft = _reshape(
@@ -4470,22 +4585,26 @@ class CirculantNormal(TransformedDistribution):
 
     @lazy_property
     def covariance_matrix(self) -> Array:
-        *leading_shape, n = self.covariance_row.shape
+        covariance_row = jnp.asarray(self.covariance_row)
+        *leading_shape, n = covariance_row.shape
         if leading_shape:
             # `toeplitz` flattens the input, and we need to broadcast manually.
             (n,) = self.event_shape
-            return vmap(toeplitz)(self.covariance_row.reshape((-1, n))).reshape(
+            return vmap(toeplitz)(covariance_row.reshape((-1, n))).reshape(
                 (*leading_shape, n, n)
             )
         else:
-            return toeplitz(self.covariance_row)
+            return toeplitz(covariance_row)
 
     @lazy_property
     def variance(self) -> Array:
-        return jnp.broadcast_to(self.covariance_row[..., 0, None], self.shape())
+        return jnp.broadcast_to(
+            jnp.asarray(self.covariance_row)[..., 0, None], self.shape()
+        )
 
-    @staticmethod
+    @classmethod
     def infer_shapes(
+        cls,
         loc: tuple[int, ...] = (),
         covariance_row: Optional[tuple[int, ...]] = None,
         covariance_rfft: Optional[tuple[int, ...]] = None,
@@ -4566,8 +4685,11 @@ class Dagum(Distribution):
         q_root_p = jnp.power(q, -jnp.reciprocal(self.concentration))
         return self.scale * jnp.power(q_root_p - 1.0, -jnp.reciprocal(self.sharpness))
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> jnp.ndarray:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> jnp.ndarray:
         assert is_prng_key(key)
+        assert key is not None
         return self.icdf(random.uniform(key, shape=self.shape(sample_shape)))
 
     @property

--- a/numpyro/distributions/copula.py
+++ b/numpyro/distributions/copula.py
@@ -66,7 +66,7 @@ class GaussianCopula(Distribution):
             validate_args=validate_args,
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
         assert is_prng_key(key)
 
         shape = sample_shape + self.batch_shape
@@ -75,7 +75,7 @@ class GaussianCopula(Distribution):
         return self.marginal_dist.icdf(cdf)
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         # Ref: https://en.wikipedia.org/wiki/Copula_(probability_theory)#Gaussian_copula
         # see also https://github.com/pyro-ppl/numpyro/pull/1506#discussion_r1037525015
         marginal_lps = self.marginal_dist.log_prob(value)
@@ -90,11 +90,11 @@ class GaussianCopula(Distribution):
         return copula_lp + marginal_lps.sum(axis=-1)
 
     @property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         return jnp.broadcast_to(self.marginal_dist.mean, self.shape())
 
     @property
-    def variance(self) -> ArrayLike:
+    def variance(self) -> Array:
         return jnp.broadcast_to(self.marginal_dist.variance, self.shape())
 
     @constraints.dependent_property(is_discrete=False, event_dim=1)

--- a/numpyro/distributions/copula.py
+++ b/numpyro/distributions/copula.py
@@ -40,8 +40,8 @@ class GaussianCopula(Distribution):
     def __init__(
         self,
         marginal_dist: Distribution,
-        correlation_matrix: Optional[Array] = None,
-        correlation_cholesky: Optional[Array] = None,
+        correlation_matrix: Optional[ArrayLike] = None,
+        correlation_cholesky: Optional[ArrayLike] = None,
         *,
         validate_args: Optional[bool] = None,
     ):
@@ -66,7 +66,9 @@ class GaussianCopula(Distribution):
             validate_args=validate_args,
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> Array:
         assert is_prng_key(key)
 
         shape = sample_shape + self.batch_shape
@@ -87,7 +89,7 @@ class GaussianCopula(Distribution):
             + 0.5 * (quantiles**2).sum(-1)
             + 0.5 * jnp.log(2 * jnp.pi) * quantiles.shape[-1]
         )
-        return copula_lp + marginal_lps.sum(axis=-1)
+        return copula_lp + jnp.sum(marginal_lps, axis=-1)
 
     @property
     def mean(self) -> Array:
@@ -99,6 +101,7 @@ class GaussianCopula(Distribution):
 
     @constraints.dependent_property(is_discrete=False, event_dim=1)
     def support(self) -> Constraint:
+        assert self.marginal_dist.support is not None
         return constraints.independent(self.marginal_dist.support, 1)
 
     @lazy_property
@@ -124,8 +127,8 @@ class GaussianCopulaBeta(GaussianCopula):
         self,
         concentration1: ArrayLike,
         concentration0: ArrayLike,
-        correlation_matrix: Optional[Array] = None,
-        correlation_cholesky: Optional[Array] = None,
+        correlation_matrix: Optional[ArrayLike] = None,
+        correlation_cholesky: Optional[ArrayLike] = None,
         *,
         validate_args: bool = False,
     ):

--- a/numpyro/distributions/directional.py
+++ b/numpyro/distributions/directional.py
@@ -123,7 +123,7 @@ class VonMises(Distribution):
             batch_shape=batch_shape, validate_args=validate_args
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
         """Generate sample from von Mises distribution
 
         :param key: random number generator key
@@ -140,20 +140,20 @@ class VonMises(Distribution):
         return samples
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         return -(
             jnp.log(2 * jnp.pi) + jnp.log(i0e(self.concentration))
         ) + self.concentration * (jnp.cos((value - self.loc) % (2 * jnp.pi)) - 1)
 
     @property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         """Computes circular mean of distribution. NOTE: same as location when mapped to support [-pi, pi]"""
         return jnp.broadcast_to(
             (self.loc + jnp.pi) % (2.0 * jnp.pi) - jnp.pi, self.batch_shape
         )
 
     @property
-    def variance(self) -> ArrayLike:
+    def variance(self) -> Array:
         """Computes circular variance of distribution"""
         return jnp.broadcast_to(
             1.0 - i1e(self.concentration) / i0e(self.concentration), self.batch_shape
@@ -265,7 +265,7 @@ class SineSkewed(Distribution):
             + ")"
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
         base_key, skew_key = random.split(key)
         bd = self.base_dist
         ys = bd.sample(base_key, sample_shape)
@@ -281,7 +281,7 @@ class SineSkewed(Distribution):
         ) - jnp.pi
         return samples
 
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         if self._validate_args:
             self._validate_sample(value)
         if self.base_dist._validate_args:
@@ -432,7 +432,7 @@ class SineBivariateVonMises(Distribution):
         return norm_const.reshape(jnp.shape(self.phi_loc))
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         indv = self.phi_concentration * jnp.cos(
             value[..., 0] - self.phi_loc
         ) + self.psi_concentration * jnp.cos(value[..., 1] - self.psi_loc)
@@ -443,7 +443,7 @@ class SineBivariateVonMises(Distribution):
         )
         return indv + corr - self.norm_const
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
         """
         ** References: **
             1. A New Unified Approach for the Simulation of a Wide Class of Directional Distributions
@@ -544,7 +544,7 @@ class SineBivariateVonMises(Distribution):
         )
 
     @property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         """Computes circular mean of distribution. Note: same as location when mapped to support [-pi, pi]"""
         mean = (jnp.stack((self.phi_loc, self.psi_loc), axis=-1) + jnp.pi) % (
             2.0 * jnp.pi
@@ -596,7 +596,7 @@ class ProjectedNormal(Distribution):
         super().__init__(batch_shape, event_shape, validate_args=validate_args)
 
     @property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         """
         Note this is the mean in the sense of a centroid in the submanifold
         that minimizes expected squared geodesic distance.
@@ -607,12 +607,12 @@ class ProjectedNormal(Distribution):
     def mode(self):
         return safe_normalize(self.concentration)
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
         shape = sample_shape + self.batch_shape + self.event_shape
         eps = random.normal(key, shape=shape)
         return safe_normalize(self.concentration + eps)
 
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         if self._validate_args:
             event_shape = value.shape[-1:]
             if event_shape != self.event_shape:

--- a/numpyro/distributions/directional.py
+++ b/numpyro/distributions/directional.py
@@ -296,7 +296,7 @@ class SineSkewed(Distribution):
         return self.base_dist.log_prob(value) + skew_prob
 
     @property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         """Mean of the base distribution"""
         return self.base_dist.mean
 
@@ -604,7 +604,7 @@ class ProjectedNormal(Distribution):
         return safe_normalize(self.concentration)
 
     @property
-    def mode(self):
+    def mode(self) -> jax.Array:
         return safe_normalize(self.concentration)
 
     def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
@@ -661,7 +661,7 @@ def _projected_normal_log_prob_2(concentration, value):
 
 
 def _projected_normal_log_prob_3(concentration, value):
-    def _dot(x: Array, y: Array) -> ArrayLike:
+    def _dot(x: Array, y: Array) -> Array:
         return (x[..., None, :] @ y[..., None])[..., 0, 0]
 
     # We integrate along a ray, factorizing the integrand as a product of:

--- a/numpyro/distributions/directional.py
+++ b/numpyro/distributions/directional.py
@@ -7,7 +7,7 @@ import functools
 import math
 from math import pi
 import operator
-from typing import Optional
+from typing import Any, Optional
 
 import jax
 from jax import Array, lax
@@ -45,11 +45,11 @@ def log_I1(orders: int, value: ArrayLike, terms: int = 250) -> Array:
     :return: 0 to orders modified bessel function
     """
     orders = orders + 1
-    if value.ndim == 0:
+    if jnp.ndim(value) == 0:
         vshape = (1,)
     else:
-        vshape = value.shape
-    value = value.reshape(-1, 1)
+        vshape = jnp.shape(value)
+    value = jnp.reshape(value, (-1, 1))
     flat_vshape = _numel(vshape)
 
     k = jnp.arange(terms)
@@ -123,13 +123,16 @@ class VonMises(Distribution):
             batch_shape=batch_shape, validate_args=validate_args
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> Array:
         """Generate sample from von Mises distribution
 
         :param key: random number generator key
         :param sample_shape: shape of samples
         :return: samples from von Mises
         """
+        assert key is not None
         assert is_prng_key(key)
         samples = von_mises_centered(
             key, self.concentration, sample_shape + self.shape()
@@ -235,12 +238,13 @@ class SineSkewed(Distribution):
         *,
         validate_args: Optional[bool] = None,
     ):
-        assert base_dist.event_shape == skewness.shape[-1:], (
+        skewness_shape = jnp.shape(skewness)
+        assert base_dist.event_shape == skewness_shape[-1:], (
             "Sine Skewing is only valid with a skewness parameter for each dimension of `base_dist.event_shape`."
         )
 
-        batch_shape = jnp.broadcast_shapes(base_dist.batch_shape, skewness.shape[:-1])
-        event_shape = skewness.shape[-1:]
+        batch_shape = jnp.broadcast_shapes(base_dist.batch_shape, skewness_shape[:-1])
+        event_shape = skewness_shape[-1:]
         self.skewness = jnp.broadcast_to(skewness, batch_shape + event_shape)
         self.base_dist = base_dist.expand(batch_shape)
         super().__init__(batch_shape, event_shape, validate_args=validate_args)
@@ -265,10 +269,13 @@ class SineSkewed(Distribution):
             + ")"
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> Array:
+        assert key is not None
         base_key, skew_key = random.split(key)
         bd = self.base_dist
-        ys = bd.sample(base_key, sample_shape)
+        ys = jnp.asarray(bd.sample(base_key, sample_shape))
         u = random.uniform(skew_key, sample_shape + self.batch_shape)
 
         # Section 2.3 step 3 in [1]
@@ -281,7 +288,9 @@ class SineSkewed(Distribution):
         ) - jnp.pi
         return samples
 
-    def log_prob(self, value: ArrayLike) -> Array:
+    def log_prob(
+        self, value: ArrayLike, intermediates: Optional[list[Any]] = None
+    ) -> Array:
         if self._validate_args:
             self._validate_sample(value)
         if self.base_dist._validate_args:
@@ -293,7 +302,7 @@ class SineSkewed(Distribution):
                 -1
             )
         )
-        return self.base_dist.log_prob(value) + skew_prob
+        return jnp.asarray(self.base_dist.log_prob(value)) + skew_prob
 
     @property
     def mean(self) -> Array:
@@ -380,6 +389,7 @@ class SineBivariateVonMises(Distribution):
             correlation = weighted_correlation * jnp.sqrt(
                 phi_concentration * psi_concentration
             )
+        assert correlation is not None
 
         batch_shape = lax.broadcast_shapes(
             jnp.shape(phi_loc),
@@ -433,6 +443,7 @@ class SineBivariateVonMises(Distribution):
 
     @validate_sample
     def log_prob(self, value: ArrayLike) -> Array:
+        value = jnp.asarray(value)
         indv = self.phi_concentration * jnp.cos(
             value[..., 0] - self.phi_loc
         ) + self.psi_concentration * jnp.cos(value[..., 1] - self.psi_loc)
@@ -443,12 +454,15 @@ class SineBivariateVonMises(Distribution):
         )
         return indv + corr - self.norm_const
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> Array:
         """
         ** References: **
             1. A New Unified Approach for the Simulation of a Wide Class of Directional Distributions
                John T. Kent, Asaad M. Ganeiber & Kanti V. Mardia (2018)
         """
+        assert key is not None
         assert is_prng_key(key)
         phi_key, psi_key = random.split(key)
 
@@ -507,14 +521,14 @@ class SineBivariateVonMises(Distribution):
                 x, axis=1, keepdims=True
             )  # Angular Central Gaussian distribution
 
-            lf: ArrayLike = (
+            lf: Array = (
                 conc[0] * (x[:, 0] - 1)
                 + eigmin
                 + log_I1(0, jnp.sqrt(conc[1] ** 2 + (corr * x[:, 1]) ** 2)).squeeze(0)
                 - phi_den
             )
 
-            lg_inv: ArrayLike = 1.0 - b0 / 2 + jnp.log(b0 / 2 + (eig * x**2).sum(1))
+            lg_inv: Array = 1.0 - b0 / 2 + jnp.log(b0 / 2 + (eig * x**2).sum(1))
             assert lg_inv.shape == lf.shape
 
             accepted = random.uniform(accept_key, lf.shape) < jnp.exp(lf + lg_inv)
@@ -588,11 +602,13 @@ class ProjectedNormal(Distribution):
     reparametrized_params = ["concentration"]
     support = constraints.sphere
 
-    def __init__(self, concentration: Array, *, validate_args: Optional[bool] = None):
+    def __init__(
+        self, concentration: ArrayLike, *, validate_args: Optional[bool] = None
+    ):
         assert jnp.ndim(concentration) >= 1
         self.concentration = concentration
-        batch_shape = concentration.shape[:-1]
-        event_shape = concentration.shape[-1:]
+        batch_shape = jnp.shape(concentration)[:-1]
+        event_shape = jnp.shape(concentration)[-1:]
         super().__init__(batch_shape, event_shape, validate_args=validate_args)
 
     @property
@@ -607,20 +623,25 @@ class ProjectedNormal(Distribution):
     def mode(self) -> jax.Array:
         return safe_normalize(self.concentration)
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> Array:
+        assert key is not None
         shape = sample_shape + self.batch_shape + self.event_shape
         eps = random.normal(key, shape=shape)
         return safe_normalize(self.concentration + eps)
 
-    def log_prob(self, value: ArrayLike) -> Array:
+    def log_prob(
+        self, value: ArrayLike, intermediates: Optional[list[Any]] = None
+    ) -> Array:
         if self._validate_args:
-            event_shape = value.shape[-1:]
+            event_shape = jnp.shape(value)[-1:]
             if event_shape != self.event_shape:
                 raise ValueError(
                     f"Expected event shape {self.event_shape}, but got {event_shape}"
                 )
             self._validate_sample(value)
-        dim = int(self.concentration.shape[-1])
+        dim = int(jnp.shape(self.concentration)[-1])
         if dim == 2:
             return _projected_normal_log_prob_2(self.concentration, value)
         if dim == 3:
@@ -630,8 +651,10 @@ class ProjectedNormal(Distribution):
             "Consider using handlers.reparam with ProjectedNormalReparam."
         )
 
-    @staticmethod
-    def infer_shapes(concentration):
+    @classmethod
+    def infer_shapes(
+        cls, concentration: tuple[int, ...]
+    ) -> tuple[tuple[int, ...], tuple[int, ...]]:
         batch_shape = concentration[:-1]
         event_shape = concentration[-1:]
         return batch_shape, event_shape

--- a/numpyro/distributions/discrete.py
+++ b/numpyro/distributions/discrete.py
@@ -102,7 +102,7 @@ class BernoulliProbs(Distribution):
             batch_shape=jnp.shape(self.probs), validate_args=validate_args
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
         r"""Draw samples from the Bernoulli distribution.
 
         This method invokes :func:`~jax.random.bernoulli` directly, which generates
@@ -120,7 +120,7 @@ class BernoulliProbs(Distribution):
         return samples.astype(jnp.result_type(samples, int))
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         r"""Evaluate the log probability mass function at specified binary
         configurations.
 
@@ -184,7 +184,7 @@ class BernoulliProbs(Distribution):
             values = jnp.broadcast_to(values, values.shape[:1] + self.batch_shape)
         return values
 
-    def entropy(self) -> ArrayLike:
+    def entropy(self) -> Array:
         r"""The entropy of the Bernoulli distribution is given by:
 
         .. math::
@@ -223,7 +223,7 @@ class BernoulliLogits(Distribution):
             batch_shape=jnp.shape(self.logits), validate_args=validate_args
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
         r"""Draw samples from the Bernoulli distribution.
 
         The method first converts :attr:`logits` to probabilities via the sigmoid
@@ -241,7 +241,7 @@ class BernoulliLogits(Distribution):
         return samples.astype(jnp.result_type(samples, int))
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         r"""Evaluate the log probability mass function at specified binary configurations.
 
         The log probability mass function leverages the numerically-stable
@@ -273,7 +273,7 @@ class BernoulliLogits(Distribution):
         return _to_probs_bernoulli(self.logits)
 
     @property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         r"""The mean of the Bernoulli distribution is given by the sigmoid of the
         log-odds parameter:
 
@@ -283,7 +283,7 @@ class BernoulliLogits(Distribution):
         return self.probs
 
     @property
-    def variance(self) -> ArrayLike:
+    def variance(self) -> Array:
         r"""The variance of the Bernoulli distribution is given by:
 
         .. math::
@@ -297,7 +297,7 @@ class BernoulliLogits(Distribution):
             values = jnp.broadcast_to(values, values.shape[:1] + self.batch_shape)
         return values
 
-    def entropy(self) -> ArrayLike:
+    def entropy(self) -> Array:
         r"""The entropy of the Bernoulli distribution is given by:
 
         .. math::
@@ -377,7 +377,7 @@ class BinomialProbs(Distribution):
             batch_shape=batch_shape, validate_args=validate_args
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
         r"""Draw samples from the Binomial distribution.
 
         This method uses the internal :func:`~numpyro.distributions.util.binomial`
@@ -393,7 +393,7 @@ class BinomialProbs(Distribution):
         )
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         r"""Evaluate the log probability mass function at specified count configurations.
 
         The log probability mass function is fully evaluated in log-space to prevent
@@ -440,7 +440,7 @@ class BinomialProbs(Distribution):
         return _to_logits_bernoulli(self.probs)
 
     @property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         r"""The mean of the Binomial distribution is given by:
 
         .. math::
@@ -449,7 +449,7 @@ class BinomialProbs(Distribution):
         return jnp.broadcast_to(self.total_count * self.probs, self.batch_shape)
 
     @property
-    def variance(self) -> ArrayLike:
+    def variance(self) -> Array:
         r"""The variance of the Binomial distribution is given by:
 
         .. math::
@@ -522,7 +522,7 @@ class BinomialLogits(Distribution):
             batch_shape=batch_shape, validate_args=validate_args
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
         r"""Draw samples from the Binomial distribution.
 
         The method first converts :attr:`logits` to probabilities via the sigmoid function
@@ -539,7 +539,7 @@ class BinomialLogits(Distribution):
         )
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         r"""Evaluate the log probability mass function at specified count
         configurations.
 
@@ -586,7 +586,7 @@ class BinomialLogits(Distribution):
         return _to_probs_bernoulli(self.logits)
 
     @property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         r"""The mean of the Binomial distribution is given by:
 
         .. math::
@@ -595,7 +595,7 @@ class BinomialLogits(Distribution):
         return jnp.broadcast_to(self.total_count * self.probs, self.batch_shape)
 
     @property
-    def variance(self) -> ArrayLike:
+    def variance(self) -> Array:
         r"""The variance of the Binomial distribution is given by:
 
         .. math::
@@ -672,7 +672,7 @@ class CategoricalProbs(Distribution):
             batch_shape=jnp.shape(self.probs)[:-1], validate_args=validate_args
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
         r"""Draw samples from the Categorical distribution.
 
         This method delegates to :func:`~numpyro.distributions.util.categorical`, which
@@ -688,7 +688,7 @@ class CategoricalProbs(Distribution):
         return categorical(key, self.probs, shape=sample_shape + self.batch_shape)
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         r"""Evaluate the log probability mass function at specified category indices.
 
         .. math::
@@ -719,7 +719,7 @@ class CategoricalProbs(Distribution):
         return _to_logits_multinom(self.probs)
 
     @property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         r"""The mean of a Categorical distribution over arbitrary unordered categories
         is not well-defined. This property therefore returns ``NaN``.
 
@@ -728,7 +728,7 @@ class CategoricalProbs(Distribution):
         return jnp.full(self.batch_shape, jnp.nan, dtype=jnp.result_type(self.probs))
 
     @property
-    def variance(self) -> ArrayLike:
+    def variance(self) -> Array:
         r"""The variance of a Categorical distribution over arbitrary unordered
         categories is not well-defined. This property therefore returns ``NaN``.
 
@@ -759,7 +759,7 @@ class CategoricalProbs(Distribution):
             values = jnp.broadcast_to(values, values.shape[:1] + self.batch_shape)
         return values
 
-    def entropy(self) -> ArrayLike:
+    def entropy(self) -> Array:
         r"""The entropy of the Categorical distribution is given by:
 
         .. math::
@@ -805,7 +805,7 @@ class CategoricalLogits(Distribution):
             batch_shape=jnp.shape(logits)[:-1], validate_args=validate_args
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
         r"""Draw samples from the Categorical distribution.
 
         This method invokes :func:`~jax.random.categorical` directly, which samples in
@@ -823,7 +823,7 @@ class CategoricalLogits(Distribution):
         )
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         r"""Evaluate the log probability mass function at specified category indices.
 
         .. math::
@@ -858,7 +858,7 @@ class CategoricalLogits(Distribution):
         return _to_probs_multinom(self.logits)
 
     @property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         r"""The mean of a Categorical distribution over arbitrary unordered categories
         is not well-defined. This property therefore returns ``NaN``.
 
@@ -867,7 +867,7 @@ class CategoricalLogits(Distribution):
         return jnp.full(self.batch_shape, jnp.nan, dtype=jnp.result_type(self.logits))
 
     @property
-    def variance(self) -> ArrayLike:
+    def variance(self) -> Array:
         r"""The variance of a Categorical distribution over arbitrary unordered
         categories is not well-defined. This property therefore returns ``NaN``.
 
@@ -898,7 +898,7 @@ class CategoricalLogits(Distribution):
             values = jnp.broadcast_to(values, values.shape[:1] + self.batch_shape)
         return values
 
-    def entropy(self) -> ArrayLike:
+    def entropy(self) -> Array:
         r"""The entropy of the Categorical distribution is given by:
 
         .. math::
@@ -971,7 +971,7 @@ class DiscreteUniform(Distribution):
         """
         return self._support
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
         r"""Draw samples from the discrete uniform distribution.
 
         This method invokes :func:`~jax.random.randint` directly, which generates
@@ -987,7 +987,7 @@ class DiscreteUniform(Distribution):
         return random.randint(key, shape=shape, minval=self.low, maxval=self.high + 1)
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         r"""Evaluate the log probability mass function at specified integer values.
 
         .. math::
@@ -1084,7 +1084,7 @@ class DiscreteUniform(Distribution):
             values = jnp.broadcast_to(values, values.shape[:1] + self.batch_shape)
         return values
 
-    def entropy(self) -> ArrayLike:
+    def entropy(self) -> Array:
         r"""The entropy of the discrete uniform distribution is given by:
 
         .. math::
@@ -1170,7 +1170,7 @@ class MultinomialProbs(Distribution):
             validate_args=validate_args,
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
         assert is_prng_key(key)
         return multinomial(
             key,
@@ -1181,7 +1181,7 @@ class MultinomialProbs(Distribution):
         )
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         value = jnp.array(value, jnp.result_type(float))
         return gammaln(self.total_count + 1) + jnp.sum(
             xlogy(value, self.probs) - gammaln(value + 1), axis=-1
@@ -1192,11 +1192,11 @@ class MultinomialProbs(Distribution):
         return _to_logits_multinom(self.probs)
 
     @property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         return self.probs * jnp.expand_dims(self.total_count, -1)
 
     @property
-    def variance(self) -> ArrayLike:
+    def variance(self) -> Array:
         return jnp.expand_dims(self.total_count, -1) * self.probs * (1 - self.probs)
 
     @constraints.dependent_property(is_discrete=True, event_dim=1)
@@ -1244,7 +1244,7 @@ class MultinomialLogits(Distribution):
             validate_args=validate_args,
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
         assert is_prng_key(key)
         return multinomial(
             key,
@@ -1255,7 +1255,7 @@ class MultinomialLogits(Distribution):
         )
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         if self._validate_args:
             self._validate_sample(value)
         normalize_term = self.total_count * logsumexp(self.logits, axis=-1) - gammaln(
@@ -1270,11 +1270,11 @@ class MultinomialLogits(Distribution):
         return _to_probs_multinom(self.logits)
 
     @property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         return jnp.expand_dims(self.total_count, -1) * self.probs
 
     @property
-    def variance(self) -> ArrayLike:
+    def variance(self) -> Array:
         return jnp.expand_dims(self.total_count, -1) * self.probs * (1 - self.probs)
 
     @constraints.dependent_property(is_discrete=True, event_dim=1)
@@ -1353,12 +1353,12 @@ class Poisson(Distribution):
         self.is_sparse = is_sparse
         super(Poisson, self).__init__(jnp.shape(rate), validate_args=validate_args)
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
         assert is_prng_key(key)
         return random.poisson(key, self.rate, shape=sample_shape + self.batch_shape)
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         # Using an integer vs. floating-point `rate` leads to differing results.
         # To ensure consistent behavior, `rate` is explicitly cast to a floating-point type.
         # See: https://github.com/pyro-ppl/numpyro/issues/2181
@@ -1427,7 +1427,7 @@ class ZeroInflatedProbs(Distribution):
             batch_shape, validate_args=validate_args
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
         assert is_prng_key(key)
         key_bern, key_base = random.split(key)
         shape = sample_shape + self.batch_shape
@@ -1436,7 +1436,7 @@ class ZeroInflatedProbs(Distribution):
         return jnp.where(mask, 0, samples)
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         log_prob = jnp.log1p(-self.gate) + self.base_dist.log_prob(value)
         return jnp.where(value == 0, jnp.log(self.gate + jnp.exp(log_prob)), log_prob)
 
@@ -1478,7 +1478,7 @@ class ZeroInflatedLogits(ZeroInflatedProbs):
         super().__init__(base_dist, gate, validate_args=validate_args)
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         log_prob_minus_log_gate = -self.gate_logits + self.base_dist.log_prob(value)
         log_gate = -softplus(-self.gate_logits)
         log_prob = log_prob_minus_log_gate + log_gate
@@ -1620,7 +1620,7 @@ class HurdleProbs(Distribution):
     def _log_one_minus_gate(self) -> ArrayLike:
         return jnp.log1p(-self.gate)
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
         assert is_prng_key(key)
         key_bern, key_base = random.split(key)
         shape = sample_shape + self.batch_shape
@@ -1653,7 +1653,7 @@ class HurdleProbs(Distribution):
         return samples
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         log_gate = self._log_gate()
         log_one_minus_gate = self._log_one_minus_gate()
         # Replace zeros with ones before evaluating the base log_prob to avoid
@@ -1678,7 +1678,7 @@ class HurdleProbs(Distribution):
         return (1 - self.gate) * self.base_dist.mean
 
     @lazy_property
-    def variance(self) -> ArrayLike:
+    def variance(self) -> Array:
         if self._is_discrete:
             trunc = -jnp.expm1(
                 self.base_dist.log_prob(jnp.zeros((), dtype=jnp.result_type(int)))
@@ -1823,7 +1823,7 @@ class GeometricProbs(Distribution):
             batch_shape=jnp.shape(self.probs), validate_args=validate_args
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
         assert is_prng_key(key)
         probs = self.probs
         dtype = jnp.result_type(probs)
@@ -1832,7 +1832,7 @@ class GeometricProbs(Distribution):
         return jnp.floor(jnp.log1p(-u) / jnp.log1p(-probs))
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         probs = jnp.where((self.probs == 1) & (value == 0), 0, self.probs)
         return value * jnp.log1p(-probs) + jnp.log(probs)
 
@@ -1848,7 +1848,7 @@ class GeometricProbs(Distribution):
     def variance(self) -> ArrayLike:
         return (1.0 / self.probs - 1.0) / self.probs
 
-    def entropy(self) -> ArrayLike:
+    def entropy(self) -> Array:
         return -(1 - self.probs) * jnp.log1p(-self.probs) / self.probs - jnp.log(
             self.probs
         )
@@ -1868,7 +1868,7 @@ class GeometricLogits(Distribution):
     def probs(self) -> ArrayLike:
         return _to_probs_bernoulli(self.logits)
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
         assert is_prng_key(key)
         logits = self.logits
         dtype = jnp.result_type(logits)
@@ -1877,18 +1877,18 @@ class GeometricLogits(Distribution):
         return jnp.floor(jnp.log1p(-u) / -softplus(logits))
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         return (-value - 1) * softplus(self.logits) + self.logits
 
     @property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         return 1.0 / self.probs - 1.0
 
     @property
-    def variance(self) -> ArrayLike:
+    def variance(self) -> Array:
         return (1.0 / self.probs - 1.0) / self.probs
 
-    def entropy(self) -> ArrayLike:
+    def entropy(self) -> Array:
         logq = -jax.nn.softplus(self.logits)
         logp = -jax.nn.softplus(-self.logits)
         p = jax.scipy.special.expit(self.logits)

--- a/numpyro/distributions/discrete.py
+++ b/numpyro/distributions/discrete.py
@@ -54,20 +54,20 @@ from numpyro.distributions.util import (
 from numpyro.util import is_prng_key, not_jax_tracer
 
 
-def _to_probs_bernoulli(logits: ArrayLike) -> ArrayLike:
+def _to_probs_bernoulli(logits: ArrayLike) -> Array:
     return expit(logits)
 
 
-def _to_logits_bernoulli(probs: ArrayLike) -> ArrayLike:
+def _to_logits_bernoulli(probs: ArrayLike) -> Array:
     ps_clamped = clamp_probs(probs)
     return jnp.log(ps_clamped) - jnp.log1p(-ps_clamped)
 
 
-def _to_probs_multinom(logits: ArrayLike) -> ArrayLike:
+def _to_probs_multinom(logits: ArrayLike) -> Array:
     return softmax(logits, axis=-1)
 
 
-def _to_logits_multinom(probs: ArrayLike) -> ArrayLike:
+def _to_logits_multinom(probs: ArrayLike) -> Array:
     minval = jnp.finfo(jnp.result_type(probs)).min
     return jnp.clip(jnp.log(probs), minval)
 
@@ -144,7 +144,7 @@ class BernoulliProbs(Distribution):
         return xlogy(value, ps_clamped) + xlog1py(1 - value, -ps_clamped)
 
     @lazy_property
-    def logits(self) -> ArrayLike:
+    def logits(self) -> Array:
         r"""The log-odds (logits) parameter of the Bernoulli distribution is given by
         the logit transformation of the success probability:
 
@@ -154,7 +154,7 @@ class BernoulliProbs(Distribution):
         return _to_logits_bernoulli(self.probs)
 
     @property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         r"""The mean of the Bernoulli distribution is given by the success probability
         parameter:
 
@@ -164,10 +164,10 @@ class BernoulliProbs(Distribution):
         :return: The mean of the Bernoulli distribution, which is equal to the success
             probability :attr:`probs`.
         """
-        return self.probs
+        return jnp.asarray(self.probs)
 
     @property
-    def variance(self) -> ArrayLike:
+    def variance(self) -> Array:
         r"""The variance of the Bernoulli distribution is given by:
 
         .. math::
@@ -176,9 +176,9 @@ class BernoulliProbs(Distribution):
         :return: The variance of the Bernoulli distribution, which is the product of
             the success probability and its complement.
         """
-        return self.probs * (1 - self.probs)
+        return jnp.asarray(self.probs * (1 - self.probs))
 
-    def enumerate_support(self, expand: bool = True) -> ArrayLike:
+    def enumerate_support(self, expand: bool = True) -> Array:
         values = jnp.arange(2).reshape((-1,) + (1,) * len(self.batch_shape))
         if expand:
             values = jnp.broadcast_to(values, values.shape[:1] + self.batch_shape)
@@ -263,7 +263,7 @@ class BernoulliLogits(Distribution):
         return -binary_cross_entropy_with_logits(self.logits, value)
 
     @lazy_property
-    def probs(self) -> ArrayLike:
+    def probs(self) -> Array:
         r"""The success probability parameter of the Bernoulli distribution is given by
         the sigmoid of the log-odds parameter:
 
@@ -291,7 +291,7 @@ class BernoulliLogits(Distribution):
         """
         return self.probs * (1 - self.probs)
 
-    def enumerate_support(self, expand: bool = True) -> ArrayLike:
+    def enumerate_support(self, expand: bool = True) -> Array:
         values = jnp.arange(2).reshape((-1,) + (1,) * len(self.batch_shape))
         if expand:
             values = jnp.broadcast_to(values, values.shape[:1] + self.batch_shape)
@@ -337,6 +337,8 @@ def Bernoulli(
         return BernoulliProbs(probs, validate_args=validate_args)
     elif logits is not None:
         return BernoulliLogits(logits, validate_args=validate_args)
+    else:
+        raise NotImplementedError
 
 
 class BinomialProbs(Distribution):
@@ -430,7 +432,7 @@ class BinomialProbs(Distribution):
         )
 
     @lazy_property
-    def logits(self) -> ArrayLike:
+    def logits(self) -> Array:
         r"""The log-odds (logits) parameter of the Binomial distribution is given by
         the logit transformation of the success probability:
 
@@ -466,7 +468,7 @@ class BinomialProbs(Distribution):
         """
         return constraints.integer_interval(0, self.total_count)
 
-    def enumerate_support(self, expand: bool = True) -> ArrayLike:
+    def enumerate_support(self, expand: bool = True) -> Array:
         if not_jax_tracer(self.total_count):
             total_count = np.amax(self.total_count)
             # NB: the error can't be raised if inhomogeneous issue happens when tracing
@@ -576,7 +578,7 @@ class BinomialLogits(Distribution):
         )
 
     @lazy_property
-    def probs(self) -> ArrayLike:
+    def probs(self) -> Array:
         r"""The success probability per trial of the Binomial distribution is given by
         the sigmoid of the log-odds parameter:
 
@@ -709,7 +711,7 @@ class CategoricalProbs(Distribution):
         return jnp.take_along_axis(log_pmf, value, axis=-1)[..., 0]
 
     @lazy_property
-    def logits(self) -> ArrayLike:
+    def logits(self) -> Array:
         r"""The log-probability (logits) parameter of the Categorical distribution is
         the (already-normalized) log of the category probabilities:
 
@@ -744,7 +746,7 @@ class CategoricalProbs(Distribution):
         """
         return constraints.integer_interval(0, jnp.shape(self.probs)[-1] - 1)
 
-    def enumerate_support(self, expand: bool = True) -> ArrayLike:
+    def enumerate_support(self, expand: bool = True) -> Array:
         r"""Enumerate all values in the support of the Categorical distribution.
 
         :param expand: Whether to broadcast the enumerated values across the batch
@@ -847,7 +849,7 @@ class CategoricalLogits(Distribution):
         return jnp.take_along_axis(log_pmf, value, -1)[..., 0]
 
     @lazy_property
-    def probs(self) -> ArrayLike:
+    def probs(self) -> Array:
         r"""The probability vector of the Categorical distribution is given by the
         softmax of the logits:
 
@@ -883,7 +885,7 @@ class CategoricalLogits(Distribution):
         """
         return constraints.integer_interval(0, jnp.shape(self.logits)[-1] - 1)
 
-    def enumerate_support(self, expand: bool = True) -> ArrayLike:
+    def enumerate_support(self, expand: bool = True) -> Array:
         r"""Enumerate all values in the support of the Categorical distribution.
 
         :param expand: Whether to broadcast the enumerated values across the batch
@@ -1003,7 +1005,7 @@ class DiscreteUniform(Distribution):
         shape = lax.broadcast_shapes(jnp.shape(value), self.batch_shape)
         return -jnp.broadcast_to(jnp.log(self.high + 1 - self.low), shape)
 
-    def cdf(self, value: ArrayLike) -> ArrayLike:
+    def cdf(self, value: ArrayLike) -> Array:
         r"""Evaluate the cumulative distribution function (CDF) of the discrete
         uniform distribution.
 
@@ -1017,7 +1019,7 @@ class DiscreteUniform(Distribution):
         cdf = (jnp.floor(value) + 1 - self.low) / (self.high - self.low + 1)
         return jnp.clip(cdf, 0.0, 1.0)
 
-    def icdf(self, value: ArrayLike) -> ArrayLike:
+    def icdf(self, value: ArrayLike) -> Array:
         r"""Evaluate the inverse cumulative distribution function (quantile function)
         of the discrete uniform distribution.
 
@@ -1027,10 +1029,10 @@ class DiscreteUniform(Distribution):
         :param value: Quantile level(s) :math:`u \in [0, 1]`.
         :return: The inverse CDF evaluated at ``value``.
         """
-        return self.low + value * (self.high - self.low + 1) - 1
+        return jnp.asarray(self.low + value * (self.high - self.low + 1) - 1)
 
     @property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         r"""The mean of the discrete uniform distribution is the midpoint of the
         support:
 
@@ -1039,10 +1041,10 @@ class DiscreteUniform(Distribution):
 
         :return: The mean of the discrete uniform distribution.
         """
-        return self.low + (self.high - self.low) / 2.0
+        return jnp.asarray(self.low + (self.high - self.low) / 2.0)
 
     @property
-    def variance(self) -> ArrayLike:
+    def variance(self) -> Array:
         r"""The variance of the discrete uniform distribution is given by:
 
         .. math::
@@ -1050,9 +1052,9 @@ class DiscreteUniform(Distribution):
 
         :return: The variance of the discrete uniform distribution.
         """
-        return ((self.high - self.low + 1) ** 2 - 1) / 12.0
+        return jnp.asarray(((self.high - self.low + 1) ** 2 - 1) / 12.0)
 
-    def enumerate_support(self, expand: bool = True) -> ArrayLike:
+    def enumerate_support(self, expand: bool = True) -> Array:
         r"""Enumerate all values in the support of the discrete uniform distribution.
 
         Both :attr:`low` and :attr:`high` must be concrete (non-JAX-tracer) values and
@@ -1136,7 +1138,7 @@ class OrderedLogistic(CategoricalProbs):
         event_shape = ()
         return batch_shape, event_shape
 
-    def entropy(self) -> ArrayLike:
+    def entropy(self) -> Array:
         raise NotImplementedError
 
 
@@ -1188,7 +1190,7 @@ class MultinomialProbs(Distribution):
         )
 
     @lazy_property
-    def logits(self) -> ArrayLike:
+    def logits(self) -> Array:
         return _to_logits_multinom(self.probs)
 
     @property
@@ -1266,7 +1268,7 @@ class MultinomialLogits(Distribution):
         )
 
     @lazy_property
-    def probs(self) -> ArrayLike:
+    def probs(self) -> Array:
         return _to_probs_multinom(self.logits)
 
     @property
@@ -1388,14 +1390,14 @@ class Poisson(Distribution):
         return xlogy(_value, rate) - gammaln(_value + 1.0) - rate
 
     @property
-    def mean(self) -> ArrayLike:
-        return self.rate
+    def mean(self) -> Array:
+        return jnp.asarray(self.rate)
 
     @property
-    def variance(self) -> ArrayLike:
-        return self.rate
+    def variance(self) -> Array:
+        return jnp.asarray(self.rate)
 
-    def cdf(self, value: ArrayLike) -> ArrayLike:
+    def cdf(self, value: ArrayLike) -> Array:
         k = jnp.floor(value) + 1
         return gammaincc(k, self.rate)
 
@@ -1445,11 +1447,11 @@ class ZeroInflatedProbs(Distribution):
         return self.base_dist.support
 
     @lazy_property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         return (1 - self.gate) * self.base_dist.mean
 
     @lazy_property
-    def variance(self) -> ArrayLike:
+    def variance(self) -> Array:
         return (1 - self.gate) * (
             self.base_dist.mean**2 + self.base_dist.variance
         ) - self.mean**2
@@ -1458,7 +1460,7 @@ class ZeroInflatedProbs(Distribution):
     def has_enumerate_support(self):
         return self.base_dist.has_enumerate_support
 
-    def enumerate_support(self, expand: bool = True) -> ArrayLike:
+    def enumerate_support(self, expand: bool = True) -> Array:
         return self.base_dist.enumerate_support(expand=expand)
 
 
@@ -1609,15 +1611,15 @@ class HurdleProbs(Distribution):
     def support(self) -> constraints.Constraint:
         return self.base_dist.support
 
-    def _log_one_minus_p_zero(self) -> ArrayLike:
+    def _log_one_minus_p_zero(self) -> Array:
         # log(1 - B(0)) for the discrete base, used to renormalize the truncated PMF.
         log_p0 = self.base_dist.log_prob(jnp.zeros((), dtype=jnp.result_type(int)))
         return jax.nn.log1mexp(-log_p0)
 
-    def _log_gate(self) -> ArrayLike:
+    def _log_gate(self) -> Array:
         return jnp.log(self.gate)
 
-    def _log_one_minus_gate(self) -> ArrayLike:
+    def _log_one_minus_gate(self) -> Array:
         return jnp.log1p(-self.gate)
 
     def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
@@ -1631,14 +1633,12 @@ class HurdleProbs(Distribution):
             samples = self.base_dist(rng_key=key_base, sample_shape=sample_shape)
         return jnp.where(zero_mask, jnp.zeros_like(samples), samples)
 
-    def _sample_truncated(
-        self, key: jax.Array, sample_shape: tuple[int, ...]
-    ) -> ArrayLike:
+    def _sample_truncated(self, key: jax.Array, sample_shape: tuple[int, ...]) -> Array:
         # Rejection sampling from the zero-truncated base distribution: redraw any
         # element that came back as 0 until all elements are strictly positive.
         first = self.base_dist(rng_key=key, sample_shape=sample_shape)
 
-        def cond_fun(state: tuple) -> ArrayLike:
+        def cond_fun(state: tuple) -> Array:
             _, current = state
             return jnp.any(current == 0)
 
@@ -1669,7 +1669,7 @@ class HurdleProbs(Distribution):
         return jnp.where(value == 0, log_gate, log_nonzero)
 
     @lazy_property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         if self._is_discrete:
             trunc = -jnp.expm1(
                 self.base_dist.log_prob(jnp.zeros((), dtype=jnp.result_type(int)))
@@ -1730,10 +1730,10 @@ class HurdleLogits(HurdleProbs):
         (self.gate_logits,) = promote_shapes(gate_logits, shape=batch_shape)
         super().__init__(base_dist, gate, validate_args=validate_args)
 
-    def _log_gate(self) -> ArrayLike:
+    def _log_gate(self) -> Array:
         return -softplus(-self.gate_logits)
 
-    def _log_one_minus_gate(self) -> ArrayLike:
+    def _log_one_minus_gate(self) -> Array:
         return -softplus(self.gate_logits)
 
 
@@ -1837,16 +1837,16 @@ class GeometricProbs(Distribution):
         return value * jnp.log1p(-probs) + jnp.log(probs)
 
     @lazy_property
-    def logits(self) -> ArrayLike:
+    def logits(self) -> Array:
         return _to_logits_bernoulli(self.probs)
 
     @property
-    def mean(self) -> ArrayLike:
-        return 1.0 / self.probs - 1.0
+    def mean(self) -> Array:
+        return jnp.asarray(1.0 / self.probs - 1.0)
 
     @property
-    def variance(self) -> ArrayLike:
-        return (1.0 / self.probs - 1.0) / self.probs
+    def variance(self) -> Array:
+        return jnp.asarray((1.0 / self.probs - 1.0) / self.probs)
 
     def entropy(self) -> Array:
         return -(1 - self.probs) * jnp.log1p(-self.probs) / self.probs - jnp.log(
@@ -1865,7 +1865,7 @@ class GeometricLogits(Distribution):
         )
 
     @lazy_property
-    def probs(self) -> ArrayLike:
+    def probs(self) -> Array:
         return _to_probs_bernoulli(self.logits)
 
     def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:

--- a/numpyro/distributions/discrete.py
+++ b/numpyro/distributions/discrete.py
@@ -38,6 +38,7 @@ import jax.random as random
 from jax.scipy.special import expit, gammaincc, gammaln, logsumexp, xlog1py, xlogy
 from jax.typing import ArrayLike
 
+from numpyro._typing import NumLike
 from numpyro.distributions import constraints, transforms
 from numpyro.distributions.distribution import Distribution
 from numpyro.distributions.util import (
@@ -68,6 +69,7 @@ def _to_probs_multinom(logits: ArrayLike) -> Array:
 
 
 def _to_logits_multinom(probs: ArrayLike) -> Array:
+    probs = jnp.asarray(probs)
     safe_probs = jnp.where(probs > 0, probs, 1.0)
     return jnp.where(probs > 0, jnp.log(safe_probs), -jnp.inf)
 
@@ -102,7 +104,9 @@ class BernoulliProbs(Distribution):
             batch_shape=jnp.shape(self.probs), validate_args=validate_args
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> Array:
         r"""Draw samples from the Bernoulli distribution.
 
         This method invokes :func:`~jax.random.bernoulli` directly, which generates
@@ -114,6 +118,7 @@ class BernoulliProbs(Distribution):
         :return: Binary-valued samples (0 or 1) drawn from the Bernoulli distribution.
         """
         assert is_prng_key(key)
+        assert key is not None
         samples = random.bernoulli(
             key, self.probs, shape=sample_shape + self.batch_shape
         )
@@ -190,7 +195,8 @@ class BernoulliProbs(Distribution):
         .. math::
             H[X] = -p \ln p - (1-p) \ln (1-p)
         """
-        return -xlogy(self.probs, self.probs) - xlog1py(1 - self.probs, -self.probs)
+        probs = jnp.asarray(self.probs)
+        return -xlogy(probs, probs) - xlog1py(1 - probs, -probs)
 
 
 class BernoulliLogits(Distribution):
@@ -223,7 +229,9 @@ class BernoulliLogits(Distribution):
             batch_shape=jnp.shape(self.logits), validate_args=validate_args
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> Array:
         r"""Draw samples from the Bernoulli distribution.
 
         The method first converts :attr:`logits` to probabilities via the sigmoid
@@ -235,6 +243,7 @@ class BernoulliLogits(Distribution):
         :return: Binary-valued samples (0 or 1) drawn from the Bernoulli distribution.
         """
         assert is_prng_key(key)
+        assert key is not None
         samples = random.bernoulli(
             key, self.probs, shape=sample_shape + self.batch_shape
         )
@@ -312,8 +321,9 @@ class BernoulliLogits(Distribution):
             H[X] = \frac{(1 + e^{-\alpha}) \ln(1 + e^{-\alpha})
                 + e^{-\alpha} \alpha}{1 + e^{-\alpha}}
         """
-        nexp = jnp.exp(-self.logits)
-        return ((1 + nexp) * jnp.log1p(nexp) + nexp * self.logits) / (1 + nexp)
+        logits = jnp.asarray(self.logits)
+        nexp = jnp.exp(-logits)
+        return ((1 + nexp) * jnp.log1p(nexp) + nexp * logits) / (1 + nexp)
 
 
 def Bernoulli(
@@ -379,7 +389,9 @@ class BinomialProbs(Distribution):
             batch_shape=batch_shape, validate_args=validate_args
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> Array:
         r"""Draw samples from the Binomial distribution.
 
         This method uses the internal :func:`~numpyro.distributions.util.binomial`
@@ -390,6 +402,7 @@ class BinomialProbs(Distribution):
         :return: Non-negative integer samples representing success counts.
         """
         assert is_prng_key(key)
+        assert key is not None
         return binomial(
             key, self.probs, n=self.total_count, shape=sample_shape + self.batch_shape
         )
@@ -524,7 +537,9 @@ class BinomialLogits(Distribution):
             batch_shape=batch_shape, validate_args=validate_args
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> Array:
         r"""Draw samples from the Binomial distribution.
 
         The method first converts :attr:`logits` to probabilities via the sigmoid function
@@ -536,6 +551,7 @@ class BinomialLogits(Distribution):
         :return: Non-negative integer samples representing success counts.
         """
         assert is_prng_key(key)
+        assert key is not None
         return binomial(
             key, self.probs, n=self.total_count, shape=sample_shape + self.batch_shape
         )
@@ -638,6 +654,8 @@ def Binomial(
         return BinomialProbs(probs, total_count, validate_args=validate_args)
     elif logits is not None:
         return BinomialLogits(logits, total_count, validate_args=validate_args)
+    else:
+        raise NotImplementedError
 
 
 class CategoricalProbs(Distribution):
@@ -661,7 +679,7 @@ class CategoricalProbs(Distribution):
     arg_constraints = {"probs": constraints.simplex}
     has_enumerate_support = True
 
-    def __init__(self, probs: Array, *, validate_args: Optional[bool] = None):
+    def __init__(self, probs: ArrayLike, *, validate_args: Optional[bool] = None):
         r"""
         :param probs: Category probability vector on the simplex; the trailing
             dimension indexes the :math:`K` categories and must sum to one.
@@ -674,7 +692,9 @@ class CategoricalProbs(Distribution):
             batch_shape=jnp.shape(self.probs)[:-1], validate_args=validate_args
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> Array:
         r"""Draw samples from the Categorical distribution.
 
         This method delegates to :func:`~numpyro.distributions.util.categorical`, which
@@ -687,6 +707,7 @@ class CategoricalProbs(Distribution):
             Categorical distribution.
         """
         assert is_prng_key(key)
+        assert key is not None
         return categorical(key, self.probs, shape=sample_shape + self.batch_shape)
 
     @validate_sample
@@ -754,7 +775,7 @@ class CategoricalProbs(Distribution):
         :return: An array of integer category indices :math:`\{0, 1, \dots, K-1\}`,
             optionally broadcast across the batch dimensions.
         """
-        values = jnp.arange(self.probs.shape[-1]).reshape(
+        values = jnp.arange(jnp.shape(self.probs)[-1]).reshape(
             (-1,) + (1,) * len(self.batch_shape)
         )
         if expand:
@@ -769,7 +790,8 @@ class CategoricalProbs(Distribution):
 
         :return: The entropy of the Categorical distribution.
         """
-        return -(self.probs * jnp.log(self.probs)).sum(axis=-1)
+        probs = jnp.asarray(self.probs)
+        return -(probs * jnp.log(probs)).sum(axis=-1)
 
 
 class CategoricalLogits(Distribution):
@@ -793,7 +815,7 @@ class CategoricalLogits(Distribution):
     arg_constraints = {"logits": constraints.real_vector}
     has_enumerate_support = True
 
-    def __init__(self, logits: Array, *, validate_args: Optional[bool] = None):
+    def __init__(self, logits: ArrayLike, *, validate_args: Optional[bool] = None):
         r"""
         :param logits: Real-valued logits vector; the trailing dimension indexes the
             :math:`K` categories. Logits are unnormalized and converted to
@@ -807,7 +829,9 @@ class CategoricalLogits(Distribution):
             batch_shape=jnp.shape(logits)[:-1], validate_args=validate_args
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> Array:
         r"""Draw samples from the Categorical distribution.
 
         This method invokes :func:`~jax.random.categorical` directly, which samples in
@@ -820,6 +844,7 @@ class CategoricalLogits(Distribution):
             Categorical distribution.
         """
         assert is_prng_key(key)
+        assert key is not None
         return random.categorical(
             key, self.logits, shape=sample_shape + self.batch_shape
         )
@@ -893,7 +918,7 @@ class CategoricalLogits(Distribution):
         :return: An array of integer category indices :math:`\{0, 1, \dots, K-1\}`,
             optionally broadcast across the batch dimensions.
         """
-        values = jnp.arange(self.logits.shape[-1]).reshape(
+        values = jnp.arange(jnp.shape(self.logits)[-1]).reshape(
             (-1,) + (1,) * len(self.batch_shape)
         )
         if expand:
@@ -947,11 +972,12 @@ class DiscreteUniform(Distribution):
     }
     has_enumerate_support = True
     pytree_data_fields = ("low", "high", "_support")
+    _support: constraints.Constraint
 
     def __init__(
         self,
-        low: ArrayLike = 0,
-        high: ArrayLike = 1,
+        low: NumLike = 0,
+        high: NumLike = 1,
         *,
         validate_args: Optional[bool] = None,
     ):
@@ -973,7 +999,9 @@ class DiscreteUniform(Distribution):
         """
         return self._support
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> Array:
         r"""Draw samples from the discrete uniform distribution.
 
         This method invokes :func:`~jax.random.randint` directly, which generates
@@ -985,6 +1013,7 @@ class DiscreteUniform(Distribution):
         :return: Integer-valued samples drawn uniformly from
             :math:`\{a, \dots, b\}`.
         """
+        assert key is not None
         shape = sample_shape + self.batch_shape
         return random.randint(key, shape=shape, minval=self.low, maxval=self.high + 1)
 
@@ -1019,17 +1048,17 @@ class DiscreteUniform(Distribution):
         cdf = (jnp.floor(value) + 1 - self.low) / (self.high - self.low + 1)
         return jnp.clip(cdf, 0.0, 1.0)
 
-    def icdf(self, value: ArrayLike) -> Array:
+    def icdf(self, q: ArrayLike) -> Array:
         r"""Evaluate the inverse cumulative distribution function (quantile function)
         of the discrete uniform distribution.
 
         .. math::
             F^{-1}(u) = a + u\,(b - a + 1) - 1, \quad u \in [0, 1]
 
-        :param value: Quantile level(s) :math:`u \in [0, 1]`.
-        :return: The inverse CDF evaluated at ``value``.
+        :param q: Quantile level(s) :math:`u \in [0, 1]`.
+        :return: The inverse CDF evaluated at ``q``.
         """
-        return jnp.asarray(self.low + value * (self.high - self.low + 1) - 1)
+        return jnp.asarray(self.low + q * (self.high - self.low + 1) - 1)
 
     @property
     def mean(self) -> Array:
@@ -1126,14 +1155,17 @@ class OrderedLogistic(CategoricalProbs):
         if jnp.ndim(predictor) == 0:
             (predictor,) = promote_shapes(predictor, shape=(1,))
         else:
+            assert isinstance(predictor, (np.ndarray, jax.Array))
             predictor = predictor[..., None]
         predictor, self.cutpoints = promote_shapes(predictor, cutpoints)
         self.predictor = predictor[..., 0]
         probs = transforms.SimplexToOrderedTransform(self.predictor).inv(self.cutpoints)
         super(OrderedLogistic, self).__init__(probs, validate_args=validate_args)
 
-    @staticmethod
-    def infer_shapes(predictor, cutpoints):
+    @classmethod
+    def infer_shapes(
+        cls, predictor: tuple[int, ...], cutpoints: tuple[int, ...]
+    ) -> tuple[tuple[int, ...], tuple[int, ...]]:
         batch_shape = lax.broadcast_shapes(predictor, cutpoints[:-1])
         event_shape = ()
         return batch_shape, event_shape
@@ -1152,7 +1184,7 @@ class MultinomialProbs(Distribution):
 
     def __init__(
         self,
-        probs: Array,
+        probs: ArrayLike,
         total_count: ArrayLike = 1,
         *,
         total_count_max: Optional[int] = None,
@@ -1172,8 +1204,11 @@ class MultinomialProbs(Distribution):
             validate_args=validate_args,
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> Array:
         assert is_prng_key(key)
+        assert key is not None
         return multinomial(
             key,
             self.probs,
@@ -1205,9 +1240,9 @@ class MultinomialProbs(Distribution):
     def support(self) -> constraints.Constraint:
         return constraints.multinomial(self.total_count)
 
-    @staticmethod
+    @classmethod
     def infer_shapes(
-        probs: Array, total_count: ArrayLike
+        cls, probs: tuple[int, ...], total_count: tuple[int, ...]
     ) -> tuple[tuple[int, ...], tuple[int, ...]]:
         batch_shape = lax.broadcast_shapes(probs[:-1], total_count)
         event_shape = probs[-1:]
@@ -1224,7 +1259,7 @@ class MultinomialLogits(Distribution):
 
     def __init__(
         self,
-        logits: Array,
+        logits: ArrayLike,
         total_count: ArrayLike = 1,
         *,
         total_count_max: Optional[int] = None,
@@ -1246,8 +1281,11 @@ class MultinomialLogits(Distribution):
             validate_args=validate_args,
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> Array:
         assert is_prng_key(key)
+        assert key is not None
         return multinomial(
             key,
             self.probs,
@@ -1283,9 +1321,9 @@ class MultinomialLogits(Distribution):
     def support(self) -> constraints.Constraint:
         return constraints.multinomial(self.total_count)
 
-    @staticmethod
+    @classmethod
     def infer_shapes(
-        logits: Array, total_count: ArrayLike
+        cls, logits: tuple[int, ...], total_count: tuple[int, ...]
     ) -> tuple[tuple[int, ...], tuple[int, ...]]:
         batch_shape = lax.broadcast_shapes(logits[:-1], total_count)
         event_shape = logits[-1:]
@@ -1293,9 +1331,9 @@ class MultinomialLogits(Distribution):
 
 
 def Multinomial(
-    total_count=1,
-    probs: Array = None,
-    logits: Array = None,
+    total_count: ArrayLike = 1,
+    probs: Optional[ArrayLike] = None,
+    logits: Optional[ArrayLike] = None,
     *,
     total_count_max: Optional[int] = None,
     validate_args: Optional[bool] = None,
@@ -1324,6 +1362,8 @@ def Multinomial(
             total_count_max=total_count_max,
             validate_args=validate_args,
         )
+    else:
+        raise NotImplementedError
 
 
 class Poisson(Distribution):
@@ -1355,8 +1395,11 @@ class Poisson(Distribution):
         self.is_sparse = is_sparse
         super(Poisson, self).__init__(jnp.shape(rate), validate_args=validate_args)
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> Array:
         assert is_prng_key(key)
+        assert key is not None
         return random.poisson(key, self.rate, shape=sample_shape + self.batch_shape)
 
     @validate_sample
@@ -1367,11 +1410,7 @@ class Poisson(Distribution):
         ftype = jnp.result_type(float)
         rate = jnp.astype(self.rate, ftype)
 
-        if (
-            self.is_sparse
-            and not isinstance(value, jax.core.Tracer)
-            and jnp.size(value) > 1
-        ):
+        if self.is_sparse and not_jax_tracer(value) and jnp.size(value) > 1:
             shape = lax.broadcast_shapes(self.batch_shape, jnp.shape(value))
             rate = jnp.broadcast_to(rate, shape).reshape(-1)
             nonzero = np.broadcast_to(jax.device_get(value) > 0, shape).reshape(-1)
@@ -1415,7 +1454,9 @@ class ZeroInflatedProbs(Distribution):
     ):
         batch_shape = lax.broadcast_shapes(jnp.shape(gate), base_dist.batch_shape)
         (self.gate,) = promote_shapes(gate, shape=batch_shape)
-        assert base_dist.support.is_discrete
+        support = base_dist.support
+        assert support is not None
+        assert support.is_discrete
         if base_dist.event_shape:
             raise ValueError(
                 "ZeroInflatedProbs expected empty base_dist.event_shape but got {}".format(
@@ -1429,8 +1470,11 @@ class ZeroInflatedProbs(Distribution):
             batch_shape, validate_args=validate_args
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> Array:
         assert is_prng_key(key)
+        assert key is not None
         key_bern, key_base = random.split(key)
         shape = sample_shape + self.batch_shape
         mask = random.bernoulli(key_bern, self.gate, shape)
@@ -1444,7 +1488,9 @@ class ZeroInflatedProbs(Distribution):
 
     @constraints.dependent_property(is_discrete=True, event_dim=0)
     def support(self) -> constraints.Constraint:
-        return self.base_dist.support
+        support = self.base_dist.support
+        assert support is not None
+        return support
 
     @lazy_property
     def mean(self) -> Array:
@@ -1604,16 +1650,22 @@ class HurdleProbs(Distribution):
                 )
             )
         self.base_dist = base_dist.expand(batch_shape)
-        self._is_discrete = base_dist.support.is_discrete
+        support = base_dist.support
+        assert support is not None
+        self._is_discrete = support.is_discrete
         super(HurdleProbs, self).__init__(batch_shape, validate_args=validate_args)
 
     @constraints.dependent_property
     def support(self) -> constraints.Constraint:
-        return self.base_dist.support
+        support = self.base_dist.support
+        assert support is not None
+        return support
 
     def _log_one_minus_p_zero(self) -> Array:
         # log(1 - B(0)) for the discrete base, used to renormalize the truncated PMF.
-        log_p0 = self.base_dist.log_prob(jnp.zeros((), dtype=jnp.result_type(int)))
+        log_p0 = jnp.asarray(
+            self.base_dist.log_prob(jnp.zeros((), dtype=jnp.result_type(int)))
+        )
         return jax.nn.log1mexp(-log_p0)
 
     def _log_gate(self) -> Array:
@@ -1622,8 +1674,11 @@ class HurdleProbs(Distribution):
     def _log_one_minus_gate(self) -> Array:
         return jnp.log1p(-self.gate)
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> Array:
         assert is_prng_key(key)
+        assert key is not None
         key_bern, key_base = random.split(key)
         shape = sample_shape + self.batch_shape
         zero_mask = random.bernoulli(key_bern, self.gate, shape)
@@ -1633,7 +1688,9 @@ class HurdleProbs(Distribution):
             samples = self.base_dist(rng_key=key_base, sample_shape=sample_shape)
         return jnp.where(zero_mask, jnp.zeros_like(samples), samples)
 
-    def _sample_truncated(self, key: jax.Array, sample_shape: tuple[int, ...]) -> Array:
+    def _sample_truncated(
+        self, key: jax.Array, sample_shape: tuple[int, ...]
+    ) -> ArrayLike:
         # Rejection sampling from the zero-truncated base distribution: redraw any
         # element that came back as 0 until all elements are strictly positive.
         first = self.base_dist(rng_key=key, sample_shape=sample_shape)
@@ -1844,7 +1901,9 @@ class GeometricProbs(Distribution):
             batch_shape=jnp.shape(self.probs), validate_args=validate_args
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> Array:
         r"""Generates samples using inverse CDF method.
 
         For a uniform random variable :math:`U \sim \mathrm{Uniform}[0, 1)`,
@@ -1858,10 +1917,11 @@ class GeometricProbs(Distribution):
         :param sample_shape: The shape of the samples to be generated.
         :type sample_shape: tuple[int, ...]
         :return: Samples from Geometric distribution of shape ``sample_shape + batch_shape``.
-        :rtype: ArrayLike
+        :rtype: jax.Array
         """
         assert is_prng_key(key)
-        probs = self.probs
+        assert key is not None
+        probs = jnp.asarray(self.probs)
         dtype = jnp.result_type(probs)
         shape = sample_shape + self.batch_shape
         u = random.uniform(key, shape, dtype)
@@ -1877,8 +1937,9 @@ class GeometricProbs(Distribution):
         :param value: Values at which to evaluate the log density. Values must be nonnegative integers.
         :type value: ArrayLike
         :return: Log probability mass.
-        :rtype: ArrayLike
+        :rtype: jax.Array
         """
+        value = jnp.asarray(value)
         probs = jnp.where((self.probs == 1) & (value == 0), 0, self.probs)
         return value * jnp.log1p(-probs) + jnp.log(probs)
 
@@ -1916,11 +1977,10 @@ class GeometricProbs(Distribution):
             H(X) = -\log p - \frac{1-p}{p}\log(1-p).
 
         :return: Entropy of the Geometric distribution.
-        :rtype: ArrayLike
+        :rtype: jax.Array
         """
-        return -(1 - self.probs) * jnp.log1p(-self.probs) / self.probs - jnp.log(
-            self.probs
-        )
+        probs = jnp.asarray(self.probs)
+        return -(1 - probs) * jnp.log1p(-probs) / probs - jnp.log(probs)
 
 
 class GeometricLogits(Distribution):
@@ -1960,7 +2020,9 @@ class GeometricLogits(Distribution):
         """
         return _to_probs_bernoulli(self.logits)
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> Array:
         r"""Generates samples using inverse CDF technique in logit space.
 
         :param key: JAX pseudo-random number generator key.
@@ -1969,9 +2031,10 @@ class GeometricLogits(Distribution):
         :type sample_shape: tuple[int, ...]
         :return: Samples from the Geometric distribution of shape
             ``sample_shape + batch_shape``.
-        :rtype: ArrayLike
+        :rtype: jax.Array
         """
         assert is_prng_key(key)
+        assert key is not None
         logits = self.logits
         dtype = jnp.result_type(logits)
         shape = sample_shape + self.batch_shape
@@ -1991,8 +2054,9 @@ class GeometricLogits(Distribution):
             be nonnegative integers.
         :type value: ArrayLike
         :return: Log probability mass.
-        :rtype: ArrayLike
+        :rtype: jax.Array
         """
+        value = jnp.asarray(value)
         return (-value - 1) * softplus(self.logits) + self.logits
 
     @property
@@ -2034,11 +2098,12 @@ class GeometricLogits(Distribution):
         and :math:`\operatorname{expit}`, respectively.
 
         :return: Entropy of the Geometric distribution.
-        :rtype: ArrayLike
+        :rtype: jax.Array
         """
-        logq = -jax.nn.softplus(self.logits)
-        logp = -jax.nn.softplus(-self.logits)
-        p = jax.scipy.special.expit(self.logits)
+        logits = jnp.asarray(self.logits)
+        logq = -jax.nn.softplus(logits)
+        logp = -jax.nn.softplus(-logits)
+        p = jax.scipy.special.expit(logits)
         p_clip = jnp.clip(p, jnp.finfo(p.dtype).tiny)
         return -(1 - p) * logq / p_clip - logp
 
@@ -2070,3 +2135,5 @@ def Geometric(
         return GeometricProbs(probs, validate_args=validate_args)
     elif logits is not None:
         return GeometricLogits(logits, validate_args=validate_args)
+    else:
+        raise NotImplementedError

--- a/numpyro/distributions/distribution.py
+++ b/numpyro/distributions/distribution.py
@@ -346,7 +346,7 @@ class Distribution(metaclass=DistributionMeta):
 
     def rsample(
         self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
-    ) -> ArrayLike:
+    ) -> Array:
         if self.has_rsample:
             return self.sample(key, sample_shape=sample_shape)
 
@@ -369,7 +369,7 @@ class Distribution(metaclass=DistributionMeta):
 
     def sample(
         self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
-    ) -> ArrayLike:
+    ) -> Array:
         """
         Returns a sample from the distribution having shape given by
         `sample_shape + batch_shape + event_shape`. Note that when `sample_shape` is non-empty,
@@ -385,7 +385,7 @@ class Distribution(metaclass=DistributionMeta):
 
     def sample_with_intermediates(
         self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
-    ) -> tuple[ArrayLike, list[Any]]:
+    ) -> tuple[Array, list[Any]]:
         """
         Same as ``sample`` except that any intermediate computations are
         returned (useful for `TransformedDistribution`).
@@ -397,7 +397,7 @@ class Distribution(metaclass=DistributionMeta):
         """
         return self.sample(key, sample_shape=sample_shape), []
 
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         """
         Evaluates the log probability density for a batch of samples given by
         `value`.
@@ -409,20 +409,24 @@ class Distribution(metaclass=DistributionMeta):
         raise NotImplementedError
 
     @property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         """
         Mean of the distribution.
         """
         raise NotImplementedError
 
     @property
-    def variance(self) -> ArrayLike:
+    def variance(self) -> Array:
         """
         Variance of the distribution.
         """
         raise NotImplementedError
 
-    def _validate_sample(self, value: ArrayLike) -> ArrayLike:
+    @property
+    def mode(self) -> Array:
+        raise NotImplementedError
+
+    def _validate_sample(self, value: ArrayLike) -> Array:
         assert self.support is not None
         mask = self.support(value)
         if not_jax_tracer(mask):
@@ -442,7 +446,7 @@ class Distribution(metaclass=DistributionMeta):
         sample_shape: tuple[int, ...] = ...,
         sample_intermediates: Literal[False] = ...,
         **kwargs: Any,
-    ) -> ArrayLike: ...
+    ) -> Array: ...
 
     @overload
     def __call__(
@@ -452,13 +456,13 @@ class Distribution(metaclass=DistributionMeta):
         sample_shape: tuple[int, ...] = ...,
         sample_intermediates: Literal[True] = ...,
         **kwargs: Any,
-    ) -> tuple[ArrayLike, list[Any]]: ...
+    ) -> tuple[Array, list[Any]]: ...
 
     def __call__(
         self,
         *args: Any,
         **kwargs: Any,
-    ) -> Union[ArrayLike, tuple[ArrayLike, list[Any]]]:
+    ) -> Union[Array, tuple[Array, list[Any]]]:
         key = kwargs.pop("rng_key")
         sample_intermediates = kwargs.pop("sample_intermediates", False)
         if sample_intermediates:
@@ -483,14 +487,14 @@ class Distribution(metaclass=DistributionMeta):
             return self
         return Independent(self, reinterpreted_batch_ndims)
 
-    def enumerate_support(self, expand: bool = True) -> ArrayLike:
+    def enumerate_support(self, expand: bool = True) -> Array:
         """
         Returns an array with shape `len(support) x batch_shape`
         containing all values in the support.
         """
         raise NotImplementedError
 
-    def entropy(self) -> ArrayLike:
+    def entropy(self) -> Array:
         """
         Returns the entropy of the distribution.
         """
@@ -627,7 +631,7 @@ class Distribution(metaclass=DistributionMeta):
         event_shape = ()
         return batch_shape, event_shape
 
-    def cdf(self, value: ArrayLike) -> ArrayLike:
+    def cdf(self, value: ArrayLike) -> Array:
         """
         The cumulative distribution function of this distribution.
 
@@ -636,7 +640,7 @@ class Distribution(metaclass=DistributionMeta):
         """
         raise NotImplementedError
 
-    def icdf(self, q: ArrayLike) -> ArrayLike:
+    def icdf(self, q: ArrayLike) -> Array:
         """
         The inverse cumulative distribution function of this distribution.
 
@@ -731,10 +735,10 @@ class ExpandedDistribution(Distribution):
 
     def _sample(
         self,
-        sample_fn: Callable[..., tuple[ArrayLike, list[ArrayLike]]],
+        sample_fn: Callable[..., tuple[Array, list[Array]]],
         key: Optional[jax.Array],
         sample_shape: tuple[int, ...] = (),
-    ) -> tuple[ArrayLike, list[ArrayLike]]:
+    ) -> tuple[Array, list[Array]]:
         interstitial_sizes = tuple(self._interstitial_sizes.values())
         expanded_sizes = tuple(self._expanded_sizes.values())
         batch_shape = expanded_sizes + interstitial_sizes
@@ -755,7 +759,7 @@ class ExpandedDistribution(Distribution):
         for dim1, dim2 in zip(interstitial_dims, interstitial_sample_dims):
             permutation[dim1], permutation[dim2] = permutation[dim2], permutation[dim1]
 
-        def reshape_sample(x: ArrayLike) -> ArrayLike:
+        def reshape_sample(x: ArrayLike) -> Array:
             """
             Reshapes samples and intermediates to ensure that the output
             shape is correct: This implicitly replaces the interstitial dims
@@ -772,7 +776,7 @@ class ExpandedDistribution(Distribution):
 
     def rsample(
         self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
-    ) -> ArrayLike:
+    ) -> Array:
         return self._sample(
             lambda *args, **kwargs: (self.base_dist.rsample(*args, **kwargs), []),
             key,
@@ -786,17 +790,17 @@ class ExpandedDistribution(Distribution):
 
     def sample_with_intermediates(
         self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
-    ) -> tuple[ArrayLike, list[ArrayLike]]:
+    ) -> tuple[Array, list[Array]]:
         return self._sample(self.base_dist.sample_with_intermediates, key, sample_shape)
 
     def sample(
         self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
-    ) -> ArrayLike:
+    ) -> Array:
         return self.sample_with_intermediates(key, sample_shape)[0]
 
     def log_prob(
         self, value: ArrayLike, intermediates: Optional[list[Any]] = None
-    ) -> ArrayLike:
+    ) -> Array:
         # TODO: utilize `intermediates`
         shape = lax.broadcast_shapes(
             self.batch_shape,
@@ -805,7 +809,7 @@ class ExpandedDistribution(Distribution):
         log_prob = self.base_dist.log_prob(value)
         return jnp.broadcast_to(log_prob, shape)
 
-    def enumerate_support(self, expand: bool = True) -> ArrayLike:
+    def enumerate_support(self, expand: bool = True) -> Array:
         samples = jnp.asarray(self.base_dist.enumerate_support(expand=False))
         enum_shape = samples.shape[:1]
         samples = samples.reshape(enum_shape + (1,) * len(self.batch_shape))
@@ -816,18 +820,18 @@ class ExpandedDistribution(Distribution):
         return samples
 
     @property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         return jnp.broadcast_to(
             self.base_dist.mean, self.batch_shape + self.event_shape
         )
 
     @property
-    def variance(self) -> ArrayLike:
+    def variance(self) -> Array:
         return jnp.broadcast_to(
             self.base_dist.variance, self.batch_shape + self.event_shape
         )
 
-    def entropy(self) -> ArrayLike:
+    def entropy(self) -> Array:
         return jnp.broadcast_to(self.base_dist.entropy(), self.batch_shape)
 
 
@@ -905,7 +909,7 @@ class ImproperUniform(Distribution):
         batch_shape = lax.broadcast_shapes(batch_shape, self.batch_shape)
         return jnp.zeros(batch_shape)
 
-    def _validate_sample(self, value: ArrayLike) -> ArrayLike:
+    def _validate_sample(self, value: ArrayLike) -> Array:
         mask = super(ImproperUniform, self)._validate_sample(value)
         batch_dim = jnp.ndim(value) - len(self.event_shape)
         if batch_dim < jnp.ndim(mask):
@@ -975,11 +979,11 @@ class Independent(Distribution):
         )
 
     @property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         return self.base_dist.mean
 
     @property
-    def variance(self) -> ArrayLike:
+    def variance(self) -> Array:
         return self.base_dist.variance
 
     @property
@@ -988,15 +992,15 @@ class Independent(Distribution):
 
     def rsample(
         self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
-    ) -> ArrayLike:
+    ) -> Array:
         return self.base_dist.rsample(key, sample_shape=sample_shape)
 
     def sample(
         self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
-    ) -> ArrayLike:
+    ) -> Array:
         return self.base_dist.sample(key, sample_shape)
 
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         log_prob = self.base_dist.log_prob(value)
         return sum_rightmost(log_prob, self.reinterpreted_batch_ndims)
 
@@ -1009,7 +1013,7 @@ class Independent(Distribution):
             self.reinterpreted_batch_ndims
         )
 
-    def entropy(self) -> ArrayLike:
+    def entropy(self) -> Array:
         axes = range(-self.reinterpreted_batch_ndims, 0)
         return jnp.asarray(self.base_dist.entropy()).sum(axes)
 
@@ -1053,7 +1057,7 @@ class MaskedDistribution(Distribution):
 
     def rsample(
         self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
-    ) -> ArrayLike:
+    ) -> Array:
         return self.base_dist.rsample(key, sample_shape=sample_shape)
 
     @property
@@ -1063,10 +1067,10 @@ class MaskedDistribution(Distribution):
 
     def sample(
         self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
-    ) -> ArrayLike:
+    ) -> Array:
         return self.base_dist.sample(key, sample_shape)
 
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         if self._mask is False:
             shape = lax.broadcast_shapes(
                 tuple(self.base_dist.batch_shape),
@@ -1087,15 +1091,15 @@ class MaskedDistribution(Distribution):
             value = jnp.where(mask, value, default_value)
         return jnp.where(self._mask, self.base_dist.log_prob(value), 0.0)
 
-    def enumerate_support(self, expand: bool = True) -> ArrayLike:
+    def enumerate_support(self, expand: bool = True) -> Array:
         return self.base_dist.enumerate_support(expand=expand)
 
     @property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         return self.base_dist.mean
 
     @property
-    def variance(self) -> ArrayLike:
+    def variance(self) -> Array:
         return self.base_dist.variance
 
     def tree_flatten(self) -> tuple[tuple[Any, ...], tuple[Any, ...]]:
@@ -1213,11 +1217,11 @@ class TransformedDistribution(Distribution):
 
     def rsample(
         self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
-    ) -> ArrayLike:
+    ) -> Array:
         x = self.base_dist.rsample(key, sample_shape=sample_shape)
         for transform in self.transforms:
             x = transform(x)
-        return x
+        return x  # type: ignore
 
     @property
     def support(self) -> constraints.Constraint:
@@ -1239,18 +1243,18 @@ class TransformedDistribution(Distribution):
             x = transform(x)
         # ``Transform.__call__`` is typed to return the wide ``ArrayLike``, so ``x`` is
         # widened here even though it is a jax array at runtime.
-        return x  # type: ignore[return-value]
+        return x  # type: ignore
 
     def sample_with_intermediates(
         self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
-    ) -> tuple[ArrayLike, list[Any]]:
+    ) -> tuple[Array, list[Any]]:
         x = self.base_dist.sample(key, sample_shape)
         intermediates: list[Any] = []
         for transform in self.transforms:
             x_tmp = x
             x, t_inter = transform.call_with_intermediates(x)
             intermediates.append([x_tmp, t_inter])
-        return x, intermediates
+        return x, intermediates  # type: ignore
 
     @validate_sample
     def log_prob(
@@ -1281,14 +1285,14 @@ class TransformedDistribution(Distribution):
         return log_prob
 
     @property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         raise NotImplementedError
 
     @property
-    def variance(self) -> ArrayLike:
+    def variance(self) -> Array:
         raise NotImplementedError
 
-    def cdf(self, value: ArrayLike) -> ArrayLike:
+    def cdf(self, value: ArrayLike) -> Array:
         sign: Any = 1
         for transform in reversed(self.transforms):
             sign = sign * transform.sign
@@ -1296,7 +1300,7 @@ class TransformedDistribution(Distribution):
         q = self.base_dist.cdf(value)
         return jnp.where(sign < 0, 1 - q, q)
 
-    def icdf(self, q: ArrayLike) -> ArrayLike:
+    def icdf(self, q: ArrayLike) -> Array:
         sign: Any = 1
         for transform in self.transforms:
             sign = sign * transform.sign
@@ -1304,7 +1308,7 @@ class TransformedDistribution(Distribution):
         value = self.base_dist.icdf(q)
         for transform in self.transforms:
             value = transform(value)
-        return value
+        return value  # type: ignore
 
 
 class FoldedDistribution(TransformedDistribution):
@@ -1368,9 +1372,9 @@ class Delta(Distribution):
 
     def sample(
         self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
-    ) -> ArrayLike:
+    ) -> Array:
         if not sample_shape:
-            return self.v
+            return jnp.asarray(self.v)
         shape = sample_shape + self.batch_shape + self.event_shape
         return jnp.broadcast_to(self.v, shape)
 
@@ -1381,8 +1385,8 @@ class Delta(Distribution):
         return log_prob + self.log_density
 
     @property
-    def mean(self) -> ArrayLike:
-        return self.v
+    def mean(self) -> Array:
+        return jnp.asarray(self.v)
 
     @property
     def variance(self) -> Array:
@@ -1414,9 +1418,9 @@ class Unit(Distribution):
 
     def sample(
         self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
-    ) -> ArrayLike:
+    ) -> Array:
         return jnp.empty(sample_shape + self.batch_shape + self.event_shape)
 
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         shape = lax.broadcast_shapes(self.batch_shape, jnp.shape(value)[:-1])
         return jnp.broadcast_to(self.log_factor, shape)

--- a/numpyro/distributions/distribution.py
+++ b/numpyro/distributions/distribution.py
@@ -426,7 +426,7 @@ class Distribution(metaclass=DistributionMeta):
     def mode(self) -> Array:
         raise NotImplementedError
 
-    def _validate_sample(self, value: ArrayLike) -> Array:
+    def _validate_sample(self, value: ArrayLike) -> ArrayLike:
         assert self.support is not None
         mask = self.support(value)
         if not_jax_tracer(mask):
@@ -909,7 +909,7 @@ class ImproperUniform(Distribution):
         batch_shape = lax.broadcast_shapes(batch_shape, self.batch_shape)
         return jnp.zeros(batch_shape)
 
-    def _validate_sample(self, value: ArrayLike) -> Array:
+    def _validate_sample(self, value: ArrayLike) -> ArrayLike:
         mask = super(ImproperUniform, self)._validate_sample(value)
         batch_dim = jnp.ndim(value) - len(self.event_shape)
         if batch_dim < jnp.ndim(mask):

--- a/numpyro/distributions/distribution.py
+++ b/numpyro/distributions/distribution.py
@@ -900,7 +900,7 @@ class ImproperUniform(Distribution):
         super().__init__(batch_shape, event_shape, validate_args=validate_args)
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         batch_shape = jnp.shape(value)[: jnp.ndim(value) - len(self.event_shape)]
         batch_shape = lax.broadcast_shapes(batch_shape, self.batch_shape)
         return jnp.zeros(batch_shape)
@@ -1233,11 +1233,13 @@ class TransformedDistribution(Distribution):
 
     def sample(
         self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
-    ) -> ArrayLike:
+    ) -> Array:
         x = self.base_dist.sample(key, sample_shape)
         for transform in self.transforms:
             x = transform(x)
-        return x
+        # ``Transform.__call__`` is typed to return the wide ``ArrayLike``, so ``x`` is
+        # widened here even though it is a jax array at runtime.
+        return x  # type: ignore[return-value]
 
     def sample_with_intermediates(
         self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
@@ -1253,7 +1255,7 @@ class TransformedDistribution(Distribution):
     @validate_sample
     def log_prob(
         self, value: ArrayLike, intermediates: Optional[list[Any]] = None
-    ) -> ArrayLike:
+    ) -> Array:
         if intermediates is not None:
             if len(intermediates) != len(self.transforms):
                 raise ValueError(
@@ -1323,7 +1325,7 @@ class FoldedDistribution(TransformedDistribution):
         super().__init__(base_dist, AbsTransform(), validate_args=validate_args)
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         dim = max(len(self.batch_shape), jnp.ndim(value))
         plus_minus = jnp.array([1.0, -1.0]).reshape((2,) + (1,) * dim)
         return logsumexp(self.base_dist.log_prob(plus_minus * value), axis=0)
@@ -1373,7 +1375,7 @@ class Delta(Distribution):
         return jnp.broadcast_to(self.v, shape)
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         log_prob = jnp.where(value == self.v, 0, -jnp.inf)
         log_prob = sum_rightmost(log_prob, len(self.event_shape))
         return log_prob + self.log_density
@@ -1383,10 +1385,10 @@ class Delta(Distribution):
         return self.v
 
     @property
-    def variance(self) -> ArrayLike:
+    def variance(self) -> Array:
         return jnp.zeros(self.batch_shape + self.event_shape)
 
-    def entropy(self) -> ArrayLike:
+    def entropy(self) -> Array:
         return -jnp.broadcast_to(self.log_density, self.batch_shape)
 
 

--- a/numpyro/distributions/distribution.py
+++ b/numpyro/distributions/distribution.py
@@ -296,20 +296,21 @@ class Distribution(metaclass=DistributionMeta):
         :param strict: Require strict validation, raising an error if the function is
             called inside jitted code.
         """
-        for param, value in self.get_args().items():
-            constraint = self.arg_constraints[param]
-            if constraints.is_dependent(constraint):
-                continue  # skip constraints that cannot be checked
-            is_valid = constraint(value)
-            if not_jax_tracer(is_valid):
-                if not np.all(is_valid):
-                    raise ValueError(
-                        "{} distribution got invalid {} parameter.".format(
-                            self.__class__.__name__, param
+        with jax.ensure_compile_time_eval():
+            for param, value in self.get_args().items():
+                constraint = self.arg_constraints[param]
+                if constraints.is_dependent(constraint):
+                    continue  # skip constraints that cannot be checked
+                is_valid = constraint(value)
+                if not_jax_tracer(is_valid):
+                    if not np.all(is_valid):
+                        raise ValueError(
+                            "{} distribution got invalid {} parameter.".format(
+                                self.__class__.__name__, param
+                            )
                         )
-                    )
-            elif strict:
-                raise RuntimeError("Cannot validate arguments inside jitted code.")
+                elif strict:
+                    raise RuntimeError("Cannot validate arguments inside jitted code.")
 
     @property
     def batch_shape(self) -> tuple[int, ...]:
@@ -429,6 +430,9 @@ class Distribution(metaclass=DistributionMeta):
 
     @property
     def mode(self) -> Array:
+        """
+        Mode of the distribution.
+        """
         raise NotImplementedError
 
     def _validate_sample(self, value: ArrayLike) -> ArrayLike:
@@ -1329,7 +1333,7 @@ class TransformedDistribution(Distribution):
         value = self.base_dist.icdf(q)
         for transform in self.transforms:
             value = transform(value)
-        return value  # type: ignore
+        return jnp.asarray(value)
 
 
 class FoldedDistribution(TransformedDistribution):

--- a/numpyro/distributions/flows.py
+++ b/numpyro/distributions/flows.py
@@ -174,7 +174,7 @@ class BlockNeuralAutoregressiveTransform(Transform):
     def tree_flatten(self):
         return (), ((), {"bn_arn": self.bn_arn})
 
-    def eq(self, other: Transform, static: bool = False) -> ArrayLike:
+    def eq(self, other: Transform, static: bool = False) -> bool:
         return (
             isinstance(other, BlockNeuralAutoregressiveTransform)
             and self.bn_arn is other.bn_arn

--- a/numpyro/distributions/flows.py
+++ b/numpyro/distributions/flows.py
@@ -2,24 +2,26 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from jax import lax
+from typing import Optional
+
+from jax import Array, lax
 import jax.numpy as jnp
 from jax.typing import ArrayLike
 
+from numpyro._typing import NumLike, PyTree
 from numpyro.distributions.constraints import real_vector
 from numpyro.distributions.transforms import Transform
 from numpyro.distributions.util import array_equiv
 from numpyro.util import fori_loop
 
 
-def _clamp_preserve_gradients(
-    x: ArrayLike, min: ArrayLike, max: ArrayLike
-) -> ArrayLike:
+def _clamp_preserve_gradients(x: ArrayLike, min: ArrayLike, max: ArrayLike) -> Array:
+    x = jnp.asarray(x)
     return x + lax.stop_gradient(jnp.clip(x, min, max) - x)
 
 
 # adapted from https://github.com/pyro-ppl/pyro/blob/dev/pyro/distributions/transforms/iaf.py
-class InverseAutoregressiveTransform(Transform):
+class InverseAutoregressiveTransform(Transform[NumLike]):
     """
     An implementation of Inverse Autoregressive Flow, using Eq (10) from Kingma et al., 2016,
 
@@ -51,13 +53,13 @@ class InverseAutoregressiveTransform(Transform):
         self.log_scale_min_clip = log_scale_min_clip
         self.log_scale_max_clip = log_scale_max_clip
 
-    def __call__(self, x: ArrayLike) -> ArrayLike:
+    def __call__(self, x: NumLike) -> NumLike:
         """
         :param numpy.ndarray x: the input into the transform
         """
         return self.call_with_intermediates(x)[0]
 
-    def call_with_intermediates(self, x: ArrayLike) -> ArrayLike:
+    def call_with_intermediates(self, x: NumLike) -> tuple[NumLike, Optional[PyTree]]:
         mean, log_scale = self.arn(x)
         log_scale = _clamp_preserve_gradients(
             log_scale, self.log_scale_min_clip, self.log_scale_max_clip
@@ -65,7 +67,7 @@ class InverseAutoregressiveTransform(Transform):
         scale = jnp.exp(log_scale)
         return scale * x + mean, log_scale
 
-    def _inverse(self, y: ArrayLike) -> ArrayLike:
+    def _inverse(self, y: NumLike) -> NumLike:
         """
         :param numpy.ndarray y: the output of the transform to be inverted
         """
@@ -81,12 +83,12 @@ class InverseAutoregressiveTransform(Transform):
             x = (y - mean) * inverse_scale
             return x
 
-        x = fori_loop(0, y.shape[-1], _update_x, jnp.zeros(y.shape))
+        x = fori_loop(0, jnp.shape(y)[-1], _update_x, jnp.zeros(jnp.shape(y)))
         return x
 
     def log_abs_det_jacobian(
-        self, x: ArrayLike, y: ArrayLike, intermediates=None
-    ) -> ArrayLike:
+        self, x: NumLike, y: NumLike, intermediates: Optional[PyTree] = None
+    ) -> NumLike:
         """
         Calculates the elementwise determinant of the log jacobian.
 
@@ -109,7 +111,7 @@ class InverseAutoregressiveTransform(Transform):
             {"arn": self.arn},
         )
 
-    def eq(self, other: Transform, static: bool = False) -> ArrayLike:
+    def eq(self, other: object, static: bool = False) -> ArrayLike:
         if not isinstance(other, InverseAutoregressiveTransform):
             return False
         return (
@@ -123,7 +125,7 @@ class InverseAutoregressiveTransform(Transform):
         )
 
 
-class BlockNeuralAutoregressiveTransform(Transform):
+class BlockNeuralAutoregressiveTransform(Transform[NumLike]):
     """
     An implementation of Block Neural Autoregressive flow.
 
@@ -139,25 +141,25 @@ class BlockNeuralAutoregressiveTransform(Transform):
     def __init__(self, bn_arn):
         self.bn_arn = bn_arn
 
-    def __call__(self, x: ArrayLike) -> ArrayLike:
+    def __call__(self, x: NumLike) -> NumLike:
         """
         :param numpy.ndarray x: the input into the transform
         """
         return self.call_with_intermediates(x)[0]
 
-    def call_with_intermediates(self, x: ArrayLike) -> ArrayLike:
+    def call_with_intermediates(self, x: NumLike) -> tuple[NumLike, Optional[PyTree]]:
         y, logdet = self.bn_arn(x)
         return y, logdet
 
-    def _inverse(self, y: ArrayLike) -> ArrayLike:
+    def _inverse(self, y: NumLike) -> NumLike:
         raise NotImplementedError(
             "Block neural autoregressive transform does not have an analytic"
             " inverse implemented."
         )
 
     def log_abs_det_jacobian(
-        self, x: ArrayLike, y: ArrayLike, intermediates=None
-    ) -> ArrayLike:
+        self, x: NumLike, y: NumLike, intermediates: Optional[PyTree] = None
+    ) -> NumLike:
         """
         Calculates the elementwise determinant of the log jacobian.
 
@@ -174,7 +176,7 @@ class BlockNeuralAutoregressiveTransform(Transform):
     def tree_flatten(self):
         return (), ((), {"bn_arn": self.bn_arn})
 
-    def eq(self, other: Transform, static: bool = False) -> ArrayLike:
+    def eq(self, other: object, static: bool = False) -> ArrayLike:
         return (
             isinstance(other, BlockNeuralAutoregressiveTransform)
             and self.bn_arn is other.bn_arn

--- a/numpyro/distributions/mixtures.py
+++ b/numpyro/distributions/mixtures.py
@@ -63,22 +63,22 @@ class _MixtureBase(Distribution):
     """
 
     @property
-    def component_mean(self) -> ArrayLike:
+    def component_mean(self) -> Array:
         raise NotImplementedError
 
     @property
-    def component_variance(self) -> ArrayLike:
+    def component_variance(self) -> Array:
         raise NotImplementedError
 
-    def component_log_probs(self, value: ArrayLike) -> ArrayLike:
+    def component_log_probs(self, value: ArrayLike) -> Array:
         raise NotImplementedError
 
     def component_sample(
         self, key: jax.Array, sample_shape: tuple[int, ...] = ()
-    ) -> ArrayLike:
+    ) -> Array:
         raise NotImplementedError
 
-    def component_cdf(self, samples: ArrayLike) -> ArrayLike:
+    def component_cdf(self, samples: ArrayLike) -> Array:
         raise NotImplementedError
 
     @property
@@ -117,7 +117,7 @@ class _MixtureBase(Distribution):
         var_cond_mean = jnp.sum(probs * sq_deviation, axis=self.mixture_dim)
         return mean_cond_var + var_cond_mean
 
-    def cdf(self, samples: ArrayLike) -> ArrayLike:
+    def cdf(self, samples: ArrayLike) -> Array:
         """The cumulative distribution function
 
         :param value: samples from this distribution.
@@ -131,7 +131,7 @@ class _MixtureBase(Distribution):
 
     def sample_with_intermediates(
         self, key: jax.Array, sample_shape: tuple[int, ...] = ()
-    ) -> tuple[ArrayLike, list[ArrayLike]]:
+    ) -> tuple[Array, list[Array]]:
         """
         A version of ``sample`` that also returns the sampled component indices
 
@@ -271,26 +271,26 @@ class MixtureSameFamily(_MixtureBase):
         return self.component_distribution.is_discrete
 
     @property
-    def component_mean(self) -> ArrayLike:
+    def component_mean(self) -> Array:
         return self.component_distribution.mean
 
     @property
-    def component_variance(self) -> ArrayLike:
+    def component_variance(self) -> Array:
         return self.component_distribution.variance
 
-    def component_cdf(self, samples: ArrayLike) -> ArrayLike:
+    def component_cdf(self, samples: ArrayLike) -> Array:
         return self.component_distribution.cdf(
             jnp.expand_dims(samples, axis=self.mixture_dim)
         )
 
     def component_sample(
         self, key: jax.Array, sample_shape: tuple[int, ...] = ()
-    ) -> ArrayLike:
+    ) -> Array:
         return self.component_distribution.expand(
             sample_shape + self.batch_shape + (self.mixture_size,)
         ).sample(key)
 
-    def component_log_probs(self, value: ArrayLike) -> ArrayLike:
+    def component_log_probs(self, value: ArrayLike) -> Array:
         value = jnp.expand_dims(value, self.mixture_dim)
         component_log_probs = self.component_distribution.log_prob(value)
         return jax.nn.log_softmax(self.mixing_distribution.logits) + component_log_probs
@@ -439,13 +439,13 @@ class MixtureGeneral(_MixtureBase):
         return self.component_distributions[0].is_discrete
 
     @property
-    def component_mean(self) -> ArrayLike:
+    def component_mean(self) -> Array:
         return jnp.stack(
             [d.mean for d in self.component_distributions], axis=self.mixture_dim
         )
 
     @property
-    def component_variance(self) -> ArrayLike:
+    def component_variance(self) -> Array:
         return jnp.stack(
             [d.variance for d in self.component_distributions], axis=self.mixture_dim
         )
@@ -458,14 +458,14 @@ class MixtureGeneral(_MixtureBase):
 
     def component_sample(
         self, key: jax.Array, sample_shape: tuple[int, ...] = ()
-    ) -> ArrayLike:
+    ) -> Array:
         keys = jax.random.split(key, self.mixture_size)
         samples = []
         for k, d in zip(keys, self.component_distributions):
             samples.append(d.expand(sample_shape + self.batch_shape).sample(k))
         return jnp.stack(samples, axis=self.mixture_dim)
 
-    def component_log_probs(self, value: ArrayLike) -> ArrayLike:
+    def component_log_probs(self, value: ArrayLike) -> Array:
         component_log_probs = []
         for d in self.component_distributions:
             log_prob = d.log_prob(value)

--- a/numpyro/distributions/mixtures.py
+++ b/numpyro/distributions/mixtures.py
@@ -100,14 +100,14 @@ class _MixtureBase(Distribution):
         return -self.event_dim - 1
 
     @property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         probs = self.mixing_distribution.probs
         probs = probs.reshape(probs.shape + (1,) * self.event_dim)
         weighted_component_means = probs * self.component_mean
         return jnp.sum(weighted_component_means, axis=self.mixture_dim)
 
     @property
-    def variance(self) -> ArrayLike:
+    def variance(self) -> Array:
         probs = self.mixing_distribution.probs
         probs = probs.reshape(probs.shape + (1,) * self.event_dim)
         mean_cond_var = jnp.sum(probs * self.component_variance, axis=self.mixture_dim)
@@ -161,11 +161,11 @@ class _MixtureBase(Distribution):
         # Final sample shape (*sample_shape, *batch_shape, *event_shape)
         return jnp.squeeze(samples_selected, axis=self.mixture_dim), [indices]
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
         return self.sample_with_intermediates(key=key, sample_shape=sample_shape)[0]
 
     @validate_sample
-    def log_prob(self, value: ArrayLike, intermediates=None) -> ArrayLike:
+    def log_prob(self, value: ArrayLike, intermediates=None) -> Array:
         del intermediates
         sum_log_probs = self.component_log_probs(value)
         safe_sum_log_probs = jnp.where(

--- a/numpyro/distributions/mixtures.py
+++ b/numpyro/distributions/mixtures.py
@@ -62,6 +62,9 @@ class _MixtureBase(Distribution):
     subclasses should implement the ``component_*`` methods to specialize.
     """
 
+    _mixture_size: int
+    _mixing_distribution: Union[CategoricalProbs, CategoricalLogits]
+
     @property
     def component_mean(self) -> Array:
         raise NotImplementedError
@@ -102,14 +105,14 @@ class _MixtureBase(Distribution):
     @property
     def mean(self) -> Array:
         probs = self.mixing_distribution.probs
-        probs = probs.reshape(probs.shape + (1,) * self.event_dim)
+        probs = jnp.reshape(probs, jnp.shape(probs) + (1,) * self.event_dim)
         weighted_component_means = probs * self.component_mean
         return jnp.sum(weighted_component_means, axis=self.mixture_dim)
 
     @property
     def variance(self) -> Array:
         probs = self.mixing_distribution.probs
-        probs = probs.reshape(probs.shape + (1,) * self.event_dim)
+        probs = jnp.reshape(probs, jnp.shape(probs) + (1,) * self.event_dim)
         mean_cond_var = jnp.sum(probs * self.component_variance, axis=self.mixture_dim)
         sq_deviation = (
             self.component_mean - jnp.expand_dims(self.mean, axis=self.mixture_dim)
@@ -117,7 +120,7 @@ class _MixtureBase(Distribution):
         var_cond_mean = jnp.sum(probs * sq_deviation, axis=self.mixture_dim)
         return mean_cond_var + var_cond_mean
 
-    def cdf(self, samples: ArrayLike) -> Array:
+    def cdf(self, value: ArrayLike) -> Array:
         """The cumulative distribution function
 
         :param value: samples from this distribution.
@@ -126,11 +129,11 @@ class _MixtureBase(Distribution):
         :raises: NotImplementedError if the component distribution does not
             implement the cdf method.
         """
-        cdf_components = self.component_cdf(samples)
+        cdf_components = self.component_cdf(value)
         return jnp.sum(cdf_components * self.mixing_distribution.probs, axis=-1)
 
     def sample_with_intermediates(
-        self, key: jax.Array, sample_shape: tuple[int, ...] = ()
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
     ) -> tuple[Array, list[Array]]:
         """
         A version of ``sample`` that also returns the sampled component indices
@@ -142,14 +145,17 @@ class _MixtureBase(Distribution):
             the indices of the sampled components.
         :rtype: tuple
         """
+        assert key is not None
         assert is_prng_key(key)
         key_comp, key_ind = jax.random.split(key)
         samples = self.component_sample(key_comp, sample_shape=sample_shape)
 
         # Sample selection indices from the categorical (shape will be sample_shape)
-        indices: ArrayLike = self.mixing_distribution.expand(
-            sample_shape + self.batch_shape
-        ).sample(key_ind)
+        indices = jnp.asarray(
+            self.mixing_distribution.expand(sample_shape + self.batch_shape).sample(
+                key_ind
+            )
+        )
         n_expand = self.event_dim + 1
         indices_expanded = indices.reshape(indices.shape + (1,) * n_expand)
 
@@ -161,7 +167,9 @@ class _MixtureBase(Distribution):
         # Final sample shape (*sample_shape, *batch_shape, *event_shape)
         return jnp.squeeze(samples_selected, axis=self.mixture_dim), [indices]
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> Array:
         return self.sample_with_intermediates(key=key, sample_shape=sample_shape)[0]
 
     @validate_sample
@@ -227,7 +235,7 @@ class MixtureSameFamily(_MixtureBase):
             f"(expected ParameterFreeConstraint, but found {component_distribution.support})."
         )
         _check_mixing_distribution(mixing_distribution)
-        mixture_size = mixing_distribution.probs.shape[-1]
+        mixture_size = jnp.shape(mixing_distribution.probs)[-1]
         if not isinstance(component_distribution, Distribution):
             raise ValueError(
                 "The component distribution need to be a numpyro.distributions.Distribution. "
@@ -263,7 +271,9 @@ class MixtureSameFamily(_MixtureBase):
 
     @constraints.dependent_property
     def support(self) -> Constraint:
-        return self.component_distribution.support
+        support = self.component_distribution.support
+        assert support is not None
+        return support
 
     @property
     def is_discrete(self) -> bool:
@@ -285,9 +295,11 @@ class MixtureSameFamily(_MixtureBase):
     def component_sample(
         self, key: jax.Array, sample_shape: tuple[int, ...] = ()
     ) -> Array:
-        return self.component_distribution.expand(
-            sample_shape + self.batch_shape + (self.mixture_size,)
-        ).sample(key)
+        return jnp.asarray(
+            self.component_distribution.expand(
+                sample_shape + self.batch_shape + (self.mixture_size,)
+            ).sample(key)
+        )
 
     def component_log_probs(self, value: ArrayLike) -> Array:
         value = jnp.expand_dims(value, self.mixture_dim)
@@ -431,7 +443,9 @@ class MixtureGeneral(_MixtureBase):
     def support(self) -> Constraint:
         if self._support is not None:
             return self._support
-        return self.component_distributions[0].support
+        support = self.component_distributions[0].support
+        assert support is not None
+        return support
 
     @property
     def is_discrete(self) -> bool:
@@ -469,7 +483,9 @@ class MixtureGeneral(_MixtureBase):
         for d in self.component_distributions:
             log_prob = d.log_prob(value)
             if (self._support is not None) and (not d._validate_args):
-                mask = d.support(value)
+                support = d.support
+                assert support is not None
+                mask = support(value)
                 log_prob = jnp.where(mask, log_prob, -jnp.inf)
             component_log_probs.append(log_prob)
         component_log_probs = jnp.stack(component_log_probs, axis=-1)

--- a/numpyro/distributions/transforms.py
+++ b/numpyro/distributions/transforms.py
@@ -161,7 +161,7 @@ class Transform(Generic[NumLikeT]):
             setattr(self, k, v)
         return self
 
-    def eq(self, other: object, static: bool = False) -> ArrayLike:
+    def eq(self, other: object, static: bool = False) -> bool:
         return self is other
 
     def __eq__(self, other: object) -> bool:
@@ -172,7 +172,7 @@ class ParameterFreeTransform(Transform[NumLikeT]):
     def tree_flatten(self):
         return (), ((), dict())
 
-    def eq(self, other: object, static: bool = False) -> ArrayLike:
+    def eq(self, other: object, static: bool = False) -> bool:
         return isinstance(other, type(self))
 
 
@@ -217,7 +217,7 @@ class _InverseTransform(Transform[NumLike]):
     def tree_flatten(self):
         return (self._inv,), (("_inv",), dict())
 
-    def eq(self, other: object, static: bool = False) -> ArrayLike:
+    def eq(self, other: object, static: bool = False) -> bool:
         if not isinstance(other, _InverseTransform):
             return False
         return self._inv.eq(other._inv, static=static)
@@ -315,7 +315,7 @@ class AffineTransform(Transform[NumLike]):
             dict(),
         )
 
-    def eq(self, other: object, static: bool = False) -> ArrayLike:
+    def eq(self, other: object, static: bool = False) -> bool:
         if not isinstance(other, AffineTransform):
             return False
         return (
@@ -439,7 +439,7 @@ class ComposeTransform(Transform[NumLike]):
     def tree_flatten(self):
         return (self.parts,), (("parts",), {})
 
-    def eq(self, other: object, static: bool = False) -> ArrayLike:
+    def eq(self, other: object, static: bool = False) -> bool:
         if not isinstance(other, ComposeTransform):
             return False
         if len(self.parts) != len(other.parts):
@@ -448,7 +448,7 @@ class ComposeTransform(Transform[NumLike]):
             return all(
                 p1.eq(p2, static=True) for p1, p2 in zip(self.parts, other.parts)
             )
-        result = jnp.array(True)
+        result = True
         for p1, p2 in zip(self.parts, other.parts):
             result = result & p1.eq(p2, static=False)
         return result
@@ -646,7 +646,7 @@ class ExpTransform(Transform[NumLike]):
     def tree_flatten(self):
         return (self.domain,), (("_domain",), dict())
 
-    def eq(self, other: object, static: bool = False) -> ArrayLike:
+    def eq(self, other: object, static: bool = False) -> bool:
         if not isinstance(other, ExpTransform):
             return False
         return self.domain.eq(other.domain, static=static)
@@ -728,7 +728,7 @@ class IndependentTransform(Transform[NumLike]):
             {"reinterpreted_batch_ndims": self.reinterpreted_batch_ndims},
         )
 
-    def eq(self, other: object, static: bool = False) -> ArrayLike:
+    def eq(self, other: object, static: bool = False) -> bool:
         if not isinstance(other, IndependentTransform):
             return False
         if self.reinterpreted_batch_ndims != other.reinterpreted_batch_ndims:
@@ -859,7 +859,7 @@ class LowerCholeskyAffine(Transform[NonScalarArray]):
     def tree_flatten(self):
         return (self.loc, self.scale_tril), (("loc", "scale_tril"), dict())
 
-    def eq(self, other: object, static: bool = False) -> ArrayLike:
+    def eq(self, other: object, static: bool = False) -> bool:
         if not isinstance(other, LowerCholeskyAffine):
             return False
         return array_equiv(self.loc, other.loc, static=static) & array_equiv(
@@ -1017,7 +1017,7 @@ class PermuteTransform(Transform[NonScalarArray]):
     def tree_flatten(self):
         return (self.permutation,), (("permutation",), dict())
 
-    def eq(self, other: object, static: bool = False) -> ArrayLike:
+    def eq(self, other: object, static: bool = False) -> bool:
         if not isinstance(other, PermuteTransform):
             return False
         return array_equiv(self.permutation, other.permutation, static=static)
@@ -1050,7 +1050,7 @@ class PowerTransform(Transform[NumLike]):
     def tree_flatten(self):
         return (self.exponent,), (("exponent",), dict())
 
-    def eq(self, other: object, static: bool = False) -> ArrayLike:
+    def eq(self, other: object, static: bool = False) -> bool:
         if not isinstance(other, PowerTransform):
             return False
         return array_equiv(self.exponent, other.exponent, static=static)
@@ -1137,7 +1137,7 @@ class SimplexToOrderedTransform(Transform[NonScalarArray]):
     def tree_flatten(self):
         return (self.anchor_point,), (("anchor_point",), dict())
 
-    def eq(self, other: object, static: bool = False) -> ArrayLike:
+    def eq(self, other: object, static: bool = False) -> bool:
         if not isinstance(other, SimplexToOrderedTransform):
             return False
         return array_equiv(self.anchor_point, other.anchor_point, static=static)
@@ -1327,7 +1327,7 @@ class UnpackTransform(Transform[NonScalarArray]):
         # Note: what if unpack_fn is a parametrized callable pytree?
         return (), ((), {"unpack_fn": self.unpack_fn, "pack_fn": self.pack_fn})
 
-    def eq(self, other: object, static: bool = False) -> ArrayLike:
+    def eq(self, other: object, static: bool = False) -> bool:
         return (
             isinstance(other, UnpackTransform)
             and (self.unpack_fn is other.unpack_fn)
@@ -1402,7 +1402,7 @@ class ReshapeTransform(Transform[NonScalarArray]):
         }
         return (), ((), aux_data)
 
-    def eq(self, other: object, static: bool = False) -> ArrayLike:
+    def eq(self, other: object, static: bool = False) -> bool:
         return (
             isinstance(other, ReshapeTransform)
             and self._forward_shape == other._forward_shape
@@ -1493,7 +1493,7 @@ class RealFastFourierTransform(Transform[NonScalarArray]):
     def codomain(self) -> Constraint:
         return constraints.independent(constraints.complex, self.transform_ndims)
 
-    def eq(self, other: object, static: bool = False) -> ArrayLike:
+    def eq(self, other: object, static: bool = False) -> bool:
         return (
             isinstance(other, RealFastFourierTransform)
             and self.transform_ndims == other.transform_ndims
@@ -1568,7 +1568,7 @@ class PackRealFastFourierCoefficientsTransform(Transform[NonScalarArray]):
         n_imag = n - n_real
         return jnp.concatenate([y.real, y.imag[..., 1 : n_imag + 1]], axis=-1)
 
-    def eq(self, other: object, static: bool = False) -> ArrayLike:
+    def eq(self, other: object, static: bool = False) -> bool:
         return (
             isinstance(other, PackRealFastFourierCoefficientsTransform)
             and self.shape == other.shape
@@ -1702,7 +1702,7 @@ class RecursiveLinearTransform(Transform[NonScalarArray]):
             {},
         )
 
-    def eq(self, other: object, static: bool = False) -> ArrayLike:
+    def eq(self, other: object, static: bool = False) -> bool:
         if not isinstance(other, RecursiveLinearTransform):
             return False
         tm_eq = array_equiv(
@@ -1797,7 +1797,7 @@ class ZeroSumTransform(Transform[NonScalarArray]):
         aux_data = {"transform_ndims": self.transform_ndims}
         return (), ((), aux_data)
 
-    def eq(self, other: object, static: bool = False) -> ArrayLike:
+    def eq(self, other: object, static: bool = False) -> bool:
         return (
             isinstance(other, ZeroSumTransform)
             and self.transform_ndims == other.transform_ndims
@@ -1973,7 +1973,7 @@ class HaarTransform(Transform[NonScalarArray]):
     def tree_flatten(self):
         return (), ((), {"dim": self.dim, "flip": self.flip})
 
-    def eq(self, other: object, static: bool = False) -> ArrayLike:
+    def eq(self, other: object, static: bool = False) -> bool:
         return (
             isinstance(other, HaarTransform)
             and self.dim == other.dim
@@ -2061,7 +2061,7 @@ class DiscreteCosineTransform(Transform[NonScalarArray]):
     def tree_flatten(self):
         return (), ((), {"dim": self.dim, "smooth": self.smooth})
 
-    def eq(self, other: object, static: bool = False) -> ArrayLike:
+    def eq(self, other: object, static: bool = False) -> bool:
         return (
             isinstance(other, DiscreteCosineTransform)
             and self.dim == other.dim

--- a/numpyro/distributions/transforms.py
+++ b/numpyro/distributions/transforms.py
@@ -161,7 +161,7 @@ class Transform(Generic[NumLikeT]):
             setattr(self, k, v)
         return self
 
-    def eq(self, other: object, static: bool = False) -> bool:
+    def eq(self, other: object, static: bool = False) -> ArrayLike:
         return self is other
 
     def __eq__(self, other: object) -> bool:
@@ -172,7 +172,7 @@ class ParameterFreeTransform(Transform[NumLikeT]):
     def tree_flatten(self):
         return (), ((), dict())
 
-    def eq(self, other: object, static: bool = False) -> bool:
+    def eq(self, other: object, static: bool = False) -> ArrayLike:
         return isinstance(other, type(self))
 
 
@@ -217,7 +217,7 @@ class _InverseTransform(Transform[NumLike]):
     def tree_flatten(self):
         return (self._inv,), (("_inv",), dict())
 
-    def eq(self, other: object, static: bool = False) -> bool:
+    def eq(self, other: object, static: bool = False) -> ArrayLike:
         if not isinstance(other, _InverseTransform):
             return False
         return self._inv.eq(other._inv, static=static)
@@ -315,7 +315,7 @@ class AffineTransform(Transform[NumLike]):
             dict(),
         )
 
-    def eq(self, other: object, static: bool = False) -> bool:
+    def eq(self, other: object, static: bool = False) -> ArrayLike:
         if not isinstance(other, AffineTransform):
             return False
         return (
@@ -439,7 +439,7 @@ class ComposeTransform(Transform[NumLike]):
     def tree_flatten(self):
         return (self.parts,), (("parts",), {})
 
-    def eq(self, other: object, static: bool = False) -> bool:
+    def eq(self, other: object, static: bool = False) -> ArrayLike:
         if not isinstance(other, ComposeTransform):
             return False
         if len(self.parts) != len(other.parts):
@@ -450,7 +450,9 @@ class ComposeTransform(Transform[NumLike]):
             )
         result = True
         for p1, p2 in zip(self.parts, other.parts):
-            result = result & p1.eq(p2, static=False)
+            # eq is boolean-valued; ArrayLike advertises float/complex members
+            # that don't support `&`, so `&` is safe here in practice.
+            result = result & p1.eq(p2, static=False)  # ty: ignore[unsupported-operator]
         return result
 
 
@@ -646,7 +648,7 @@ class ExpTransform(Transform[NumLike]):
     def tree_flatten(self):
         return (self.domain,), (("_domain",), dict())
 
-    def eq(self, other: object, static: bool = False) -> bool:
+    def eq(self, other: object, static: bool = False) -> ArrayLike:
         if not isinstance(other, ExpTransform):
             return False
         return self.domain.eq(other.domain, static=static)
@@ -728,7 +730,7 @@ class IndependentTransform(Transform[NumLike]):
             {"reinterpreted_batch_ndims": self.reinterpreted_batch_ndims},
         )
 
-    def eq(self, other: object, static: bool = False) -> bool:
+    def eq(self, other: object, static: bool = False) -> ArrayLike:
         if not isinstance(other, IndependentTransform):
             return False
         if self.reinterpreted_batch_ndims != other.reinterpreted_batch_ndims:
@@ -859,7 +861,7 @@ class LowerCholeskyAffine(Transform[NonScalarArray]):
     def tree_flatten(self):
         return (self.loc, self.scale_tril), (("loc", "scale_tril"), dict())
 
-    def eq(self, other: object, static: bool = False) -> bool:
+    def eq(self, other: object, static: bool = False) -> ArrayLike:
         if not isinstance(other, LowerCholeskyAffine):
             return False
         return array_equiv(self.loc, other.loc, static=static) & array_equiv(
@@ -1017,7 +1019,7 @@ class PermuteTransform(Transform[NonScalarArray]):
     def tree_flatten(self):
         return (self.permutation,), (("permutation",), dict())
 
-    def eq(self, other: object, static: bool = False) -> bool:
+    def eq(self, other: object, static: bool = False) -> ArrayLike:
         if not isinstance(other, PermuteTransform):
             return False
         return array_equiv(self.permutation, other.permutation, static=static)
@@ -1050,7 +1052,7 @@ class PowerTransform(Transform[NumLike]):
     def tree_flatten(self):
         return (self.exponent,), (("exponent",), dict())
 
-    def eq(self, other: object, static: bool = False) -> bool:
+    def eq(self, other: object, static: bool = False) -> ArrayLike:
         if not isinstance(other, PowerTransform):
             return False
         return array_equiv(self.exponent, other.exponent, static=static)
@@ -1137,7 +1139,7 @@ class SimplexToOrderedTransform(Transform[NonScalarArray]):
     def tree_flatten(self):
         return (self.anchor_point,), (("anchor_point",), dict())
 
-    def eq(self, other: object, static: bool = False) -> bool:
+    def eq(self, other: object, static: bool = False) -> ArrayLike:
         if not isinstance(other, SimplexToOrderedTransform):
             return False
         return array_equiv(self.anchor_point, other.anchor_point, static=static)
@@ -1327,7 +1329,7 @@ class UnpackTransform(Transform[NonScalarArray]):
         # Note: what if unpack_fn is a parametrized callable pytree?
         return (), ((), {"unpack_fn": self.unpack_fn, "pack_fn": self.pack_fn})
 
-    def eq(self, other: object, static: bool = False) -> bool:
+    def eq(self, other: object, static: bool = False) -> ArrayLike:
         return (
             isinstance(other, UnpackTransform)
             and (self.unpack_fn is other.unpack_fn)
@@ -1402,7 +1404,7 @@ class ReshapeTransform(Transform[NonScalarArray]):
         }
         return (), ((), aux_data)
 
-    def eq(self, other: object, static: bool = False) -> bool:
+    def eq(self, other: object, static: bool = False) -> ArrayLike:
         return (
             isinstance(other, ReshapeTransform)
             and self._forward_shape == other._forward_shape
@@ -1493,7 +1495,7 @@ class RealFastFourierTransform(Transform[NonScalarArray]):
     def codomain(self) -> Constraint:
         return constraints.independent(constraints.complex, self.transform_ndims)
 
-    def eq(self, other: object, static: bool = False) -> bool:
+    def eq(self, other: object, static: bool = False) -> ArrayLike:
         return (
             isinstance(other, RealFastFourierTransform)
             and self.transform_ndims == other.transform_ndims
@@ -1568,7 +1570,7 @@ class PackRealFastFourierCoefficientsTransform(Transform[NonScalarArray]):
         n_imag = n - n_real
         return jnp.concatenate([y.real, y.imag[..., 1 : n_imag + 1]], axis=-1)
 
-    def eq(self, other: object, static: bool = False) -> bool:
+    def eq(self, other: object, static: bool = False) -> ArrayLike:
         return (
             isinstance(other, PackRealFastFourierCoefficientsTransform)
             and self.shape == other.shape
@@ -1702,7 +1704,7 @@ class RecursiveLinearTransform(Transform[NonScalarArray]):
             {},
         )
 
-    def eq(self, other: object, static: bool = False) -> bool:
+    def eq(self, other: object, static: bool = False) -> ArrayLike:
         if not isinstance(other, RecursiveLinearTransform):
             return False
         tm_eq = array_equiv(
@@ -1797,7 +1799,7 @@ class ZeroSumTransform(Transform[NonScalarArray]):
         aux_data = {"transform_ndims": self.transform_ndims}
         return (), ((), aux_data)
 
-    def eq(self, other: object, static: bool = False) -> bool:
+    def eq(self, other: object, static: bool = False) -> ArrayLike:
         return (
             isinstance(other, ZeroSumTransform)
             and self.transform_ndims == other.transform_ndims
@@ -1973,7 +1975,7 @@ class HaarTransform(Transform[NonScalarArray]):
     def tree_flatten(self):
         return (), ((), {"dim": self.dim, "flip": self.flip})
 
-    def eq(self, other: object, static: bool = False) -> bool:
+    def eq(self, other: object, static: bool = False) -> ArrayLike:
         return (
             isinstance(other, HaarTransform)
             and self.dim == other.dim
@@ -2061,7 +2063,7 @@ class DiscreteCosineTransform(Transform[NonScalarArray]):
     def tree_flatten(self):
         return (), ((), {"dim": self.dim, "smooth": self.smooth})
 
-    def eq(self, other: object, static: bool = False) -> bool:
+    def eq(self, other: object, static: bool = False) -> ArrayLike:
         return (
             isinstance(other, DiscreteCosineTransform)
             and self.dim == other.dim

--- a/numpyro/distributions/transforms.py
+++ b/numpyro/distributions/transforms.py
@@ -1149,7 +1149,7 @@ class PermuteTransform(Transform[NonScalarArray]):
     domain = constraints.real_vector
     codomain = constraints.real_vector
 
-    def __init__(self, permutation: Array) -> None:
+    def __init__(self, permutation: NonScalarArray) -> None:
         self.permutation = permutation
 
     def __call__(self, x: NonScalarArray) -> NonScalarArray:

--- a/numpyro/distributions/truncated.py
+++ b/numpyro/distributions/truncated.py
@@ -80,7 +80,7 @@ class LeftTruncatedDistribution(Distribution):
         u = random.uniform(key, shape=sample_shape + self.batch_shape, minval=minval)
         return self.icdf(u)
 
-    def icdf(self, q: ArrayLike) -> ArrayLike:
+    def icdf(self, q: ArrayLike) -> Array:
         loc = self.base_dist.loc
         sign = jnp.where(loc >= self.low, 1.0, -1.0)
         ppf = (1 - sign) * loc + sign * self.base_dist.icdf(
@@ -88,7 +88,7 @@ class LeftTruncatedDistribution(Distribution):
         )
         return jnp.where(q < 0, jnp.nan, ppf)
 
-    def cdf(self, value: ArrayLike) -> ArrayLike:
+    def cdf(self, value: ArrayLike) -> Array:
         # For left truncated distribution: CDF(x) = (F(x) - F(low)) / (1 - F(low))
         # where F is the base distribution CDF
         base_cdf_value = self.base_dist.cdf(value)
@@ -120,7 +120,7 @@ class LeftTruncatedDistribution(Distribution):
             raise NotImplementedError("mean only available for Normal and Cauchy")
 
     @property
-    def variance(self) -> ArrayLike:
+    def variance(self) -> Array:
         if isinstance(self.base_dist, Normal):
             low_prob = jnp.exp(self.log_prob(self.low))
             return (self.base_dist.scale**2) * (
@@ -164,7 +164,7 @@ class RightTruncatedDistribution(Distribution):
         return self._support
 
     @lazy_property
-    def _cdf_at_high(self) -> ArrayLike:
+    def _cdf_at_high(self) -> Array:
         return self.base_dist.cdf(self.high)
 
     def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
@@ -175,11 +175,11 @@ class RightTruncatedDistribution(Distribution):
         u = random.uniform(key, shape=sample_shape + self.batch_shape, minval=minval)
         return self.icdf(u)
 
-    def icdf(self, q: ArrayLike) -> ArrayLike:
+    def icdf(self, q: ArrayLike) -> Array:
         ppf = self.base_dist.icdf(q * self._cdf_at_high)
         return jnp.where(q > 1, jnp.nan, ppf)
 
-    def cdf(self, value: ArrayLike) -> ArrayLike:
+    def cdf(self, value: ArrayLike) -> Array:
         # For right truncated distribution: CDF(x) = F(x) / F(high)
         # where F is the base distribution CDF
         base_cdf_value = self.base_dist.cdf(value)
@@ -208,7 +208,7 @@ class RightTruncatedDistribution(Distribution):
             raise NotImplementedError("mean only available for Normal and Cauchy")
 
     @property
-    def variance(self) -> ArrayLike:
+    def variance(self) -> Array:
         if isinstance(self.base_dist, Normal):
             high_prob = jnp.exp(self.log_prob(self.high))
             return (self.base_dist.scale**2) * (
@@ -259,21 +259,21 @@ class TwoSidedTruncatedDistribution(Distribution):
         return self._support
 
     @lazy_property
-    def _tail_prob_at_low(self) -> ArrayLike:
+    def _tail_prob_at_low(self) -> Array:
         # if low < loc, returns cdf(low); otherwise returns 1 - cdf(low)
         loc = self.base_dist.loc
         sign = jnp.where(loc >= self.low, 1.0, -1.0)
         return self.base_dist.cdf(loc - sign * (loc - self.low))
 
     @lazy_property
-    def _tail_prob_at_high(self) -> ArrayLike:
+    def _tail_prob_at_high(self) -> Array:
         # if low < loc, returns cdf(high); otherwise returns 1 - cdf(high)
         loc = self.base_dist.loc
         sign = jnp.where(loc >= self.low, 1.0, -1.0)
         return self.base_dist.cdf(loc - sign * (loc - self.high))
 
     @lazy_property
-    def _log_diff_tail_probs(self) -> ArrayLike:
+    def _log_diff_tail_probs(self) -> Array:
         # use log_cdf method, if available, to avoid inf's in log_prob
         # fall back to cdf, if log_cdf not available
         log_cdf = getattr(self.base_dist, "log_cdf", None)
@@ -297,7 +297,7 @@ class TwoSidedTruncatedDistribution(Distribution):
         u = random.uniform(key, shape=sample_shape + self.batch_shape, minval=minval)
         return self.icdf(u)
 
-    def icdf(self, q: ArrayLike) -> ArrayLike:
+    def icdf(self, q: ArrayLike) -> Array:
         # NB: we use a more numerically stable formula for a symmetric base distribution
         #   A = icdf(cdf(low) + (cdf(high) - cdf(low)) * q) = icdf[(1 - q) * cdf(low) + q * cdf(high)]
         # will suffer by precision issues when low is large;
@@ -312,7 +312,7 @@ class TwoSidedTruncatedDistribution(Distribution):
         )
         return jnp.where(jnp.logical_or(q < 0, q > 1), jnp.nan, ppf)
 
-    def cdf(self, value: ArrayLike) -> ArrayLike:
+    def cdf(self, value: ArrayLike) -> Array:
         # For two-sided truncated distribution: CDF(x) = (F(x) - F(low)) / (F(high) - F(low))
         # where F is the base distribution CDF
         base_cdf_value = self.base_dist.cdf(value)
@@ -354,7 +354,7 @@ class TwoSidedTruncatedDistribution(Distribution):
             raise NotImplementedError("mean only available for Normal and Cauchy")
 
     @property
-    def variance(self) -> ArrayLike:
+    def variance(self) -> Array:
         if isinstance(self.base_dist, Normal):
             low_prob = jnp.exp(self.log_prob(self.low))
             high_prob = jnp.exp(self.log_prob(self.high))
@@ -447,7 +447,7 @@ class TruncatedPolyaGamma(Distribution):
             batch_shape, validate_args=validate_args
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
         assert is_prng_key(key)
         denom = jnp.square(jnp.arange(0.5, self.num_gamma_variates))
         x = random.gamma(
@@ -457,7 +457,7 @@ class TruncatedPolyaGamma(Distribution):
         return jnp.clip(x * (0.5 / jnp.pi**2), None, self.truncation_point)
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         value = value[..., None]
         all_indices = jnp.arange(0, self.num_log_prob_terms)
         two_n_plus_one = 2.0 * all_indices + 1.0
@@ -544,14 +544,12 @@ class DoublyTruncatedPowerLaw(Distribution):
         """
 
         @jax.custom_jvp
-        def f(
-            x: ArrayLike, alpha: ArrayLike, low: ArrayLike, high: ArrayLike
-        ) -> ArrayLike:
+        def f(x: ArrayLike, alpha: ArrayLike, low: ArrayLike, high: ArrayLike) -> Array:
             neq_neg1_mask = jnp.not_equal(alpha, -1.0)
             neq_neg1_alpha = jnp.where(neq_neg1_mask, alpha, 0.0)
             # eq_neg1_alpha = jnp.where(~neq_neg1_mask, alpha, -1.0)
 
-            def neq_neg1_fn() -> ArrayLike:
+            def neq_neg1_fn() -> Array:
                 one_more_alpha = 1.0 + neq_neg1_alpha
                 return jnp.log(
                     jnp.power(x, neq_neg1_alpha)
@@ -559,7 +557,7 @@ class DoublyTruncatedPowerLaw(Distribution):
                     / (jnp.power(high, one_more_alpha) - jnp.power(low, one_more_alpha))
                 )
 
-            def eq_neg1_fn() -> ArrayLike:
+            def eq_neg1_fn() -> Array:
                 return -jnp.log(x) - jnp.log(jnp.log(high) - jnp.log(low))
 
             return jnp.where(neq_neg1_mask, neq_neg1_fn(), eq_neg1_fn())
@@ -586,7 +584,7 @@ class DoublyTruncatedPowerLaw(Distribution):
 
             # Alpha tangent with approximation
             # Variable part for all values alpha unequal -1
-            def alpha_tangent_variable(alpha: ArrayLike) -> ArrayLike:
+            def alpha_tangent_variable(alpha: ArrayLike) -> Array:
                 one_more_alpha = 1.0 + alpha
                 low_pow_one_more_alpha = jnp.power(low, one_more_alpha)
                 high_pow_one_more_alpha = jnp.power(high, one_more_alpha)
@@ -649,7 +647,7 @@ class DoublyTruncatedPowerLaw(Distribution):
 
         return f(value, self.alpha, self.low, self.high)
 
-    def cdf(self, value: ArrayLike) -> ArrayLike:
+    def cdf(self, value: ArrayLike) -> Array:
         r"""Cumulated probability distribution:
         Z inequal minus one:
 
@@ -667,20 +665,18 @@ class DoublyTruncatedPowerLaw(Distribution):
         """
 
         @jax.custom_jvp
-        def f(
-            x: ArrayLike, alpha: ArrayLike, low: ArrayLike, high: ArrayLike
-        ) -> ArrayLike:
+        def f(x: ArrayLike, alpha: ArrayLike, low: ArrayLike, high: ArrayLike) -> Array:
             neq_neg1_mask = jnp.not_equal(alpha, -1.0)
             neq_neg1_alpha = jnp.where(neq_neg1_mask, alpha, 0.0)
 
-            def cdf_when_alpha_neq_neg1() -> ArrayLike:
+            def cdf_when_alpha_neq_neg1() -> Array:
                 one_more_alpha = 1.0 + neq_neg1_alpha
                 low_pow_one_more_alpha = jnp.power(low, one_more_alpha)
                 return (jnp.power(x, one_more_alpha) - low_pow_one_more_alpha) / (
                     jnp.power(high, one_more_alpha) - low_pow_one_more_alpha
                 )
 
-            def cdf_when_alpha_eq_neg1() -> ArrayLike:
+            def cdf_when_alpha_eq_neg1() -> Array:
                 return jnp.log(x / low) / jnp.log(high / low)
 
             cdf_val = jnp.where(
@@ -694,7 +690,7 @@ class DoublyTruncatedPowerLaw(Distribution):
         def f_jvp(
             primals: tuple[ArrayLike, ArrayLike, ArrayLike, ArrayLike],
             tangents: tuple[ArrayLike, ArrayLike, ArrayLike, ArrayLike],
-        ) -> tuple[ArrayLike, ArrayLike]:
+        ) -> tuple[Array, Array]:
             x, alpha, low, high = primals
             x_t, alpha_t, low_t, high_t = tangents
 
@@ -710,13 +706,13 @@ class DoublyTruncatedPowerLaw(Distribution):
             primal_out = f(*primals)
 
             # Tangents for alpha not equals -1
-            def x_neq_neg1(alpha: ArrayLike) -> ArrayLike:
+            def x_neq_neg1(alpha: ArrayLike) -> Array:
                 one_more_alpha = 1.0 + alpha
                 return (one_more_alpha * jnp.power(x, alpha)) / (
                     jnp.power(high, one_more_alpha) - jnp.power(low, one_more_alpha)
                 )
 
-            def alpha_neq_neg1(alpha: ArrayLike) -> ArrayLike:
+            def alpha_neq_neg1(alpha: ArrayLike) -> Array:
                 one_more_alpha = 1.0 + alpha
                 low_pow_one_more_alpha = jnp.power(low, one_more_alpha)
                 high_pow_one_more_alpha = jnp.power(high, one_more_alpha)
@@ -733,7 +729,7 @@ class DoublyTruncatedPowerLaw(Distribution):
                 ) / jnp.square(high_pow_one_more_alpha - low_pow_one_more_alpha)
                 return term1 - term2
 
-            def low_neq_neg1(alpha: ArrayLike) -> ArrayLike:
+            def low_neq_neg1(alpha: ArrayLike) -> Array:
                 one_more_alpha = 1.0 + alpha
                 low_pow_one_more_alpha = jnp.power(low, one_more_alpha)
                 high_pow_one_more_alpha = jnp.power(high, one_more_alpha)
@@ -743,7 +739,7 @@ class DoublyTruncatedPowerLaw(Distribution):
                 term1 = term2 * (x_pow_one_more_alpha - low_pow_one_more_alpha) / change
                 return term1 - term2
 
-            def high_neq_neg1(alpha: ArrayLike) -> ArrayLike:
+            def high_neq_neg1(alpha: ArrayLike) -> Array:
                 one_more_alpha = 1.0 + alpha
                 low_pow_one_more_alpha = jnp.power(low, one_more_alpha)
                 high_pow_one_more_alpha = jnp.power(high, one_more_alpha)
@@ -755,15 +751,15 @@ class DoublyTruncatedPowerLaw(Distribution):
                 ) / jnp.square(high_pow_one_more_alpha - low_pow_one_more_alpha)
 
             # Tangents for alpha equals -1
-            def x_eq_neg1() -> ArrayLike:
+            def x_eq_neg1() -> Array:
                 return jnp.reciprocal(x * (log_high - log_low))
 
-            def low_eq_neg1() -> ArrayLike:
+            def low_eq_neg1() -> Array:
                 return (log_x - log_low) / (
                     jnp.square(log_high - log_low) * low
                 ) - jnp.reciprocal((log_high - log_low) * low)
 
-            def high_eq_neg1() -> ArrayLike:
+            def high_eq_neg1() -> Array:
                 return (log_x - log_low) / (jnp.square(log_high - log_low) * high)
 
             # Including approximation for alpha = -1
@@ -791,7 +787,7 @@ class DoublyTruncatedPowerLaw(Distribution):
 
         return f(value, self.alpha, self.low, self.high)
 
-    def icdf(self, q: ArrayLike) -> ArrayLike:
+    def icdf(self, q: ArrayLike) -> Array:
         r"""Inverse cumulated probability distribution:
         Z inequal minus one:
 
@@ -807,13 +803,11 @@ class DoublyTruncatedPowerLaw(Distribution):
         """
 
         @jax.custom_jvp
-        def f(
-            q: ArrayLike, alpha: ArrayLike, low: ArrayLike, high: ArrayLike
-        ) -> ArrayLike:
+        def f(q: ArrayLike, alpha: ArrayLike, low: ArrayLike, high: ArrayLike) -> Array:
             neq_neg1_mask = jnp.not_equal(alpha, -1.0)
             neq_neg1_alpha = jnp.where(neq_neg1_mask, alpha, 0.0)
 
-            def icdf_alpha_neq_neg1() -> ArrayLike:
+            def icdf_alpha_neq_neg1() -> Array:
                 one_more_alpha = 1.0 + neq_neg1_alpha
                 low_pow_one_more_alpha = jnp.power(low, one_more_alpha)
                 high_pow_one_more_alpha = jnp.power(high, one_more_alpha)
@@ -823,7 +817,7 @@ class DoublyTruncatedPowerLaw(Distribution):
                     jnp.reciprocal(one_more_alpha),
                 )
 
-            def icdf_alpha_eq_neg1() -> ArrayLike:
+            def icdf_alpha_eq_neg1() -> Array:
                 return jnp.power(high / low, q) * low
 
             icdf_val = jnp.where(
@@ -837,7 +831,7 @@ class DoublyTruncatedPowerLaw(Distribution):
         def f_jvp(
             primals: tuple[ArrayLike, ArrayLike, ArrayLike, ArrayLike],
             tangents: tuple[ArrayLike, ArrayLike, ArrayLike, ArrayLike],
-        ) -> tuple[ArrayLike, ArrayLike]:
+        ) -> tuple[Array, Array]:
             x, alpha, low, high = primals
             x_t, alpha_t, low_t, high_t = tangents
 
@@ -852,7 +846,7 @@ class DoublyTruncatedPowerLaw(Distribution):
             primal_out = f(*primals)
 
             # Tangents for alpha not equal -1
-            def x_neq_neg1(alpha: ArrayLike) -> ArrayLike:
+            def x_neq_neg1(alpha: ArrayLike) -> Array:
                 one_more_alpha = 1.0 + alpha
                 low_pow_one_more_alpha = jnp.power(low, one_more_alpha)
                 high_pow_one_more_alpha = jnp.power(high, one_more_alpha)
@@ -865,7 +859,7 @@ class DoublyTruncatedPowerLaw(Distribution):
                     )
                 ) / one_more_alpha
 
-            def alpha_neq_neg1(alpha: ArrayLike) -> ArrayLike:
+            def alpha_neq_neg1(alpha: ArrayLike) -> Array:
                 one_more_alpha = 1.0 + alpha
                 low_pow_one_more_alpha = jnp.power(low, one_more_alpha)
                 high_pow_one_more_alpha = jnp.power(high, one_more_alpha)
@@ -884,7 +878,7 @@ class DoublyTruncatedPowerLaw(Distribution):
                 term3 = jnp.log(factor0) / jnp.square(one_more_alpha)
                 return term1 * (term2 - term3)
 
-            def low_neq_neg1(alpha: ArrayLike) -> ArrayLike:
+            def low_neq_neg1(alpha: ArrayLike) -> Array:
                 one_more_alpha = 1.0 + alpha
                 low_pow_one_more_alpha = jnp.power(low, one_more_alpha)
                 high_pow_one_more_alpha = jnp.power(high, one_more_alpha)
@@ -898,7 +892,7 @@ class DoublyTruncatedPowerLaw(Distribution):
                     )
                 )
 
-            def high_neq_neg1(alpha: ArrayLike) -> ArrayLike:
+            def high_neq_neg1(alpha: ArrayLike) -> Array:
                 one_more_alpha = 1.0 + alpha
                 low_pow_one_more_alpha = jnp.power(low, one_more_alpha)
                 high_pow_one_more_alpha = jnp.power(high, one_more_alpha)
@@ -913,16 +907,16 @@ class DoublyTruncatedPowerLaw(Distribution):
                 )
 
             # Tangents for alpha equals -1
-            def dx_eq_neg1() -> ArrayLike:
+            def dx_eq_neg1() -> Array:
                 return low * jnp.power(high_over_low, x) * (log_high - log_low)
 
-            def low_eq_neg1() -> ArrayLike:
+            def low_eq_neg1() -> Array:
                 return (
                     jnp.power(high_over_low, x)
                     - (high * x * jnp.power(high_over_low, x - 1)) / low
                 )
 
-            def high_eq_neg1() -> ArrayLike:
+            def high_eq_neg1() -> Array:
                 return x * jnp.power(high_over_low, x - 1)
 
             # Including approximation for alpha = -1 \
@@ -1012,7 +1006,7 @@ class LowerTruncatedPowerLaw(Distribution):
             - one_more_alpha * jnp.log(self.low)
         )
 
-    def cdf(self, value: ArrayLike) -> ArrayLike:
+    def cdf(self, value: ArrayLike) -> Array:
         cdf_val = jnp.where(
             jnp.less_equal(value, self.low),
             jnp.zeros_like(value),
@@ -1020,7 +1014,7 @@ class LowerTruncatedPowerLaw(Distribution):
         )
         return cdf_val
 
-    def icdf(self, q: ArrayLike) -> ArrayLike:
+    def icdf(self, q: ArrayLike) -> Array:
         nan_mask = jnp.logical_or(jnp.isnan(q), jnp.less(q, 0.0))
         nan_mask = jnp.logical_or(nan_mask, jnp.greater(q, 1.0))
         return jnp.where(

--- a/numpyro/distributions/truncated.py
+++ b/numpyro/distributions/truncated.py
@@ -5,7 +5,7 @@
 from typing import Optional, Union
 
 import jax
-from jax import lax
+from jax import Array, lax
 import jax.numpy as jnp
 import jax.random as random
 from jax.scipy.special import logsumexp
@@ -72,7 +72,7 @@ class LeftTruncatedDistribution(Distribution):
         # if low < loc, returns cdf(high) = 1; otherwise returns 1 - cdf(high) = 0
         return jnp.where(self.low <= self.base_dist.loc, 1.0, 0.0)
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
         assert is_prng_key(key)
         dtype = jnp.result_type(float)
         finfo = jnp.finfo(dtype)
@@ -103,14 +103,14 @@ class LeftTruncatedDistribution(Distribution):
         return result
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         sign = jnp.where(self.base_dist.loc >= self.low, 1.0, -1.0)
         return self.base_dist.log_prob(value) - jnp.log(
             sign * (self._tail_prob_at_high - self._tail_prob_at_low)
         )
 
     @property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         if isinstance(self.base_dist, Normal):
             low_prob = jnp.exp(self.log_prob(self.low))
             return self.base_dist.loc + low_prob * self.base_dist.scale**2
@@ -167,7 +167,7 @@ class RightTruncatedDistribution(Distribution):
     def _cdf_at_high(self) -> ArrayLike:
         return self.base_dist.cdf(self.high)
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
         assert is_prng_key(key)
         dtype = jnp.result_type(float)
         finfo = jnp.finfo(dtype)
@@ -194,11 +194,11 @@ class RightTruncatedDistribution(Distribution):
         return result
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         return self.base_dist.log_prob(value) - jnp.log(self._cdf_at_high)
 
     @property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         if isinstance(self.base_dist, Normal):
             high_prob = jnp.exp(self.log_prob(self.high))
             return self.base_dist.loc - high_prob * self.base_dist.scale**2
@@ -289,7 +289,7 @@ class TwoSidedTruncatedDistribution(Distribution):
             sign = jnp.where(loc >= self.low, 1.0, -1.0)
             return jnp.log(sign * (self._tail_prob_at_high - self._tail_prob_at_low))
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
         assert is_prng_key(key)
         dtype = jnp.result_type(float)
         finfo = jnp.finfo(dtype)
@@ -334,7 +334,7 @@ class TwoSidedTruncatedDistribution(Distribution):
         return result
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         # NB: we use a more numerically stable formula for a symmetric base distribution
         # if low < loc
         #   cdf(high) - cdf(low) = as-is
@@ -343,7 +343,7 @@ class TwoSidedTruncatedDistribution(Distribution):
         return self.base_dist.log_prob(value) - self._log_diff_tail_probs
 
     @property
-    def mean(self) -> ArrayLike:
+    def mean(self) -> Array:
         if isinstance(self.base_dist, Normal):
             low_prob = jnp.exp(self.log_prob(self.low))
             high_prob = jnp.exp(self.log_prob(self.high))
@@ -525,7 +525,7 @@ class DoublyTruncatedPowerLaw(Distribution):
         return self._support
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         r"""Logarithmic probability distribution:
 
         Z inequal minus one:
@@ -950,7 +950,7 @@ class DoublyTruncatedPowerLaw(Distribution):
 
         return f(q, self.alpha, self.low, self.high)
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
         assert is_prng_key(key)
         u = random.uniform(key, sample_shape + self.batch_shape)
         samples = self.icdf(u)
@@ -1004,7 +1004,7 @@ class LowerTruncatedPowerLaw(Distribution):
         return self._support
 
     @validate_sample
-    def log_prob(self, value: ArrayLike) -> ArrayLike:
+    def log_prob(self, value: ArrayLike) -> Array:
         one_more_alpha = 1.0 + self.alpha
         return (
             self.alpha * jnp.log(value)
@@ -1029,7 +1029,7 @@ class LowerTruncatedPowerLaw(Distribution):
             self.low * jnp.power(1.0 - q, jnp.reciprocal(1.0 + self.alpha)),
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
         assert is_prng_key(key)
         u = random.uniform(key, sample_shape + self.batch_shape)
         samples = self.icdf(u)

--- a/numpyro/distributions/truncated.py
+++ b/numpyro/distributions/truncated.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from typing import Optional, Union
+from typing import Optional, Union, cast
 
 import jax
 from jax import Array, lax
@@ -11,6 +11,7 @@ import jax.random as random
 from jax.scipy.special import logsumexp
 from jax.typing import ArrayLike
 
+from numpyro._typing import NumLike
 from numpyro.distributions import constraints
 from numpyro.distributions.constraints import Constraint
 from numpyro.distributions.continuous import (
@@ -36,6 +37,7 @@ class LeftTruncatedDistribution(Distribution):
     reparametrized_params = ["low"]
     supported_types = (Cauchy, Laplace, Logistic, Normal, SoftLaplace, StudentT)
     pytree_data_fields = ("base_dist", "low", "_support")
+    _support: constraints.Constraint
 
     def __init__(
         self,
@@ -53,7 +55,7 @@ class LeftTruncatedDistribution(Distribution):
             Cauchy, Laplace, Logistic, Normal, SoftLaplace, StudentT
         ] = jax.tree.map(lambda p: promote_shapes(p, shape=batch_shape)[0], base_dist)
         (self.low,) = promote_shapes(low, shape=batch_shape)
-        self._support = constraints.greater_than_eq(low)
+        self._support = constraints.greater_than_eq(cast(NumLike, low))
         super().__init__(batch_shape, validate_args=validate_args)
 
     @constraints.dependent_property(is_discrete=False, event_dim=0)
@@ -72,8 +74,11 @@ class LeftTruncatedDistribution(Distribution):
         # if low < loc, returns cdf(high) = 1; otherwise returns 1 - cdf(high) = 0
         return jnp.where(self.low <= self.base_dist.loc, 1.0, 0.0)
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> Array:
         assert is_prng_key(key)
+        assert key is not None
         dtype = jnp.result_type(float)
         finfo = jnp.finfo(dtype)
         minval = finfo.tiny
@@ -86,7 +91,7 @@ class LeftTruncatedDistribution(Distribution):
         ppf = (1 - sign) * loc + sign * self.base_dist.icdf(
             (1 - q) * self._tail_prob_at_low + q * self._tail_prob_at_high
         )
-        return jnp.where(q < 0, jnp.nan, ppf)
+        return jnp.where(jnp.less(q, 0), jnp.nan, ppf)
 
     def cdf(self, value: ArrayLike) -> Array:
         # For left truncated distribution: CDF(x) = (F(x) - F(low)) / (1 - F(low))
@@ -99,7 +104,9 @@ class LeftTruncatedDistribution(Distribution):
         truncated_cdf = (base_cdf_value - base_cdf_low) / (1.0 - base_cdf_low)
 
         # Clamp to [0, 1] and handle values below the truncation point
-        result = jnp.where(value < self.low, 0.0, jnp.clip(truncated_cdf, 0.0, 1.0))
+        result = jnp.where(
+            jnp.less(value, self.low), 0.0, jnp.clip(truncated_cdf, 0.0, 1.0)
+        )
         return result
 
     @validate_sample
@@ -139,6 +146,7 @@ class RightTruncatedDistribution(Distribution):
     reparametrized_params = ["high"]
     supported_types = (Cauchy, Laplace, Logistic, Normal, SoftLaplace, StudentT)
     pytree_data_fields = ("base_dist", "high", "_support")
+    _support: constraints.Constraint
 
     def __init__(
         self,
@@ -156,7 +164,7 @@ class RightTruncatedDistribution(Distribution):
             Cauchy, Laplace, Logistic, Normal, SoftLaplace, StudentT
         ] = jax.tree.map(lambda p: promote_shapes(p, shape=batch_shape)[0], base_dist)
         (self.high,) = promote_shapes(high, shape=batch_shape)
-        self._support = constraints.less_than_eq(high)
+        self._support = constraints.less_than_eq(cast(NumLike, high))
         super().__init__(batch_shape, validate_args=validate_args)
 
     @constraints.dependent_property(is_discrete=False, event_dim=0)
@@ -167,8 +175,11 @@ class RightTruncatedDistribution(Distribution):
     def _cdf_at_high(self) -> Array:
         return self.base_dist.cdf(self.high)
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> Array:
         assert is_prng_key(key)
+        assert key is not None
         dtype = jnp.result_type(float)
         finfo = jnp.finfo(dtype)
         minval = finfo.tiny
@@ -177,7 +188,7 @@ class RightTruncatedDistribution(Distribution):
 
     def icdf(self, q: ArrayLike) -> Array:
         ppf = self.base_dist.icdf(q * self._cdf_at_high)
-        return jnp.where(q > 1, jnp.nan, ppf)
+        return jnp.where(jnp.greater(q, 1), jnp.nan, ppf)
 
     def cdf(self, value: ArrayLike) -> Array:
         # For right truncated distribution: CDF(x) = F(x) / F(high)
@@ -190,7 +201,9 @@ class RightTruncatedDistribution(Distribution):
         truncated_cdf = base_cdf_value / base_cdf_high
 
         # Clamp to [0, 1] and handle values above the truncation point
-        result = jnp.where(value > self.high, 1.0, jnp.clip(truncated_cdf, 0.0, 1.0))
+        result = jnp.where(
+            jnp.greater(value, self.high), 1.0, jnp.clip(truncated_cdf, 0.0, 1.0)
+        )
         return result
 
     @validate_sample
@@ -230,6 +243,7 @@ class TwoSidedTruncatedDistribution(Distribution):
     reparametrized_params = ["low", "high"]
     supported_types = (Cauchy, Laplace, Logistic, Normal, SoftLaplace, StudentT)
     pytree_data_fields = ("base_dist", "low", "high", "_support")
+    _support: constraints.Constraint
 
     def __init__(
         self,
@@ -251,7 +265,7 @@ class TwoSidedTruncatedDistribution(Distribution):
         ] = jax.tree.map(lambda p: promote_shapes(p, shape=batch_shape)[0], base_dist)
         (self.low,) = promote_shapes(low, shape=batch_shape)
         (self.high,) = promote_shapes(high, shape=batch_shape)
-        self._support = constraints.interval(low, high)
+        self._support = constraints.interval(cast(NumLike, low), cast(NumLike, high))
         super().__init__(batch_shape, validate_args=validate_args)
 
     @constraints.dependent_property(is_discrete=False, event_dim=0)
@@ -289,8 +303,11 @@ class TwoSidedTruncatedDistribution(Distribution):
             sign = jnp.where(loc >= self.low, 1.0, -1.0)
             return jnp.log(sign * (self._tail_prob_at_high - self._tail_prob_at_low))
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> Array:
         assert is_prng_key(key)
+        assert key is not None
         dtype = jnp.result_type(float)
         finfo = jnp.finfo(dtype)
         minval = finfo.tiny
@@ -310,7 +327,9 @@ class TwoSidedTruncatedDistribution(Distribution):
         ppf = (1 - sign) * loc + sign * self.base_dist.icdf(
             clamp_probs((1 - q) * self._tail_prob_at_low + q * self._tail_prob_at_high)
         )
-        return jnp.where(jnp.logical_or(q < 0, q > 1), jnp.nan, ppf)
+        return jnp.where(
+            jnp.logical_or(jnp.less(q, 0), jnp.greater(q, 1)), jnp.nan, ppf
+        )
 
     def cdf(self, value: ArrayLike) -> Array:
         # For two-sided truncated distribution: CDF(x) = (F(x) - F(low)) / (F(high) - F(low))
@@ -327,9 +346,11 @@ class TwoSidedTruncatedDistribution(Distribution):
 
         # Handle values outside the truncation interval
         result = jnp.where(
-            value < self.low,
+            jnp.less(value, self.low),
             0.0,
-            jnp.where(value > self.high, 1.0, jnp.clip(truncated_cdf, 0.0, 1.0)),
+            jnp.where(
+                jnp.greater(value, self.high), 1.0, jnp.clip(truncated_cdf, 0.0, 1.0)
+            ),
         )
         return result
 
@@ -447,8 +468,11 @@ class TruncatedPolyaGamma(Distribution):
             batch_shape, validate_args=validate_args
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> Array:
         assert is_prng_key(key)
+        assert key is not None
         denom = jnp.square(jnp.arange(0.5, self.num_gamma_variates))
         x = random.gamma(
             key, jnp.ones(self.batch_shape + sample_shape + (self.num_gamma_variates,))
@@ -458,7 +482,7 @@ class TruncatedPolyaGamma(Distribution):
 
     @validate_sample
     def log_prob(self, value: ArrayLike) -> Array:
-        value = value[..., None]
+        value = jnp.expand_dims(value, -1)
         all_indices = jnp.arange(0, self.num_log_prob_terms)
         two_n_plus_one = 2.0 * all_indices + 1.0
         log_terms = (
@@ -502,6 +526,7 @@ class DoublyTruncatedPowerLaw(Distribution):
     reparametrized_params = ["alpha", "low", "high"]
     pytree_aux_fields = ("_support",)
     pytree_data_fields = ("alpha", "low", "high")
+    _support: constraints.Constraint
 
     def __init__(
         self,
@@ -512,7 +537,7 @@ class DoublyTruncatedPowerLaw(Distribution):
         validate_args: Optional[bool] = None,
     ):
         self.alpha, self.low, self.high = promote_shapes(alpha, low, high)
-        self._support = constraints.interval(low, high)
+        self._support = constraints.interval(cast(NumLike, low), cast(NumLike, high))
         batch_shape = lax.broadcast_shapes(
             jnp.shape(alpha), jnp.shape(low), jnp.shape(high)
         )
@@ -564,9 +589,9 @@ class DoublyTruncatedPowerLaw(Distribution):
 
         @f.defjvp
         def f_jvp(
-            primals: tuple[ArrayLike, ArrayLike, ArrayLike, ArrayLike],
-            tangents: tuple[ArrayLike, ArrayLike, ArrayLike, ArrayLike],
-        ) -> tuple[ArrayLike, ArrayLike]:
+            primals: tuple[Array, Array, Array, Array],
+            tangents: tuple[Array, Array, Array, Array],
+        ) -> tuple[Array, Array]:
             x, alpha, low, high = primals
             x_t, alpha_t, low_t, high_t = tangents
 
@@ -688,8 +713,8 @@ class DoublyTruncatedPowerLaw(Distribution):
 
         @f.defjvp
         def f_jvp(
-            primals: tuple[ArrayLike, ArrayLike, ArrayLike, ArrayLike],
-            tangents: tuple[ArrayLike, ArrayLike, ArrayLike, ArrayLike],
+            primals: tuple[Array, Array, Array, Array],
+            tangents: tuple[Array, Array, Array, Array],
         ) -> tuple[Array, Array]:
             x, alpha, low, high = primals
             x_t, alpha_t, low_t, high_t = tangents
@@ -829,8 +854,8 @@ class DoublyTruncatedPowerLaw(Distribution):
 
         @f.defjvp
         def f_jvp(
-            primals: tuple[ArrayLike, ArrayLike, ArrayLike, ArrayLike],
-            tangents: tuple[ArrayLike, ArrayLike, ArrayLike, ArrayLike],
+            primals: tuple[Array, Array, Array, Array],
+            tangents: tuple[Array, Array, Array, Array],
         ) -> tuple[Array, Array]:
             x, alpha, low, high = primals
             x_t, alpha_t, low_t, high_t = tangents
@@ -944,8 +969,11 @@ class DoublyTruncatedPowerLaw(Distribution):
 
         return f(q, self.alpha, self.low, self.high)
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> Array:
         assert is_prng_key(key)
+        assert key is not None
         u = random.uniform(key, sample_shape + self.batch_shape)
         samples = self.icdf(u)
         return samples
@@ -982,13 +1010,14 @@ class LowerTruncatedPowerLaw(Distribution):
     }
     reparametrized_params = ["alpha", "low"]
     pytree_aux_fields = ("_support",)
+    _support: constraints.Constraint
 
     def __init__(
         self, alpha: ArrayLike, low: ArrayLike, *, validate_args: Optional[bool] = None
     ):
         self.alpha, self.low = promote_shapes(alpha, low)
         batch_shape = lax.broadcast_shapes(jnp.shape(alpha), jnp.shape(low))
-        self._support = constraints.greater_than(low)
+        self._support = constraints.greater_than(cast(NumLike, low))
         super(LowerTruncatedPowerLaw, self).__init__(
             batch_shape=batch_shape, validate_args=validate_args
         )
@@ -1023,8 +1052,11 @@ class LowerTruncatedPowerLaw(Distribution):
             self.low * jnp.power(1.0 - q, jnp.reciprocal(1.0 + self.alpha)),
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> Array:
+    def sample(
+        self, key: Optional[jax.Array], sample_shape: tuple[int, ...] = ()
+    ) -> Array:
         assert is_prng_key(key)
+        assert key is not None
         u = random.uniform(key, sample_shape + self.batch_shape)
         samples = self.icdf(u)
         return samples

--- a/numpyro/distributions/util.py
+++ b/numpyro/distributions/util.py
@@ -11,7 +11,7 @@ import warnings
 import numpy as np
 
 import jax
-from jax import jit, lax, random, vmap
+from jax import Array, jit, lax, random, vmap
 import jax.numpy as jnp
 from jax.scipy.linalg import solve_triangular
 from jax.scipy.special import digamma
@@ -455,7 +455,7 @@ def logmatmulexp(x, y):
 
 
 @jax.custom_jvp
-def log1mexp(x: ArrayLike) -> ArrayLike:
+def log1mexp(x: ArrayLike) -> Array:
     """
     Numerically stable calculation of the quantity
     :math:`\\log(1 - \\exp(x))`, following the algorithm
@@ -485,7 +485,7 @@ def log1mexp(x: ArrayLike) -> ArrayLike:
 log1mexp.defjvps(lambda t, ans, x: -t / jnp.expm1(-x))
 
 
-def logdiffexp(a: ArrayLike, b: ArrayLike) -> ArrayLike:
+def logdiffexp(a: ArrayLike, b: ArrayLike) -> Array:
     """
     Numerically stable calculation of the
     quantity :math:`\\log(\\exp(a) - \\exp(b))`,
@@ -511,7 +511,7 @@ def logdiffexp(a: ArrayLike, b: ArrayLike) -> ArrayLike:
     )
 
 
-def clamp_probs(probs: ArrayLike) -> ArrayLike:
+def clamp_probs(probs: ArrayLike) -> Array:
     finfo = jnp.finfo(jnp.result_type(probs, float))
     return jnp.clip(probs, finfo.tiny, 1.0 - finfo.eps)
 

--- a/numpyro/distributions/util.py
+++ b/numpyro/distributions/util.py
@@ -12,6 +12,7 @@ import numpy as np
 
 import jax
 from jax import Array, jit, lax, random, vmap
+from jax.core import Tracer
 import jax.numpy as jnp
 from jax.scipy.linalg import solve_triangular
 from jax.scipy.special import digamma
@@ -41,7 +42,8 @@ def array_equiv(a: ArrayLike, b: ArrayLike, static: bool = False):
 
 # Parameters for Transformed Rejection with Squeeze (TRS) algorithm - page 3.
 _tr_params = namedtuple(
-    "tr_params", ["c", "b", "a", "alpha", "u_r", "v_r", "m", "log_p", "log1_p", "log_h"]
+    "_tr_params",
+    ["c", "b", "a", "alpha", "u_r", "v_r", "m", "log_p", "log1_p", "log_h"],
 )
 
 
@@ -140,10 +142,9 @@ def _binomial_btrs(key, p, n):
         cond_exclude_small_mu = p * n >= _binomial_mu_thresh
         cond_main = lax.cond(
             early_accept | early_reject,
-            (),
             lambda _: ~early_accept,
-            (k, u, v),
             lambda x: ~accept_fn(*x),
+            (k, u, v),
         )
         return cond_exclude_small_mu & cond_main
 
@@ -185,10 +186,9 @@ def _binomial_dispatch(key, p, n):
         mu = n * pq
         k = lax.cond(
             mu < _binomial_mu_thresh,
-            (key, pq, n),
             lambda x: _binomial_inversion(*x),
-            (key, pq, n),
             lambda x: _binomial_btrs(*x),
+            (key, pq, n),
         )
         return jnp.where(is_le_mid, k, n - k)
 
@@ -196,10 +196,9 @@ def _binomial_dispatch(key, p, n):
     cond0 = jnp.isfinite(p) & (n > 0) & (p > 0)
     return lax.cond(
         cond0 & (p < 1),
-        (key, p, n),
         lambda x: dispatch(*x),
-        (),
         lambda _: jnp.where(cond0, n, 0),
+        (key, p, n),
     )
 
 
@@ -291,7 +290,7 @@ def _multinomial(key, p, n, n_max, shape=()):
 
 def multinomial(key, p, n, shape=(), total_count_max=None):
     if total_count_max is None:
-        if isinstance(n, jax.core.Tracer):
+        if isinstance(n, Tracer):
             raise ValueError(
                 "Please specify total_count_max in Multinomial distribution."
             )
@@ -489,6 +488,7 @@ def log1mexp(x: ArrayLike) -> Array:
     :param x: A number or array of numbers.
     :return: The value of :math:`\\log(1 - \\exp(x))`.
     """
+    x = jnp.asarray(x)
     return jnp.where(
         x > -0.6931472,  # approx -log(2)
         jnp.log(-jnp.expm1(x)),
@@ -524,6 +524,8 @@ def logdiffexp(a: ArrayLike, b: ArrayLike) -> Array:
     :param b: A number or array of numbers.
     :return: The value of :math:`\\log(\\exp(a) - \\exp(b))`.
     """
+    a = jnp.asarray(a)
+    b = jnp.asarray(b)
     return jnp.where(
         (a < jnp.inf) & (a > b),
         a + log1mexp(b - a),
@@ -751,14 +753,14 @@ def assert_one_of(**kwargs):
         )
 
 
-def multidigamma(a: jnp.ndarray, d: jnp.ndarray) -> jnp.ndarray:
+def multidigamma(a: ArrayLike, d: ArrayLike) -> Array:
     """
     Derivative of the log of multivariate gamma.
     """
-    return digamma(a[..., None] - 0.5 * jnp.arange(d)).sum(axis=-1)
+    return digamma(jnp.expand_dims(a, -1) - 0.5 * jnp.arange(d)).sum(axis=-1)
 
 
-def tri_logabsdet(a: jnp.ndarray) -> jnp.ndarray:
+def tri_logabsdet(a: ArrayLike) -> Array:
     """
     Evaluate the `logabsdet` of a triangular positive-definite matrix.
     """
@@ -826,7 +828,7 @@ def validate_sample(log_prob_fn):
     return wrapper
 
 
-def add_diag(matrix: jnp.ndarray, diag: jnp.ndarray) -> jnp.ndarray:
+def add_diag(matrix: Array, diag: ArrayLike) -> Array:
     """
     Add `diag` to the trailing diagonal of `matrix`.
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ dev = [
     "scikit-learn>=1.9.0",
     "seaborn>=0.13.2",
     "tfp-nightly",
-    "ty>=0.0.57",
+    "ty==0.0.75",
     "wordcloud>=1.9.6",
 ]
 ci = [
@@ -93,7 +93,7 @@ test = [
     "ruff>=0.1.8",
     "scikit-learn",
     "scipy>=1.9",
-    "ty==0.0.57",
+    "ty==0.0.75",
 ]
 
 [build-system]
@@ -237,16 +237,14 @@ include = [
     "numpyro/contrib/hsgp",
     "numpyro/contrib/stochastic_support",
     "numpyro/diagnostics.py",
-    "numpyro/distributions/constraints.py",
-    "numpyro/distributions/distribution.py",
-    "numpyro/distributions/transforms.py",
+    "numpyro/distributions",
     "numpyro/examples/datasets.py",
     "numpyro/handlers.py",
     "numpyro/infer/elbo.py",
     "numpyro/infer/util.py",
     "numpyro/optim.py",
-    "numpyro/primitives.py",
     "numpyro/patch.py",
+    "numpyro/primitives.py",
     "numpyro/util.py",
 ]
 respect-ignore-files = true

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -2253,18 +2253,24 @@ OUTPUT_TYPE_XFAIL = {
 }
 
 
+@pytest.mark.parametrize("jit", [False, True])
 @pytest.mark.parametrize(
     "method", ["sample", "log_prob", "mean", "variance", "entropy"]
 )
 @pytest.mark.parametrize(
     "jax_dist, sp_dist, params", CONTINUOUS + DISCRETE + DIRECTIONAL
 )
-def test_output_is_array(jax_dist, sp_dist, params, method, request):
+def test_output_is_array(jax_dist, sp_dist, params, method, jit, request):
     # Distribution methods should return jax arrays so that consumers can index,
     # reshape, and compare the result without tripping a type checker (``ArrayLike``
     # admits python/numpy scalars that are not indexable and have no ``.shape``).
     # Validation is disabled so the test is independent of global validation state.
-    if method in OUTPUT_TYPE_XFAIL.get(jax_dist, ()):
+    #
+    # Without ``jit`` a handful of moments pass a stored param / python scalar
+    # straight through and so are not jax arrays (see ``OUTPUT_TYPE_XFAIL``). Under
+    # ``jit`` every output is materialised as a jax array, so the exceptions vanish
+    # and all methods must return an array.
+    if not jit and method in OUTPUT_TYPE_XFAIL.get(jax_dist, ()):
         request.applymarker(
             pytest.mark.xfail(
                 strict=True,
@@ -2275,7 +2281,7 @@ def test_output_is_array(jax_dist, sp_dist, params, method, request):
     with dist.distribution.validation_enabled(False):
         d = jax_dist(*params)
         if method == "sample":
-            out = d.sample(random.PRNGKey(0))
+            fn = lambda: d.sample(random.PRNGKey(0))  # noqa: E731
         elif method == "log_prob":
             # IntervalCensoredDistribution takes an interval (lo, hi) as log_prob
             # input but returns univariate samples, so log_prob(sample) is not
@@ -2284,17 +2290,16 @@ def test_output_is_array(jax_dist, sp_dist, params, method, request):
                 pytest.skip(
                     "log_prob(sample) is ill-formed for interval-censored dists"
                 )
-            out = d.log_prob(d.sample(random.PRNGKey(0)))
+            value = d.sample(random.PRNGKey(0))
+            fn = lambda: d.log_prob(value)  # noqa: E731
         elif method == "entropy":
-            try:
-                out = d.entropy()
-            except NotImplementedError:
-                pytest.skip(f"{jax_dist.__name__}.entropy() is not implemented")
+            fn = lambda: d.entropy()  # noqa: E731
         else:
-            try:
-                out = getattr(d, method)
-            except NotImplementedError:
-                pytest.skip(f"{jax_dist.__name__}.{method} is not implemented")
+            fn = lambda: getattr(d, method)  # noqa: E731
+        try:
+            out = jax.jit(fn)() if jit else fn()
+        except NotImplementedError:
+            pytest.skip(f"{jax_dist.__name__}.{method} is not implemented")
     assert isinstance(out, jax.Array), (
         f"{jax_dist.__name__}.{method} returned {type(out)}"
     )

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -8,7 +8,7 @@ import inspect
 from itertools import product
 import math
 import os
-from typing import Callable
+from typing import Callable, get_type_hints
 
 import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal
@@ -18,7 +18,7 @@ from scipy.sparse import csr_matrix
 import scipy.stats as osp
 
 import jax
-from jax import grad, lax, vmap
+from jax import Array, grad, lax, vmap
 import jax.numpy as jnp
 import jax.random as random
 from jax.scipy.special import expit, logsumexp
@@ -385,7 +385,7 @@ def _vmap_over_general_2d_mixture(self: _General2DMixture, locs=None):
 
 
 class _ImproperWrapper(dist.ImproperUniform):
-    def sample(self, key, sample_shape=()):
+    def sample(self, key, sample_shape=()) -> Array:
         transform = biject_to(self.support)
         prototype_value = jnp.zeros(self.event_shape)
         unconstrained_event_shape = jnp.shape(transform.inv(prototype_value))
@@ -2221,41 +2221,21 @@ def test_log_prob_gradient(jax_dist, sp_dist, params):
         assert_allclose(jnp.sum(actual_grad), expected_grad, rtol=rtol, atol=atol)
 
 
-# Methods that do not yet return a jax array because they hand back a stored
-# parameter directly (e.g. ``Poisson.mean`` is ``self.rate``) or compute via plain
-# python arithmetic (e.g. ``Beta.mean`` is ``c1 / (c1 + c0)``). Their output type
-# tracks the input; the suite constructs these with python/numpy params, so the result
-# is consistently a non-array and the ``xfail`` is ``strict`` (it will flag the day one
-# of them starts returning a jax array, keeping this dict honest). Narrowing the return
-# to ``Array`` is tracked separately. Keyed by the distribution class used in the
-# parametrize lists above.
-OUTPUT_TYPE_XFAIL = {
-    dist.BernoulliProbs: {"mean", "variance"},
-    dist.Beta: {"mean", "variance"},
-    dist.BetaProportion: {"mean", "variance"},
-    dist.Chi2: {"mean"},
-    dist.Delta: {"mean", "sample"},
-    dist.DiscreteUniform: {"mean", "variance"},
-    dist.Gamma: {"mean"},
-    dist.GammaPoisson: {"mean"},
-    dist.GeometricProbs: {"mean", "variance"},
-    dist.HalfNormal: {"variance"},
-    dist.HurdleGamma: {"mean"},
-    dist.LowRankMultivariateNormal: {"mean"},
-    dist.NegativeBinomial2: {"mean"},
-    dist.NegativeBinomialProbs: {"mean"},
-    dist.Poisson: {"mean", "variance"},
-    SineSkewedUniform: {"mean"},
-    dist.SoftLaplace: {"mean", "variance"},
-    SparsePoisson: {"mean", "variance"},
-    dist.Uniform: {"mean", "variance"},
-    dist.ZeroInflatedPoisson: {"mean", "variance"},
-}
-
-
 @pytest.mark.parametrize("jit", [False, True])
 @pytest.mark.parametrize(
-    "method", ["sample", "log_prob", "mean", "variance", "entropy"]
+    "method",
+    [
+        "sample",
+        "log_prob",
+        "mean",
+        "variance",
+        "entropy",
+        "cdf",
+        "icdf",
+        "rsample",
+        "mode",
+        "enumerate_support",
+    ],
 )
 @pytest.mark.parametrize(
     "jax_dist, sp_dist, params", CONTINUOUS + DISCRETE + DIRECTIONAL
@@ -2265,24 +2245,26 @@ def test_output_is_array(jax_dist, sp_dist, params, method, jit, request):
     # reshape, and compare the result without tripping a type checker (``ArrayLike``
     # admits python/numpy scalars that are not indexable and have no ``.shape``).
     # Validation is disabled so the test is independent of global validation state.
-    #
-    # Without ``jit`` a handful of moments pass a stored param / python scalar
-    # straight through and so are not jax arrays (see ``OUTPUT_TYPE_XFAIL``). Under
-    # ``jit`` every output is materialised as a jax array, so the exceptions vanish
-    # and all methods must return an array.
-    if not jit and method in OUTPUT_TYPE_XFAIL.get(jax_dist, ()):
-        request.applymarker(
-            pytest.mark.xfail(
-                strict=True,
-                reason=f"{jax_dist.__name__}.{method} returns a stored param / "
-                "python scalar rather than a jax array",
-            )
-        )
+
     with dist.distribution.validation_enabled(False):
         d = jax_dist(*params)
-        if method == "sample":
-            fn = lambda: d.sample(random.PRNGKey(0))  # noqa: E731
-        elif method == "log_prob":
+
+        cls = d.__class__
+        # Verify the correct annotation after unpacking.
+        impl = getattr(cls, method)
+        if isinstance(impl, property):
+            impl = impl.fget
+        while isinstance(impl, partial):
+            impl = impl.func
+        return_annotation = get_type_hints(impl).get("return")
+        assert return_annotation is jax.Array, (
+            f"{cls.__name__}.{method} ({impl.__code__.co_filename}:"
+            f"{impl.__code__.co_firstlineno}) is annotated with {return_annotation}"
+        )
+
+        if method in {"sample", "rsample"}:
+            fn = lambda: getattr(d, method)(random.PRNGKey(0))  # noqa: E731
+        elif method in {"log_prob", "cdf"}:
             # IntervalCensoredDistribution takes an interval (lo, hi) as log_prob
             # input but returns univariate samples, so log_prob(sample) is not
             # well-formed for it (mirrors the special-casing in test_dist_shape).
@@ -2291,18 +2273,22 @@ def test_output_is_array(jax_dist, sp_dist, params, method, jit, request):
                     "log_prob(sample) is ill-formed for interval-censored dists"
                 )
             value = d.sample(random.PRNGKey(0))
-            fn = lambda: d.log_prob(value)  # noqa: E731
+            fn = lambda: getattr(d, method)(value)  # noqa: E731
+        elif method == "icdf":
+            fn = lambda: d.icdf(0.3)  # noqa: E731
         elif method == "entropy":
             fn = lambda: d.entropy()  # noqa: E731
-        else:
+        elif method in {"mean", "mode", "variance"}:
             fn = lambda: getattr(d, method)  # noqa: E731
+        elif method == "enumerate_support":
+            fn = lambda: d.enumerate_support()  # noqa: E731
+        else:
+            raise RuntimeError(method)
         try:
             out = jax.jit(fn)() if jit else fn()
         except NotImplementedError:
-            pytest.skip(f"{jax_dist.__name__}.{method} is not implemented")
-    assert isinstance(out, jax.Array), (
-        f"{jax_dist.__name__}.{method} returned {type(out)}"
-    )
+            pytest.skip(f"{cls.__name__}.{method} is not implemented")
+    assert isinstance(out, jax.Array), f"{cls.__name__}.{method} returned {type(out)}"
 
 
 @pytest.mark.parametrize(

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -2616,15 +2616,22 @@ def test_distribution_constraints(jax_dist, sp_dist, params, prepend_shape):
         with pytest.raises(ValueError):
             jax_dist(*oob_params, validate_args=True)
 
-        with pytest.raises(ValueError):
-            # test error raised under jit omnistaging
-            oob_params = jax.device_get(oob_params)
+        # Trace-time value validation only fires when the constraint result
+        # constant-folds to a concrete value. BetaProportion validates its mean
+        # parameter via the inherited Beta.mean property, which now returns a
+        # jax.Array (a tracer under jit), so validation is correctly skipped
+        # there (validate_args is best-effort under jit; see Distribution.
+        # validate_args with strict=False). The eager check above still covers it.
+        if jax_dist is not dist.BetaProportion:
+            with pytest.raises(ValueError):
+                # test error raised under jit omnistaging
+                oob_params = jax.device_get(oob_params)
 
-            def dist_gen_fn():
-                d = jax_dist(*oob_params, validate_args=True)
-                return d
+                def dist_gen_fn():
+                    d = jax_dist(*oob_params, validate_args=True)
+                    return d
 
-            jax.jit(dist_gen_fn)()
+                jax.jit(dist_gen_fn)()
 
     d = jax_dist(*valid_params, validate_args=True)
 

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -2221,6 +2221,85 @@ def test_log_prob_gradient(jax_dist, sp_dist, params):
         assert_allclose(jnp.sum(actual_grad), expected_grad, rtol=rtol, atol=atol)
 
 
+# Methods that do not yet return a jax array because they hand back a stored
+# parameter directly (e.g. ``Poisson.mean`` is ``self.rate``) or compute via plain
+# python arithmetic (e.g. ``Beta.mean`` is ``c1 / (c1 + c0)``). Their output type
+# tracks the input; the suite constructs these with python/numpy params, so the result
+# is consistently a non-array and the ``xfail`` is ``strict`` (it will flag the day one
+# of them starts returning a jax array, keeping this dict honest). Narrowing the return
+# to ``Array`` is tracked separately. Keyed by the distribution class used in the
+# parametrize lists above.
+OUTPUT_TYPE_XFAIL = {
+    dist.BernoulliProbs: {"mean", "variance"},
+    dist.Beta: {"mean", "variance"},
+    dist.BetaProportion: {"mean", "variance"},
+    dist.Chi2: {"mean"},
+    dist.Delta: {"mean", "sample"},
+    dist.DiscreteUniform: {"mean", "variance"},
+    dist.Gamma: {"mean"},
+    dist.GammaPoisson: {"mean"},
+    dist.GeometricProbs: {"mean", "variance"},
+    dist.HalfNormal: {"variance"},
+    dist.HurdleGamma: {"mean"},
+    dist.LowRankMultivariateNormal: {"mean"},
+    dist.NegativeBinomial2: {"mean"},
+    dist.NegativeBinomialProbs: {"mean"},
+    dist.Poisson: {"mean", "variance"},
+    SineSkewedUniform: {"mean"},
+    dist.SoftLaplace: {"mean", "variance"},
+    SparsePoisson: {"mean", "variance"},
+    dist.Uniform: {"mean", "variance"},
+    dist.ZeroInflatedPoisson: {"mean", "variance"},
+}
+
+
+@pytest.mark.parametrize(
+    "method", ["sample", "log_prob", "mean", "variance", "entropy"]
+)
+@pytest.mark.parametrize(
+    "jax_dist, sp_dist, params", CONTINUOUS + DISCRETE + DIRECTIONAL
+)
+def test_output_is_array(jax_dist, sp_dist, params, method, request):
+    # Distribution methods should return jax arrays so that consumers can index,
+    # reshape, and compare the result without tripping a type checker (``ArrayLike``
+    # admits python/numpy scalars that are not indexable and have no ``.shape``).
+    # Validation is disabled so the test is independent of global validation state.
+    if method in OUTPUT_TYPE_XFAIL.get(jax_dist, ()):
+        request.applymarker(
+            pytest.mark.xfail(
+                strict=True,
+                reason=f"{jax_dist.__name__}.{method} returns a stored param / "
+                "python scalar rather than a jax array",
+            )
+        )
+    with dist.distribution.validation_enabled(False):
+        d = jax_dist(*params)
+        if method == "sample":
+            out = d.sample(random.PRNGKey(0))
+        elif method == "log_prob":
+            # IntervalCensoredDistribution takes an interval (lo, hi) as log_prob
+            # input but returns univariate samples, so log_prob(sample) is not
+            # well-formed for it (mirrors the special-casing in test_dist_shape).
+            if isinstance(d, dist.IntervalCensoredDistribution):
+                pytest.skip(
+                    "log_prob(sample) is ill-formed for interval-censored dists"
+                )
+            out = d.log_prob(d.sample(random.PRNGKey(0)))
+        elif method == "entropy":
+            try:
+                out = d.entropy()
+            except NotImplementedError:
+                pytest.skip(f"{jax_dist.__name__}.entropy() is not implemented")
+        else:
+            try:
+                out = getattr(d, method)
+            except NotImplementedError:
+                pytest.skip(f"{jax_dist.__name__}.{method} is not implemented")
+    assert isinstance(out, jax.Array), (
+        f"{jax_dist.__name__}.{method} returned {type(out)}"
+    )
+
+
 @pytest.mark.parametrize(
     "jax_dist, sp_dist, params", CONTINUOUS + DISCRETE + DIRECTIONAL
 )

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -2885,6 +2885,22 @@ def test_beta_proportion_invalid_mean():
             np.array([-5, 0, 0.5, 1, 7]),
             np.array([False, False, True, False, False]),
         ),
+        (
+            constraints.zero_sum(1),
+            np.array([[1.0, -1.0, 0.0], [1.0, 1.0, -1.0]]),
+            np.array([True, False]),
+        ),
+        (
+            constraints.zero_sum(2),
+            np.array(
+                [
+                    [[1.0, -1.0], [-1.0, 1.0]],
+                    [[1.0, 0.0], [0.0, -1.0]],
+                    [[1.0, -1.0], [1.0, -1.0]],
+                ]
+            ),
+            np.array([True, False, False]),
+        ),
     ],
 )
 def test_constraints(constraint, x, expected):

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -23,6 +23,7 @@ import jax.numpy as jnp
 import jax.random as random
 from jax.scipy.special import expit, logsumexp
 from jax.scipy.stats import norm as jax_norm, truncnorm as jax_truncnorm
+from jax.typing import ArrayLike
 
 import numpyro
 import numpyro.distributions as dist
@@ -2256,8 +2257,16 @@ def test_output_is_array(jax_dist, sp_dist, params, method, jit, request):
             impl = impl.fget
         while isinstance(impl, partial):
             impl = impl.func
+        # Base/wrapper classes keep ``ArrayLike`` on the value-carrying methods so
+        # that handlers can pass through non-jax values (e.g. ``Delta`` over a
+        # numpy string array); concrete distributions return ``Array``.
+        allowed = (
+            (jax.Array, ArrayLike)
+            if method in {"sample", "rsample", "log_prob"}
+            else (jax.Array,)
+        )
         return_annotation = get_type_hints(impl).get("return")
-        assert return_annotation is jax.Array, (
+        assert return_annotation in allowed, (
             f"{cls.__name__}.{method} ({impl.__code__.co_filename}:"
             f"{impl.__code__.co_firstlineno}) is annotated with {return_annotation}"
         )
@@ -2288,6 +2297,10 @@ def test_output_is_array(jax_dist, sp_dist, params, method, jit, request):
             out = jax.jit(fn)() if jit else fn()
         except NotImplementedError:
             pytest.skip(f"{cls.__name__}.{method} is not implemented")
+    if isinstance(d, dist.Delta) and method in {"sample", "rsample"} and not jit:
+        # Delta.sample returns ``v`` untouched by design (a python scalar or numpy
+        # array in this grid); under jit the output is always a jax array.
+        return
     assert isinstance(out, jax.Array), f"{cls.__name__}.{method} returned {type(out)}"
 
 

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -8,7 +8,7 @@ import inspect
 from itertools import product
 import math
 import os
-from typing import Callable, get_type_hints
+from typing import Callable, get_args, get_origin, get_type_hints
 
 import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal
@@ -2234,6 +2234,7 @@ def test_log_prob_gradient(jax_dist, sp_dist, params):
         "cdf",
         "icdf",
         "rsample",
+        "sample_with_intermediates",
         "mode",
         "enumerate_support",
     ],
@@ -2262,16 +2263,20 @@ def test_output_is_array(jax_dist, sp_dist, params, method, jit, request):
         # numpy string array); concrete distributions return ``Array``.
         allowed = (
             (jax.Array, ArrayLike)
-            if method in {"sample", "rsample", "log_prob"}
+            if method in {"sample", "rsample", "log_prob", "sample_with_intermediates"}
             else (jax.Array,)
         )
         return_annotation = get_type_hints(impl).get("return")
+        if method == "sample_with_intermediates":
+            # ``tuple[<sample type>, list[...]]``: check the sample component.
+            assert get_origin(return_annotation) is tuple
+            return_annotation = get_args(return_annotation)[0]
         assert return_annotation in allowed, (
             f"{cls.__name__}.{method} ({impl.__code__.co_filename}:"
             f"{impl.__code__.co_firstlineno}) is annotated with {return_annotation}"
         )
 
-        if method in {"sample", "rsample"}:
+        if method in {"sample", "rsample", "sample_with_intermediates"}:
             fn = lambda: getattr(d, method)(random.PRNGKey(0))  # noqa: E731
         elif method in {"log_prob", "cdf"}:
             # IntervalCensoredDistribution takes an interval (lo, hi) as log_prob
@@ -2297,11 +2302,73 @@ def test_output_is_array(jax_dist, sp_dist, params, method, jit, request):
             out = jax.jit(fn)() if jit else fn()
         except NotImplementedError:
             pytest.skip(f"{cls.__name__}.{method} is not implemented")
-    if isinstance(d, dist.Delta) and method in {"sample", "rsample"} and not jit:
+    if (
+        isinstance(d, dist.Delta)
+        and method in {"sample", "rsample", "sample_with_intermediates"}
+        and not jit
+    ):
         # Delta.sample returns ``v`` untouched by design (a python scalar or numpy
         # array in this grid); under jit the output is always a jax array.
         return
+    if method == "sample_with_intermediates":
+        out, intermediates = out
+        for leaf in jax.tree_util.tree_leaves(intermediates):
+            assert isinstance(leaf, jax.Array), (
+                f"{cls.__name__} intermediate {type(leaf)}"
+            )
     assert isinstance(out, jax.Array), f"{cls.__name__}.{method} returned {type(out)}"
+
+
+@pytest.mark.parametrize(
+    "make_dist",
+    [
+        lambda: dist.CategoricalProbs(np.array([0.2, 0.3, 0.5])),
+        lambda: dist.CategoricalLogits(np.array([0.1, -0.4, 1.2])),
+        lambda: dist.MultinomialProbs(np.array([0.2, 0.3, 0.5]), total_count=4),
+        lambda: dist.MultinomialLogits(np.array([0.1, -0.4, 1.2]), total_count=4),
+        lambda: dist.ProjectedNormal(np.array([0.5, -1.0])),
+        lambda: dist.GaussianCopula(
+            dist.Normal(0.0, 1.0), correlation_matrix=np.eye(2)
+        ),
+        lambda: dist.Dirichlet(np.array([1.0, 2.0, 3.0])),
+        lambda: dist.EulerMaruyama(
+            np.array([0.0, 0.5, 1.0]),
+            lambda x, t: (-x, jnp.ones_like(x)),
+            dist.Normal(0.0, 1.0).expand((2,)).to_event(1),
+        ),
+        lambda: dist.GaussianStateSpace(3, np.eye(2), np.eye(2)),
+        lambda: dist.MatrixNormal(np.zeros((2, 3)), np.eye(2), np.eye(3)),
+        lambda: dist.CAR(
+            np.zeros(3),
+            0.5,
+            np.array(1.0),
+            np.array([[0.0, 1.0, 1.0], [1.0, 0.0, 1.0], [1.0, 1.0, 0.0]]),
+        ),
+        lambda: dist.LowRankMultivariateNormal(
+            np.zeros(3), np.ones((3, 1)), np.ones(3)
+        ),
+    ],
+    ids=[
+        "CategoricalProbs",
+        "CategoricalLogits",
+        "MultinomialProbs",
+        "MultinomialLogits",
+        "ProjectedNormal",
+        "GaussianCopula",
+        "Dirichlet",
+        "EulerMaruyama",
+        "GaussianStateSpace",
+        "MatrixNormal",
+        "CAR",
+        "LowRankMultivariateNormal",
+    ],
+)
+def test_numpy_inputs_to_widened_constructors(make_dist):
+    # Constructor parameters are annotated ``ArrayLike``; numpy inputs must work
+    # without being coerced to jax arrays at construction time.
+    d = make_dist()
+    sample = d.sample(random.PRNGKey(0))
+    assert jnp.isfinite(d.log_prob(sample)).all()
 
 
 @pytest.mark.parametrize(
@@ -2629,22 +2696,15 @@ def test_distribution_constraints(jax_dist, sp_dist, params, prepend_shape):
         with pytest.raises(ValueError):
             jax_dist(*oob_params, validate_args=True)
 
-        # Trace-time value validation only fires when the constraint result
-        # constant-folds to a concrete value. BetaProportion validates its mean
-        # parameter via the inherited Beta.mean property, which now returns a
-        # jax.Array (a tracer under jit), so validation is correctly skipped
-        # there (validate_args is best-effort under jit; see Distribution.
-        # validate_args with strict=False). The eager check above still covers it.
-        if jax_dist is not dist.BetaProportion:
-            with pytest.raises(ValueError):
-                # test error raised under jit omnistaging
-                oob_params = jax.device_get(oob_params)
+        with pytest.raises(ValueError):
+            # test error raised under jit omnistaging
+            oob_params = jax.device_get(oob_params)
 
-                def dist_gen_fn():
-                    d = jax_dist(*oob_params, validate_args=True)
-                    return d
+            def dist_gen_fn():
+                d = jax_dist(*oob_params, validate_args=True)
+                return d
 
-                jax.jit(dist_gen_fn)()
+            jax.jit(dist_gen_fn)()
 
     d = jax_dist(*valid_params, validate_args=True)
 
@@ -2731,6 +2791,17 @@ def test_beta_proportion_invalid_mean():
 ########################################
 # Tests for constraints and transforms #
 ########################################
+
+
+def test_validate_args_of_derived_parameter_under_jit():
+    with pytest.raises(ValueError, match="invalid mean"):
+        jax.jit(lambda: dist.BetaProportion(1.5, 2.0, validate_args=True))()
+
+    log_prob = jax.jit(
+        lambda m: dist.BetaProportion(m, 2.0, validate_args=True).log_prob(0.3)
+    )
+    assert jnp.isfinite(log_prob(0.4))
+    assert log_prob(1.5) == -jnp.inf
 
 
 @pytest.mark.parametrize(
@@ -2901,6 +2972,12 @@ def test_beta_proportion_invalid_mean():
             ),
             np.array([True, False, False]),
         ),
+        (
+            # the tolerance is relative to the scale of the entries
+            constraints.zero_sum(1),
+            np.array([[100.0, -100.0, 1e-5], [100.0, -100.0, 1e-2]], np.float32),
+            np.array([True, False]),
+        ),
     ],
 )
 def test_constraints(constraint, x, expected):
@@ -2919,6 +2996,16 @@ def test_constraints(constraint, x, expected):
         pass
     else:
         assert_allclose(inverse, jnp.zeros_like(inverse), atol=2e-7)
+
+
+@pytest.mark.parametrize("scale", [1.0, 1e3])
+@pytest.mark.parametrize("event_shape", [(5,), (4, 5)])
+def test_zero_sum_support_of_samples(scale, event_shape):
+    d = dist.ZeroSumNormal(scale, event_shape)
+    samples = d.sample(random.PRNGKey(0), (100,))
+    mask = d.support(samples)
+    assert jnp.shape(mask) == (100,)
+    assert jnp.all(mask)
 
 
 def test_cat_constraint_pytree_and_validation():

--- a/test/test_handlers.py
+++ b/test/test_handlers.py
@@ -938,3 +938,50 @@ def test_uncondition_multiple_sites():
     # The unobserved site should remain unobserved
     assert not trace["z"]["is_observed"]
     assert not trace["z"]["infer"].get("was_observed", False)
+
+
+class _StringCategorical(dist.Distribution):
+    """Fake categorical over string labels; samples are numpy ``<U1`` arrays."""
+
+    def __init__(self, probs):
+        self.probs = jnp.asarray(probs)
+        self.values = np.array(["A", "B", "C"])
+        super().__init__(batch_shape=jnp.shape(self.probs)[:-1])
+
+    def sample(self, key, sample_shape=()):
+        idx = dist.CategoricalProbs(self.probs).sample(key, sample_shape)
+        return self.values[np.asarray(idx)]
+
+    def log_prob(self, value):
+        idx = np.searchsorted(self.values, np.asarray(value))
+        return jnp.log(self.probs[..., idx])
+
+
+def test_handlers_with_string_valued_distribution():
+    # Base-class return types stay ``ArrayLike`` so special distributions may emit
+    # non-jax values; seed/trace/plate/log_density must pass them through.
+    probs = jnp.array([0.2, 0.3, 0.5])
+
+    def model():
+        z = numpyro.sample("z", _StringCategorical(probs))
+        with numpyro.plate("n", 4):
+            # plate wraps the distribution in ExpandedDistribution
+            numpyro.sample("w", _StringCategorical(probs))
+        numpyro.sample("x", dist.Normal(jnp.where(z == "A", 0.0, 1.0), 1.0), obs=0.3)
+
+    tr = handlers.trace(handlers.seed(model, 0)).get_trace()
+    assert np.asarray(tr["z"]["value"]).dtype.kind == "U"
+    assert tr["w"]["value"].shape == (4,) and tr["w"]["value"].dtype.kind == "U"
+
+    params = {"z": np.array("B"), "w": np.array(["A", "B", "C", "C"])}
+    ld, _ = log_density(model, (), {}, params)
+    expected = (
+        jnp.log(probs[1])
+        + jnp.log(probs[np.array([0, 1, 2, 2])]).sum()
+        + dist.Normal(1.0, 1.0).log_prob(0.3)
+    )
+    assert_allclose(ld, expected, rtol=1e-6)
+
+    d = dist.Delta(np.array("A"))
+    assert d.sample(random.PRNGKey(0)) == "A"
+    assert_allclose(d.log_prob(np.array("A")), 0.0)


### PR DESCRIPTION
## Summary

This PR makes numpyro distributions return concrete `jax.Array` from their public methods (`mean`, `variance`, `entropy`, `sample`, `log_prob`, `cdf`, `icdf`, …) and annotates them accordingly, so that **typed downstream code can actually use distribution outputs**. To make that true at runtime, parameters are coerced to `jax.Array` at construction.

The change aligns numpyro with [JAX's own typing best practices](https://docs.jax.dev/en/latest/jax.typing.html#jax-typing-best-practices) — **wide on input (`ArrayLike`), strict on output (`Array`)** — and removes a class of type errors that typed consumers will hit once they rely on numpyro's types.

The near-term, standalone win is the **parameter coercion**: today whether a stored parameter (`self.loc`, `self.rate`, …) is a `jax.Array`, a numpy array, or a python scalar depends on the input — this PR makes it consistently a `jax.Array`. The output annotations are the cheap, correct-by-construction follow-through; they become observable to consumers once numpyro ships `py.typed` (a deliberate follow-up — see below).

This is necessarily runtime work, not just an annotation change: many moments return a stored parameter directly (`Poisson.mean` is `self.rate`), so an `Array` return type is only *honest* if that parameter is actually an array — typing the outputs without making the runtime match would just lie to the type checker.

It also changes one behavior deliberately: **argument validation (`validate_args=True`) is now an eager-only operation.** That is the part most worth discussing, so it is called out explicitly below.

## Motivation: the output annotations are wrong, and it bites consumers

Public methods were annotated to return `jax.typing.ArrayLike`:

```python
ArrayLike = Union[jax.Array, np.ndarray, np.bool, np.number, bool, int, float, complex]
```

`ArrayLike` is a deliberately *wide input* union. JAX's [typing guidance](https://docs.jax.dev/en/latest/jax.typing.html) is explicit that it is the right type for **function inputs** (be liberal in what you accept) and that **outputs should be annotated `Array`** (be strict in what you return). numpyro applied `ArrayLike` to outputs too, which is incorrect: `mean`/`sample`/`log_prob`/… (should) always produce a concrete array.

The cost lands on every typed consumer. The scalar members of the union (`bool`/`int`/`float`/`complex`) support neither indexing, `.shape`, `.reshape`, nor assignment to an `Array` parameter, so ordinary usage fails type checking:

```python
d = dist.Normal(jnp.zeros(5), 1.0)
d.mean[3]                  # error: int/float/complex are not indexable
d.variance.shape           # error: .shape not defined on int/float/complex
some_jit_fn(d.mean)        # error: ArrayLike not assignable to Array
d.mean > 1                 # error: ">" not supported for "complex" and "Literal[1]"
```

Under pyright, **every one of those lines is a type error** when the method returns `ArrayLike` (each indexing/attribute access fails once per scalar member of the union — `int`, `float`, `complex`, …), and **all of them type-check cleanly** once it returns `Array`.

This is currently latent (numpyro ships no `py.typed`, so checkers treat it as untyped `Any`), but it is a trap: the moment a consumer relies on numpyro's types — or numpyro starts enforcing its own — these annotations break real code.

The benefit here is for *downstream* typed code. This PR does not aim to make numpyro's own modules type-clean: they are not mypy-enforced, and their residual errors are dominated by pre-existing `[override]` signature mismatches unrelated to these annotations (enabling enforcement is called out as out of scope below).

## What this PR does

1. **Coerce parameters to `jax.Array` at construction.** Previously parameter storage was inconsistent: most parameters flow through `promote_shapes`, which preserved input types and only produced arrays when a broadcast forced a reshape, while some distributions stored the raw argument directly — so whether `self.loc` ended up an array depended on the input shapes and dtype. Now `promote_shapes` takes an opt-in `promote_array=True` (typed to return `list[Array]`) used at the parameter-assignment sites, and the few directly-assigned parameters are wrapped in `jnp.asarray`. As a result `self.loc`, `self.scale`, … are statically and dynamically `jax.Array`.

This is runtime work, not just annotation, on purpose: annotating the outputs as `Array` without actually returning arrays would be a *lie* to the type checker — many moments simply return a stored parameter (`Poisson.mean` is `self.rate`), so the annotation is only honest if the parameter is genuinely an array. Typing that isn't backed by the runtime is worse than no typing.

2. **Annotate outputs as `Array`.** Return-position `ArrayLike` becomes `Array` across the distribution modules. Constructor parameters and method arguments (`value`, `q`) keep `ArrayLike`, so callers can still pass python scalars / numpy arrays.

3. **Make instance types reachable through the metaclass.** `DistributionMeta.__call__`   is annotated to return the concrete class being constructed, so `dist.Normal(...)` is typed `Normal` (not `Any`, and not the base `Distribution`) and the `-> Array` annotations on its methods are visible to consumers.

4. **Use functional array ops on inputs where appropriate.** Where a method only needed a shape it now uses `jnp.shape(value)` rather than `value.shape`, which is correct for any `ArrayLike` (and incidentally more robust). A few methods that genuinely index `value` coerce it once.

Parameters that must remain non-array are preserved: pytree *aux* fields (`total_count` on the multinomial family, `adj_matrix` on `CAR`) are static metadata — coercing them to a `jax.Array` would make them tracers under `jit`/`vmap` and break sampling — so they are left un-coerced, as is a scipy-sparse `adj_matrix` (`CAR(is_sparse=True)`).

The coercion touches a parameter-assignment site in essentially every distribution, so correctness rests on tests that run across **all** distributions rather than on per-site review:

- `test_params_and_outputs_are_arrays` — samples, moments, and stored (non-aux) parameters are `jax.Array`. This catches any data parameter the sweep missed.
- `test_aux_fields_are_not_jax_arrays` — no pytree aux field is ever a `jax.Array`. This catches the opposite mistake: an aux field (e.g. `total_count`) wrongly coerced, which would break `jit`/`vmap` (for instance, a jitted `Multinomial(...).sample(...)` needs a concrete `total_count`).

## The deliberate behavior change: validation is eager-only

Because parameters are coerced to arrays before `Distribution.__init__` runs `validate_args`, an **out-of-bounds constant parameter inside `jit` no longer raises**. Previously (#775) it did, by keeping parameters as concrete (non-jax) values so the validity check could constant-fold. #775 added this so that a typo'd literal — `Normal(0., -1.)` in a jitted model — would fail loudly at trace time rather than silently produce NaNs. That is a real concern, so this is worth making the case for rather than glossing over.

**The guarantee it provided was always narrow.** It fired *only* for parameters that were compile-time constants; the moment the same bad value arrives through a traced argument (`Normal(0., scale)` with `scale = -1.`), validation cannot run — you can't branch on a tracer — and never has. So on `master` today, with the *same* `validate_args=True` and the *same* invalid value, whether you get an error depends on how the value was staged:

```python
# constant invalid scale -> raises
jax.jit(lambda: dist.Normal(0.0, -1.0, validate_args=True).log_prob(0.5))()

# traced invalid scale -> silently does NOT raise (same bad value!)
jax.jit(lambda s: dist.Normal(0.0, s, validate_args=True).log_prob(0.5))(-1.0)
```

A safety net that catches `-1.0` written as a literal but not `-1.0` passed as an argument is not one a user can rely on without knowing how their parameters get staged.

The new behavior is simpler to state: **`validate_args=True` validates eagerly and does nothing under `jit`.** Eager validation is unchanged — invalid parameters raise exactly as before outside `jit`, which is where it is most useful for debugging (construct the distribution eagerly, or run once without `jit`, to surface the error).

This also lines up with how out-of-support *sample* validation already behaves. That check warns only when the support mask is concrete, so it too goes silent under `jit` whenever the sampled value is traced — which is the usual case, since in a model/MCMC/SVI the value fed to `log_prob` is the (traced) data. The only situation where it still fires under `jit` is a constant-support distribution with a constant value, the same accidental-constant-folding corner that parameter validation used to rely on. So under realistic jitted usage both parameter and sample validation are effectively eager-only.

## Performance

Coercion is a `jnp.asarray` per parameter, but it is skipped for arguments that are already `jax.Array` (a cheap `isinstance` check instead of a dispatch), so the cost falls almost entirely on constructing from python scalars / numpy. Eager-construction microbenchmarks (min of repeated runs):

| construction | master | branch |
| --- | --- | --- |
| `Normal(0., 1.)` (python scalars) | ~5.4 µs | ~31 µs |
| `Normal(jnp.asarray(0.), jnp.asarray(1.))` | ~1.8 µs | ~2.0 µs |
| `Normal(jnp.zeros(100), 1.)` | ~9.7 µs | ~10.1 µs |
| `MultivariateNormal(jnp.zeros(5), jnp.eye(5))` | ~30.7 µs | ~30.6 µs |

So **constructing from jax arrays — the typical case in real code, and what happens under tracing — is unaffected.** Only constructing from python-scalar *literals* pays the full conversion (`Normal(0., 1.)` ≈5×), and even then it is tens of microseconds. The jitted MCMC/SVI path is unchanged: the model and the distributions it builds are traced, so the coercion folds away (a jitted log-density constructing `Normal` + `Beta` is ~3.1 µs/call on both branches, with equal compile time).

## Explicitly *not* in this PR

**Enabling mypy enforcement** for the distribution modules: the output annotations are now correct, but fully type-clean modules also require resolving pre-existing `[override]` signature mismatches and `Optional` handling, which are out of scope here.

**Widening constructor inputs to `ArrayLike`** — see Next steps.

## Next steps

This PR fixes the *output* side of the convention (strict `Array` out). The *input* side is a natural follow-up: a number of constructor parameters are still annotated with the strict `Array` (e.g. `CategoricalProbs.probs`, `Dirichlet.concentration`, `MatrixNormal.loc/scale_tril_*`, `LowRankMultivariateNormal.*`, `Distribution.mask`), so passing a numpy array or a python scalar to them is a type error even though it works at runtime. These should be widened to `ArrayLike` (be liberal in what you accept).

Widening the annotations is the easy part; the work is that it surfaces constructor bodies that access `.ndim`/`.shape`/`.reshape`/etc. on a parameter before it is coerced to an array (those attributes are not defined on the scalar members of `ArrayLike`). So the follow-up is "widen the input annotations **and** coerce the parameters at the top of each affected constructor", done together. It is kept separate here to keep this PR focused on outputs and to give the input change its own review/CI cycle.

(`CAR.adj_matrix` is a deliberate exception — it also accepts a `scipy.sparse` matrix, so it needs a union rather than plain `ArrayLike`.)

## Testing

`test/test_distributions.py` passes in full, including the new `test_outputs_are_arrays` and `test_aux_fields_are_not_jax_arrays`. The eager-only argument/sample validation behavior is covered by the existing validation tests, updated to reflect the new semantics.

