### PR TITLE
Add HaarTransform and DiscreteCosineTransform

### DIFF
--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -1064,9 +1064,25 @@ CorrMatrixCholeskyTransform
     :show-inheritance:
     :member-order: bysource
 
+DiscreteCosineTransform
+^^^^^^^^^^^^^^^^^^^^^^^
+.. autoclass:: numpyro.distributions.transforms.DiscreteCosineTransform
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :member-order: bysource
+
 ExpTransform
 ^^^^^^^^^^^^
 .. autoclass:: numpyro.distributions.transforms.ExpTransform
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :member-order: bysource
+
+HaarTransform
+^^^^^^^^^^^^^
+.. autoclass:: numpyro.distributions.transforms.HaarTransform
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/source/reparam.rst
+++ b/docs/source/reparam.rst
@@ -69,3 +69,30 @@ Explicit Reparameterization
     :show-inheritance:
     :member-order: bysource
     :special-members: __call__
+
+Unit Jacobian Transforms
+------------------------
+.. autoclass:: numpyro.infer.reparam.UnitJacobianReparam
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :member-order: bysource
+    :special-members: __call__
+
+Haar Transform
+--------------
+.. autoclass:: numpyro.infer.reparam.HaarReparam
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :member-order: bysource
+    :special-members: __call__
+
+Discrete Cosine Transform
+-------------------------
+.. autoclass:: numpyro.infer.reparam.DiscreteCosineReparam
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :member-order: bysource
+    :special-members: __call__

--- a/numpyro/distributions/transforms.py
+++ b/numpyro/distributions/transforms.py
@@ -2026,16 +2026,16 @@ class DiscreteCosineTransform(Transform[NonScalarArray]):
 
     def __call__(self, x: NonScalarArray) -> NonScalarArray:
         self.forward_shape(jnp.shape(x))
-        y = jax.scipy.fft.dct(x, type=2, norm="ortho", axis=self.dim)
+        y = jax.scipy.fft.dct(jnp.asarray(x), type=2, norm="ortho", axis=self.dim)
         if self.smooth:
-            y = y * self._weight(x.shape[self.dim], y.dtype)
+            y = y * self._weight(jnp.shape(x)[self.dim], y.dtype)
         return y
 
     def _inverse(self, y: NonScalarArray) -> NonScalarArray:
         self.inverse_shape(jnp.shape(y))
         if self.smooth:
