### PR TITLE
Bugfix/null mixture-weights grad

### DIFF
--- a/numpyro/distributions/discrete.py
+++ b/numpyro/distributions/discrete.py
@@ -638,24 +638,40 @@ def Binomial(
         return BinomialLogits(logits, total_count, validate_args=validate_args)
 
 
-class CategoricalProbs(Distribution):
-    r"""A Categorical discrete random variable over :math:`K` mutually exclusive
-    outcomes, parameterized by a probability vector on the simplex.
+class _CategoricalBase(Distribution):
+    has_enumerate_support = True
 
-    The Probability Mass Function (PMF) of the Categorical distribution is defined as:
+    @property
+    def _param(self) -> ArrayLike:
+        """The raw parameter (``probs`` or ``logits``) stored at construction.
 
-    .. math::
-        P(X = k \mid \mathbf{p}) = p_k, \quad k \in \{0, 1, \dots, K-1\}
+        Used for batch/event-shape and dtype queries so that neither the
+        ``probs`` nor the ``logits`` conversion is triggered.
+        """
+        raise NotImplementedError
 
-    where the probability vector :math:`\mathbf{p} = (p_0, p_1, \dots, p_{K-1})`
-    satisfies :math:`p_k \ge 0` and :math:`\sum_{k=0}^{K-1} p_k = 1`.
+    @property
+    def mean(self) -> ArrayLike:
+        return jnp.full(self.batch_shape, jnp.nan, dtype=jnp.result_type(self._param))
 
-    Where, :math:`\mathbf{p}` represents the category probability vector
-    (:attr:`probs`), :math:`K` is the number of categories (the size of the trailing
-    dimension of :attr:`probs`), and :math:`k` is the observed category index
-    (:attr:`value`). The support domain is :math:`k \in \{0, 1, \dots, K-1\}`.
-    """
+    @property
+    def variance(self) -> ArrayLike:
+        return jnp.full(self.batch_shape, jnp.nan, dtype=jnp.result_type(self._param))
 
+    @constraints.dependent_property(is_discrete=True, event_dim=0)
+    def support(self) -> constraints.Constraint:
+        return constraints.integer_interval(0, jnp.shape(self._param)[-1] - 1)
+
+    def enumerate_support(self, expand: bool = True) -> ArrayLike:
+        values = jnp.arange(jnp.shape(self._param)[-1]).reshape(
+            (-1,) + (1,) * len(self.batch_shape)
+        )
+        if expand:
+            values = jnp.broadcast_to(values, values.shape[:1] + self.batch_shape)
+        return values
+
+
+class CategoricalProbs(_CategoricalBase):
     arg_constraints = {"probs": constraints.simplex}
     has_enumerate_support = True
 
@@ -672,18 +688,13 @@ class CategoricalProbs(Distribution):
             batch_shape=jnp.shape(self.probs)[:-1], validate_args=validate_args
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
-        r"""Draw samples from the Categorical distribution.
+    @property
+    def _param(self) -> ArrayLike:
+        return self.probs
 
-        This method delegates to :func:`~numpyro.distributions.util.categorical`, which
-        internally relies on :func:`~jax.random.categorical` over the log-probabilities
-        of :attr:`probs`.
-
-        :param key: A JAX random number generator key (PRNG state).
-        :param sample_shape: Desired sample dimensions to prepend to the batch shape.
-        :return: Integer-valued samples in :math:`\{0, 1, \dots, K-1\}` drawn from the
-            Categorical distribution.
-        """
+    def sample(
+        self, key: jax.Array, sample_shape: tuple[int, ...] = ()
+    ) -> ArrayLike:
         assert is_prng_key(key)
         return categorical(key, self.probs, shape=sample_shape + self.batch_shape)
 
@@ -718,47 +729,6 @@ class CategoricalProbs(Distribution):
         """
         return _to_logits_multinom(self.probs)
 
-    @property
-    def mean(self) -> ArrayLike:
-        r"""The mean of a Categorical distribution over arbitrary unordered categories
-        is not well-defined. This property therefore returns ``NaN``.
-
-        :return: An array of NaNs with shape equal to :attr:`batch_shape`.
-        """
-        return jnp.full(self.batch_shape, jnp.nan, dtype=jnp.result_type(self.probs))
-
-    @property
-    def variance(self) -> ArrayLike:
-        r"""The variance of a Categorical distribution over arbitrary unordered
-        categories is not well-defined. This property therefore returns ``NaN``.
-
-        :return: An array of NaNs with shape equal to :attr:`batch_shape`.
-        """
-        return jnp.full(self.batch_shape, jnp.nan, dtype=jnp.result_type(self.probs))
-
-    @constraints.dependent_property(is_discrete=True, event_dim=0)
-    def support(self) -> constraints.Constraint:
-        r"""The support of the Categorical distribution is the set of integers
-        :math:`\{0, 1, \dots, K-1\}`, where :math:`K` is the number of categories
-        inferred from the trailing dimension of :attr:`probs`.
-        """
-        return constraints.integer_interval(0, jnp.shape(self.probs)[-1] - 1)
-
-    def enumerate_support(self, expand: bool = True) -> ArrayLike:
-        r"""Enumerate all values in the support of the Categorical distribution.
-
-        :param expand: Whether to broadcast the enumerated values across the batch
-            shape. Default is True.
-        :return: An array of integer category indices :math:`\{0, 1, \dots, K-1\}`,
-            optionally broadcast across the batch dimensions.
-        """
-        values = jnp.arange(self.probs.shape[-1]).reshape(
-            (-1,) + (1,) * len(self.batch_shape)
-        )
-        if expand:
-            values = jnp.broadcast_to(values, values.shape[:1] + self.batch_shape)
-        return values
-
     def entropy(self) -> ArrayLike:
         r"""The entropy of the Categorical distribution is given by:
 
@@ -770,24 +740,7 @@ class CategoricalProbs(Distribution):
         return -(self.probs * jnp.log(self.probs)).sum(axis=-1)
 
 
-class CategoricalLogits(Distribution):
-    r"""A Categorical discrete random variable over :math:`K` mutually exclusive
-    outcomes, parameterized by unnormalized log-probabilities (logits).
-
-    The Probability Mass Function (PMF) of the Categorical distribution is defined,
-    via the softmax transformation of the logits, as:
-
-    .. math::
-        P(X = k \mid \boldsymbol{\alpha}) = \frac{\exp(\alpha_k)}{\sum_{j=0}^{K-1}
-        \exp(\alpha_j)}, \quad k \in \{0, 1, \dots, K-1\}
-
-    Where, :math:`\boldsymbol{\alpha} = (\alpha_0, \alpha_1, \dots, \alpha_{K-1})`
-    is the real-valued logits vector (:attr:`logits`), :math:`K` is the number of
-    categories (the size of the trailing dimension of :attr:`logits`), and :math:`k`
-    is the observed category index (:attr:`value`). The support domain is
-    :math:`k \in \{0, 1, \dots, K-1\}`.
-    """
-
+class CategoricalLogits(_CategoricalBase):
     arg_constraints = {"logits": constraints.real_vector}
     has_enumerate_support = True
 
@@ -805,18 +758,13 @@ class CategoricalLogits(Distribution):
             batch_shape=jnp.shape(logits)[:-1], validate_args=validate_args
         )
 
