### PR TITLE
Avoid unnecessary deepcopy in `random_*_module` and `promote_batch_shape`

### DIFF
--- a/numpyro/contrib/module.py
+++ b/numpyro/contrib/module.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from collections import namedtuple
-from copy import deepcopy
 from functools import partial
 
 import jax
@@ -136,6 +135,17 @@ ParamShape = namedtuple("ParamShape", ["shape"])
 jtu.register_pytree_node(
     ParamShape, lambda x: ((None,), x.shape), lambda shape, x: ParamShape(shape)
 )
+
+
+def _copy_structure(params):
+    """
+    A helper to copy the nested dict structure of ``params`` while sharing the
+    leaves, so that :func:`_update_params` can replace entries without mutating
+    the input and without copying array data.
+    """
+    return {
+        k: _copy_structure(v) if isinstance(v, dict) else v for k, v in params.items()
+    }
 
 
 def _update_params(params, new_params, prior, prefix=""):
@@ -296,7 +306,7 @@ def random_flax_module(
         **kwargs,
     )
     params = nn.args[0]
-    new_params = deepcopy(params)
+    new_params = _copy_structure(params)
     with numpyro.handlers.scope(prefix=name):
         _update_params(params, new_params, prior)
     nn_new = partial(nn.func, new_params, *nn.args[1:], **nn.keywords)
