### PR TITLE
doc(gh-2187): docstrings for Dirichlet and Geometric

### DIFF
--- a/numpyro/distributions/continuous.py
+++ b/numpyro/distributions/continuous.py
@@ -505,7 +505,8 @@ class Dirichlet(Distribution):
         )
 
     def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
-        r"""
+        r"""Generates samples using :func:`~jax.random.dirichlet`.
+
         :param key: JAX PRNGKey for reproducibility.
         :type key: jax.Array
         :param sample_shape: The shape of the samples to be generated.
@@ -577,7 +578,7 @@ class Dirichlet(Distribution):
 
         .. math::
             H(X) = \sum_{i=1}^{K} \ln \Gamma(\alpha_i)
-            - \ln \Gamma(\alpha_0)
+            - \ln \Gamma(\alpha_0)sample(self, key: jax.Array, sample_shape: tu
             + (\alpha_0-K)\psi(\alpha_0)
             - \sum_{i=1}^{K}(\alpha_i-1)\psi(\alpha_i),
 

--- a/numpyro/distributions/continuous.py
+++ b/numpyro/distributions/continuous.py
@@ -456,6 +456,31 @@ class Cauchy(Distribution):
 
 
 class Dirichlet(Distribution):
+    r"""Dirichlet distribution parameterized by concentration (:attr:`concentration`).
+
+    The probability density function (PDF) is defined as:
+
+    .. math:: 
+        f(\mathbf{x}; \boldsymbol{\alpha}) = \frac{\Gamma(\alpha_0)}{\prod_{i=1}^{K}\Gamma(\alpha_i)}
+        \prod_{i=1}^{K}x_i^{\alpha_i-1},
+
+    where :math:`\alpha_0 = \sum_{i=1}^{K}\alpha_i`,
+    each concentration parameter satisfies :math:`\alpha_i > 0`, and
+    :math:`\mathbf{x}` lies on the probability simplex in
+    :math:`\mathbb{R}^{K}`:
+
+    .. math:: 
+        x_i \geq 0, \qquad \sum_{i=1}^{K}x_i = 1.
+
+    :param concentration: Positive concentration parameters. The final
+        dimension determines the event size.
+    :type concentration: ArrayLike
+    :param validate_args: Whether to validate input constraints, defaults to
+        ``None``.
+    :type validate_args: bool, optional
+    """
+
+
     arg_constraints = {
         "concentration": constraints.independent(constraints.positive, 1)
     }
@@ -481,6 +506,17 @@ class Dirichlet(Distribution):
         )
 
     def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+        r"""Generates samples using :func:`~jax.random.dirichlet`.
+
+        :func:`~jax.random.dirichlet` draws sample using gamma distribution.
+        
+        :param key: JAX PRNGKey for reproducibility.
+        :type key: jax.Array
+        :param sample_shape: The shape of the samples to be generated.
+        :type sample_shape: tuple[int, ...]
+        :return: Samples from the Dirichlet distribution of shape ``sample_shape + batch_shape + event_shape``.
+        :rtype: ArrayLike
+        """
         assert is_prng_key(key)
         shape = sample_shape + self.batch_shape
         samples = random.dirichlet(key, self.concentration, shape=shape)
@@ -490,6 +526,18 @@ class Dirichlet(Distribution):
 
     @validate_sample
     def log_prob(self, value: ArrayLike) -> ArrayLike:
+        r"""Calculates the log of the probability density function.
+
+        .. math::
+           \log f(\mathbf{x}; \boldsymbol{\alpha}) = \log\Gamma(\alpha_0)
+            - \sum_{i=1}^{K}\log\Gamma(\alpha_i)
+            + \sum_{i=1}^{K}(\alpha_i - 1)\log x_i.
+
+        :param value: Values at which to evaluate the log density.
+        :type value: ArrayLike
+        :return: Log probability density.
+        :rtype: ArrayLike
+        """
         normalize_term = jnp.sum(gammaln(self.concentration), axis=-1) - gammaln(
             jnp.sum(self.concentration, axis=-1)
         )
@@ -500,10 +548,25 @@ class Dirichlet(Distribution):
 
     @property
     def mean(self) -> ArrayLike:
+        r"""Calculates the mean of the Dirichlet distribution per element.
+
+        .. math:: 
+            \mathbb{E}[X_i] = \frac{\alpha_i}{\alpha_0},
+        
+        where :math:`\alpha_0 = \sum_{j=1}^K\alpha_j`,
+        """
         return self.concentration / jnp.sum(self.concentration, axis=-1, keepdims=True)
 
     @property
     def variance(self) -> ArrayLike:
+        r"""Calculates the variance of the Dirichlet distribution.
+
+        .. math:: 
+            \mathrm{Var}(X_i) = \frac{\alpha_i(\alpha_0-\alpha_i)}
+            {\alpha_0^2(\alpha_0+1)},
+
+        where :math:`\alpha_0 = \sum_{j=1}^K\alpha_j`,
+        """
         con0 = jnp.sum(self.concentration, axis=-1, keepdims=True)
         return self.concentration * (con0 - self.concentration) / (con0**2 * (con0 + 1))
 
@@ -514,6 +577,17 @@ class Dirichlet(Distribution):
         return batch_shape, event_shape
 
     def entropy(self) -> ArrayLike:
+        r"""Entropy of the Dirichlet distribution.
+
+        .. math:: 
+            H(X) = \log B(\boldsymbol{\alpha})
+            + (\alpha_0-K)\psi(\alpha_0)
+            - \sum_{i=1}^{K}(\alpha_i-1)\psi(\alpha_i),
+
+        where :math:`\alpha_0 = \sum_{i=1}^{K}\alpha_i`,
+        :math:`B(\boldsymbol{\alpha})` is the multivariate beta function, and
+        :math:`\psi` is the digamma function.
+        """
         (n,) = self.event_shape
         total = self.concentration.sum(axis=-1)
         return (

--- a/numpyro/distributions/continuous.py
+++ b/numpyro/distributions/continuous.py
@@ -460,7 +460,7 @@ class Dirichlet(Distribution):
 
     The probability density function (PDF) is defined as:
 
-    .. math:: 
+    .. math::
         f(\mathbf{x}; \boldsymbol{\alpha}) = \frac{\Gamma(\alpha_0)}{\prod_{i=1}^{K}\Gamma(\alpha_i)}
         \prod_{i=1}^{K}x_i^{\alpha_i-1},
 
@@ -469,17 +469,16 @@ class Dirichlet(Distribution):
     :math:`\mathbf{x}` lies on the probability simplex in
     :math:`\mathbb{R}^{K}`:
 
-    .. math:: 
+    .. math::
         x_i \geq 0, \qquad \sum_{i=1}^{K}x_i = 1.
 
     :param concentration: Positive concentration parameters. The final
-        dimension determines the event size.
+        dimension determines the event size (:math: `\alpha`)
     :type concentration: ArrayLike
     :param validate_args: Whether to validate input constraints, defaults to
         ``None``.
     :type validate_args: bool, optional
     """
-
 
     arg_constraints = {
         "concentration": constraints.independent(constraints.positive, 1)
@@ -509,7 +508,7 @@ class Dirichlet(Distribution):
         r"""Generates samples using :func:`~jax.random.dirichlet`.
 
         :func:`~jax.random.dirichlet` draws sample using gamma distribution.
-        
+
         :param key: JAX PRNGKey for reproducibility.
         :type key: jax.Array
         :param sample_shape: The shape of the samples to be generated.
@@ -550,9 +549,9 @@ class Dirichlet(Distribution):
     def mean(self) -> ArrayLike:
         r"""Calculates the mean of the Dirichlet distribution per element.
 
-        .. math:: 
+        .. math::
             \mathbb{E}[X_i] = \frac{\alpha_i}{\alpha_0},
-        
+
         where :math:`\alpha_0 = \sum_{j=1}^K\alpha_j`,
         """
         return self.concentration / jnp.sum(self.concentration, axis=-1, keepdims=True)
@@ -561,11 +560,11 @@ class Dirichlet(Distribution):
     def variance(self) -> ArrayLike:
         r"""Calculates the variance of the Dirichlet distribution.
 
-        .. math:: 
+        .. math::
             \mathrm{Var}(X_i) = \frac{\alpha_i(\alpha_0-\alpha_i)}
             {\alpha_0^2(\alpha_0+1)},
 
-        where :math:`\alpha_0 = \sum_{j=1}^K\alpha_j`,
+        where :math:`\alpha_0 = \sum_{j=1}^K\alpha_j`
         """
         con0 = jnp.sum(self.concentration, axis=-1, keepdims=True)
         return self.concentration * (con0 - self.concentration) / (con0**2 * (con0 + 1))
@@ -579,7 +578,7 @@ class Dirichlet(Distribution):
     def entropy(self) -> ArrayLike:
         r"""Entropy of the Dirichlet distribution.
 
-        .. math:: 
+        .. math::
             H(X) = \log B(\boldsymbol{\alpha})
             + (\alpha_0-K)\psi(\alpha_0)
             - \sum_{i=1}^{K}(\alpha_i-1)\psi(\alpha_i),

--- a/numpyro/distributions/continuous.py
+++ b/numpyro/distributions/continuous.py
@@ -492,6 +492,10 @@ class Dirichlet(Distribution):
         *,
         validate_args: Optional[bool] = None,
     ) -> None:
+        r"""
+        :param concentration: Positive concentration parameters. The final dimension determines the event size (:math: `\alpha`)
+        :param validate_args: If True, enforce domain constraints during initialization.
+        """
         if jnp.ndim(concentration) < 1:
             raise ValueError(
                 "`concentration` parameter must be at least one-dimensional."

--- a/numpyro/distributions/continuous.py
+++ b/numpyro/distributions/continuous.py
@@ -492,11 +492,6 @@ class Dirichlet(Distribution):
         *,
         validate_args: Optional[bool] = None,
     ) -> None:
-        r"""
-        :param concentration: Positive concentration parameters.
-            The final dimension determines the event size (:math:`\alpha`)
-        :param validate_args: If True, enforce domain constraints during initialization.
-        """
         if jnp.ndim(concentration) < 1:
             raise ValueError(
                 "`concentration` parameter must be at least one-dimensional."
@@ -510,10 +505,7 @@ class Dirichlet(Distribution):
         )
 
     def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
-        r"""Generates samples using :func:`~jax.random.dirichlet`.
-
-        :func:`~jax.random.dirichlet` draws sample using gamma distribution.
-
+        r"""
         :param key: JAX PRNGKey for reproducibility.
         :type key: jax.Array
         :param sample_shape: The shape of the samples to be generated.
@@ -584,7 +576,8 @@ class Dirichlet(Distribution):
         r"""Entropy of the Dirichlet distribution.
 
         .. math::
-            H(X) = \log B(\boldsymbol{\alpha})
+            H(X) = \sum_{i=1}^{K} \ln \Gamma(\alpha_i)
+            - \ln \Gamma(\alpha_0)
             + (\alpha_0-K)\psi(\alpha_0)
             - \sum_{i=1}^{K}(\alpha_i-1)\psi(\alpha_i),
 

--- a/numpyro/distributions/continuous.py
+++ b/numpyro/distributions/continuous.py
@@ -578,7 +578,7 @@ class Dirichlet(Distribution):
 
         .. math::
             H(X) = \sum_{i=1}^{K} \ln \Gamma(\alpha_i)
-            - \ln \Gamma(\alpha_0)sample(self, key: jax.Array, sample_shape: tu
+            - \ln \Gamma(\alpha_0)
             + (\alpha_0-K)\psi(\alpha_0)
             - \sum_{i=1}^{K}(\alpha_i-1)\psi(\alpha_i),
 

--- a/numpyro/distributions/continuous.py
+++ b/numpyro/distributions/continuous.py
@@ -493,7 +493,7 @@ class Dirichlet(Distribution):
         validate_args: Optional[bool] = None,
     ) -> None:
         r"""
-        :param concentration: Positive concentration parameters. 
+        :param concentration: Positive concentration parameters.
             The final dimension determines the event size (:math:`\alpha`)
         :param validate_args: If True, enforce domain constraints during initialization.
         """

--- a/numpyro/distributions/continuous.py
+++ b/numpyro/distributions/continuous.py
@@ -473,7 +473,7 @@ class Dirichlet(Distribution):
         x_i \geq 0, \qquad \sum_{i=1}^{K}x_i = 1.
 
     :param concentration: Positive concentration parameters. The final
-        dimension determines the event size (:math: `\alpha`)
+        dimension determines the event size (:math:`\alpha`)
     :type concentration: ArrayLike
     :param validate_args: Whether to validate input constraints, defaults to
         ``None``.
@@ -493,7 +493,8 @@ class Dirichlet(Distribution):
         validate_args: Optional[bool] = None,
     ) -> None:
         r"""
-        :param concentration: Positive concentration parameters. The final dimension determines the event size (:math: `\alpha`)
+        :param concentration: Positive concentration parameters. 
+            The final dimension determines the event size (:math:`\alpha`)
         :param validate_args: If True, enforce domain constraints during initialization.
         """
         if jnp.ndim(concentration) < 1:

--- a/numpyro/distributions/discrete.py
+++ b/numpyro/distributions/discrete.py
@@ -1839,6 +1839,10 @@ class GeometricProbs(Distribution):
     support = constraints.nonnegative_integer
 
     def __init__(self, probs: ArrayLike, *, validate_args: Optional[bool] = None):
+        r"""
+        :param probs: Probability of success on each trial (:math:`p`).
+        :param validate_args: If True, enforce domain constraints during initialization.
+        """
         self.probs = probs
         super(GeometricProbs, self).__init__(
             batch_shape=jnp.shape(self.probs), validate_args=validate_args
@@ -1884,7 +1888,7 @@ class GeometricProbs(Distribution):
 
     @lazy_property
     def logits(self) -> ArrayLike:
-        r"""The log-odds corresponding to the success probability.
+        r"""Calculates the logits corresponding to the success probability.
 
         .. math::
             \ell = \log\left(\frac{p}{1-p}\right).
@@ -1931,10 +1935,10 @@ class GeometricLogits(Distribution):
         \left(1-\sigma(\ell)\right)^k,
         \qquad k \in \{0, 1, 2, \ldots\}.
 
-    where :math:`\ell` denote the log-odds parameter,
+    where :math:`\ell` denote the logits parameter,
     :math:`p = \sigma(\ell) = \frac{1}{1+\exp(-\ell)}` is the probability of success.
 
-    :param logits: Log-odds of success on each trial (:math:`logits`).
+    :param logits: Logits of success on each trial (:math:`logits`).
     :type logits: ArrayLike
     :param validate_args: Whether to validate input constraints, defaults to
         ``None``.
@@ -1945,6 +1949,10 @@ class GeometricLogits(Distribution):
     support = constraints.nonnegative_integer
 
     def __init__(self, logits: ArrayLike, *, validate_args: Optional[bool] = None):
+        r"""
+        :param logits: Logits of success on each trial (:math:`logits`).
+        :param validate_args: If True, enforce domain constraints during initialization.
+        """
         self.logits = logits
         super(GeometricLogits, self).__init__(
             batch_shape=jnp.shape(self.logits), validate_args=validate_args

--- a/numpyro/distributions/discrete.py
+++ b/numpyro/distributions/discrete.py
@@ -1839,10 +1839,6 @@ class GeometricProbs(Distribution):
     support = constraints.nonnegative_integer
 
     def __init__(self, probs: ArrayLike, *, validate_args: Optional[bool] = None):
-        r"""
-        :param probs: Probability of success on each trial (:math:`p`).
-        :param validate_args: If True, enforce domain constraints during initialization.
-        """
         self.probs = probs
         super(GeometricProbs, self).__init__(
             batch_shape=jnp.shape(self.probs), validate_args=validate_args
@@ -1936,7 +1932,7 @@ class GeometricLogits(Distribution):
         \qquad k \in \{0, 1, 2, \ldots\}.
 
     where :math:`\ell` denote the logits parameter,
-    :math:`p = \sigma(\ell) = \frac{1}{1+\exp(-\ell)}` is the probability of success.
+    :math:`p = \sigma(\ell) = \displaystyle\frac{1}{1+\exp(-\ell)}` is the probability of success.
 
     :param logits: Logits of success on each trial (:math:`logits`).
     :type logits: ArrayLike
@@ -1949,10 +1945,6 @@ class GeometricLogits(Distribution):
     support = constraints.nonnegative_integer
 
     def __init__(self, logits: ArrayLike, *, validate_args: Optional[bool] = None):
-        r"""
-        :param logits: Logits of success on each trial (:math:`logits`).
-        :param validate_args: If True, enforce domain constraints during initialization.
-        """
         self.logits = logits
         super(GeometricLogits, self).__init__(
             batch_shape=jnp.shape(self.logits), validate_args=validate_args
@@ -1991,8 +1983,9 @@ class GeometricLogits(Distribution):
         r"""Calculates the log probability mass function.
 
         .. math::
-            \log P(X = k; \ell) = \log\sigma(\ell)
-            + k\log\left(1-\sigma(\ell)\right).
+           \log P(X = k; \ell) = \ell - (k + 1) \operatorname{softplus}(\ell),
+
+        where, :math:`\operatorname{softplus}` is :func:`~jax.nn.softplus`.
 
         :param value: Number of failures before the first success. Values must
             be nonnegative integers.
@@ -2007,7 +2000,7 @@ class GeometricLogits(Distribution):
         r"""Calculates the mean of the Geometric distribution.
 
         .. math::
-            E[X] = \frac{1-p}{p},
+            E[X] = \frac{1}{p}-1,
 
         where :math:`p=\sigma(\ell)`.
         """
@@ -2020,6 +2013,11 @@ class GeometricLogits(Distribution):
         .. math::
             \operatorname{Var}(X) = \frac{1-p}{p^2},
 
+        implemented as,
+
+        .. math::
+            \operatorname{Var}(X) = \frac{1/p-1}{p},
+
         where :math:`p=\sigma(\ell)`.
         """
         return (1.0 / self.probs - 1.0) / self.probs
@@ -2028,9 +2026,12 @@ class GeometricLogits(Distribution):
         r"""Calculates the entropy of the Geometric distribution.
 
         .. math::
-            H(X) = -\log p - \frac{1-p}{p}\log(1-p),
+            H(X) = -\frac{1-p}{p}\ln{q}-\ln{p},
 
-        where :math:`p=\sigma(\ell)`.
+        where, :math:`\ln{p}=-\operatorname{softplus}(-\ell)`, :math:`\ln{q}=-\operatorname{softplus}(\ell)`,
+        and :math:`p=\operatorname{expit}(\ell)`. Implementation uses :func:`~jax.nn.softplus`
+        and :func:`~jax.scipy.special.expit` for :math:`\operatorname{softplus}`
+        and :math:`\operatorname{expit}`, respectively.
 
         :return: Entropy of the Geometric distribution.
         :rtype: ArrayLike
@@ -2062,7 +2063,7 @@ def Geometric(
     :type validate_args: bool, optional
     :return: A probability- or logit-parameterized Geometric distribution.
     :rtype: Union[GeometricProbs, GeometricLogits]
-    :raises ValueError: If both or neither of ``probs`` and ``logits`` are specified.
+    :raises ValueError: If both or neither of :attr:`probs` and :attr:`logits` are specified.
     """
     assert_one_of(probs=probs, logits=logits)
     if probs is not None:

--- a/numpyro/distributions/discrete.py
+++ b/numpyro/distributions/discrete.py
@@ -1814,6 +1814,27 @@ class HurdlePoisson(HurdleProbs):
 
 
 class GeometricProbs(Distribution):
+    r"""A Geometric discrete random variable representing the number of failures
+    before the first success, parameterized by the success probability
+    (:attr:`probs`).
+
+    The probability mass function (PMF) is defined as:
+
+    .. math::
+
+        P(X = k; p) = p(1-p)^k
+
+    where :math:`p \in (0,1]` is the probability of success on each independent trial.
+    :math:`k \in \{0, 1, 2, \ldots\}` is the number of failures before first success.
+    Equivalently, the first success occurs on trial :math:`k+1`.
+
+    :param probs: Probability of success on each trial (:math:`p`).
+    :type probs: ArrayLike
+    :param validate_args: Whether to validate input constraints, defaults to
+        ``None``.
+    :type validate_args: bool, optional
+    """
+
     arg_constraints = {"probs": constraints.unit_interval}
     support = constraints.nonnegative_integer
 
@@ -1824,6 +1845,21 @@ class GeometricProbs(Distribution):
         )
 
     def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+        r"""Generates samples using inverse CDF method.
+
+        For a uniform random variable :math:`U \sim \mathrm{Uniform}[0, 1)`,
+        a Geometric sample is obtained as:
+
+        .. math::
+            X = \left\lfloor \frac{\log(1-U)}{\log(1-p)} \right\rfloor.
+
+        :param key: JAX PRNGKey for reproducibility.
+        :type key: jax.Array
+        :param sample_shape: The shape of the samples to be generated.
+        :type sample_shape: tuple[int, ...]
+        :return: Samples from Geometric distribution of shape ``sample_shape + batch_shape``.
+        :rtype: ArrayLike
+        """
         assert is_prng_key(key)
         probs = self.probs
         dtype = jnp.result_type(probs)
@@ -1833,28 +1869,78 @@ class GeometricProbs(Distribution):
 
     @validate_sample
     def log_prob(self, value: ArrayLike) -> ArrayLike:
+        r"""Calculates the log of the probability mass function.
+
+        .. math::
+            \log P(X = k; p) = k\log(1-p) + \log p.
+
+        :param value: Values at which to evaluate the log density. Values must be nonnegative integers.
+        :type value: ArrayLike
+        :return: Log probability mass.
+        :rtype: ArrayLike
+        """
         probs = jnp.where((self.probs == 1) & (value == 0), 0, self.probs)
         return value * jnp.log1p(-probs) + jnp.log(probs)
 
     @lazy_property
     def logits(self) -> ArrayLike:
+        r"""The log-odds corresponding to the success probability.
+
+        .. math::
+            \ell = \log\left(\frac{p}{1-p}\right).
+        """
         return _to_logits_bernoulli(self.probs)
 
     @property
     def mean(self) -> ArrayLike:
+        r"""Calculates the mean of the Geometric distribution.
+
+        .. math::
+            \mathbb{E}[X] = \frac{1-p}{p}.
+        """
         return 1.0 / self.probs - 1.0
 
     @property
     def variance(self) -> ArrayLike:
+        r"""Calculates the variance of the Geometric distribution.
+
+        .. math::
+            \operatorname{Var}(X) = \frac{1-p}{p^2}.
+        """
         return (1.0 / self.probs - 1.0) / self.probs
 
     def entropy(self) -> ArrayLike:
+        r"""Entropy of the Geometric distribution.
+
+        .. math::
+            H(X) = -\log p - \frac{1-p}{p}\log(1-p).
+
+        :return: Entropy of the Geometric distribution.
+        :rtype: ArrayLike
+        """
         return -(1 - self.probs) * jnp.log1p(-self.probs) / self.probs - jnp.log(
             self.probs
         )
 
 
 class GeometricLogits(Distribution):
+    r"""Geometric distribution parameterized by logits (:attr:`logits`).
+
+    .. math::
+        P(X = k \mid \ell) = \sigma(\ell)
+        \left(1-\sigma(\ell)\right)^k,
+        \qquad k \in \{0, 1, 2, \ldots\}.
+
+    where :math:`\ell` denote the log-odds parameter,
+    :math:`p = \sigma(\ell) = \frac{1}{1+\exp(-\ell)}` is the probability of success.
+
+    :param logits: Log-odds of success on each trial (:math:`logits`).
+    :type logits: ArrayLike
+    :param validate_args: Whether to validate input constraints, defaults to
+        ``None``.
+    :type validate_args: bool, optional
+    """
+
     arg_constraints = {"logits": constraints.real}
     support = constraints.nonnegative_integer
 
@@ -1866,9 +1952,25 @@ class GeometricLogits(Distribution):
 
     @lazy_property
     def probs(self) -> ArrayLike:
+        r"""The success probability obtained by applying the sigmoid function
+        to the logits.
+
+        .. math::
+            p = \sigma(\ell) = \frac{1}{1+\exp(-\ell)}.
+        """
         return _to_probs_bernoulli(self.logits)
 
     def sample(self, key: jax.Array, sample_shape: tuple[int, ...] = ()) -> ArrayLike:
+        r"""Generates samples using inverse CDF technique in logit space.
+
+        :param key: JAX pseudo-random number generator key.
+        :type key: jax.Array
+        :param sample_shape: Sample dimensions to prepend to the batch shape.
+        :type sample_shape: tuple[int, ...]
+        :return: Samples from the Geometric distribution of shape
+            ``sample_shape + batch_shape``.
+        :rtype: ArrayLike
+        """
         assert is_prng_key(key)
         logits = self.logits
         dtype = jnp.result_type(logits)
@@ -1878,17 +1980,53 @@ class GeometricLogits(Distribution):
 
     @validate_sample
     def log_prob(self, value: ArrayLike) -> ArrayLike:
+        r"""Calculates the log probability mass function.
+
+        .. math::
+            \log P(X = k; \ell) = \log\sigma(\ell)
+            + k\log\left(1-\sigma(\ell)\right).
+
+        :param value: Number of failures before the first success. Values must
+            be nonnegative integers.
+        :type value: ArrayLike
+        :return: Log probability mass.
+        :rtype: ArrayLike
+        """
         return (-value - 1) * softplus(self.logits) + self.logits
 
     @property
     def mean(self) -> ArrayLike:
+        r"""Calculates the mean of the Geometric distribution.
+
+        .. math::
+            E[X] = \frac{1-p}{p},
+
+        where :math:`p=\sigma(\ell)`.
+        """
         return 1.0 / self.probs - 1.0
 
     @property
     def variance(self) -> ArrayLike:
+        r"""Calculates the variance of the Geometric distribution.
+
+        .. math::
+            \operatorname{Var}(X) = \frac{1-p}{p^2},
+
+        where :math:`p=\sigma(\ell)`.
+        """
         return (1.0 / self.probs - 1.0) / self.probs
 
     def entropy(self) -> ArrayLike:
+        r"""Calculates the entropy of the Geometric distribution.
+
+        .. math::
+            H(X) = -\log p - \frac{1-p}{p}\log(1-p),
+
+        where :math:`p=\sigma(\ell)`.
+
+        :return: Entropy of the Geometric distribution.
+        :rtype: ArrayLike
+        """
         logq = -jax.nn.softplus(self.logits)
         logp = -jax.nn.softplus(-self.logits)
         p = jax.scipy.special.expit(self.logits)
@@ -1902,6 +2040,22 @@ def Geometric(
     *,
     validate_args: Optional[bool] = None,
 ) -> Union[GeometricProbs, GeometricLogits]:
+    r"""Geometric distribution parameterized by either probabilities
+    or logits.
+
+    Exactly one of :attr:`probs` or :attr:`logits` must be specified.
+
+    :param probs: Probability of success on each independent trial (:math:`p`).
+    :type probs: ArrayLike, optional
+    :param logits: Logits of success on each independent trial.
+    :type logits: ArrayLike, optional
+    :param validate_args: Whether to validate input constraints, defaults to
+        ``None``.
+    :type validate_args: bool, optional
+    :return: A probability- or logit-parameterized Geometric distribution.
+    :rtype: Union[GeometricProbs, GeometricLogits]
+    :raises ValueError: If both or neither of ``probs`` and ``logits`` are specified.
+    """
     assert_one_of(probs=probs, logits=logits)
     if probs is not None:
         return GeometricProbs(probs, validate_args=validate_args)


### PR DESCRIPTION
Part of #2187.

Adds documentation for 2 more distributions from the docs checklist, follows similar structure as #2202 

- `Dirichlet` — class, `__init__`, `sample`, `log_prob`, `mean`, `variance`, `entropy`
- `GeometricProbs` — class, `__init__`, `sample`, `log_prob`, `logits`, `mean`, `variance`, `entropy`
- `GeometricLogits` — class, `__init__`, `probs`, `sample`, `log_prob`, `logits`, `mean`, `variance`, `entropy`
- `Geometric` — function

Docstrings only, no logic changes.

Verified:
- make lint
- make format