-            y = y / self._weight(y.shape[self.dim], y.dtype)
-        return jax.scipy.fft.idct(y, type=2, norm="ortho", axis=self.dim)
+            y = y / self._weight(jnp.shape(y)[self.dim], y.dtype)
+        return jax.scipy.fft.idct(jnp.asarray(y), type=2, norm="ortho", axis=self.dim)
 
     def log_abs_det_jacobian(
         self,

--- a/numpyro/distributions/transforms.py
+++ b/numpyro/distributions/transforms.py
@@ -13,6 +13,7 @@ import jax
 from jax import Array, lax, vmap
 from jax.nn import log_sigmoid, softplus
 import jax.numpy as jnp
+import jax.scipy.fft
 from jax.scipy.linalg import solve_triangular
 from jax.scipy.special import expit, logit
 from jax.tree_util import register_pytree_node
@@ -45,7 +46,9 @@ __all__ = [
     "ComposeTransform",
     "CorrCholeskyTransform",
     "CorrMatrixCholeskyTransform",
+    "DiscreteCosineTransform",
     "ExpTransform",
+    "HaarTransform",
     "IdentityTransform",
     "L1BallTransform",
     "LowerCholeskyTransform",
@@ -1827,6 +1830,234 @@ class ComplexTransform(ParameterFreeTransform[NonScalarArray]):
 
     def inverse_shape(self, shape: tuple[int, ...]) -> tuple[int, ...]:
         return shape + (2,)
+
+
+_ROOT_TWO_INVERSE: float = 1.0 / math.sqrt(2.0)
+
+
+def _haar_forward(x: NonScalarArray) -> NonScalarArray:
+    """
+    Orthonormal Haar transform along the last axis.
+
+    This matches the block-structured Haar transform used by Pyro for sequences
+    whose length is not a power of two, but it is implemented with a bounded
+    ``for`` loop over a statically known number of levels (no ``while`` loop and
+    no recursion), so it traces cleanly under ``jax.jit`` and ``jax.vmap``. The
+    output is ordered as ``[dc, hi_k, end_k, ..., hi_1, end_1]`` where ``end_i``
+    is the trailing odd element (if any) at level ``i``.
+    """
+    size = x.shape[-1]
+    num_levels = max(0, size.bit_length() - 1)
+    lo = x
+    his: list[NonScalarArray] = []
+    ends: list[NonScalarArray] = []
+    for _ in range(num_levels):
+        n = lo.shape[-1] // 2
+        even = lo[..., 0 : 2 * n : 2]
+        odd = lo[..., 1 : 2 * n : 2]
+        ends.append(lo[..., 2 * n :])
+        his.append(_ROOT_TWO_INVERSE * (even - odd))
+        lo = _ROOT_TWO_INVERSE * (even + odd)
+    parts = [lo]
+    for i in range(num_levels - 1, -1, -1):
+        parts.append(his[i])
+        parts.append(ends[i])
+    return jnp.concatenate(parts, axis=-1)
+
+
+def _haar_inverse(y: NonScalarArray) -> NonScalarArray:
+    """
+    Inverse of :func:`_haar_forward` along the last axis.
+
+    Like the forward transform, this uses a bounded ``for`` loop over a
+    statically known number of levels (no ``while`` loop and no recursion).
+    """
+    size = y.shape[-1]
+    num_levels = max(0, size.bit_length() - 1)
+    lengths: list[int] = []
+    length = size
+    for _ in range(num_levels):
+        lengths.append(length)
+        length = length // 2
+    lo = y[..., 0:1]  # dc coefficient
+    offset = 1
+    for i in range(num_levels - 1, -1, -1):  # coarsest to finest
+        level_size = lengths[i]
+        n = level_size // 2
+        e = level_size - 2 * n
+        hi = y[..., offset : offset + n]
+        offset += n
+        end = y[..., offset : offset + e]
+        offset += e
+        even = _ROOT_TWO_INVERSE * (lo + hi)
+        odd = _ROOT_TWO_INVERSE * (lo - hi)
+        even_odd = jnp.stack([even, odd], axis=-1).reshape(even.shape[:-1] + (2 * n,))
+        lo = jnp.concatenate([even_odd, end], axis=-1)
+    return lo
+
+
+class HaarTransform(Transform[NonScalarArray]):
+    """
+    Discrete Haar transform.
+
+    This computes the (orthonormal) Haar transform and its inverse along a
+    chosen axis. The Jacobian determinant is 1. For sequences with length ``T``
+    not a power of two, this implementation is equivalent to a block-structured
+    Haar transform in which block sizes decrease by factors of one half from
+    left to right.
+
+    :param dim: Dimension along which to transform. Must be negative. This is an
+        absolute dim counting from the right.
+    :param flip: Whether to flip the time axis before applying the Haar
+        transform. Defaults to False.
+    """
+
+    bijective = True
+
+    def __init__(self, dim: int = -1, flip: bool = False) -> None:
+        assert isinstance(dim, int) and dim < 0
+        self.dim = dim
+        self.flip = flip
+
+    @property
+    def domain(self) -> Constraint:
+        return constraints.independent(constraints.real, -self.dim)
+
+    @property
+    def codomain(self) -> Constraint:
+        return constraints.independent(constraints.real, -self.dim)
+
+    def __call__(self, x: NonScalarArray) -> NonScalarArray:
+        if self.dim != -1:
+            x = jnp.swapaxes(x, self.dim, -1)
+        if self.flip:
+            x = jnp.flip(x, -1)
+        y = _haar_forward(x)
+        if self.dim != -1:
+            y = jnp.swapaxes(y, self.dim, -1)
+        return y
+
+    def _inverse(self, y: NonScalarArray) -> NonScalarArray:
+        if self.dim != -1:
+            y = jnp.swapaxes(y, self.dim, -1)
+        x = _haar_inverse(y)
+        if self.flip:
+            x = jnp.flip(x, -1)
+        if self.dim != -1:
+            x = jnp.swapaxes(x, self.dim, -1)
+        return x
+
+    def log_abs_det_jacobian(
+        self,
+        x: NonScalarArray,
+        y: NonScalarArray,
+        intermediates: Optional[PyTree] = None,
+    ) -> NumLike:
+        return jnp.zeros(jnp.shape(x)[: self.dim])
+
+    def forward_shape(self, shape: tuple[int, ...]) -> tuple[int, ...]:
+        if len(shape) < -self.dim:
+            raise ValueError("Too few dimensions on input")
+        return shape
+
+    def inverse_shape(self, shape: tuple[int, ...]) -> tuple[int, ...]:
+        if len(shape) < -self.dim:
+            raise ValueError("Too few dimensions on input")
+        return shape
+
+    def tree_flatten(self):
+        return (), ((), {"dim": self.dim, "flip": self.flip})
+
+    def eq(self, other: object, static: bool = False) -> ArrayLike:
+        return (
+            isinstance(other, HaarTransform)
+            and self.dim == other.dim
+            and self.flip == other.flip
+        )
+
+
+class DiscreteCosineTransform(Transform[NonScalarArray]):
+    """
+    Discrete Cosine Transform of type II.
+
+    This computes the orthonormal DCT and its inverse along a chosen axis using
+    :func:`jax.scipy.fft.dct` and :func:`jax.scipy.fft.idct`. The Jacobian
+    determinant is 1.
+
+    When reparameterizing variables that are approximately continuous along the
+    time dimension, set ``smooth=1``. For variables that are approximately
+    continuously differentiable along the time axis, set ``smooth=2``.
+
+    :param dim: Dimension along which to transform. Must be negative. This is an
+        absolute dim counting from the right.
+    :param smooth: Smoothing parameter. When 0, this transforms white noise to
+        white noise; when 1 this transforms Brownian noise to white noise; when
+        -1 this transforms violet noise to white noise; etc. Any real number is
+        allowed. See https://en.wikipedia.org/wiki/Colors_of_noise.
+    """
+
+    bijective = True
+
+    def __init__(self, dim: int = -1, smooth: float = 0.0) -> None:
+        assert isinstance(dim, int) and dim < 0
+        self.dim = dim
+        self.smooth = float(smooth)
+
+    @property
+    def domain(self) -> Constraint:
+        return constraints.independent(constraints.real, -self.dim)
+
+    @property
+    def codomain(self) -> Constraint:
+        return constraints.independent(constraints.real, -self.dim)
+
+    def _weight(self, size: int, dtype) -> Array:
+        # Weight by frequency**smooth, where the DCT-II frequencies are
+        # ``linspace(0.5, size - 0.5, size)``. The weights are normalized so
+        # that their geometric mean is one, ensuring ``|jacobian| = 1``.
+        freq = jnp.linspace(0.5, size - 0.5, size, dtype=dtype)
+        w = freq**self.smooth
+        w = w / jnp.exp(jnp.mean(jnp.log(w)))
+        return w.reshape((size,) + (1,) * (-self.dim - 1))
+
+    def __call__(self, x: NonScalarArray) -> NonScalarArray:
+        y = jax.scipy.fft.dct(x, type=2, norm="ortho", axis=self.dim)
+        if self.smooth:
+            y = y * self._weight(x.shape[self.dim], y.dtype)
+        return y
+
+    def _inverse(self, y: NonScalarArray) -> NonScalarArray:
+        if self.smooth:
+            y = y / self._weight(y.shape[self.dim], y.dtype)
+        return jax.scipy.fft.idct(y, type=2, norm="ortho", axis=self.dim)
+
+    def log_abs_det_jacobian(
+        self,
+        x: NonScalarArray,
+        y: NonScalarArray,
+        intermediates: Optional[PyTree] = None,
+    ) -> NumLike:
+        return jnp.zeros(jnp.shape(x)[: self.dim])
+
+    def forward_shape(self, shape: tuple[int, ...]) -> tuple[int, ...]:
+        if len(shape) < -self.dim:
+            raise ValueError("Too few dimensions on input")
+        return shape
+
+    def inverse_shape(self, shape: tuple[int, ...]) -> tuple[int, ...]:
+        if len(shape) < -self.dim:
+            raise ValueError("Too few dimensions on input")
+        return shape
+
+    def tree_flatten(self):
+        return (), ((), {"dim": self.dim, "smooth": self.smooth})
+
+    def eq(self, other: object, static: bool = False) -> ArrayLike:
+        return (
+            isinstance(other, DiscreteCosineTransform)
+            and self.dim == other.dim
+            and self.smooth == other.smooth
+        )
 
 
 ##########################################################

--- a/numpyro/distributions/transforms.py
+++ b/numpyro/distributions/transforms.py
@@ -17,7 +17,7 @@ import jax.scipy.fft
 from jax.scipy.linalg import solve_triangular
 from jax.scipy.special import expit, logit
 from jax.tree_util import register_pytree_node
-from jax.typing import ArrayLike
+from jax.typing import ArrayLike, DTypeLike
 
 from numpyro._typing import (
     NonScalarArray,
@@ -1928,6 +1928,7 @@ class HaarTransform(Transform[NonScalarArray]):
         return constraints.independent(constraints.real, -self.dim)
 
     def __call__(self, x: NonScalarArray) -> NonScalarArray:
+        self.forward_shape(jnp.shape(x))
         if self.dim != -1:
             x = jnp.swapaxes(x, self.dim, -1)
         if self.flip:
@@ -1938,6 +1939,7 @@ class HaarTransform(Transform[NonScalarArray]):
         return y
 
     def _inverse(self, y: NonScalarArray) -> NonScalarArray:
+        self.inverse_shape(jnp.shape(y))
         if self.dim != -1:
             y = jnp.swapaxes(y, self.dim, -1)
         x = _haar_inverse(y)
@@ -2011,22 +2013,26 @@ class DiscreteCosineTransform(Transform[NonScalarArray]):
     def codomain(self) -> Constraint:
         return constraints.independent(constraints.real, -self.dim)
 
-    def _weight(self, size: int, dtype) -> Array:
+    def _weight(self, size: int, dtype: DTypeLike) -> Array:
         # Weight by frequency**smooth, where the DCT-II frequencies are
         # ``linspace(0.5, size - 0.5, size)``. The weights are normalized so
-        # that their geometric mean is one, ensuring ``|jacobian| = 1``.
+        # that their geometric mean is one, ensuring ``|jacobian| = 1``. The
+        # result depends only on the static ``size`` and ``smooth``, so it is
+        # constant-folded under ``jit`` and contributes zero gradient.
         freq = jnp.linspace(0.5, size - 0.5, size, dtype=dtype)
         w = freq**self.smooth
         w = w / jnp.exp(jnp.mean(jnp.log(w)))
         return w.reshape((size,) + (1,) * (-self.dim - 1))
 
     def __call__(self, x: NonScalarArray) -> NonScalarArray:
+        self.forward_shape(jnp.shape(x))
         y = jax.scipy.fft.dct(x, type=2, norm="ortho", axis=self.dim)
         if self.smooth:
             y = y * self._weight(x.shape[self.dim], y.dtype)
         return y
 
     def _inverse(self, y: NonScalarArray) -> NonScalarArray:
+        self.inverse_shape(jnp.shape(y))
         if self.smooth:
             y = y / self._weight(y.shape[self.dim], y.dtype)
         return jax.scipy.fft.idct(y, type=2, norm="ortho", axis=self.dim)

--- a/numpyro/infer/reparam.py
+++ b/numpyro/infer/reparam.py
@@ -419,6 +419,13 @@ class UnitJacobianReparam(Reparam):
     unchanged. This reparameterization works only for latent variables, not
     likelihoods. The targeted (e.g. time) axis must be an event dimension.
 
+    This is intended for latent variables with real or independent positive
+    support (the transform is applied in the unconstrained representation, via
+    ``biject_to(support).inv``). It is not meaningful for non-trivial
+    constrained supports such as simplex, ordered, or correlation matrices,
+    where the axis-wise transform does not correspond to a useful change of
+    geometry.
+
     :param transform: A transform whose Jacobian has determinant one.
     :param str suffix: A suffix to append to the auxiliary site name.
     """

--- a/numpyro/infer/reparam.py
+++ b/numpyro/infer/reparam.py
@@ -13,6 +13,12 @@ import jax.numpy as jnp
 import numpyro
 import numpyro.distributions as dist
 from numpyro.distributions import biject_to, constraints
+from numpyro.distributions.transforms import (
+    ComposeTransform,
+    DiscreteCosineTransform,
+    HaarTransform,
+    Transform,
+)
 from numpyro.distributions.util import is_identically_one, safe_normalize, sum_rightmost
 from numpyro.infer.autoguide import AutoContinuous
 from numpyro.util import not_jax_tracer
@@ -400,3 +406,98 @@ class ExplicitReparam(Reparam):
         transformed = dist.TransformedDistribution(fn, self.transform)
         x = numpyro.sample(f"{name}_base", transformed)
         return None, self.transform.inv(x)
+
+
+class UnitJacobianReparam(Reparam):
+    """
+    Reparameterizer for a :class:`~numpyro.distributions.transforms.Transform`
+    whose Jacobian determinant is one.
+
+    The latent variable is reparameterized to a new space ``y = transform(x)``
+    via a transform applied to the unconstrained representation of the latent.
+    Because the Jacobian determinant is one, the log density of the model is
+    unchanged. This reparameterization works only for latent variables, not
+    likelihoods. The targeted (e.g. time) axis must be an event dimension.
+
+    :param transform: A transform whose Jacobian has determinant one.
+    :param str suffix: A suffix to append to the auxiliary site name.
+    """
+
+    def __init__(self, transform: Transform, suffix: str = "transformed") -> None:
+        self.transform = transform
+        self.suffix = suffix
+
+    def __call__(self, name, fn, obs):
+        assert obs is None, "UnitJacobianReparam does not support observe statements"
+        fn, expand_shape, event_dim = self._unwrap(fn)
+
+        # Map the constrained latent to the (unconstrained) reparameterized space.
+        transform = ComposeTransform([biject_to(fn.support).inv, self.transform])
+        base_event_dim = max(event_dim, self.transform.domain.event_dim)
+
+        # Draw noise in the reparameterized space.
+        x = numpyro.sample(
+            f"{name}_{self.suffix}",
+            dist.TransformedDistribution(
+                self._wrap(fn, expand_shape, base_event_dim), transform
+            ),
+        )
+
+        # Differentiably transform back. This simulates a deterministic site.
+        return None, transform.inv(x)
+
+
+class HaarReparam(UnitJacobianReparam):
+    """
+    Haar wavelet reparameterizer, using a
+    :class:`~numpyro.distributions.transforms.HaarTransform`.
+
+    This is useful for sequential models where coupling along a time-like axis
+    (e.g. a banded precision matrix) introduces long-range correlation. This
+    reparameterizes to a frequency-domain representation where the posterior
+    covariance should be closer to diagonal, thereby improving the accuracy of
+    diagonal guides in SVI and the effectiveness of a diagonal mass matrix in
+    HMC.
+
+    This reparameterization works only for latent variables, not likelihoods.
+    The time axis must be an event dimension (e.g. via ``.to_event(1)``).
+
+    :param int dim: Dimension along which to transform. Must be negative. This
+        is an absolute dim counting from the right.
+    :param bool flip: Whether to flip the time axis before applying the Haar
+        transform. Defaults to False.
+    """
+
+    def __init__(self, dim: int = -1, flip: bool = False) -> None:
+        super().__init__(HaarTransform(dim=dim, flip=flip), suffix="haar")
+
+
+class DiscreteCosineReparam(UnitJacobianReparam):
+    """
+    Discrete Cosine reparameterizer, using a
+    :class:`~numpyro.distributions.transforms.DiscreteCosineTransform`.
+
+    This is useful for sequential models where coupling along a time-like axis
+    (e.g. a banded precision matrix) introduces long-range correlation. This
+    reparameterizes to a frequency-domain representation where the posterior
+    covariance should be closer to diagonal, thereby improving the accuracy of
+    diagonal guides in SVI and the effectiveness of a diagonal mass matrix in
+    HMC.
+
+    When reparameterizing variables that are approximately continuous along the
+    time dimension, set ``smooth=1``. For variables that are approximately
+    continuously differentiable along the time axis, set ``smooth=2``.
+
+    This reparameterization works only for latent variables, not likelihoods.
+    The time axis must be an event dimension (e.g. via ``.to_event(1)``).
+
+    :param int dim: Dimension along which to transform. Must be negative. This
+        is an absolute dim counting from the right.
+    :param float smooth: Smoothing parameter. When 0, this transforms white
+        noise to white noise; when 1 this transforms Brownian noise to white
+        noise; when -1 this transforms violet noise to white noise; etc. Any
+        real number is allowed. See https://en.wikipedia.org/wiki/Colors_of_noise.
+    """
+
+    def __init__(self, dim: int = -1, smooth: float = 0.0) -> None:
+        super().__init__(DiscreteCosineTransform(dim=dim, smooth=smooth), suffix="dct")

--- a/test/infer/test_reparam.py
+++ b/test/infer/test_reparam.py
@@ -18,13 +18,15 @@ from numpyro.infer import MCMC, NUTS, SVI, Trace_ELBO
 from numpyro.infer.autoguide import AutoDiagonalNormal, AutoIAFNormal
 from numpyro.infer.reparam import (
     CircularReparam,
+    DiscreteCosineReparam,
     ExplicitReparam,
+    HaarReparam,
     LocScaleReparam,
     NeuTraReparam,
     ProjectedNormalReparam,
     TransformReparam,
 )
-from numpyro.infer.util import initialize_model
+from numpyro.infer.util import initialize_model, log_density
 from numpyro.optim import Adam
 
 
@@ -439,3 +441,95 @@ def test_explicit_reparam():
     mcmc.run(random.key(2))
     samples = mcmc.get_samples()
     assert abs(samples["x"].mean() - 1) < 0.1
+
+
+# (reparam class, kwargs, auxiliary-site suffix) for the time reparameterizers.
+TIME_REPARAMS = [
+    (HaarReparam, {}, "haar"),
+    (HaarReparam, {"flip": True}, "haar"),
+    (DiscreteCosineReparam, {}, "dct"),
+    (DiscreteCosineReparam, {"smooth": 1.0}, "dct"),
+]
+
+
+@pytest.mark.parametrize("reparam_cls, kwargs, suffix", TIME_REPARAMS)
+def test_time_reparam_moments(reparam_cls, kwargs, suffix):
+    T = 6
+    loc = np.linspace(-1.0, 1.0, T)
+    scale = np.linspace(0.5, 1.5, T)
+
+    def model():
+        with numpyro.plate("particles", 100000):
+            return numpyro.sample("x", dist.Normal(loc, scale).to_event(1))
+
+    value = handlers.seed(model, 0)()
+    expected_moments = get_moments(value)
+
+    reparam = reparam_cls(**kwargs)
+    with numpyro.handlers.reparam(config={"x": reparam}):
+        with handlers.trace() as tr:
+            value = handlers.seed(model, 0)()
+    # The original site becomes deterministic and an auxiliary site is added.
+    assert tr["x"]["type"] == "deterministic"
+    assert tr[f"x_{suffix}"]["type"] == "sample"
+    actual_moments = get_moments(value)
+    assert_allclose(actual_moments, expected_moments, atol=0.05, rtol=0.05)
+
+
+@pytest.mark.parametrize("reparam_cls, kwargs, suffix", TIME_REPARAMS)
+def test_time_reparam_log_joint(reparam_cls, kwargs, suffix):
+    T = 8
+
+    def model():
+        numpyro.sample("x", dist.Normal(0.0, 1.0).expand([T]).to_event(1))
+
+    reparam = reparam_cls(**kwargs)
+    reparam_model = handlers.reparam(model, config={"x": reparam})
+    aux = random.normal(random.key(1), (T,))
+
+    # Log density of the reparameterized model at the auxiliary value.
+    log_prob_reparam, _ = log_density(reparam_model, (), {}, {f"x_{suffix}": aux})
+
+    # Recover the latent value and evaluate the original model density.
+    with handlers.trace() as tr, handlers.substitute(data={f"x_{suffix}": aux}):
+        handlers.seed(reparam_model, 0)()
+    x_value = tr["x"]["value"]
+    log_prob_original, _ = log_density(model, (), {}, {"x": x_value})
+
+    # The transform has unit Jacobian, so the log density is unchanged.
+    assert_allclose(log_prob_reparam, log_prob_original, atol=1e-4)
+
+
+@pytest.mark.parametrize("reparam_cls", [HaarReparam, DiscreteCosineReparam])
+def test_time_reparam_nuts_smoke(reparam_cls):
+    T = 10
+    data = np.linspace(-1.0, 1.0, T)
+
+    def model(data):
+        x = numpyro.sample("x", dist.Normal(0.0, 1.0).expand([T]).to_event(1))
+        numpyro.sample("obs", dist.Normal(x, 0.5).to_event(1), obs=data)
+
+    reparam_model = handlers.reparam(model, config={"x": reparam_cls()})
+    mcmc = MCMC(
+        NUTS(reparam_model),
+        num_warmup=200,
+        num_samples=200,
+        num_chains=1,
+        progress_bar=False,
+    )
+    mcmc.run(random.key(0), data=data)
+    samples = mcmc.get_samples()["x"]
+    assert samples.shape == (200, T)
+    # Conjugate posterior mean is data * (1 / 0.25) / (1 + 1 / 0.25) = 0.8 * data.
+    assert_allclose(samples.mean(0), 0.8 * data, atol=0.3)
+
+
+def test_time_reparam_does_not_support_obs():
+    def model():
+        numpyro.sample(
+            "x", dist.Normal(0.0, 1.0).expand([4]).to_event(1), obs=jnp.zeros(4)
+        )
+
+    reparam_model = handlers.reparam(model, config={"x": HaarReparam()})
+    with pytest.raises(AssertionError):
+        handlers.seed(reparam_model, 0)()

--- a/test/infer/test_reparam.py
+++ b/test/infer/test_reparam.py
@@ -12,6 +12,7 @@ import jax.numpy as jnp
 
 import numpyro
 import numpyro.distributions as dist
+from numpyro.distributions import constraints
 from numpyro.distributions.transforms import AffineTransform, ExpTransform
 import numpyro.handlers as handlers
 from numpyro.infer import MCMC, NUTS, SVI, Trace_ELBO
@@ -452,9 +453,9 @@ TIME_REPARAMS = [
 ]
 
 
+@pytest.mark.parametrize("T", [6, 7], ids=["even", "odd"])
 @pytest.mark.parametrize("reparam_cls, kwargs, suffix", TIME_REPARAMS)
-def test_time_reparam_moments(reparam_cls, kwargs, suffix):
-    T = 6
+def test_time_reparam_moments(reparam_cls, kwargs, suffix, T):
     loc = np.linspace(-1.0, 1.0, T)
     scale = np.linspace(0.5, 1.5, T)
 
@@ -533,3 +534,60 @@ def test_time_reparam_does_not_support_obs():
     reparam_model = handlers.reparam(model, config={"x": HaarReparam()})
     with pytest.raises(AssertionError):
         handlers.seed(reparam_model, 0)()
+
+
+@pytest.mark.parametrize("reparam_cls", [HaarReparam, DiscreteCosineReparam])
+def test_time_reparam_event_dim_2(reparam_cls):
+    # Reparameterize along the time axis (dim=-2) of a (T, K) latent.
+    T, K = 8, 3
+    data = np.random.RandomState(0).randn(T, K)
+
+    def model(data):
+        x = numpyro.sample("x", dist.Normal(0.0, 1.0).expand([T, K]).to_event(2))
+        numpyro.sample("obs", dist.Normal(x, 0.5).to_event(2), obs=data)
+
+    reparam_model = handlers.reparam(model, config={"x": reparam_cls(dim=-2)})
+    mcmc = MCMC(
+        NUTS(reparam_model),
+        num_warmup=200,
+        num_samples=200,
+        num_chains=1,
+        progress_bar=False,
+    )
+    mcmc.run(random.key(0), data=data)
+    samples = mcmc.get_samples()["x"]
+    assert samples.shape == (200, T, K)
+    assert_allclose(samples.mean(0), 0.8 * data, atol=0.4)
+
+
+@pytest.mark.parametrize("reparam_cls, kwargs, suffix", TIME_REPARAMS)
+def test_time_reparam_positive_support(reparam_cls, kwargs, suffix):
+    # A positive-support latent is reparameterized in the unconstrained (log)
+    # space via biject_to(support).inv; the recovered value stays positive and
+    # the posterior matches the un-reparameterized model.
+    T = 8
+    data = np.abs(np.random.RandomState(1).randn(T)) + 0.5
+
+    def model(data):
+        x = numpyro.sample("x", dist.LogNormal(0.0, 1.0).expand([T]).to_event(1))
+        numpyro.sample("obs", dist.Normal(x, 0.3).to_event(1), obs=data)
+
+    # The auxiliary site lives in unconstrained space and x stays positive.
+    reparam = reparam_cls(**kwargs)
+    with handlers.trace() as tr:
+        handlers.seed(handlers.reparam(model, config={"x": reparam}), 0)(data)
+    assert tr["x"]["type"] == "deterministic"
+    assert (tr["x"]["value"] > 0).all()
+    assert tr[f"x_{suffix}"]["fn"].support == constraints.independent(
+        constraints.real, 1
+    )
+
+    def run(config):
+        m = handlers.reparam(model, config=config) if config else model
+        mcmc = MCMC(
+            NUTS(m), num_warmup=400, num_samples=400, num_chains=1, progress_bar=False
+        )
+        mcmc.run(random.key(0), data=data)
+        return mcmc.get_samples()["x"].mean(0)
+
+    assert_allclose(run({"x": reparam}), run({}), atol=0.15)

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -48,6 +48,7 @@ from numpyro.distributions.transforms import (
     StickBreakingTransform,
     UnpackTransform,
     ZeroSumTransform,
+    _haar_forward,
     biject_to,
 )
 
@@ -521,3 +522,57 @@ def test_time_transform_requires_negative_dim(transform_cls):
         transform_cls(dim=0)
     with pytest.raises(AssertionError):
         transform_cls(dim=1)
+
+
+@pytest.mark.parametrize("T", [2, 4, 5, 7, 8, 16])
+@pytest.mark.parametrize(
+    "transform", [HaarTransform(), DiscreteCosineTransform()], ids=["haar", "dct"]
+)
+def test_time_transform_orthonormal(transform, T):
+    # Building the transform matrix by applying it to the identity basis should
+    # give an orthonormal matrix (H @ H.T == I), i.e. the transform is a
+    # volume-preserving rotation/reflection.
+    matrix = vmap(transform)(jnp.eye(T))
+    assert jnp.allclose(matrix @ matrix.T, jnp.eye(T), atol=1e-5)
+
+
+def test_haar_transform_ground_truth():
+    # Locks the orthonormal Haar convention and the output ordering
+    # [dc, hi_coarsest, ..., hi_finest].
+    x = jnp.array([1.0, 2.0, 3.0, 4.0])
+    expected = jnp.array([5.0, -2.0, -1.0 / np.sqrt(2.0), -1.0 / np.sqrt(2.0)])
+    assert jnp.allclose(_haar_forward(x), expected, atol=1e-6)
+
+
+def test_haar_transform_autodiff():
+    # Haar is orthonormal, so d/dx ||Haar(x)||^2 == 2x.
+    x = jnp.arange(8.0)
+    grad_energy = jax.grad(lambda x: jnp.sum(HaarTransform()(x) ** 2))(x)
+    assert jnp.allclose(grad_energy, 2 * x, atol=1e-5)
+
+
+@pytest.mark.parametrize("smooth", [0.0, 1.0, 2.0])
+def test_discrete_cosine_transform_autodiff(smooth):
+    x = jnp.arange(8.0)
+    grad_energy = jax.grad(
+        lambda x: jnp.sum(DiscreteCosineTransform(smooth=smooth)(x) ** 2)
+    )(x)
+    assert jnp.all(jnp.isfinite(grad_energy))
+
+
+@pytest.mark.parametrize(
+    "transform",
+    [HaarTransform(), DiscreteCosineTransform(smooth=1.5)],
+    ids=["haar", "dct"],
+)
+def test_time_transform_dtype(transform):
+    # The transform preserves the input floating dtype.
+    x = random.normal(random.key(0), (13,))
+    y = transform(x)
+    assert y.dtype == x.dtype
+    assert transform.inv(y).dtype == x.dtype
+    if jax.config.read("jax_enable_x64"):
+        x64 = x.astype(jnp.float64)
+        y64 = transform(x64)
+        assert y64.dtype == jnp.float64
+        assert jnp.allclose(transform.inv(y64), x64, atol=1e-12)

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -25,7 +25,9 @@ from numpyro.distributions.transforms import (
     ComposeTransform,
     CorrCholeskyTransform,
     CorrMatrixCholeskyTransform,
+    DiscreteCosineTransform,
     ExpTransform,
+    HaarTransform,
     IdentityTransform,
     IndependentTransform,
     L1BallTransform,
@@ -116,7 +118,13 @@ TRANSFORMS = {
     "complex": T(ComplexTransform, (), dict()),
     "corr_chol": T(CorrCholeskyTransform, (), dict()),
     "corr_matrix_chol": T(CorrMatrixCholeskyTransform, (), dict()),
+    "dct": T(DiscreteCosineTransform, (), dict()),
+    "dct_smooth": T(DiscreteCosineTransform, (), dict(smooth=1.0)),
+    "dct_dim": T(DiscreteCosineTransform, (), dict(dim=-2)),
     "exp": T(ExpTransform, (), dict()),
+    "haar": T(HaarTransform, (), dict()),
+    "haar_flip": T(HaarTransform, (), dict(flip=True)),
+    "haar_dim": T(HaarTransform, (), dict(dim=-2)),
     "identity": T(IdentityTransform, (), dict()),
     "l1_ball": T(L1BallTransform, (), dict()),
     "lower_cholesky": T(LowerCholeskyTransform, (), dict()),
@@ -282,7 +290,16 @@ def test_real_fast_fourier_transform(input_shape, shape, ndims):
         (ComposeTransform([SoftplusTransform(), SigmoidTransform()]), ()),
         (CorrCholeskyTransform(), (15,)),
         (CorrMatrixCholeskyTransform(), (15,)),
+        (DiscreteCosineTransform(), (8,)),
+        (DiscreteCosineTransform(), (5,)),
+        (DiscreteCosineTransform(smooth=1.0), (8,)),
+        (DiscreteCosineTransform(smooth=2.0), (6,)),
+        (DiscreteCosineTransform(dim=-2), (4, 5)),
         (ExpTransform(), ()),
+        (HaarTransform(), (8,)),
+        (HaarTransform(), (5,)),
+        (HaarTransform(flip=True), (8,)),
+        (HaarTransform(dim=-2), (4, 5)),
         (IdentityTransform(), ()),
         (IndependentTransform(ExpTransform(), 2), (3, 4)),
         (L1BallTransform(), (9,)),
@@ -447,3 +464,60 @@ def test_compose_sequence_domain_codomain():
         assert y.ndim == event_dim
         assert composed.codomain.event_dim == event_dim
         assert composed.domain.event_dim == 1
+
+
+@pytest.mark.parametrize("T", [1, 2, 3, 4, 5, 8, 10, 16, 17])
+@pytest.mark.parametrize("flip", [False, True])
+def test_haar_transform_roundtrip_and_energy(T, flip):
+    transform = HaarTransform(flip=flip)
+    x = random.normal(random.key(0), (3, T))
+    y = transform(x)
+    # Round-trip.
+    assert jnp.allclose(transform.inv(y), x, atol=1e-5)
+    # Orthonormal transforms preserve energy.
+    assert jnp.allclose(jnp.sum(y**2, -1), jnp.sum(x**2, -1), atol=1e-4)
+    # Unit Jacobian.
+    assert jnp.allclose(transform.log_abs_det_jacobian(x, y), 0.0, atol=1e-6)
+
+
+@pytest.mark.parametrize("T", [1, 2, 3, 4, 5, 8, 10, 16, 17])
+@pytest.mark.parametrize("smooth", [0.0, 1.0, 2.0, -1.0])
+def test_discrete_cosine_transform_roundtrip(T, smooth):
+    transform = DiscreteCosineTransform(smooth=smooth)
+    x = random.normal(random.key(0), (3, T))
+    y = transform(x)
+    assert jnp.allclose(transform.inv(y), x, atol=1e-5)
+    # Unit Jacobian holds even with smoothing (geometric-mean normalized weights).
+    assert jnp.allclose(transform.log_abs_det_jacobian(x, y), 0.0, atol=1e-6)
+    if smooth == 0.0:
+        # Matches the orthonormal DCT-II directly.
+        expected = jax.scipy.fft.dct(x, type=2, norm="ortho", axis=-1)
+        assert jnp.allclose(y, expected, atol=1e-6)
+
+
+@pytest.mark.parametrize(
+    "transform_cls, kwargs",
+    [
+        (HaarTransform, dict()),
+        (HaarTransform, dict(flip=True)),
+        (DiscreteCosineTransform, dict()),
+        (DiscreteCosineTransform, dict(smooth=1.0)),
+    ],
+)
+def test_time_transform_dim(transform_cls, kwargs):
+    # Transforming along dim=-2 matches transforming along dim=-1 of the
+    # axis-swapped input.
+    x = random.normal(random.key(0), (6, 5))
+    y_dim = transform_cls(dim=-2, **kwargs)(x)
+    y_ref = jnp.swapaxes(
+        transform_cls(dim=-1, **kwargs)(jnp.swapaxes(x, -2, -1)), -2, -1
+    )
+    assert jnp.allclose(y_dim, y_ref, atol=1e-5)
+
+
+@pytest.mark.parametrize("transform_cls", [HaarTransform, DiscreteCosineTransform])
+def test_time_transform_requires_negative_dim(transform_cls):
+    with pytest.raises(AssertionError):
+        transform_cls(dim=0)
+    with pytest.raises(AssertionError):
+        transform_cls(dim=1)


### PR DESCRIPTION
Add HaarTransform and DiscreteCosineTransform by bringing them from Pyro. 

Motivation: https://github.com/juanitorduz/numpyro_forecast/issues/12

# Haar / DCT time reparameterization: motivation and method

## 1. The problem: correlated time latents wreck inference geometry

Sequential models place a latent value at every time step. A typical prior is a random walk / local-level drift:

$$x_1 \sim \mathcal{N}(0,\sigma), \qquad x_t = x_{t-1} + \varepsilon_t, \quad \varepsilon_t \sim \mathcal{N}(0,\sigma).$$

Neighboring latents are almost equal, so the joint posterior over $(x_1,\dots,x_T)$ has strong off-diagonal correlation (a banded precision matrix for AR / random-walk processes). Geometrically the posterior is a long, thin, rotated ellipse rather than a round ball.

That geometry is poison for the two standard inference tools:

- **HMC / NUTS with a diagonal mass matrix** assumes coordinates are roughly independent with per-axis scales. A correlated, rotated posterior forces tiny step sizes, so the chain mixes slowly.
- **Mean-field (diagonal) SVI guides** cannot represent the correlations, so they fit badly.

## 2. The fix: change coordinates to a space where the posterior is round

The general trick (the "non-centered" idea) is: do not sample the awkward $x$ directly. Sample a new variable $z$ in a nicer space and define $x = f(z)$ deterministically. If $f$ is chosen so that $z$ has an approximately diagonal / isotropic posterior, then the diagonal mass matrix and the mean-field guide work well. Inference runs on $z$; $x$ is reconstructed for the likelihood.

For time series we want a **linear** map that approximately diagonalizes the covariance of the trajectory. There is a classic answer: for stationary processes the covariance is approximately Toeplitz / circulant, and circulant matrices are diagonalized exactly by the Fourier basis. So transforming to the frequency domain decorrelates the time points. Haar and DCT are two concrete, cheap, real-valued ways to do this.

## 3. The Haar transform (multi-resolution averaging / differencing)

Take adjacent pairs and form a scaled average and difference:

$$s = \tfrac{1}{\sqrt{2}}(x_1 + x_2), \qquad d = \tfrac{1}{\sqrt{2}}(x_1 - x_2).$$

The $1/\sqrt{2}$ keeps it energy-preserving (orthonormal). Then you recurse on the averages only, halving the length each level. The result is one overall coarse coefficient (the "DC" / mean), plus detail (difference) coefficients at every scale, from coarse to fine. The output ordering is `[dc, hi_coarsest, ..., hi_finest]`.

Why it helps: a slowly varying or random-walk trajectory has tiny local differences, so the high-frequency detail coefficients have low, roughly equal variance and are nearly uncorrelated, while the few coarse coefficients carry the long-range structure. The strong nearest-neighbor coupling in time becomes a near-diagonal covariance across scales. Haar is the natural choice when correlation is "blocky" / multi-scale.

## 4. The Discrete Cosine Transform (frequency modes)

The DCT-II writes the signal as a sum of cosines of increasing frequency:

$$X_k \propto \sum_{n} x_n \cos\!\Big(\tfrac{\pi k (n + \tfrac{1}{2})}{N}\Big),$$

normalized to be orthonormal. It is the real-valued cousin of the DFT with even-symmetric boundary handling, and that boundary handling is exactly why it is (asymptotically) the optimal decorrelating basis for AR(1) / first-order Markov processes, i.e. it is close to the Karhunen-Loève (PCA) basis of those covariances. Coefficient $k=0$ is the overall mean; higher $k$ capture higher-frequency wiggles. Because the modes of a stationary process are approximately independent, the DCT coefficients have an approximately diagonal posterior. DCT is the natural choice for smooth, stationary-like dynamics.

## 5. The `smooth` knob (DCT only): matching the "color" of the noise

A plain DCT decorrelates, but the scales of the modes can still differ a lot (low frequencies carry much more variance in a random walk). The `smooth` parameter rescales each frequency component by $\text{freq}^{\text{smooth}}$ to flatten that out:

- `smooth=0`: no rescaling (white noise to white noise).
- `smooth=1`: turns Brownian-motion / random-walk priors (power spectrum $\propto 1/f^2$) into white noise in the reparam space, so $z$ is isotropic and HMC sees a round posterior.
- `smooth=2`: for smoother, twice-integrated processes.

This is the "colors of noise" idea: pick `smooth` to match how rough the latent process is.

## 6. Why this is "free": unit Jacobian

Haar and DCT are orthonormal (rotations / reflections), so $|\det J| = 1$, and the `smooth` weights are normalized so their geometric mean is one (which is why the weight is divided by `exp(mean(log(w)))`). A change of variables with unit Jacobian adds no log-determinant term: the prior and posterior densities are exactly preserved. So we are not changing the model at all, only the coordinate system the sampler explores. This is what `UnitJacobianReparam` encodes, and it is why applying these reparams cannot bias the results, only improve convergence.

## 7. How it lands in the code

When you wrap a site with `HaarReparam()` / `DiscreteCosineReparam()`:

1. The handler replaces the latent `x` with an auxiliary site `x_haar` / `x_dct` sampled from the transformed prior (the pushforward through the transform). This auxiliary variable lives in the decorrelated frequency / wavelet domain with a near-diagonal posterior.
2. It deterministically reconstructs `x = inverse_transform(x_haar)` for the likelihood.
3. Inference (NUTS, SVI) operates on the well-conditioned `x_haar`; you read out `x` as a `deterministic` site.

For positive-support latents (e.g. `LogNormal`) it first maps to unconstrained space via `biject_to(support).inv` (a log), then applies Haar / DCT there. That is the `ComposeTransform([biject_to(fn.support).inv, self.transform])` step.

## Summary

Time latents are correlated because the prior couples neighbors. Haar / DCT rotate the trajectory into a frequency / multi-scale basis where those couplings approximately vanish, giving a round posterior that diagonal mass matrices and mean-field guides can handle. Because the rotation is volume-preserving it leaves the model exactly unchanged.