@@ -427,7 +437,7 @@ def random_nnx_module(
     other_args = nn.args[1:]
     keywords = nn.keywords
 
-    new_params = deepcopy(params)
+    new_params = _copy_structure(params)
 
     with numpyro.handlers.scope(prefix=name, divider=scope_divider):
         _update_params(params, new_params, prior)
@@ -543,7 +553,7 @@ def random_eqx_module(name, nn_module, prior, scope_divider="/"):
     nn = eqx_module(name, nn_module)
     params, static = eqx.partition(nn, filter_spec=eqx.is_inexact_array)
     params_dict = eqx_to_dict(params)
-    new_params = deepcopy(params_dict)
+    new_params = _copy_structure(params_dict)
     with numpyro.handlers.scope(prefix=name, divider=scope_divider):
         _update_params(params_dict, new_params, prior)
 

--- a/numpyro/contrib/module.py
+++ b/numpyro/contrib/module.py
@@ -137,17 +137,6 @@ jtu.register_pytree_node(
 )
 
 
-def _copy_structure(params):
-    """
-    A helper to copy the nested dict structure of ``params`` while sharing the
-    leaves, so that :func:`_update_params` can replace entries without mutating
-    the input and without copying array data.
-    """
-    return {
-        k: _copy_structure(v) if isinstance(v, dict) else v for k, v in params.items()
-    }
-
-
 def _update_params(params, new_params, prior, prefix=""):
     """
     A helper to recursively set prior to new_params.
@@ -306,7 +295,9 @@ def random_flax_module(
         **kwargs,
     )
     params = nn.args[0]
-    new_params = _copy_structure(params)
+    # copy the container structure while sharing the (immutable) leaves;
+    # _update_params only replaces entries, so no array data needs to be copied
+    new_params = jax.tree.map(lambda x: x, params)
     with numpyro.handlers.scope(prefix=name):
         _update_params(params, new_params, prior)
     nn_new = partial(nn.func, new_params, *nn.args[1:], **nn.keywords)
@@ -437,7 +428,9 @@ def random_nnx_module(
     other_args = nn.args[1:]
     keywords = nn.keywords
 
-    new_params = _copy_structure(params)
+    # copy the container structure while sharing the (immutable) leaves;
+    # _update_params only replaces entries, so no array data needs to be copied
+    new_params = jax.tree.map(lambda x: x, params)
 
     with numpyro.handlers.scope(prefix=name, divider=scope_divider):
         _update_params(params, new_params, prior)
@@ -553,7 +546,9 @@ def random_eqx_module(name, nn_module, prior, scope_divider="/"):
     nn = eqx_module(name, nn_module)
     params, static = eqx.partition(nn, filter_spec=eqx.is_inexact_array)
     params_dict = eqx_to_dict(params)
-    new_params = _copy_structure(params_dict)
+    # copy the container structure while sharing the (immutable) leaves;
+    # _update_params only replaces entries, so no array data needs to be copied
+    new_params = jax.tree.map(lambda x: x, params_dict)
     with numpyro.handlers.scope(prefix=name, divider=scope_divider):
         _update_params(params_dict, new_params, prior)
 

--- a/numpyro/distributions/batch_util.py
+++ b/numpyro/distributions/batch_util.py
@@ -514,7 +514,7 @@ def _default_promote_batch_shape(d: Distribution):
         attr_batch_ndim = max(0, jnp.ndim(attr) - attr_event_dim)
         attr_batch_shapes.append(jnp.shape(attr)[:attr_batch_ndim])
     resolved_batch_shape = jnp.broadcast_shapes(*attr_batch_shapes)
-    new_self = copy.deepcopy(d)
+    new_self = copy.copy(d)
     new_self._batch_shape = resolved_batch_shape
     return new_self
 
@@ -525,7 +525,10 @@ def _promote_batch_shape_expanded(d: ExpandedDistribution):
         : len(d.batch_shape) - len(d.base_dist.batch_shape)
     ]
 
-    new_self = copy.deepcopy(d)
+    # shallow copies are enough here: the only in-place updates below are to the
+    # `_batch_shape` attributes of these two fresh copies, not to shared data
+    new_self = copy.copy(d)
+    new_self.base_dist = copy.copy(d.base_dist)
 
     # new dimensions coming from a vmap or numpyro scan/enum operation
     promoted_base_dist = promote_batch_shape(new_self.base_dist)

--- a/test/contrib/test_module.py
+++ b/test/contrib/test_module.py
@@ -17,6 +17,7 @@ import numpyro
 from numpyro import handlers
 from numpyro.contrib.module import (
     ParamShape,
+    _copy_structure,
     _update_params,
     eqx_module,
     flax_module,
@@ -76,6 +77,19 @@ def test_flax_module():
         flax_model_by_kwargs(X, Y)
     assert flax_tr["nn$params"]["value"]["kernel"].shape == (100, 100)
     assert flax_tr["nn$params"]["value"]["bias"].shape == (100,)
+
+
+def test_copy_structure_shares_leaves():
+    params = {"a": {"b": np.ones(3)}, "c": np.zeros(2)}
+    copied = _copy_structure(params)
+    assert copied is not params
+    assert copied["a"] is not params["a"]
+    # leaves are shared, not copied
+    assert copied["a"]["b"] is params["a"]["b"]
+    assert copied["c"] is params["c"]
+    # replacing entries in the copy leaves the original untouched
+    copied["a"]["b"] = ParamShape((3,))
+    assert isinstance(params["a"]["b"], np.ndarray)
 
 
 def test_update_params():

--- a/test/contrib/test_module.py
+++ b/test/contrib/test_module.py
@@ -17,7 +17,6 @@ import numpyro
 from numpyro import handlers
 from numpyro.contrib.module import (
     ParamShape,
-    _copy_structure,
     _update_params,
     eqx_module,
     flax_module,
@@ -79,17 +78,24 @@ def test_flax_module():
     assert flax_tr["nn$params"]["value"]["bias"].shape == (100,)
 
 
-def test_copy_structure_shares_leaves():
-    params = {"a": {"b": np.ones(3)}, "c": np.zeros(2)}
-    copied = _copy_structure(params)
-    assert copied is not params
-    assert copied["a"] is not params["a"]
-    # leaves are shared, not copied
-    assert copied["a"]["b"] is params["a"]["b"]
-    assert copied["c"] is params["c"]
-    # replacing entries in the copy leaves the original untouched
-    copied["a"]["b"] = ParamShape((3,))
-    assert isinstance(params["a"]["b"], np.ndarray)
+def test_random_flax_module_shares_param_leaves():
+    import flax.linen as nn
+
+    with handlers.trace() as tr, handlers.seed(rng_seed=0):
+        net = random_flax_module(
+            "net",
+            nn.Dense(2),
+            prior={"kernel": dist.Normal()},
+            input_shape=(3,),
+        )
+    init_params = tr["net$params"]["value"]
+    new_params = net.args[0]
+    # parameters not covered by the prior are shared, not copied
+    assert new_params["bias"] is init_params["bias"]
+    # parameters covered by the prior are replaced by samples in the copy
+    # while the original entry is reduced to its shape
+    assert init_params["kernel"] == ParamShape((3, 2))
+    assert jnp.shape(new_params["kernel"]) == (3, 2)
 
 
 def test_update_params():

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -32,7 +32,7 @@ from numpyro.distributions import (
     kl_divergence,
     transforms,
 )
-from numpyro.distributions.batch_util import vmap_over
+from numpyro.distributions.batch_util import promote_batch_shape, vmap_over
 from numpyro.distributions.censored import (
     IntervalCensoredDistribution,
     LeftCensoredDistribution,
@@ -3819,6 +3819,32 @@ def test_vmap_validate_args():
         in_axes=(0, 0),
     )(jnp.zeros((2,)), jnp.zeros((2,)))
     assert not v_dist._validate_args
+
+
+def test_promote_batch_shape_shares_data_and_preserves_input():
+    loc = jnp.zeros((2, 3))
+    d = jax.vmap(lambda loc: dist.Normal(loc, 1.0))(loc)
+    assert d.batch_shape == (3,)
+
+    promoted = promote_batch_shape(d)
+    assert promoted.batch_shape == (2, 3)
+    # parameter arrays are shared, not copied
+    assert promoted.loc is d.loc
+    # the input distribution is not mutated
+    assert d.batch_shape == (3,)
+
+
+def test_promote_batch_shape_expanded_preserves_input():
+    loc = jnp.zeros((2, 3))
+    d = jax.vmap(lambda loc: dist.Normal(loc, 1.0).expand((4, 3)))(loc)
+    assert d.batch_shape == (4, 3)
+
+    promoted = promote_batch_shape(d)
+    assert promoted.batch_shape == (2, 4, 3)
+    assert promoted.log_prob(jnp.zeros((2, 4, 3))).shape == (2, 4, 3)
+    # the input distribution and its base distribution are not mutated
+    assert d.batch_shape == (4, 3)
+    assert d.base_dist.batch_shape == (3,)
 
 
 def test_explicit_validate_args():


### PR DESCRIPTION
## Changes made

- `numpyro/contrib/module.py`: `random_flax_module` / `random_nnx_module` / `random_eqx_module` used `copy.deepcopy(params)` before replacing entries with prior samples. Since `_update_params` only reassigns dict entries and never mutates array leaves in place, deep-copying every weight buffer is unnecessary — for large networks this duplicates all parameters on every eager model trace (e.g. during `initialize_model` or any non-jitted trace). Replaced with `jax.tree.map(lambda x: x, params)`, which copies the container structure while sharing the leaves.
- `numpyro/distributions/batch_util.py`: `_default_promote_batch_shape` deep-copied the distribution although it only reassigns `_batch_shape` afterwards; switched to `copy.copy`, consistent with the existing `MaskedDistribution` / `Independent` implementations. `_promote_batch_shape_expanded` likewise now shallow-copies `d` and `d.base_dist` instead of deep-copying, since the only in-place updates are to the `_batch_shape` attributes of those two fresh copies.

Under jit these deep copies were already no-ops (tracers deep-copy to themselves), so behavior is unchanged; the win is for eager execution.

## Benchmarks

Apple M2 (24 GB), CPU jax 0.10.2, Python 3.11. Each scenario runs in a fresh process; time is the best of 3 repeats after warmup, peak memory is `ru_maxrss`.

`promote_batch_shape` on a vmapped `ExpandedDistribution` (eager):

| base `loc` size | master | this PR | peak RSS master | peak RSS this PR |
|---|---|---|---|---|
| 400 MB | 67.6 ms | 22.4 ms (3.0×) | 2205 MB | 1405 MB |
| 1.6 GB | 264.1 ms | 90.8 ms (2.9×) | 6603 MB | 3407 MB |

Eager seeded trace of a model with `random_flax_module` (3-layer MLP):

| params | master | this PR | peak RSS master | peak RSS this PR |
|---|---|---|---|---|
| 50M (201 MB) | 570 ms | 580 ms | 1084 MB | 887 MB |
| 201M (805 MB) | 2251 ms | 2216 ms | 3022 MB | 2223 MB |

For the module path the trace time is dominated by flax init and prior sampling, so the speed change is within noise (the eliminated copy itself scales linearly: 0.6 ms at 13 MB, 8.0 ms at 200 MB, vs ~2 µs for the structure-only `jax.tree.map` copy at any size); the main win there is peak memory, which drops by about the size of the parameters.

## Links to related issues/PRs

None.

## Tests

New tests locking in the intended semantics:

- `test_promote_batch_shape_shares_data_and_preserves_input` / `test_promote_batch_shape_expanded_preserves_input` in `test/test_distributions.py` — `promote_batch_shape` shares parameter arrays with its input (would fail with the previous `deepcopy`) and mutates neither the input distribution nor its `base_dist` (guards the new shallow copies).
- `test_random_flax_module_shares_param_leaves` in `test/contrib/test_module.py` — parameters not covered by the prior are shared with the module's init params rather than copied, and prior-covered entries are replaced as before.

Existing coverage (all green locally):

- `pytest test/contrib/test_module.py` — 37 passed
- `pytest test/test_distributions.py -k "vmap or promote or expand"` — 1389 passed, 15 xfailed
- `pytest test/contrib/test_control_flow.py` — 8 passed, 1 xfailed (exercises `promote_batch_shape` via `scan`)
- `ruff check` / `ruff format --check` / `ty check` clean

## Dependencies

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)