### PR TITLE
Rename `var` -> `variance` for truncated distributions and close support.

### DIFF
--- a/numpyro/distributions/truncated.py
+++ b/numpyro/distributions/truncated.py
@@ -53,7 +53,7 @@ class LeftTruncatedDistribution(Distribution):
             Cauchy, Laplace, Logistic, Normal, SoftLaplace, StudentT
         ] = jax.tree.map(lambda p: promote_shapes(p, shape=batch_shape)[0], base_dist)
         (self.low,) = promote_shapes(low, shape=batch_shape)
-        self._support = constraints.greater_than(low)
+        self._support = constraints.greater_than_eq(low)
         super().__init__(batch_shape, validate_args=validate_args)
 
     @constraints.dependent_property(is_discrete=False, event_dim=0)
@@ -120,7 +120,7 @@ class LeftTruncatedDistribution(Distribution):
             raise NotImplementedError("mean only available for Normal and Cauchy")
 
     @property
-    def var(self) -> ArrayLike:
+    def variance(self) -> ArrayLike:
         if isinstance(self.base_dist, Normal):
             low_prob = jnp.exp(self.log_prob(self.low))
             return (self.base_dist.scale**2) * (
@@ -131,7 +131,7 @@ class LeftTruncatedDistribution(Distribution):
         elif isinstance(self.base_dist, Cauchy):
             return jnp.full(self.batch_shape, jnp.nan)
         else:
-            raise NotImplementedError("var only available for Normal and Cauchy")
+            raise NotImplementedError("variance only available for Normal and Cauchy")
 
 
 class RightTruncatedDistribution(Distribution):
@@ -156,7 +156,7 @@ class RightTruncatedDistribution(Distribution):
             Cauchy, Laplace, Logistic, Normal, SoftLaplace, StudentT
         ] = jax.tree.map(lambda p: promote_shapes(p, shape=batch_shape)[0], base_dist)
         (self.high,) = promote_shapes(high, shape=batch_shape)
-        self._support = constraints.less_than(high)
+        self._support = constraints.less_than_eq(high)
         super().__init__(batch_shape, validate_args=validate_args)
 
     @constraints.dependent_property(is_discrete=False, event_dim=0)
@@ -208,7 +208,7 @@ class RightTruncatedDistribution(Distribution):
             raise NotImplementedError("mean only available for Normal and Cauchy")
 
     @property
-    def var(self) -> ArrayLike:
+    def variance(self) -> ArrayLike:
         if isinstance(self.base_dist, Normal):
             high_prob = jnp.exp(self.log_prob(self.high))
             return (self.base_dist.scale**2) * (
@@ -219,7 +219,7 @@ class RightTruncatedDistribution(Distribution):
         elif isinstance(self.base_dist, Cauchy):
             return jnp.full(self.batch_shape, jnp.nan)
         else:
-            raise NotImplementedError("var only available for Normal and Cauchy")
+            raise NotImplementedError("variance only available for Normal and Cauchy")
 
 
 class TwoSidedTruncatedDistribution(Distribution):
@@ -354,7 +354,7 @@ class TwoSidedTruncatedDistribution(Distribution):
             raise NotImplementedError("mean only available for Normal and Cauchy")
 
     @property
-    def var(self) -> ArrayLike:
+    def variance(self) -> ArrayLike:
         if isinstance(self.base_dist, Normal):
             low_prob = jnp.exp(self.log_prob(self.low))
             high_prob = jnp.exp(self.log_prob(self.high))
@@ -367,7 +367,7 @@ class TwoSidedTruncatedDistribution(Distribution):
         elif isinstance(self.base_dist, Cauchy):
             return jnp.full(self.batch_shape, jnp.nan)
         else:
-            raise NotImplementedError("var only available for Normal and Cauchy")
+            raise NotImplementedError("variance only available for Normal and Cauchy")
 
 
 def TruncatedDistribution(

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -2240,14 +2240,6 @@ def test_mean_var(jax_dist, sp_dist, params):
     if "SineSkewed" in jax_dist.__name__:
         pytest.skip("Skewed Distribution are not symmetric about location.")
     if jax_dist in (
-        _TruncatedNormal,
-        _TruncatedCauchy,
-        dist.LeftTruncatedDistribution,
-        dist.RightTruncatedDistribution,
-        dist.TwoSidedTruncatedDistribution,
-    ):
-        pytest.skip("Truncated distributions do not has mean/var implemented")
-    if jax_dist in (
         _LeftCensoredHalfNormal,
         _RightCensoredWeibull,
         _LeftCensoredNormal,
@@ -2432,15 +2424,27 @@ def test_mean_var(jax_dist, sp_dist, params):
             sample_scale_tril = jnp.linalg.cholesky(jnp.cov(samples_mvn.T))
             jnp.allclose(sample_scale_tril, scale_tril, atol=0.5, rtol=1e-2)
     else:
-        if jnp.all(jnp.isfinite(d_jax.mean)):
-            assert_allclose(jnp.mean(samples, 0), d_jax.mean, rtol=0.05, atol=1e-2)
+        # A distribution may implement a closed-form moment only for some base
+        # families (e.g. truncated distributions only for Normal/Cauchy); others
+        # raise NotImplementedError, in which case there is nothing to compare
+        # the samples against.
+        try:
+            mean = d_jax.mean
+        except NotImplementedError:
+            mean = None
+        if mean is not None and jnp.all(jnp.isfinite(mean)):
+            assert_allclose(jnp.mean(samples, 0), mean, rtol=0.05, atol=1e-2)
         if isinstance(d_jax, dist.CAR):
             pytest.skip("CAR distribution does not have `variance` implemented.")
         if isinstance(d_jax, dist.Gompertz):
             pytest.skip("Gompertz distribution does not have `variance` implemented.")
-        if jnp.all(jnp.isfinite(d_jax.variance)):
+        try:
+            variance = d_jax.variance
+        except NotImplementedError:
+            variance = None
+        if variance is not None and jnp.all(jnp.isfinite(variance)):
             assert jnp.allclose(
-                jnp.std(samples, 0), jnp.sqrt(d_jax.variance), rtol=0.05, atol=0.05
+                jnp.std(samples, 0), jnp.sqrt(variance), rtol=0.05, atol=0.05
             )
 
 


### PR DESCRIPTION
- Rename `var` to `variance` for truncated distributions to match the base `Distribution` naming.
- Close the support for left/right truncated distribution to match the two-sided closed interval and other distributions with finite support, e.g., uniform, beta, etc.
- Include truncated distributions in mean/variance tests.
- Make mean/variance tests robust to `NotImplementedError`s similar to other tests.