### PR TITLE
doc: fix stale instructions in `docs/README`

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,19 +1,37 @@
 # Documentation
 
-Pyro Documentation is supported by [Sphinx](http://www.sphinx-doc.org/en/stable/). 
-To build the docs, run from the toplevel directory:
-```
+NumPyro documentation is built with [Sphinx](https://www.sphinx-doc.org/).
+To build the docs, run from the top-level directory:
+
+```sh
 make docs
 ```
 
-## Installation ##
-```
-pip install -r requirements.txt
+The generated HTML lands in `docs/build/html`.
+
+## Installation
+
+The documentation dependencies live in the `docs` dependency group of
+`pyproject.toml`. Install them with:
+
+```sh
+uv sync --extra cpu --group docs
 ```
 
-## Workflow ##
+Building the docs also needs [pandoc](https://pandoc.org/installing.html),
+which is not a Python package:
+
+```sh
+sudo apt install -y pandoc
+```
+
+## Workflow
+
 To change the documentation, update the `*.rst` files in `source`.
 
 To build the docstrings, `sphinx-apidoc [options] -o <output_path> <module_path> [exclude_pattern, ...]`
 
-To build the html pages, `make html`
+To build the HTML pages, run `make html` from this directory.
+
+To check the examples embedded in docstrings, run `make doctest` from this
+directory, or `make doctest` from the top-level directory.


### PR DESCRIPTION
The docs README described "Pyro Documentation" and told contributors to install from a docs/requirements.txt that no longer exists. Point it at the `docs` dependency group in pyproject.toml (matching CI), add the pandoc prerequisite, note the build output path and the doctest target, and align heading style with the root README.