-    def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
-        r"""Draw samples from the Categorical distribution.
+    @property
+    def _param(self) -> ArrayLike:
+        return self.logits
 
-        This method invokes :func:`~jax.random.categorical` directly, which samples in
-        logit-space using the Gumbel-max trick and therefore avoids materializing the
-        softmax-normalized probabilities.
-
-        :param key: A JAX random number generator key (PRNG state).
-        :param sample_shape: Desired sample dimensions to prepend to the batch shape.
-        :return: Integer-valued samples in :math:`\{0, 1, \dots, K-1\}` drawn from the
-            Categorical distribution.
-        """
+    def sample(
+        self, key: jax.Array, sample_shape: tuple[int, ...] = ()
+    ) -> ArrayLike:
         assert is_prng_key(key)
         return random.categorical(
             key, self.logits, shape=sample_shape + self.batch_shape
@@ -856,47 +804,6 @@ class CategoricalLogits(Distribution):
             \quad k \in \{0, 1, \dots, K-1\}
         """
         return _to_probs_multinom(self.logits)
-
-    @property
-    def mean(self) -> ArrayLike:
-        r"""The mean of a Categorical distribution over arbitrary unordered categories
-        is not well-defined. This property therefore returns ``NaN``.
-
-        :return: An array of NaNs with shape equal to :attr:`batch_shape`.
-        """
-        return jnp.full(self.batch_shape, jnp.nan, dtype=jnp.result_type(self.logits))
-
-    @property
-    def variance(self) -> ArrayLike:
-        r"""The variance of a Categorical distribution over arbitrary unordered
-        categories is not well-defined. This property therefore returns ``NaN``.
-
-        :return: An array of NaNs with shape equal to :attr:`batch_shape`.
-        """
-        return jnp.full(self.batch_shape, jnp.nan, dtype=jnp.result_type(self.logits))
-
-    @constraints.dependent_property(is_discrete=True, event_dim=0)
-    def support(self) -> constraints.Constraint:
-        r"""The support of the Categorical distribution is the set of integers
-        :math:`\{0, 1, \dots, K-1\}`, where :math:`K` is the number of categories
-        inferred from the trailing dimension of :attr:`logits`.
-        """
-        return constraints.integer_interval(0, jnp.shape(self.logits)[-1] - 1)
-
-    def enumerate_support(self, expand: bool = True) -> ArrayLike:
-        r"""Enumerate all values in the support of the Categorical distribution.
-
-        :param expand: Whether to broadcast the enumerated values across the batch
-            shape. Default is True.
-        :return: An array of integer category indices :math:`\{0, 1, \dots, K-1\}`,
-            optionally broadcast across the batch dimensions.
-        """
-        values = jnp.arange(self.logits.shape[-1]).reshape(
-            (-1,) + (1,) * len(self.batch_shape)
-        )
-        if expand:
-            values = jnp.broadcast_to(values, values.shape[:1] + self.batch_shape)
-        return values
 
     def entropy(self) -> ArrayLike:
         r"""The entropy of the Categorical distribution is given by:

--- a/numpyro/distributions/mixtures.py
+++ b/numpyro/distributions/mixtures.py
@@ -251,12 +251,21 @@ class MixtureSameFamily(_MixtureBase):
         *,
         validate_args: Optional[bool] = None,
     ):
-        assert isinstance(
-            component_distribution.support, constraints.ParameterFreeConstraint
-        ), (
+        # A mixture evaluates every component's density at the *same* value, so
+        # the component support must be identical across components and must not
+        # depend on their parameters. A vectorized (event-wrapped) component such
+        # as ``Normal(...).to_event(1)`` has an ``Independent`` support, which only
+        # reinterprets batch dims as event dims and introduces no parameter
+        # dependence. So unwrap any ``Independent`` layers and require the *base*
+        # support to be parameter-free.
+        base_support = component_distribution.support
+        while isinstance(base_support, constraints._IndependentConstraint):
+            base_support = base_support.base_constraint
+        assert isinstance(base_support, constraints.ParameterFreeConstraint), (
             f"Invalid component distribution: {type(component_distribution).__name__}. "
-            "The mixture components must have a support that does not depend on their parameters "
-            f"(expected ParameterFreeConstraint, but found {component_distribution.support})."
+            "The mixture components must have a support that does not depend on their "
+            "parameters (expected a (possibly Independent-wrapped) "
+            f"ParameterFreeConstraint, but found {component_distribution.support})."
         )
         _check_mixing_distribution(mixing_distribution)
         mixture_size = mixing_distribution.probs.shape[-1]

--- a/numpyro/distributions/mixtures.py
+++ b/numpyro/distributions/mixtures.py
@@ -71,6 +71,15 @@ class _MixtureBase(Distribution):
         raise NotImplementedError
 
     def component_log_probs(self, value: ArrayLike) -> ArrayLike:
+        log_probs = self._bare_component_log_probs(value)
+        return jnp.log(self.mixing_distribution.probs) + log_probs
+
+    def _bare_component_log_probs(self, value: ArrayLike) -> ArrayLike:
+        """The component log-densities ``log p_k(x)`` without the mixing weights.
+
+        Entries for out-of-support components may be ``-inf``. ``component_log_probs``
+        adds the mixing log-weights ``log(mixing_distribution.probs)`` to this.
+        """
         raise NotImplementedError
 
     def component_sample(
@@ -167,15 +176,37 @@ class _MixtureBase(Distribution):
     @validate_sample
     def log_prob(self, value: ArrayLike, intermediates=None) -> ArrayLike:
         del intermediates
-        sum_log_probs = self.component_log_probs(value)
-        safe_sum_log_probs = jnp.where(
-            jnp.isneginf(sum_log_probs), -jnp.inf, sum_log_probs
-        )
-        return jax.nn.logsumexp(
-            safe_sum_log_probs,
-            where=~jnp.isneginf(sum_log_probs),  # for numerical stability
-            axis=-1,
-        )
+        # Combine the bare component log-densities with the mixing weights via a
+        # numerically stable weighted logsumexp, keeping the weights in linear
+        # space (never taking log(w_k)):
+        #
+        #     log p(x) = log sum_k w_k p_k(x)
+        #              = m + log sum_k w_k exp(log p_k(x) - m),   m = max_k log p_k(x)
+        #
+        # This is exact in both value and gradient: d/dw_k = p_k(x) / sum_j w_j p_j(x)
+        # stays finite at w_k == 0 (unlike log(w_k), whose VJP is 1/0 = inf), and
+        # d/d(log p_k) = w_k p_k(x) / sum_j w_j p_j(x). Using jax.nn.logsumexp's
+        # `b=` argument instead would silently zero the gradient of any exactly-
+        # zero-weight component, so we compute the sum directly. Out-of-support
+        # components (log p_k = -inf) contribute an exact zero with zero gradient.
+        bare_log_probs = self._bare_component_log_probs(value)
+        probs = self.mixing_distribution.probs
+        neginf = jnp.isneginf(bare_log_probs)
+        # Max over in-support components only; fall back to 0.0 when every
+        # component is out of support (avoids -inf - (-inf) = nan under the exp).
+        m = jnp.max(jnp.where(neginf, -jnp.inf, bare_log_probs), axis=-1, keepdims=True)
+        m = lax.stop_gradient(jnp.where(jnp.isneginf(m), 0.0, m))
+        # Double `where` so no -inf reaches exp on either the forward or the
+        # backward pass; out-of-support entries are pinned to an exact 0.
+        shifted = jnp.where(neginf, 0.0, bare_log_probs - m)
+        weighted = probs * jnp.where(neginf, 0.0, jnp.exp(shifted))
+        total = jnp.sum(weighted, axis=-1)
+        # Guard log(0): when no weighted component can produce `value` (all mass
+        # on out-of-support components), the density is 0 and log_prob is -inf.
+        # The `where` keeps that -inf while giving inputs a 0 (not NaN) gradient.
+        safe_total = jnp.where(total > 0, total, 1.0)
+        log_prob = jnp.log(safe_total) + jnp.squeeze(m, axis=-1)
+        return jnp.where(total > 0, log_prob, -jnp.inf)
 
 
 class MixtureSameFamily(_MixtureBase):
@@ -290,10 +321,9 @@ class MixtureSameFamily(_MixtureBase):
             sample_shape + self.batch_shape + (self.mixture_size,)
         ).sample(key)
 
-    def component_log_probs(self, value: ArrayLike) -> ArrayLike:
+    def _bare_component_log_probs(self, value: ArrayLike) -> ArrayLike:
         value = jnp.expand_dims(value, self.mixture_dim)
-        component_log_probs = self.component_distribution.log_prob(value)
-        return jax.nn.log_softmax(self.mixing_distribution.logits) + component_log_probs
+        return self.component_distribution.log_prob(value)
 
 
 class MixtureGeneral(_MixtureBase):
@@ -465,7 +495,7 @@ class MixtureGeneral(_MixtureBase):
             samples.append(d.expand(sample_shape + self.batch_shape).sample(k))
         return jnp.stack(samples, axis=self.mixture_dim)
 
-    def component_log_probs(self, value: ArrayLike) -> ArrayLike:
+    def _bare_component_log_probs(self, value: ArrayLike) -> ArrayLike:
         component_log_probs = []
         for d in self.component_distributions:
             log_prob = d.log_prob(value)
@@ -473,8 +503,7 @@ class MixtureGeneral(_MixtureBase):
                 mask = d.support(value)
                 log_prob = jnp.where(mask, log_prob, -jnp.inf)
             component_log_probs.append(log_prob)
-        component_log_probs = jnp.stack(component_log_probs, axis=-1)
-        return jax.nn.log_softmax(self.mixing_distribution.logits) + component_log_probs
+        return jnp.stack(component_log_probs, axis=-1)
 
 
 def _check_mixing_distribution(mixing_distribution: Distribution) -> None:

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -2627,6 +2627,36 @@ def test_categorical_log_prob_grad():
     assert_allclose(grad_fx, grad_gx, atol=1e-4)
 
 
+def test_categorical_base_probs_property():
+    from numpyro.distributions.discrete import (
+        CategoricalLogits,
+        CategoricalProbs,
+        _CategoricalBase,
+    )
+
+    assert issubclass(CategoricalProbs, _CategoricalBase)
+    assert issubclass(CategoricalLogits, _CategoricalBase)
+
+    # CategoricalProbs.probs returns the stored weights directly, without ever
+    # routing through the logits (log) round-trip, so exact zeros are preserved.
+    probs = jnp.array([0.0, 0.5, 0.5])
+    cp = dist.Categorical(probs=probs)
+    assert_array_equal(cp.probs, probs)
+
+    # CategoricalLogits.probs is softmax(logits), strictly positive.
+    logits = jnp.array([0.1, 0.2, 0.3])
+    cl = dist.Categorical(logits=logits)
+    assert_allclose(cl.probs, jax.nn.softmax(logits), rtol=1e-6)
+    assert jnp.all(cl.probs > 0)
+
+    # Shared _CategoricalBase behavior on both parameterizations.
+    for d, param in [(cp, probs), (cl, logits)]:
+        assert d.support.upper_bound == jnp.shape(param)[-1] - 1
+        assert_array_equal(d.enumerate_support(expand=False).ravel(), jnp.arange(3))
+        assert jnp.isnan(d.mean)
+        assert jnp.isnan(d.variance)
+
+
 def test_beta_proportion_invalid_mean():
     with (
         dist.distribution.validation_enabled(),

--- a/test/test_distributions_mixture.py
+++ b/test/test_distributions_mixture.py
@@ -205,3 +205,108 @@ def test_mixture_rejects_parameter_dependent_components(component_dist):
 def test_mixture_accepts_parameter_free_components(component_dist):
     mixing_dist = dist.Categorical(probs=np.array([0.3, 0.7]))
     dist.MixtureSameFamily(mixing_dist, component_dist)
+
+
+def _make_mixture(mixture_cls, probs):
+    """A 3-component Normal mixture, built as SameFamily or General."""
+    locs = jnp.array([0.0, 1.0, 2.0])
+    mixing = dist.Categorical(probs=probs)
+    if mixture_cls is dist.MixtureSameFamily:
+        return dist.MixtureSameFamily(mixing, dist.Normal(locs, 1.0))
+    return dist.MixtureGeneral(mixing, [dist.Normal(loc, 1.0) for loc in locs])
+
+
+@pytest.mark.parametrize("mixture_cls", [dist.MixtureSameFamily, dist.MixtureGeneral])
+@pytest.mark.parametrize(
+    "probs",
+    [
+        np.array([0.0, 0.5, 0.5]),  # single exact-zero weight
+        np.array([0.0, 0.0, 1.0]),  # two exact-zero weights
+    ],
+)
+def test_mixture_log_prob_grad_at_zero_weight(mixture_cls, probs):
+    # A probs= mixing weight of exactly 0 used to produce a NaN gradient (the
+    # forward value was finite) because the density was written in log-weight
+    # form and log(0) has an infinite VJP. The weighted-logsumexp formulation
+    # keeps both the value and the gradient finite and exact.
+    probs = jnp.asarray(probs)
+    value = jnp.array(0.3)
+    locs = jnp.array([0.0, 1.0, 2.0])
+
+    # Reference: log sum_k w_k N(x; loc_k, 1), component densities constant in w.
+    component_probs = jnp.exp(dist.Normal(locs, 1.0).log_prob(value))
+
+    def ref(w):
+        return jnp.log(jnp.sum(w * component_probs))
+
+    def actual(w):
+        return _make_mixture(mixture_cls, w).log_prob(value)
+
+    value_ref, grad_ref = jax.value_and_grad(ref)(probs)
+    value_actual, grad_actual = jax.value_and_grad(actual)(probs)
+
+    assert jnp.isfinite(value_actual)
+    assert jnp.all(jnp.isfinite(grad_actual))
+    assert jnp.allclose(value_actual, value_ref, rtol=1e-5)
+    # Gradient is exact, including the p_k / sum_j w_j p_j slot at w_k == 0.
+    assert jnp.allclose(grad_actual, grad_ref, rtol=1e-5)
+
+
+def test_mixture_general_out_of_support_component_zero_weight():
+    # An out-of-support component (log p_k = -inf) that also has zero weight must
+    # not pollute the value or the gradient.
+    value = jnp.array(-0.5)
+
+    def actual(w):
+        mixture = dist.MixtureGeneral(
+            dist.Categorical(probs=w),
+            [dist.HalfNormal(1.0), dist.Normal(-1.0, 1.0), dist.Normal(-2.0, 1.0)],
+            support=dist.constraints.real,
+        )
+        return mixture.log_prob(value)
+
+    # HalfNormal is out of support at -0.5; give it zero weight.
+    probs = jnp.array([0.0, 0.5, 0.5])
+    component_probs = jnp.array(
+        [
+            0.0,  # out of support -> density 0
+            jnp.exp(dist.Normal(-1.0, 1.0).log_prob(value)),
+            jnp.exp(dist.Normal(-2.0, 1.0).log_prob(value)),
+        ]
+    )
+    value_ref = jnp.log(jnp.sum(probs * component_probs))
+    grad_ref = component_probs / jnp.sum(probs * component_probs)
+
+    value_actual, grad_actual = jax.value_and_grad(actual)(probs)
+    assert jnp.isfinite(value_actual)
+    assert jnp.all(jnp.isfinite(grad_actual))
+    assert jnp.allclose(value_actual, value_ref, rtol=1e-5)
+    assert jnp.allclose(grad_actual, grad_ref, rtol=1e-5)
+
+
+@pytest.mark.parametrize("mixture_cls", [dist.MixtureSameFamily, dist.MixtureGeneral])
+def test_mixture_logits_path_matches_probs(mixture_cls):
+    # A logits-parameterized mixing distribution was never affected by the bug;
+    # guard that the refactor leaves its value and gradient unchanged.
+    value = jnp.array(0.3)
+
+    def with_logits(logits):
+        probs = jax.nn.softmax(logits)
+        return _make_mixture(mixture_cls, probs).log_prob(value)
+
+    logits = jnp.array([0.5, -0.3, 0.8])
+    v, g = jax.value_and_grad(with_logits)(logits)
+    assert jnp.isfinite(v)
+    assert jnp.all(jnp.isfinite(g))
+
+
+@pytest.mark.parametrize("mixture_cls", [dist.MixtureSameFamily, dist.MixtureGeneral])
+def test_mixture_component_log_probs_are_responsibilities(mixture_cls):
+    # component_log_probs - log_prob must exponentiate to responsibilities that
+    # sum to 1 (the documented public contract).
+    value = jnp.array(0.3)
+    mixture = _make_mixture(mixture_cls, jnp.array([0.2, 0.3, 0.5]))
+    responsibilities = jnp.exp(
+        mixture.component_log_probs(value) - mixture.log_prob(value)
+    )
+    assert jnp.allclose(responsibilities.sum(), 1.0, rtol=1e-5)


### PR DESCRIPTION
So basically, there's a bugfix and a mild improvement/feature here:

* The bugfix is that the distribution internals were taking the log of `probs` in `Categorical`, even when the probabilities were specified in linear space and one of them could be a hard zero.  This was causing some NaN issues.
* This was particularly an issue in mixture distributions, where we were taking the softmax of the log of the probs, which of course assumes they were actually specified as logits in the first place.
* The minor feature is to unwrap `Independent` distributions when they're given as mixture components.