### PR TITLE
feat: compare branch speed against master and report it on the PR

### DIFF
--- a/.github/scripts/post-sticky-comment.js
+++ b/.github/scripts/post-sticky-comment.js
@@ -1,0 +1,60 @@
+// Copyright Contributors to the Pyro project.
+// SPDX-License-Identifier: Apache-2.0
+
+// Posts a benchmark report as a pull request comment, editing the bot's own
+// previous comment in place rather than adding a new one on every run.
+//
+// Shared by both commenting paths: benchmark.yml posts directly when the PR
+// comes from a branch in this repository, and benchmark-comment.yml posts on
+// its behalf when the PR comes from a fork and the benchmark job therefore had
+// a read-only token.
+
+const MARKER = '<!-- numpyro-benchmark-report -->';
+
+// GitHub rejects comment bodies over 65536 characters.
+const MAX_BODY = 65000;
+const TRUNCATE_TO = 64000;
+
+async function postStickyComment({ github, context, core }, { issue_number, body, runId }) {
+  if (!body.startsWith(MARKER)) {
+    core.setFailed('Report is missing the expected marker; refusing to post it.');
+    return null;
+  }
+
+  const runUrl =
+    `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${runId}`;
+  let text = `${body}\n<sub>Produced by [this benchmark run](${runUrl}).</sub>\n`;
+  if (text.length > MAX_BODY) {
+    text = `${text.slice(0, TRUNCATE_TO)}\n\n…truncated. See [the full report](${runUrl}).\n`;
+  }
+
+  const comments = await github.paginate(github.rest.issues.listComments, {
+    ...context.repo,
+    issue_number,
+    per_page: 100,
+  });
+  const existing = comments.find(
+    (c) => c.user.type === 'Bot' && c.body.includes(MARKER),
+  );
+
+  if (existing) {
+    await github.rest.issues.updateComment({
+      ...context.repo,
+      comment_id: existing.id,
+      body: text,
+    });
+    core.info(`Updated benchmark comment ${existing.html_url}`);
+    return existing.id;
+  }
+
+  const { data: created } = await github.rest.issues.createComment({
+    ...context.repo,
+    issue_number,
+    body: text,
+  });
+  core.info(`Created benchmark comment ${created.html_url}`);
+  return created.id;
+}
+
+module.exports = postStickyComment;
+module.exports.MARKER = MARKER;

--- a/.github/workflows/benchmark-comment.yml
+++ b/.github/workflows/benchmark-comment.yml
@@ -37,9 +37,8 @@ jobs:
           sparse-checkout: .github/scripts
           persist-credentials: false
 
-      # The benchmark job is skipped unless the PR carries the label, and a run
-      # whose jobs were all skipped still reports success, so check before
-      # reaching for an artifact that may not exist.
+      # A run whose jobs were all skipped still reports success, so check
+      # before reaching for an artifact that may not exist.
       - name: Look for the report
         id: probe
         uses: actions/github-script@v7

--- a/.github/workflows/benchmark-comment.yml
+++ b/.github/workflows/benchmark-comment.yml
@@ -26,9 +26,7 @@ jobs:
   comment:
     # Same-repo pull requests already commented from benchmark.yml itself.
     if: >-
-      github.event.workflow_run.conclusion == 'success'
-      && github.event.workflow_run.event == 'pull_request'
-      && github.event.workflow_run.head_repository.full_name != github.repository
+      github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.head_repository.full_name != github.repository
     runs-on: ubuntu-latest
     steps:
       # The default branch, not the pull request: this job has a write token,

--- a/.github/workflows/benchmark-comment.yml
+++ b/.github/workflows/benchmark-comment.yml
@@ -1,11 +1,16 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Posts the report produced by benchmark.yml as a sticky PR comment.
+# Posts the report from benchmark.yml on pull requests that came from a fork.
 #
-# This runs from the base repository with a write token, so it must never
-# execute anything out of the pull request. It only reads the artifact: the
-# Markdown body and the PR number, both of which are validated below.
+# A fork's pull_request run gets a read-only token and cannot comment, so this
+# workflow does it on that run's behalf. It holds a write token itself, so it
+# must never execute anything out of the pull request: it only reads the
+# artifact, and validates everything in it before use.
+#
+# NOTE: workflow_run only ever runs the copy of this file on the default
+# branch. Until it is merged to master it will not trigger at all, no matter
+# what is on the feature branch.
 name: Benchmark comment
 
 on:
@@ -19,9 +24,21 @@ permissions:
 
 jobs:
   comment:
-    if: github.event.workflow_run.conclusion == 'success'
+    # Same-repo pull requests already commented from benchmark.yml itself.
+    if: >-
+      github.event.workflow_run.conclusion == 'success'
+      && github.event.workflow_run.event == 'pull_request'
+      && github.event.workflow_run.head_repository.full_name != github.repository
     runs-on: ubuntu-latest
     steps:
+      # The default branch, not the pull request: this job has a write token,
+      # so the script it runs has to be the trusted copy.
+      - name: Check out the commenting script
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: .github/scripts
+          persist-credentials: false
+
       # The benchmark job is skipped unless the PR carries the label, and a run
       # whose jobs were all skipped still reports success, so check before
       # reaching for an artifact that may not exist.
@@ -55,15 +72,16 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const MARKER = '<!-- numpyro-benchmark-report -->';
+            const postStickyComment = require(
+              `${process.env.GITHUB_WORKSPACE}/.github/scripts/post-sticky-comment.js`);
 
             if (!fs.existsSync('report/pr-number.txt')) {
               core.info('No PR number in the artifact; this was a manual run.');
               return;
             }
 
-            // The artifact comes from a workflow that may have run fork code,
-            // so treat everything in it as untrusted input.
+            // The artifact was produced by a workflow that ran fork code, so
+            // everything in it is untrusted input.
             const raw = fs.readFileSync('report/pr-number.txt', 'utf8').trim();
             if (!/^[0-9]+$/.test(raw)) {
               core.setFailed(`Refusing to use malformed PR number: ${raw}`);
@@ -85,41 +103,8 @@ jobs:
               return;
             }
 
-            let body = fs.readFileSync('report/comment.md', 'utf8');
-            if (!body.startsWith(MARKER)) {
-              core.setFailed('Report is missing the expected marker.');
-              return;
-            }
-            const runUrl = `${context.serverUrl}/${context.repo.owner}/` +
-              `${context.repo.repo}/actions/runs/${context.payload.workflow_run.id}`;
-            body += `\n<sub>Produced by [this benchmark run](${runUrl}).</sub>\n`;
-
-            // GitHub rejects comment bodies over 65536 characters.
-            if (body.length > 65000) {
-              body = body.slice(0, 64000) +
-                `\n\n…truncated. See [the full report](${runUrl}).\n`;
-            }
-
-            const comments = await github.paginate(
-              github.rest.issues.listComments,
-              { ...context.repo, issue_number, per_page: 100 },
-            );
-            const existing = comments.find(
-              (c) => c.user.type === 'Bot' && c.body.includes(MARKER),
-            );
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                ...context.repo,
-                comment_id: existing.id,
-                body,
-              });
-              core.info(`Updated comment ${existing.id}.`);
-            } else {
-              await github.rest.issues.createComment({
-                ...context.repo,
-                issue_number,
-                body,
-              });
-              core.info(`Created a comment on #${issue_number}.`);
-            }
+            await postStickyComment({ github, context, core }, {
+              issue_number,
+              body: fs.readFileSync('report/comment.md', 'utf8'),
+              runId: context.payload.workflow_run.id,
+            });

--- a/.github/workflows/benchmark-comment.yml
+++ b/.github/workflows/benchmark-comment.yml
@@ -1,0 +1,125 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Posts the report produced by benchmark.yml as a sticky PR comment.
+#
+# This runs from the base repository with a write token, so it must never
+# execute anything out of the pull request. It only reads the artifact: the
+# Markdown body and the PR number, both of which are validated below.
+name: Benchmark comment
+
+on:
+  workflow_run:
+    workflows: [Benchmark]
+    types: [completed]
+
+permissions:
+  actions: read
+  pull-requests: write
+
+jobs:
+  comment:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      # The benchmark job is skipped unless the PR carries the label, and a run
+      # whose jobs were all skipped still reports success, so check before
+      # reaching for an artifact that may not exist.
+      - name: Look for the report
+        id: probe
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const artifacts = await github.paginate(
+              github.rest.actions.listWorkflowRunArtifacts,
+              { ...context.repo, run_id: context.payload.workflow_run.id, per_page: 100 },
+            );
+            const found = artifacts.some((a) => a.name === 'benchmark-report');
+            if (!found) {
+              core.info('No benchmark-report artifact; nothing to post.');
+            }
+            core.setOutput('found', String(found));
+
+      - name: Download the report
+        if: steps.probe.outputs.found == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: benchmark-report
+          path: report
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Post or update the comment
+        if: steps.probe.outputs.found == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const MARKER = '<!-- numpyro-benchmark-report -->';
+
+            if (!fs.existsSync('report/pr-number.txt')) {
+              core.info('No PR number in the artifact; this was a manual run.');
+              return;
+            }
+
+            // The artifact comes from a workflow that may have run fork code,
+            // so treat everything in it as untrusted input.
+            const raw = fs.readFileSync('report/pr-number.txt', 'utf8').trim();
+            if (!/^[0-9]+$/.test(raw)) {
+              core.setFailed(`Refusing to use malformed PR number: ${raw}`);
+              return;
+            }
+            const issue_number = Number(raw);
+
+            // Confirm the PR really is the one that triggered this run, so a
+            // crafted artifact cannot redirect the comment onto another PR.
+            const { data: pr } = await github.rest.pulls.get({
+              ...context.repo,
+              pull_number: issue_number,
+            });
+            const ran_on = context.payload.workflow_run.head_sha;
+            if (pr.head.sha !== ran_on) {
+              core.warning(
+                `Skipping: PR #${issue_number} has moved to ${pr.head.sha}, but ` +
+                `these results describe ${ran_on}.`);
+              return;
+            }
+
+            let body = fs.readFileSync('report/comment.md', 'utf8');
+            if (!body.startsWith(MARKER)) {
+              core.setFailed('Report is missing the expected marker.');
+              return;
+            }
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/` +
+              `${context.repo.repo}/actions/runs/${context.payload.workflow_run.id}`;
+            body += `\n<sub>Produced by [this benchmark run](${runUrl}).</sub>\n`;
+
+            // GitHub rejects comment bodies over 65536 characters.
+            if (body.length > 65000) {
+              body = body.slice(0, 64000) +
+                `\n\n…truncated. See [the full report](${runUrl}).\n`;
+            }
+
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              { ...context.repo, issue_number, per_page: 100 },
+            );
+            const existing = comments.find(
+              (c) => c.user.type === 'Bot' && c.body.includes(MARKER),
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                ...context.repo,
+                comment_id: existing.id,
+                body,
+              });
+              core.info(`Updated comment ${existing.id}.`);
+            } else {
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number,
+                body,
+              });
+              core.info(`Created a comment on #${issue_number}.`);
+            }

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -156,13 +156,27 @@ jobs:
 
       - name: Render the report
         working-directory: ${{ runner.temp }}/bench
+        env:
+          # On a PR the two sides are best named by their role. A manual run can
+          # compare any two refs, where the ref names are the informative part.
+          # Keep each expression on one line: YAML preserves the newline in a
+          # folded block whose continuation is indented further, which would put
+          # a line break inside the ${{ }}.
+          BASE_LABEL: ${{ github.event_name == 'pull_request' && 'baseline' || steps.refs.outputs.base_label }}
+          HEAD_LABEL: ${{ github.event_name == 'pull_request' && 'this PR' || steps.refs.outputs.head_label }}
+          BASE_REF: ${{ inputs.base_ref || 'master' }}
+          HEAD_REF: ${{ steps.refs.outputs.head_label }}
+          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
         run: |
           set -euo pipefail
           "$RUNNER_TEMP/venv-head/bin/python" -m benchmarks.compare \
             --base "$RUNNER_TEMP"/results/base-*.json \
             --head "$RUNNER_TEMP"/results/head-*.json \
-            --base-label "${{ steps.refs.outputs.base_label }}" \
-            --head-label "${{ steps.refs.outputs.head_label }}" \
+            --base-label "$BASE_LABEL" \
+            --head-label "$HEAD_LABEL" \
+            --base-ref "$BASE_REF" \
+            --head-ref "$HEAD_REF" \
+            --repo-url "$REPO_URL" \
             --output "$RUNNER_TEMP/results/comment.md" \
             --json-output "$RUNNER_TEMP/results/summary.json"
           cat "$RUNNER_TEMP/results/comment.md" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Measures this PR against its merge base and comments the result on the PR.
+# It runs on every update to a pull request, so the comment always describes
+# the current head; a full comparison takes tens of minutes.
 #
 # A pull request from a branch in this repository gets a write token, so the
 # comment is posted from here directly. A pull request from a fork gets a
@@ -12,7 +14,7 @@ name: Benchmark
 on:
   pull_request:
     branches: [master]
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened]
   workflow_dispatch:
     inputs:
       base_ref:
@@ -45,10 +47,6 @@ env:
 
 jobs:
   benchmark:
-    # Benchmarks take tens of minutes, so they are opt-in: apply the
-    # `run-benchmarks` label to a PR, or start the workflow by hand.
-    if: >-
-      github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run-benchmarks')
     runs-on: ubuntu-latest
     timeout-minutes: 120
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,11 +1,12 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Measures this PR against its merge base and uploads a rendered report.
+# Measures this PR against its merge base and comments the result on the PR.
 #
-# This workflow deliberately holds no write permissions: on a fork PR it runs
-# untrusted code. Posting the report is the job of benchmark-comment.yml, which
-# is triggered by workflow_run and only ever handles the artifact.
+# A pull request from a branch in this repository gets a write token, so the
+# comment is posted from here directly. A pull request from a fork gets a
+# read-only token no matter what the permissions block below asks for; those
+# are handled by benchmark-comment.yml, which picks up the uploaded artifact.
 name: Benchmark
 
 on:
@@ -29,6 +30,10 @@ on:
 
 permissions:
   contents: read
+  # Only actually granted for same-repo pull requests. GitHub caps the token
+  # for a fork's pull_request run at read-only regardless of what is requested
+  # here, which is why the fork path goes through benchmark-comment.yml.
+  pull-requests: write
 
 concurrency:
   group: benchmark-${{ github.event.pull_request.number || github.ref }}
@@ -161,6 +166,29 @@ jobs:
             --output "$RUNNER_TEMP/results/comment.md" \
             --json-output "$RUNNER_TEMP/results/summary.json"
           cat "$RUNNER_TEMP/results/comment.md" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Comment on the PR
+        # Same-repo pull requests have a write token here, so post directly and
+        # skip the workflow_run round trip entirely. Fork pull requests fall
+        # through to benchmark-comment.yml.
+        if: >-
+          github.event_name == 'pull_request'
+          && github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/github-script@v7
+        env:
+          REPORT: ${{ runner.temp }}/results/comment.md
+        with:
+          script: |
+            const fs = require('fs');
+            // github-script resolves a bare relative require against its own
+            // directory, so the workspace path has to be spelled out.
+            const postStickyComment = require(
+              `${process.env.GITHUB_WORKSPACE}/.github/scripts/post-sticky-comment.js`);
+            await postStickyComment({ github, context, core }, {
+              issue_number: context.issue.number,
+              body: fs.readFileSync(process.env.REPORT, 'utf8'),
+              runId: context.runId,
+            });
 
       - name: Record the PR number for the commenting workflow
         if: github.event_name == 'pull_request'

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -44,8 +44,7 @@ jobs:
     # Benchmarks take tens of minutes, so they are opt-in: apply the
     # `run-benchmarks` label to a PR, or start the workflow by hand.
     if: >-
-      github.event_name == 'workflow_dispatch'
-      || contains(github.event.pull_request.labels.*.name, 'run-benchmarks')
+      github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run-benchmarks')
     runs-on: ubuntu-latest
     timeout-minutes: 120
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -172,8 +172,7 @@ jobs:
         # skip the workflow_run round trip entirely. Fork pull requests fall
         # through to benchmark-comment.yml.
         if: >-
-          github.event_name == 'pull_request'
-          && github.event.pull_request.head.repo.full_name == github.repository
+          github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v7
         env:
           REPORT: ${{ runner.temp }}/results/comment.md

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -40,7 +40,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  BENCH_LABEL: run-benchmarks
   PYTHON_VERSION: "3.14"
   JAX_PLATFORMS: cpu
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -41,7 +41,7 @@ concurrency:
 
 env:
   BENCH_LABEL: run-benchmarks
-  PYTHON_VERSION: "3.13"
+  PYTHON_VERSION: "3.14"
   JAX_PLATFORMS: cpu
 
 jobs:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,175 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Measures this PR against its merge base and uploads a rendered report.
+#
+# This workflow deliberately holds no write permissions: on a fork PR it runs
+# untrusted code. Posting the report is the job of benchmark-comment.yml, which
+# is triggered by workflow_run and only ever handles the artifact.
+name: Benchmark
+
+on:
+  pull_request:
+    branches: [master]
+    types: [opened, synchronize, reopened, labeled]
+  workflow_dispatch:
+    inputs:
+      base_ref:
+        description: Git ref to compare against
+        default: master
+        type: string
+      rounds:
+        description: Interleaved measurement rounds per side
+        default: "2"
+        type: string
+      benchmark_args:
+        description: Extra arguments for benchmarks.runner, e.g. --suite mcmc
+        default: ""
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: benchmark-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  BENCH_LABEL: run-benchmarks
+  PYTHON_VERSION: "3.13"
+  JAX_PLATFORMS: cpu
+
+jobs:
+  benchmark:
+    # Benchmarks take tens of minutes, so they are opt-in: apply the
+    # `run-benchmarks` label to a PR, or start the workflow by hand.
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      || contains(github.event.pull_request.labels.*.name, 'run-benchmarks')
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+
+    steps:
+      - name: Check out the head commit
+        uses: actions/checkout@v6
+        with:
+          # The PR head itself, not the merge commit, so that the code measured
+          # is the code under review.
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          fetch-depth: 0
+
+      - name: Resolve the refs to compare
+        id: refs
+        env:
+          BASE_INPUT: ${{ inputs.base_ref || github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          head_sha=$(git rev-parse HEAD)
+          git fetch --no-tags origin "+refs/heads/*:refs/remotes/origin/*"
+          # Compare against the merge base rather than the tip of master, so
+          # unrelated commits landed since the PR opened do not show up as
+          # changes attributable to this branch.
+          base_sha=$(git merge-base "$head_sha" "$BASE_INPUT")
+          {
+            echo "head_sha=$head_sha"
+            echo "base_sha=$base_sha"
+            echo "head_label=${{ github.event.pull_request.head.ref || github.ref_name }}"
+            echo "base_label=$(git rev-parse --short "$base_sha")"
+          } >> "$GITHUB_OUTPUT"
+          echo "head $head_sha vs base $base_sha"
+
+      - name: Materialise the base checkout
+        run: |
+          set -euo pipefail
+          git worktree add --detach "$RUNNER_TEMP/base" "${{ steps.refs.outputs.base_sha }}"
+
+      - name: Stage the benchmark suite
+        run: |
+          set -euo pipefail
+          # Both sides are measured with the *head* revision of benchmarks/, so
+          # that a benchmark added by this PR still runs against the base.
+          # The staging directory has no numpyro/ in it, which is what lets
+          # `import numpyro` resolve to each venv's installed copy.
+          mkdir -p "$RUNNER_TEMP/bench" "$RUNNER_TEMP/results"
+          cp -r benchmarks "$RUNNER_TEMP/bench/benchmarks"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Build the head environment
+        run: |
+          set -euo pipefail
+          uv venv --python "$PYTHON_VERSION" "$RUNNER_TEMP/venv-head"
+          VIRTUAL_ENV="$RUNNER_TEMP/venv-head" uv pip install -e ".[cpu]"
+
+      - name: Build the base environment with the same JAX
+        run: |
+          set -euo pipefail
+          # A different JAX on either side would make the report measure JAX
+          # rather than NumPyro, so the head's resolution is pinned into base.
+          pins=$(VIRTUAL_ENV="$RUNNER_TEMP/venv-head" uv pip freeze \
+            | grep -E '^(jax|jaxlib)==' | tr '\n' ' ')
+          echo "pinning: $pins"
+          uv venv --python "$PYTHON_VERSION" "$RUNNER_TEMP/venv-base"
+          # shellcheck disable=SC2086
+          VIRTUAL_ENV="$RUNNER_TEMP/venv-base" uv pip install \
+            -e "$RUNNER_TEMP/base[cpu]" $pins
+
+      - name: Measure both refs
+        env:
+          ROUNDS: ${{ inputs.rounds || '2' }}
+          EXTRA_ARGS: ${{ inputs.benchmark_args || '' }}
+          HEAD_SHA: ${{ steps.refs.outputs.head_sha }}
+          BASE_SHA: ${{ steps.refs.outputs.base_sha }}
+        working-directory: ${{ runner.temp }}/bench
+        run: |
+          set -euo pipefail
+          measure () {
+            local side="$1" round="$2" commit="$3"
+            echo "::group::$side round $round"
+            # shellcheck disable=SC2086
+            "$RUNNER_TEMP/venv-$side/bin/python" -m benchmarks.runner \
+              --label "$side" \
+              --commit "$commit" \
+              --output "$RUNNER_TEMP/results/$side-$round.json" \
+              $EXTRA_ARGS
+            echo "::endgroup::"
+          }
+          for round in $(seq 1 "$ROUNDS"); do
+            # Alternate which side goes first so that a runner that gets slower
+            # (or faster) over time does not bias one side systematically.
+            if [ $((round % 2)) -eq 1 ]; then
+              measure head "$round" "$HEAD_SHA"
+              measure base "$round" "$BASE_SHA"
+            else
+              measure base "$round" "$BASE_SHA"
+              measure head "$round" "$HEAD_SHA"
+            fi
+          done
+
+      - name: Render the report
+        working-directory: ${{ runner.temp }}/bench
+        run: |
+          set -euo pipefail
+          "$RUNNER_TEMP/venv-head/bin/python" -m benchmarks.compare \
+            --base "$RUNNER_TEMP"/results/base-*.json \
+            --head "$RUNNER_TEMP"/results/head-*.json \
+            --base-label "${{ steps.refs.outputs.base_label }}" \
+            --head-label "${{ steps.refs.outputs.head_label }}" \
+            --output "$RUNNER_TEMP/results/comment.md" \
+            --json-output "$RUNNER_TEMP/results/summary.json"
+          cat "$RUNNER_TEMP/results/comment.md" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Record the PR number for the commenting workflow
+        if: github.event_name == 'pull_request'
+        run: echo "${{ github.event.pull_request.number }}" > "$RUNNER_TEMP/results/pr-number.txt"
+
+      - name: Upload the report
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-report
+          path: ${{ runner.temp }}/results
+          retention-days: 14

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -82,6 +82,11 @@ neutral unless it clears a threshold:
 | `--min-duration-ms` | 1 ms | Below this, dispatch jitter dominates the measurement. |
 | `--min-compile-ms` | 50 ms | An uncompiled benchmark still shows a small cold/warm gap from warm-up, which is not compilation. |
 
+Deltas are coloured red for a regression and green for an improvement, in grey
+when neutral. A delta **in parentheses** cleared its threshold but sits below
+the resolution floor, so it is shown without being called a change — usually a
+sign the benchmark itself is too small and should be given more work to do.
+
 Two further defences are applied by the workflow rather than the comparison
 itself: both refs are measured on the same runner, in rounds that alternate
 which side goes first, and each benchmark is reduced to its best observation

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -108,12 +108,13 @@ runner is weak evidence.
 
 ## CI
 
-`.github/workflows/benchmark.yml` is opt-in, because a full comparison takes
-tens of minutes:
+`.github/workflows/benchmark.yml` runs on every pull request against `master`,
+and again on each push to one, so the comment always describes the current
+head. A full comparison takes tens of minutes; runs for superseded pushes are
+cancelled as new ones start.
 
-- add the **`run-benchmarks`** label to a pull request, or
-- start it from the Actions tab, where `base_ref`, `rounds` and
-  `benchmark_args` can be set.
+It can also be started from the Actions tab, where `base_ref`, `rounds` and
+`benchmark_args` can be set.
 
 It builds two virtual environments — the PR head and the merge base — pinning
 the base to the head's JAX version so the report measures NumPyro rather than

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -106,11 +106,28 @@ JAX. Both are then measured with the head revision of `benchmarks/`, so a
 benchmark added by the PR still runs against the base. Where it cannot run
 there, the row is reported as `n/a` with the reason rather than being dropped.
 
-`.github/workflows/benchmark-comment.yml` posts the result as a sticky comment,
-editing its own previous comment in place. It is a separate `workflow_run`
-workflow because a `pull_request` build of a fork gets a read-only token: the
-benchmark job holds no write permission and only uploads an artifact, and the
-privileged job never executes code from the pull request.
+The result is posted as a sticky comment, editing the bot's own previous
+comment in place rather than piling up a new one per run. Which of the two
+paths does the posting depends on where the pull request came from:
+
+- **From a branch in this repository**, the run has a write token, so
+  `benchmark.yml` comments directly at the end of the job.
+- **From a fork**, GitHub caps the run's token at read-only whatever the
+  workflow asks for. `benchmark.yml` can then only upload an artifact, and
+  `.github/workflows/benchmark-comment.yml` posts on its behalf: it is
+  triggered by `workflow_run`, holds the write token itself, and never
+  executes anything out of the pull request — it reads the artifact and
+  validates the PR number and head SHA before commenting.
+
+Both call the same `.github/scripts/post-sticky-comment.js`.
+
+> **`workflow_run` only ever runs the copy of the workflow that is on the
+> default branch.** `benchmark-comment.yml` therefore does nothing at all until
+> it has been merged to `master` — which is fine for same-repo pull requests,
+> since those never reach it, but means fork PRs stay uncommented until then.
+
+The report is also written to the job summary, so it is readable from the
+Actions tab even when no comment was posted.
 
 ## Adding a benchmark
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,123 @@
+# Benchmarks
+
+Speed benchmarks used to compare a feature branch against its merge base, and
+to report the difference as a pull request comment.
+
+The suites cover MCMC (`HMC`/`NUTS`), SVI with the common autoguides, the
+distributions layer, and effect handlers. Each measurement is reported twice:
+as **run time** and as **compile time**.
+
+## Running locally
+
+The package depends on nothing beyond `numpyro[cpu]` itself.
+
+```sh
+# list what is registered
+python -m benchmarks.runner --list
+
+# measure everything, or just one suite
+python -m benchmarks.runner --output head.json
+python -m benchmarks.runner --suite distributions --output dists.json
+
+# a fast, statistically meaningless pass, for checking the harness works
+NUMPYRO_BENCH_QUICK=1 python -m benchmarks.runner --suite handlers -o smoke.json
+```
+
+To compare two revisions by hand, install each into its own environment and run
+the *same* copy of `benchmarks/` against both, from a directory that has no
+`numpyro/` source tree in it — otherwise `import numpyro` picks up the working
+copy instead of the installed one:
+
+```sh
+mkdir -p /tmp/bench && cp -r benchmarks /tmp/bench/
+cd /tmp/bench
+"$BASE_VENV/bin/python" -m benchmarks.runner --label base -o base-1.json
+"$HEAD_VENV/bin/python" -m benchmarks.runner --label head -o head-1.json
+python -m benchmarks.compare --base base-*.json --head head-*.json
+```
+
+## What the two columns mean
+
+Every benchmark is written as a *setup* function that returns a zero-argument
+*run* callable. Setup is never timed, so data generation and object
+construction stay out of the measurement:
+
+```python
+@benchmark(suite="mcmc", warm_repeats=3)
+def nuts_eight_schools():
+    """NUTS on non-centred eight schools."""
+    data = eight_schools_data()
+    mcmc = MCMC(
+        NUTS(eight_schools), num_warmup=500, num_samples=500, progress_bar=False
+    )
+
+    def run():
+        mcmc.run(random.PRNGKey(0), **data)
+        return mcmc.get_samples()
+
+    return run
+```
+
+The harness then clears the JAX caches, calls `run` once, and calls it
+`warm_repeats` more times.
+
+- **Run** is the fastest warm call — the compiled executable, cache already hot.
+- **Compile** is the cold call minus that — the tracing, lowering and XLA
+  compilation the warm calls did not have to pay for.
+
+Compile time is therefore an estimate rather than a reading off XLA's own
+timer, but it is derived identically on both sides of a comparison, which is
+what a regression report needs. Benchmarks with no jitted work (most of the
+`handlers` suite) report a near-zero compile column by construction.
+
+## Noise
+
+These run on shared GitHub runners, so `benchmarks.compare` calls a result
+neutral unless it clears a threshold:
+
+| | default | why |
+| --- | --- | --- |
+| `--run-threshold` | 5% | An A/A control run — identical code on both sides — stays within ±2%. |
+| `--compile-threshold` | 25% | The same control run swings ~20%: compile time is measured once per round, not best-of-N. |
+| `--min-duration-ms` | 1 ms | Below this, dispatch jitter dominates the measurement. |
+| `--min-compile-ms` | 50 ms | An uncompiled benchmark still shows a small cold/warm gap from warm-up, which is not compilation. |
+
+Two further defences are applied by the workflow rather than the comparison
+itself: both refs are measured on the same runner, in rounds that alternate
+which side goes first, and each benchmark is reduced to its best observation
+across rounds. A run can be slowed down by a noisy neighbour; it cannot be sped
+up past what the machine can do.
+
+**Before believing a regression, re-run it.** A single flagged row on a busy
+runner is weak evidence.
+
+## CI
+
+`.github/workflows/benchmark.yml` is opt-in, because a full comparison takes
+tens of minutes:
+
+- add the **`run-benchmarks`** label to a pull request, or
+- start it from the Actions tab, where `base_ref`, `rounds` and
+  `benchmark_args` can be set.
+
+It builds two virtual environments — the PR head and the merge base — pinning
+the base to the head's JAX version so the report measures NumPyro rather than
+JAX. Both are then measured with the head revision of `benchmarks/`, so a
+benchmark added by the PR still runs against the base. Where it cannot run
+there, the row is reported as `n/a` with the reason rather than being dropped.
+
+`.github/workflows/benchmark-comment.yml` posts the result as a sticky comment,
+editing its own previous comment in place. It is a separate `workflow_run`
+workflow because a `pull_request` build of a fork gets a read-only token: the
+benchmark job holds no write permission and only uploads an artifact, and the
+privileged job never executes code from the pull request.
+
+## Adding a benchmark
+
+Add a setup function to the relevant module under `benchmarks/suites/`. Keep it
+on public API that has been stable for a while — the same code has to run
+against the base branch, and anything freshly added will simply fail there.
+
+Aim for a warm time between roughly 1 ms and a few hundred ms: faster than that
+disappears into the noise floor, slower than that is paid four times over in
+every comparison.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -82,10 +82,20 @@ neutral unless it clears a threshold:
 | `--min-duration-ms` | 1 ms | Below this, dispatch jitter dominates the measurement. |
 | `--min-compile-ms` | 50 ms | An uncompiled benchmark still shows a small cold/warm gap from warm-up, which is not compilation. |
 
-Deltas are coloured red for a regression and green for an improvement, in grey
-when neutral. A delta **in parentheses** cleared its threshold but sits below
-the resolution floor, so it is shown without being called a change — usually a
-sign the benchmark itself is too small and should be given more work to do.
+Results are rendered as fixed-width tables inside ` ```diff ` fences rather
+than as Markdown tables: the columns stay aligned, and GitHub's diff
+highlighting colours a line red when it starts with `-` and green when it
+starts with `+`. A regression outranks an improvement, so a benchmark that got
+faster to run but slower to compile still shows red — the per-column direction
+is carried by the signed percentages. Colouring is per line, not per cell,
+which is the trade for having it work at all.
+
+A delta **in parentheses** cleared its threshold but sits below the resolution
+floor, so it is shown without being called a change — usually a sign the
+benchmark itself is too small and should be given more work to do.
+
+The environment table stays Markdown, because commit links do not survive
+inside a code block.
 
 Two further defences are applied by the workflow rather than the comparison
 itself: both refs are measured on the same runner, in rounds that alternate

--- a/benchmarks/__init__.py
+++ b/benchmarks/__init__.py
@@ -1,0 +1,14 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Speed benchmarks used to compare a feature branch against master.
+
+This package is deliberately kept out of the installed ``numpyro`` distribution
+and depends on nothing beyond ``numpyro[cpu]`` itself, so that the exact same
+benchmark definitions can be executed against two different checkouts of
+NumPyro installed into two different virtual environments.
+"""
+
+from benchmarks.harness import Benchmark, benchmark, registry, run_benchmark
+
+__all__ = ["Benchmark", "benchmark", "registry", "run_benchmark"]

--- a/benchmarks/compare.py
+++ b/benchmarks/compare.py
@@ -24,8 +24,28 @@ from typing import Any, Optional
 COMMENT_MARKER = "<!-- numpyro-benchmark-report -->"
 
 FASTER, SLOWER, NEUTRAL, UNAVAILABLE = "faster", "slower", "neutral", "n/a"
+#: Moved beyond the threshold, but the measurement is too small or too noisy to
+#: stand behind. Reported in parentheses rather than called a change.
+UNRESOLVED = "unresolved"
 
-_ICON = {FASTER: "🟢", SLOWER: "🔴", NEUTRAL: "⚪", UNAVAILABLE: "⚠️"}
+#: Hex colours for the delta columns. GitHub strips style attributes from
+#: comment HTML, so the only way to colour text is its LaTeX math rendering.
+#: These mid-tones stay legible against both the light and the dark theme,
+#: which the usual GitHub red/green pair does not.
+_COLOR = {
+    SLOWER: "e5534b",
+    FASTER: "3fb950",
+    NEUTRAL: "8b949e",
+    UNRESOLVED: "8b949e",
+    UNAVAILABLE: "8b949e",
+}
+
+
+def colored(text: str, verdict: str) -> str:
+    """Wrap ``text`` in the LaTeX GitHub renders as coloured sans-serif type."""
+    # `%` opens a comment in maths mode, so it has to be escaped.
+    escaped = text.replace("%", r"\%")
+    return f"$\\textcolor{{#{_COLOR[verdict]}}}{{\\textsf{{{escaped}}}}}$"
 
 
 def _parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
@@ -36,8 +56,28 @@ def _parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
     parser.add_argument(
         "--json-output", help="path to write a machine-readable summary"
     )
-    parser.add_argument("--base-label", default="master", help="name of the base ref")
-    parser.add_argument("--head-label", default="this PR", help="name of the head ref")
+    parser.add_argument(
+        "--base-label",
+        default="baseline",
+        help="what to call the base side in column headers",
+    )
+    parser.add_argument(
+        "--head-label",
+        default="this PR",
+        help="what to call the head side in column headers",
+    )
+    parser.add_argument(
+        "--base-ref", default="", help="branch or ref name the base side came from"
+    )
+    parser.add_argument(
+        "--head-ref", default="", help="branch or ref name the head side came from"
+    )
+    parser.add_argument(
+        "--repo-url",
+        default="",
+        help="repository URL, e.g. https://github.com/pyro-ppl/numpyro, used to "
+        "turn commit shas into links",
+    )
     parser.add_argument(
         "--run-threshold",
         type=float,
@@ -137,8 +177,9 @@ def _classify(
     if pct is None:
         return UNAVAILABLE, None
     if max(base, head) < min_duration_s:
-        # Too fast to measure reliably on a shared runner.
-        return NEUTRAL, pct
+        # Too fast to measure reliably on a shared runner. Still worth showing
+        # the number when it moved a lot, but not worth calling a regression.
+        return (UNRESOLVED if abs(pct) > threshold else NEUTRAL), pct
     if pct > threshold:
         return SLOWER, pct
     if pct < -threshold:
@@ -230,21 +271,35 @@ def fmt_duration(seconds: Optional[float]) -> str:
 
 
 def fmt_delta(pct: Optional[float], verdict: str) -> str:
+    """Render a percentage change, coloured by whether it is a regression."""
     if pct is None:
-        return f"{_ICON[UNAVAILABLE]} n/a"
-    return f"{_ICON[verdict]} {pct:+.1f}%"
+        return colored("n/a", UNAVAILABLE)
+    if verdict == UNRESOLVED:
+        return colored(f"({pct:+.1f}%)", verdict)
+    return colored(f"{pct:+.1f}%", verdict)
+
+
+def commit_link(sha: str, repo_url: str) -> str:
+    """Render a commit sha, linked to the repository when the URL is known."""
+    if not sha:
+        return "—"
+    short = sha[:8]
+    if not repo_url:
+        return f"`{short}`"
+    return f"[`{short}`]({repo_url.rstrip('/')}/commit/{sha})"
 
 
 def _table(rows: list[dict[str, Any]], base_label: str, head_label: str) -> list[str]:
     lines = [
-        f"| Benchmark | Run ({base_label}) | Run ({head_label}) | Δ run "
-        f"| Compile ({base_label}) | Compile ({head_label}) | Δ compile |",
+        f"| Benchmark | Run · {base_label} | Run · {head_label} | Δ run "
+        f"| Compile · {base_label} | Compile · {head_label} | Δ compile |",
         "| --- | ---: | ---: | ---: | ---: | ---: | ---: |",
     ]
     for row in rows:
         name = f"`{row['name']}`"
         if row["note"]:
-            name += " ⚠️"
+            # Flagged rather than dropped; the reason is listed below the table.
+            name += " †"
         lines.append(
             "| {name} | {br} | {hr} | {dr} | {bc} | {hc} | {dc} |".format(
                 name=name,
@@ -259,22 +314,25 @@ def _table(rows: list[dict[str, Any]], base_label: str, head_label: str) -> list
     return lines
 
 
-def _headline(rows: list[dict[str, Any]]) -> str:
-    slower = sum(1 for r in rows if r["run_verdict"] == SLOWER)
-    faster = sum(1 for r in rows if r["run_verdict"] == FASTER)
-    c_slower = sum(1 for r in rows if r["compile_verdict"] == SLOWER)
-    c_faster = sum(1 for r in rows if r["compile_verdict"] == FASTER)
+def _tally(rows: list[dict[str, Any]], field: str, name: str) -> str:
+    slower = sum(1 for r in rows if r[field] == SLOWER)
+    faster = sum(1 for r in rows if r[field] == FASTER)
+    if not slower and not faster:
+        return f"**{name}**: unchanged"
+    counts = [
+        colored(f"{faster} faster", FASTER if faster else NEUTRAL),
+        colored(f"{slower} slower", SLOWER if slower else NEUTRAL),
+    ]
+    return f"**{name}**: " + ", ".join(counts)
 
-    parts = []
-    if slower or faster:
-        parts.append(f"**run time**: {faster} faster, {slower} slower")
-    else:
-        parts.append("**run time**: no change")
-    if c_slower or c_faster:
-        parts.append(f"**compile time**: {c_faster} faster, {c_slower} slower")
-    else:
-        parts.append("**compile time**: no change")
-    return " · ".join(parts)
+
+def _headline(rows: list[dict[str, Any]]) -> str:
+    return " · ".join(
+        (
+            _tally(rows, "run_verdict", "run time"),
+            _tally(rows, "compile_verdict", "compile time"),
+        )
+    )
 
 
 def render(
@@ -292,11 +350,24 @@ def render(
     ]
     problems = [r for r in rows if r["note"]]
 
+    def side(label: str, ref: str, meta: dict[str, Any]) -> str:
+        parts = [f"**{label}**"]
+        if ref:
+            parts.append(f"`{ref}`")
+        if meta["commit"]:
+            parts.append(f"at {commit_link(meta['commit'], args.repo_url)}")
+        return " ".join(parts)
+
     out = [
         COMMENT_MARKER,
-        "## ⚡ Benchmark report",
+        "## Benchmark report",
         "",
-        f"`{args.head_label}` vs `{args.base_label}` — {_headline(rows)}",
+        "{} vs {}".format(
+            side(args.head_label, args.head_ref, head),
+            side(args.base_label, args.base_ref, base),
+        ),
+        "",
+        _headline(rows),
         "",
     ]
 
@@ -354,7 +425,7 @@ def render(
     if problems:
         out += [
             "<details>",
-            "<summary>⚠️ Benchmarks that did not compare cleanly</summary>",
+            "<summary>† Benchmarks that did not compare cleanly</summary>",
             "",
         ]
         for row in problems:
@@ -378,11 +449,16 @@ def render(
         f"{args.min_compile_ms:g} ms (compile) — a shared CI runner cannot resolve changes "
         "below that. Compile time gets the looser band because it is measured once per "
         "round rather than best-of-N, and swings by roughly 20% even between two runs of "
-        "identical code.",
+        "identical code. A delta shown in parentheses did clear its threshold, but "
+        "on a measurement below the resolution floor, so it is reported without "
+        "being called a change.",
         "",
-        "| | base | head |",
+        f"| | {args.base_label} | {args.head_label} |",
         "| --- | --- | --- |",
-        f"| commit | `{base['commit'][:12] or '—'}` | `{head['commit'][:12] or '—'}` |",
+        f"| ref | {f'`{args.base_ref}`' if args.base_ref else '—'} "
+        f"| {f'`{args.head_ref}`' if args.head_ref else '—'} |",
+        f"| commit | {commit_link(base['commit'], args.repo_url)} "
+        f"| {commit_link(head['commit'], args.repo_url)} |",
         f"| numpyro | {base['metadata'].get('numpyro_version', '—')} "
         f"| {head['metadata'].get('numpyro_version', '—')} |",
         f"| jax | {base['metadata'].get('jax_version', '—')} "
@@ -412,6 +488,11 @@ def main(argv: Optional[list[str]] = None) -> int:
         args.min_duration_ms,
         args.min_compile_ms,
     )
+    # `Δ compile` is the widest header, so keep the label pair from pushing the
+    # table into a horizontal scroll on a narrow screen.
+    for name in ("base_label", "head_label"):
+        if len(getattr(args, name)) > 24:
+            setattr(args, name, getattr(args, name)[:23] + "…")
     body = render(rows, base, head, args)
 
     if args.output:

--- a/benchmarks/compare.py
+++ b/benchmarks/compare.py
@@ -1,0 +1,445 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Compare two sets of benchmark measurements and render a Markdown report.
+
+Usage::
+
+    python -m benchmarks.compare \\
+        --base base-1.json base-2.json \\
+        --head head-1.json head-2.json \\
+        --output comment.md
+
+Several JSON files may be given per side. Each benchmark is reduced to the
+*best* observation across those rounds, which is the standard defence against
+shared-CI-runner noise: a run can be slowed down by a noisy neighbour, but it
+cannot be sped up below the machine's real capability.
+"""
+
+import argparse
+import json
+from typing import Any, Optional
+
+#: HTML marker used to find and update the bot's own comment in place.
+COMMENT_MARKER = "<!-- numpyro-benchmark-report -->"
+
+FASTER, SLOWER, NEUTRAL, UNAVAILABLE = "faster", "slower", "neutral", "n/a"
+
+_ICON = {FASTER: "🟢", SLOWER: "🔴", NEUTRAL: "⚪", UNAVAILABLE: "⚠️"}
+
+
+def _parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--base", nargs="+", required=True, help="base JSON report(s)")
+    parser.add_argument("--head", nargs="+", required=True, help="head JSON report(s)")
+    parser.add_argument("-o", "--output", help="path to write the Markdown report to")
+    parser.add_argument(
+        "--json-output", help="path to write a machine-readable summary"
+    )
+    parser.add_argument("--base-label", default="master", help="name of the base ref")
+    parser.add_argument("--head-label", default="this PR", help="name of the head ref")
+    parser.add_argument(
+        "--run-threshold",
+        type=float,
+        default=5.0,
+        help="percent change in run time below which a result is called neutral",
+    )
+    parser.add_argument(
+        "--compile-threshold",
+        type=float,
+        default=25.0,
+        help=(
+            "percent change in compile time below which a result is called neutral; "
+            "looser than the run threshold because an A/A control run shows compile "
+            "time swinging ~20 percent on identical code"
+        ),
+    )
+    parser.add_argument(
+        "--min-duration-ms",
+        type=float,
+        default=1.0,
+        help="ignore run-time changes below this, where relative noise dominates",
+    )
+    parser.add_argument(
+        "--min-compile-ms",
+        type=float,
+        default=50.0,
+        help=(
+            "ignore compile-time changes below this. A benchmark with no jitted work "
+            "still shows a small cold/warm difference from dispatch warm-up, which is "
+            "jitter rather than compilation"
+        ),
+    )
+    parser.add_argument(
+        "--fail-on-regression",
+        action="store_true",
+        help="exit non-zero when any run-time regression is detected",
+    )
+    return parser.parse_args(argv)
+
+
+# --------------------------------------------------------------------------- #
+# Loading and reduction
+# --------------------------------------------------------------------------- #
+
+
+def load_side(paths: list[str]) -> dict[str, Any]:
+    """Load one side's rounds and reduce each benchmark to its best observation."""
+    best: dict[str, dict[str, Any]] = {}
+    metadata: dict[str, Any] = {}
+    commit = ""
+    rounds = 0
+
+    for path in paths:
+        with open(path) as f:
+            report = json.load(f)
+        rounds += 1
+        metadata = metadata or report.get("metadata", {})
+        commit = commit or report.get("commit", "")
+        for record in report["results"]:
+            key = f"{record['suite']}.{record['name']}"
+            if record["status"] != "ok":
+                # Keep the first failure so the reason can be reported, but let
+                # any successful round from another attempt win.
+                best.setdefault(key, record)
+                continue
+            current = best.get(key)
+            if (
+                current is None
+                or current["status"] != "ok"
+                or record["warm_min_s"] < current["warm_min_s"]
+            ):
+                best[key] = record
+
+    return {"records": best, "metadata": metadata, "commit": commit, "rounds": rounds}
+
+
+# --------------------------------------------------------------------------- #
+# Comparison
+# --------------------------------------------------------------------------- #
+
+
+def _pct(base: float, head: float) -> Optional[float]:
+    if base <= 0:
+        return None
+    return (head - base) / base * 100.0
+
+
+def _classify(
+    base: Optional[float],
+    head: Optional[float],
+    threshold: float,
+    min_duration_s: float,
+) -> tuple[str, Optional[float]]:
+    if base is None or head is None:
+        return UNAVAILABLE, None
+    pct = _pct(base, head)
+    if pct is None:
+        return UNAVAILABLE, None
+    if max(base, head) < min_duration_s:
+        # Too fast to measure reliably on a shared runner.
+        return NEUTRAL, pct
+    if pct > threshold:
+        return SLOWER, pct
+    if pct < -threshold:
+        return FASTER, pct
+    return NEUTRAL, pct
+
+
+def compare(
+    base: dict[str, Any],
+    head: dict[str, Any],
+    run_threshold: float,
+    compile_threshold: float,
+    min_duration_ms: float,
+    min_compile_ms: float = 50.0,
+) -> list[dict[str, Any]]:
+    """Build one comparison row per benchmark present on either side."""
+    min_duration_s = min_duration_ms / 1e3
+    min_compile_s = min_compile_ms / 1e3
+    rows = []
+
+    for key in sorted(set(base["records"]) | set(head["records"])):
+        base_rec = base["records"].get(key)
+        head_rec = head["records"].get(key)
+        suite, _, name = key.partition(".")
+
+        def metric(rec: Optional[dict[str, Any]], field: str) -> Optional[float]:
+            if rec is None or rec["status"] != "ok":
+                return None
+            return rec[field]
+
+        base_run = metric(base_rec, "warm_min_s")
+        head_run = metric(head_rec, "warm_min_s")
+        base_compile = metric(base_rec, "compile_s")
+        head_compile = metric(head_rec, "compile_s")
+
+        run_verdict, run_pct = _classify(
+            base_run, head_run, run_threshold, min_duration_s
+        )
+        compile_verdict, compile_pct = _classify(
+            base_compile, head_compile, compile_threshold, min_compile_s
+        )
+
+        note = ""
+        if base_rec is None:
+            note = "new benchmark, not present on the base ref"
+        elif head_rec is None:
+            note = "benchmark missing from this PR"
+        elif base_rec["status"] != "ok" and head_rec["status"] != "ok":
+            note = f"failed on both sides: {head_rec.get('error', '')}"
+        elif base_rec["status"] != "ok":
+            note = f"failed on the base ref: {base_rec.get('error', '')}"
+        elif head_rec["status"] != "ok":
+            note = f"failed on this PR: {head_rec.get('error', '')}"
+
+        rows.append(
+            {
+                "key": key,
+                "suite": suite,
+                "name": name,
+                "description": (head_rec or base_rec or {}).get("description", ""),
+                "base_run_s": base_run,
+                "head_run_s": head_run,
+                "run_pct": run_pct,
+                "run_verdict": run_verdict,
+                "base_compile_s": base_compile,
+                "head_compile_s": head_compile,
+                "compile_pct": compile_pct,
+                "compile_verdict": compile_verdict,
+                "note": note,
+            }
+        )
+    return rows
+
+
+# --------------------------------------------------------------------------- #
+# Rendering
+# --------------------------------------------------------------------------- #
+
+
+def fmt_duration(seconds: Optional[float]) -> str:
+    """Render a duration with a unit that keeps three significant figures."""
+    if seconds is None:
+        return "—"
+    if seconds < 1e-3:
+        return f"{seconds * 1e6:.0f} µs"
+    if seconds < 1.0:
+        return f"{seconds * 1e3:.1f} ms"
+    return f"{seconds:.2f} s"
+
+
+def fmt_delta(pct: Optional[float], verdict: str) -> str:
+    if pct is None:
+        return f"{_ICON[UNAVAILABLE]} n/a"
+    return f"{_ICON[verdict]} {pct:+.1f}%"
+
+
+def _table(rows: list[dict[str, Any]], base_label: str, head_label: str) -> list[str]:
+    lines = [
+        f"| Benchmark | Run ({base_label}) | Run ({head_label}) | Δ run "
+        f"| Compile ({base_label}) | Compile ({head_label}) | Δ compile |",
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for row in rows:
+        name = f"`{row['name']}`"
+        if row["note"]:
+            name += " ⚠️"
+        lines.append(
+            "| {name} | {br} | {hr} | {dr} | {bc} | {hc} | {dc} |".format(
+                name=name,
+                br=fmt_duration(row["base_run_s"]),
+                hr=fmt_duration(row["head_run_s"]),
+                dr=fmt_delta(row["run_pct"], row["run_verdict"]),
+                bc=fmt_duration(row["base_compile_s"]),
+                hc=fmt_duration(row["head_compile_s"]),
+                dc=fmt_delta(row["compile_pct"], row["compile_verdict"]),
+            )
+        )
+    return lines
+
+
+def _headline(rows: list[dict[str, Any]]) -> str:
+    slower = sum(1 for r in rows if r["run_verdict"] == SLOWER)
+    faster = sum(1 for r in rows if r["run_verdict"] == FASTER)
+    c_slower = sum(1 for r in rows if r["compile_verdict"] == SLOWER)
+    c_faster = sum(1 for r in rows if r["compile_verdict"] == FASTER)
+
+    parts = []
+    if slower or faster:
+        parts.append(f"**run time**: {faster} faster, {slower} slower")
+    else:
+        parts.append("**run time**: no change")
+    if c_slower or c_faster:
+        parts.append(f"**compile time**: {c_faster} faster, {c_slower} slower")
+    else:
+        parts.append("**compile time**: no change")
+    return " · ".join(parts)
+
+
+def render(
+    rows: list[dict[str, Any]],
+    base: dict[str, Any],
+    head: dict[str, Any],
+    args: argparse.Namespace,
+) -> str:
+    """Render the full Markdown comment body."""
+    significant = [
+        r
+        for r in rows
+        if r["run_verdict"] in (FASTER, SLOWER)
+        or r["compile_verdict"] in (FASTER, SLOWER)
+    ]
+    problems = [r for r in rows if r["note"]]
+
+    out = [
+        COMMENT_MARKER,
+        "## ⚡ Benchmark report",
+        "",
+        f"`{args.head_label}` vs `{args.base_label}` — {_headline(rows)}",
+        "",
+    ]
+
+    if base["metadata"].get("quick_mode") or head["metadata"].get("quick_mode"):
+        out += [
+            "> [!CAUTION]",
+            "> Measured with `NUMPYRO_BENCH_QUICK=1`, which takes a single warm "
+            "repeat per benchmark. These numbers are a smoke test of the harness, "
+            "not a result: expect tens of percent of noise on unchanged code.",
+            "",
+        ]
+
+    # A difference in the surrounding stack means the numbers describe that
+    # difference rather than the change under review, so say so up front.
+    for field, label in (("jax_version", "JAX"), ("python_version", "Python")):
+        base_value = base["metadata"].get(field)
+        head_value = head["metadata"].get(field)
+        if base_value and head_value and base_value != head_value:
+            out += [
+                "> [!WARNING]",
+                f"> The two sides ran on different {label} versions "
+                f"(`{base_value}` vs `{head_value}`). This comparison reflects that "
+                "difference as much as it reflects the change under review.",
+                "",
+            ]
+
+    if significant:
+        out += [
+            f"### Significant changes ({len(significant)})",
+            "",
+            *_table(significant, args.base_label, args.head_label),
+            "",
+        ]
+    else:
+        out += [
+            "### No significant changes",
+            "",
+            f"Every benchmark stayed within ±{args.run_threshold:g}% run time and "
+            f"±{args.compile_threshold:g}% compile time.",
+            "",
+        ]
+
+    suites = sorted({r["suite"] for r in rows})
+    out += ["<details>", "<summary>Full results</summary>", ""]
+    for suite in suites:
+        suite_rows = [r for r in rows if r["suite"] == suite]
+        out += [
+            f"#### `{suite}`",
+            "",
+            *_table(suite_rows, args.base_label, args.head_label),
+            "",
+        ]
+    out += ["</details>", ""]
+
+    if problems:
+        out += [
+            "<details>",
+            "<summary>⚠️ Benchmarks that did not compare cleanly</summary>",
+            "",
+        ]
+        for row in problems:
+            out.append(f"- `{row['key']}` — {row['note']}")
+        out += ["", "</details>", ""]
+
+    out += [
+        "<details>",
+        "<summary>Methodology and environment</summary>",
+        "",
+        "Each benchmark is set up untimed, then called once with the JAX caches "
+        "cleared and several more times warm. **Run** is the fastest warm call; "
+        "**compile** is the first call minus that, i.e. the tracing, lowering and "
+        "XLA compilation the warm calls did not have to pay for.",
+        "",
+        f"Both refs were measured on the same runner over "
+        f"{min(base['rounds'], head['rounds'])} interleaved round(s), taking the best "
+        "observation per benchmark. A result is called neutral when it moves less than "
+        f"±{args.run_threshold:g}% (run) or ±{args.compile_threshold:g}% (compile), or when "
+        f"the measurement itself is under {args.min_duration_ms:g} ms (run) / "
+        f"{args.min_compile_ms:g} ms (compile) — a shared CI runner cannot resolve changes "
+        "below that. Compile time gets the looser band because it is measured once per "
+        "round rather than best-of-N, and swings by roughly 20% even between two runs of "
+        "identical code.",
+        "",
+        "| | base | head |",
+        "| --- | --- | --- |",
+        f"| commit | `{base['commit'][:12] or '—'}` | `{head['commit'][:12] or '—'}` |",
+        f"| numpyro | {base['metadata'].get('numpyro_version', '—')} "
+        f"| {head['metadata'].get('numpyro_version', '—')} |",
+        f"| jax | {base['metadata'].get('jax_version', '—')} "
+        f"| {head['metadata'].get('jax_version', '—')} |",
+        f"| backend | {base['metadata'].get('jax_backend', '—')} "
+        f"| {head['metadata'].get('jax_backend', '—')} |",
+        f"| python | {base['metadata'].get('python_version', '—')} "
+        f"| {head['metadata'].get('python_version', '—')} |",
+        "",
+        f"Runner: `{head['metadata'].get('platform', 'unknown')}`, "
+        f"{head['metadata'].get('cpu_count', '?')} CPUs.",
+        "",
+        "</details>",
+    ]
+    return "\n".join(out) + "\n"
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = _parse_args(argv)
+    base = load_side(args.base)
+    head = load_side(args.head)
+    rows = compare(
+        base,
+        head,
+        args.run_threshold,
+        args.compile_threshold,
+        args.min_duration_ms,
+        args.min_compile_ms,
+    )
+    body = render(rows, base, head, args)
+
+    if args.output:
+        with open(args.output, "w") as f:
+            f.write(body)
+    else:
+        print(body)
+
+    regressions = [r for r in rows if r["run_verdict"] == SLOWER]
+    if args.json_output:
+        summary = {
+            "regressions": len(regressions),
+            "improvements": sum(1 for r in rows if r["run_verdict"] == FASTER),
+            "compile_regressions": sum(
+                1 for r in rows if r["compile_verdict"] == SLOWER
+            ),
+            "problems": [r["key"] for r in rows if r["note"]],
+            "rows": rows,
+        }
+        with open(args.json_output, "w") as f:
+            json.dump(summary, f, indent=2, sort_keys=True)
+
+    if args.fail_on_regression and regressions:
+        keys = ", ".join(r["key"] for r in regressions)
+        print(f"run-time regressions detected: {keys}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/compare.py
+++ b/benchmarks/compare.py
@@ -28,25 +28,6 @@ FASTER, SLOWER, NEUTRAL, UNAVAILABLE = "faster", "slower", "neutral", "n/a"
 #: stand behind. Reported in parentheses rather than called a change.
 UNRESOLVED = "unresolved"
 
-#: Hex colours for the delta columns. GitHub strips style attributes from
-#: comment HTML, so the only way to colour text is its LaTeX math rendering.
-#: These mid-tones stay legible against both the light and the dark theme,
-#: which the usual GitHub red/green pair does not.
-_COLOR = {
-    SLOWER: "e5534b",
-    FASTER: "3fb950",
-    NEUTRAL: "8b949e",
-    UNRESOLVED: "8b949e",
-    UNAVAILABLE: "8b949e",
-}
-
-
-def colored(text: str, verdict: str) -> str:
-    """Wrap ``text`` in the LaTeX GitHub renders as coloured sans-serif type."""
-    # `%` opens a comment in maths mode, so it has to be escaped.
-    escaped = text.replace("%", r"\%")
-    return f"$\\textcolor{{#{_COLOR[verdict]}}}{{\\textsf{{{escaped}}}}}$"
-
 
 def _parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
@@ -271,12 +252,14 @@ def fmt_duration(seconds: Optional[float]) -> str:
 
 
 def fmt_delta(pct: Optional[float], verdict: str) -> str:
-    """Render a percentage change, coloured by whether it is a regression."""
+    """Render a percentage change as plain text."""
     if pct is None:
-        return colored("n/a", UNAVAILABLE)
+        return "n/a"
     if verdict == UNRESOLVED:
-        return colored(f"({pct:+.1f}%)", verdict)
-    return colored(f"{pct:+.1f}%", verdict)
+        # Parenthesised: it cleared the threshold, but on a measurement too
+        # small to stand behind.
+        return f"({pct:+.1f}%)"
+    return f"{pct:+.1f}%"
 
 
 def commit_link(sha: str, repo_url: str) -> str:
@@ -289,50 +272,115 @@ def commit_link(sha: str, repo_url: str) -> str:
     return f"[`{short}`]({repo_url.rstrip('/')}/commit/{sha})"
 
 
+def _prefix(row: dict[str, Any]) -> str:
+    """Pick the character that colours a row inside a ``diff`` fence.
+
+    A regression outranks an improvement, so a benchmark that got faster to run
+    but slower to compile still shows up red. Only the line as a whole can be
+    coloured; the per-column direction is carried by the signed percentages.
+    """
+    verdicts = (row["run_verdict"], row["compile_verdict"])
+    if SLOWER in verdicts:
+        return "-"
+    if FASTER in verdicts:
+        return "+"
+    return " "
+
+
 def _table(rows: list[dict[str, Any]], base_label: str, head_label: str) -> list[str]:
-    lines = [
-        f"| Benchmark | Run · {base_label} | Run · {head_label} | Δ run "
-        f"| Compile · {base_label} | Compile · {head_label} | Δ compile |",
-        "| --- | ---: | ---: | ---: | ---: | ---: | ---: |",
-    ]
-    for row in rows:
-        name = f"`{row['name']}`"
-        if row["note"]:
-            # Flagged rather than dropped; the reason is listed below the table.
-            name += " †"
-        lines.append(
-            "| {name} | {br} | {hr} | {dr} | {bc} | {hc} | {dc} |".format(
-                name=name,
-                br=fmt_duration(row["base_run_s"]),
-                hr=fmt_duration(row["head_run_s"]),
-                dr=fmt_delta(row["run_pct"], row["run_verdict"]),
-                bc=fmt_duration(row["base_compile_s"]),
-                hc=fmt_duration(row["head_compile_s"]),
-                dc=fmt_delta(row["compile_pct"], row["compile_verdict"]),
-            )
-        )
-    return lines
+    """Render rows as an aligned monospace table inside a ``diff`` fence.
 
+    GitHub highlights a ``diff`` block by line: one starting with ``-`` is red
+    and one starting with ``+`` is green. That gives real colour without the
+    LaTeX workaround, and a fixed-width block keeps the numbers in columns
+    instead of letting a Markdown table squeeze them.
+    """
+    if not rows:
+        return []
 
-def _tally(rows: list[dict[str, Any]], field: str, name: str) -> str:
-    slower = sum(1 for r in rows if r[field] == SLOWER)
-    faster = sum(1 for r in rows if r[field] == FASTER)
-    if not slower and not faster:
-        return f"**{name}**: unchanged"
-    counts = [
-        colored(f"{faster} faster", FASTER if faster else NEUTRAL),
-        colored(f"{slower} slower", SLOWER if slower else NEUTRAL),
-    ]
-    return f"**{name}**: " + ", ".join(counts)
-
-
-def _headline(rows: list[dict[str, Any]]) -> str:
-    return " · ".join(
+    body = [
         (
-            _tally(rows, "run_verdict", "run time"),
-            _tally(rows, "compile_verdict", "compile time"),
+            _prefix(row),
+            row["name"] + (" †" if row["note"] else ""),
+            fmt_duration(row["base_run_s"]),
+            fmt_duration(row["head_run_s"]),
+            fmt_delta(row["run_pct"], row["run_verdict"]),
+            fmt_duration(row["base_compile_s"]),
+            fmt_duration(row["head_compile_s"]),
+            fmt_delta(row["compile_pct"], row["compile_verdict"]),
         )
+        for row in rows
+    ]
+    headers = (
+        "benchmark",
+        base_label,
+        head_label,
+        "Δ",
+        base_label,
+        head_label,
+        "Δ",
     )
+    widths = [
+        max(len(header), max(len(cell[i + 1]) for cell in body))
+        for i, header in enumerate(headers)
+    ]
+
+    def line(cells: tuple[str, ...]) -> str:
+        name = cells[1].ljust(widths[0])
+        run = "  ".join(c.rjust(w) for c, w in zip(cells[2:5], widths[1:4]))
+        compile_ = "  ".join(c.rjust(w) for c, w in zip(cells[5:8], widths[4:7]))
+        return f"{cells[0]} {name}   {run}     {compile_}".rstrip()
+
+    run_span = sum(widths[1:4]) + 4
+    compile_span = sum(widths[4:7]) + 4
+    group = (
+        " " * (2 + widths[0] + 3)
+        + " run time ".center(run_span, "─")
+        + "     "
+        + " compile time ".center(compile_span, "─")
+    )
+    header = line((" ",) + headers)
+    # A rule drawn with ASCII hyphens would read as a diff file header, so use
+    # box drawing.
+    rule = "─" * len(header)
+
+    return [
+        "```diff",
+        group,
+        header,
+        rule,
+        *(line(cells) for cells in body),
+        "```",
+    ]
+
+
+def _legend() -> list[str]:
+    return [
+        "<sub>Red is slower, green is faster; a row is coloured by the worse of "
+        "its two columns. A delta in parentheses cleared the threshold on a "
+        "measurement below the resolution floor, so it is shown without being "
+        "called a change. † marks a benchmark that could not be compared — see "
+        "below.</sub>",
+    ]
+
+
+def _headline(rows: list[dict[str, Any]]) -> list[str]:
+    """Render the counts as a small coloured ``diff`` block."""
+    metrics = (("run_verdict", "run time"), ("compile_verdict", "compile time"))
+    width = max(len(name) for _, name in metrics)
+
+    lines = []
+    for field, name in metrics:
+        slower = sum(1 for r in rows if r[field] == SLOWER)
+        faster = sum(1 for r in rows if r[field] == FASTER)
+        label = f"{name}:".ljust(width + 1)
+        if slower:
+            lines.append(f"- {label} {slower} slower, {faster} faster")
+        elif faster:
+            lines.append(f"+ {label} {faster} faster")
+        else:
+            lines.append(f"  {label} unchanged across {len(rows)} benchmarks")
+    return ["```diff", *lines, "```"]
 
 
 def render(
@@ -367,7 +415,7 @@ def render(
             side(args.base_label, args.base_ref, base),
         ),
         "",
-        _headline(rows),
+        *_headline(rows),
         "",
     ]
 
@@ -409,6 +457,8 @@ def render(
             f"±{args.compile_threshold:g}% compile time.",
             "",
         ]
+    # The full results below carry the same notation either way.
+    out += [*_legend(), ""]
 
     suites = sorted({r["suite"] for r in rows})
     out += ["<details>", "<summary>Full results</summary>", ""]

--- a/benchmarks/harness.py
+++ b/benchmarks/harness.py
@@ -1,0 +1,171 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Timing harness that separates JIT compilation cost from warm execution cost.
+
+Every benchmark is written as a *setup* function that returns a zero-argument
+*run* callable::
+
+    @benchmark(suite="mcmc", warm_repeats=3)
+    def nuts_logistic_regression():
+        "NUTS on a 1000x10 logistic regression."
+        mcmc, kwargs = ...          # not timed
+
+        def run():
+            mcmc.run(random.key(0), **kwargs)
+            return mcmc.get_samples()
+
+        return run
+
+The setup body is never timed, so data generation and object construction do
+not pollute the measurement. The harness then calls ``run`` once with the JAX
+caches cleared -- that first call pays for tracing, lowering and XLA
+compilation -- and a further ``warm_repeats`` times with the compiled
+executable already cached.
+
+``compile_s`` is therefore ``cold_s - warm_min_s``: the part of the first call
+that the following calls did not have to pay for. It is an estimate rather than
+an exact reading of XLA's own timer, but it is measured identically on both
+sides of a comparison, which is what matters for a regression report.
+"""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+import gc
+import os
+import platform
+import statistics
+import sys
+import time
+import traceback
+from typing import Any, Optional
+
+import jax
+
+__all__ = ["Benchmark", "benchmark", "collect_metadata", "registry", "run_benchmark"]
+
+#: Set ``NUMPYRO_BENCH_QUICK=1`` to shrink every benchmark to a single warm
+#: repeat. Intended for smoke-testing the harness itself, not for reporting.
+QUICK = os.environ.get("NUMPYRO_BENCH_QUICK", "") not in ("", "0", "false")
+
+_REGISTRY: dict[str, "Benchmark"] = {}
+
+
+@dataclass(frozen=True)
+class Benchmark:
+    """A single named measurement."""
+
+    name: str
+    suite: str
+    description: str
+    setup: Callable[[], Callable[[], Any]]
+    warm_repeats: int
+
+    @property
+    def key(self) -> str:
+        """Fully qualified identifier, e.g. ``mcmc.nuts_logistic_regression``."""
+        return f"{self.suite}.{self.name}"
+
+
+def benchmark(
+    *,
+    suite: str,
+    name: Optional[str] = None,
+    warm_repeats: int = 5,
+) -> Callable[[Callable[[], Callable[[], Any]]], Callable[[], Callable[[], Any]]]:
+    """Register a setup function as a benchmark.
+
+    :param suite: Group the benchmark belongs to, e.g. ``"mcmc"``.
+    :param name: Benchmark name; defaults to the decorated function's name.
+    :param warm_repeats: Number of post-compilation timed repeats.
+    """
+
+    def decorator(
+        fn: Callable[[], Callable[[], Any]],
+    ) -> Callable[[], Callable[[], Any]]:
+        bench = Benchmark(
+            name=name or fn.__name__,
+            suite=suite,
+            description=(fn.__doc__ or "").strip().splitlines()[0]
+            if fn.__doc__
+            else "",
+            setup=fn,
+            warm_repeats=1 if QUICK else warm_repeats,
+        )
+        if bench.key in _REGISTRY:
+            raise ValueError(f"duplicate benchmark {bench.key!r}")
+        _REGISTRY[bench.key] = bench
+        return fn
+
+    return decorator
+
+
+def registry() -> dict[str, Benchmark]:
+    """Return every registered benchmark, keyed by ``suite.name``."""
+    return dict(_REGISTRY)
+
+
+def _timed(run: Callable[[], Any]) -> float:
+    """Time one call to ``run``, waiting for all device work to land."""
+    start = time.perf_counter()
+    jax.block_until_ready(run())
+    return time.perf_counter() - start
+
+
+def run_benchmark(bench: Benchmark) -> dict[str, Any]:
+    """Measure one benchmark and return a JSON-serialisable record.
+
+    A benchmark that raises is reported with ``status="error"`` rather than
+    aborting the run: a newly added benchmark is expected to fail against an
+    older base checkout that lacks the feature under test.
+    """
+    record: dict[str, Any] = {
+        "name": bench.name,
+        "suite": bench.suite,
+        "description": bench.description,
+        "status": "ok",
+    }
+    try:
+        # Clear before setup so the cold call below genuinely recompiles, while
+        # any compilation triggered by data generation stays untimed.
+        jax.clear_caches()
+        gc.collect()
+        run = bench.setup()
+
+        cold_s = _timed(run)
+        warm = [_timed(run) for _ in range(bench.warm_repeats)]
+    except Exception as exc:  # noqa: BLE001 - reported, not swallowed
+        record["status"] = "error"
+        record["error"] = f"{type(exc).__name__}: {exc}"
+        record["traceback"] = traceback.format_exc()
+        return record
+
+    warm_min = min(warm)
+    record.update(
+        cold_s=cold_s,
+        warm_min_s=warm_min,
+        warm_median_s=statistics.median(warm),
+        warm_stdev_s=statistics.stdev(warm) if len(warm) > 1 else 0.0,
+        warm_repeats=len(warm),
+        # The first call also runs the workload once, so the excess over the
+        # cheapest warm call is what compilation cost.
+        compile_s=max(cold_s - warm_min, 0.0),
+    )
+    return record
+
+
+def collect_metadata() -> dict[str, Any]:
+    """Describe the environment a set of measurements was taken in."""
+    import numpyro
+
+    return {
+        "numpyro_version": numpyro.__version__,
+        "jax_version": jax.__version__,
+        "jax_backend": jax.default_backend(),
+        "jax_device_count": jax.device_count(),
+        "python_version": sys.version.split()[0],
+        "platform": platform.platform(),
+        "processor": platform.processor(),
+        "cpu_count": os.cpu_count(),
+        "quick_mode": QUICK,
+    }

--- a/benchmarks/models.py
+++ b/benchmarks/models.py
@@ -1,0 +1,128 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Models and synthetic datasets shared by the benchmark suites.
+
+Data is generated from a fixed NumPy seed rather than downloaded, so a
+benchmark run never depends on the network and always sees identical inputs.
+Everything here must stay on public NumPyro API that has been stable for a
+while: these models are executed against both the feature branch *and* the base
+branch, so anything freshly added would make the base side fail to run.
+"""
+
+from typing import Any, Optional
+
+import numpy as np
+
+import jax.numpy as jnp
+
+import numpyro
+import numpyro.distributions as dist
+
+__all__ = [
+    "eight_schools",
+    "eight_schools_data",
+    "hierarchical_glm",
+    "hierarchical_glm_data",
+    "logistic_regression",
+    "logistic_regression_data",
+    "neals_funnel",
+]
+
+
+# --------------------------------------------------------------------------- #
+# Models
+# --------------------------------------------------------------------------- #
+
+
+def logistic_regression(
+    features: jnp.ndarray, labels: Optional[jnp.ndarray] = None
+) -> None:
+    """Flat Bayesian logistic regression -- a dense, well-conditioned target."""
+    coefs = numpyro.sample(
+        "coefs", dist.Normal(0.0, 1.0).expand([features.shape[1]]).to_event(1)
+    )
+    intercept = numpyro.sample("intercept", dist.Normal(0.0, 5.0))
+    logits = features @ coefs + intercept
+    numpyro.sample("obs", dist.Bernoulli(logits=logits), obs=labels)
+
+
+def eight_schools(sigma: jnp.ndarray, y: Optional[jnp.ndarray] = None) -> None:
+    """Non-centred eight schools -- small, but exercises deterministic sites."""
+    mu = numpyro.sample("mu", dist.Normal(0.0, 5.0))
+    tau = numpyro.sample("tau", dist.HalfCauchy(5.0))
+    with numpyro.plate("J", sigma.shape[0]):
+        theta_base = numpyro.sample("theta_base", dist.Normal(0.0, 1.0))
+        theta = numpyro.deterministic("theta", mu + tau * theta_base)
+        numpyro.sample("obs", dist.Normal(theta, sigma), obs=y)
+
+
+def hierarchical_glm(
+    group_idx: jnp.ndarray,
+    features: jnp.ndarray,
+    n_groups: int,
+    y: Optional[jnp.ndarray] = None,
+) -> None:
+    """Partially pooled linear regression -- nested plates and broadcasting."""
+    n_features = features.shape[1]
+    mu = numpyro.sample("mu", dist.Normal(0.0, 1.0).expand([n_features]).to_event(1))
+    tau = numpyro.sample("tau", dist.HalfNormal(1.0).expand([n_features]).to_event(1))
+    with numpyro.plate("groups", n_groups):
+        offset = numpyro.sample(
+            "offset", dist.Normal(0.0, 1.0).expand([n_features]).to_event(1)
+        )
+    beta = mu + tau * offset
+    sigma = numpyro.sample("sigma", dist.HalfNormal(1.0))
+    loc = jnp.sum(features * beta[group_idx], axis=-1)
+    numpyro.sample("obs", dist.Normal(loc, sigma), obs=y)
+
+
+def neals_funnel(dim: int = 10) -> None:
+    """Neal's funnel -- pathological geometry, stresses the NUTS trajectory."""
+    y = numpyro.sample("y", dist.Normal(0.0, 3.0))
+    numpyro.sample("x", dist.Normal(jnp.zeros(dim), jnp.exp(y / 2)).to_event(1))
+
+
+# --------------------------------------------------------------------------- #
+# Datasets
+# --------------------------------------------------------------------------- #
+
+
+def logistic_regression_data(
+    n_rows: int = 1000, n_features: int = 10, seed: int = 0
+) -> dict[str, Any]:
+    """Design matrix and Bernoulli labels for :func:`logistic_regression`."""
+    rng = np.random.default_rng(seed)
+    features = rng.normal(size=(n_rows, n_features))
+    coefs = rng.normal(size=n_features)
+    probs = 1.0 / (1.0 + np.exp(-features @ coefs))
+    labels = rng.binomial(1, probs)
+    return {
+        "features": jnp.asarray(features, dtype=jnp.float32),
+        "labels": jnp.asarray(labels, dtype=jnp.int32),
+    }
+
+
+def eight_schools_data() -> dict[str, Any]:
+    """The canonical eight schools treatment effects and standard errors."""
+    return {
+        "sigma": jnp.array([15.0, 10.0, 16.0, 11.0, 9.0, 11.0, 10.0, 18.0]),
+        "y": jnp.array([28.0, 8.0, -3.0, 7.0, -1.0, 1.0, 18.0, 12.0]),
+    }
+
+
+def hierarchical_glm_data(
+    n_rows: int = 2000, n_features: int = 5, n_groups: int = 20, seed: int = 0
+) -> dict[str, Any]:
+    """Grouped regression data for :func:`hierarchical_glm`."""
+    rng = np.random.default_rng(seed)
+    group_idx = rng.integers(0, n_groups, size=n_rows)
+    features = rng.normal(size=(n_rows, n_features))
+    beta = rng.normal(size=(n_groups, n_features))
+    y = np.sum(features * beta[group_idx], axis=-1) + rng.normal(scale=0.5, size=n_rows)
+    return {
+        "group_idx": jnp.asarray(group_idx, dtype=jnp.int32),
+        "features": jnp.asarray(features, dtype=jnp.float32),
+        "n_groups": n_groups,
+        "y": jnp.asarray(y, dtype=jnp.float32),
+    }

--- a/benchmarks/runner.py
+++ b/benchmarks/runner.py
@@ -1,0 +1,134 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run the benchmark suites and write the measurements to JSON.
+
+Usage::
+
+    python -m benchmarks.runner --output head.json --label head
+    python -m benchmarks.runner --list
+    python -m benchmarks.runner --suite distributions --output dists.json
+
+The module must be importable while ``numpyro`` resolves to whichever checkout
+is installed in the active environment, so run it from a directory that does
+*not* contain a ``numpyro/`` source tree (the CI workflow copies ``benchmarks/``
+into a scratch directory for exactly this reason).
+"""
+
+import argparse
+import json
+import re
+import sys
+import time
+from typing import Optional
+
+from benchmarks.harness import collect_metadata, registry, run_benchmark
+from benchmarks.suites import SUITE_ORDER
+
+
+def _parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("-o", "--output", help="path to write the JSON report to")
+    parser.add_argument(
+        "--label",
+        default="results",
+        help="name for this set of measurements, e.g. 'head' or 'base'",
+    )
+    parser.add_argument(
+        "--commit", default="", help="commit sha these results describe"
+    )
+    parser.add_argument(
+        "--suite",
+        action="append",
+        choices=SUITE_ORDER,
+        help="restrict to a suite; repeatable",
+    )
+    parser.add_argument(
+        "--filter", help="only run benchmarks whose 'suite.name' matches this regex"
+    )
+    parser.add_argument("--list", action="store_true", help="list benchmarks and exit")
+    return parser.parse_args(argv)
+
+
+def select(suites: Optional[list[str]] = None, pattern: Optional[str] = None) -> list:
+    """Return the registered benchmarks matching ``suites`` and ``pattern``."""
+    benches = list(registry().values())
+    if suites:
+        benches = [b for b in benches if b.suite in suites]
+    if pattern:
+        regex = re.compile(pattern)
+        benches = [b for b in benches if regex.search(b.key)]
+    order = {name: i for i, name in enumerate(SUITE_ORDER)}
+    return sorted(benches, key=lambda b: (order.get(b.suite, len(order)), b.name))
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = _parse_args(argv)
+    benches = select(args.suite, args.filter)
+
+    if args.list:
+        for bench in benches:
+            print(f"{bench.key}\t{bench.description}")
+        return 0
+
+    if not benches:
+        print("no benchmarks selected", file=sys.stderr)
+        return 1
+
+    metadata = collect_metadata()
+    print(
+        f"running {len(benches)} benchmarks against numpyro "
+        f"{metadata['numpyro_version']} on jax {metadata['jax_version']} "
+        f"({metadata['jax_backend']})",
+        file=sys.stderr,
+    )
+
+    results = []
+    started = time.perf_counter()
+    for i, bench in enumerate(benches, start=1):
+        print(
+            f"[{i}/{len(benches)}] {bench.key} ... ",
+            end="",
+            file=sys.stderr,
+            flush=True,
+        )
+        record = run_benchmark(bench)
+        results.append(record)
+        if record["status"] == "ok":
+            print(
+                f"run {record['warm_min_s'] * 1e3:.1f} ms, "
+                f"compile {record['compile_s'] * 1e3:.1f} ms",
+                file=sys.stderr,
+            )
+        else:
+            print(f"FAILED ({record['error']})", file=sys.stderr)
+
+    report = {
+        "label": args.label,
+        "commit": args.commit,
+        "metadata": metadata,
+        "wall_time_s": time.perf_counter() - started,
+        "results": results,
+    }
+
+    payload = json.dumps(report, indent=2, sort_keys=True)
+    if args.output:
+        with open(args.output, "w") as f:
+            f.write(payload + "\n")
+        print(f"wrote {args.output}", file=sys.stderr)
+    else:
+        print(payload)
+
+    failed = [r["name"] for r in results if r["status"] == "error"]
+    if failed:
+        print(
+            f"{len(failed)} benchmark(s) failed: {', '.join(failed)}", file=sys.stderr
+        )
+    # Failures are reported in the JSON and rendered as 'n/a' in the comparison;
+    # they must not fail the run, because a benchmark for a brand new feature
+    # will legitimately fail against the base checkout.
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/suites/__init__.py
+++ b/benchmarks/suites/__init__.py
@@ -1,0 +1,15 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Benchmark suites.
+
+Importing this package imports every module below it, which is what populates
+the registry in :mod:`benchmarks.harness`.
+"""
+
+from benchmarks.suites import distributions, handlers, mcmc, svi
+
+__all__ = ["distributions", "handlers", "mcmc", "svi"]
+
+#: Suite names in the order they should be reported.
+SUITE_ORDER = ["mcmc", "svi", "distributions", "handlers"]

--- a/benchmarks/suites/distributions.py
+++ b/benchmarks/suites/distributions.py
@@ -1,0 +1,203 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Distribution benchmarks: ``log_prob``, ``sample`` and transform hot paths.
+
+These are the cheapest and least noisy measurements in the report. The
+distribution object is usually constructed *inside* the jitted function so that
+argument validation and constraint machinery show up in the compile-time
+column, where a regression in that layer is visible.
+"""
+
+import jax
+from jax import random
+import jax.numpy as jnp
+
+from benchmarks.harness import benchmark
+import numpyro.distributions as dist
+from numpyro.distributions.transforms import StickBreakingTransform, biject_to
+
+# Elementwise kernels need a big batch to rise above the sub-millisecond noise
+# floor of a shared CI runner; quadratic ones (Cholesky, rejection sampling)
+# get their own smaller sizes so a single benchmark cannot dominate the suite.
+BATCH = 65536
+DIM = 64
+MATRIX_BATCH = 4096
+MATRIX_DIM = 32
+SAMPLE_BATCH = 2048
+TRANSFORM_BATCH = 16384
+# Drawing the Dirichlet test data is itself expensive, so it gets a smaller
+# batch than the other elementwise log_prob benchmarks.
+DIRICHLET_BATCH = 16384
+
+
+def _jit_call(fn, *args):
+    """Return a runner that calls ``fn`` under ``jax.jit`` with fixed args."""
+    compiled = jax.jit(fn)
+
+    def run():
+        return compiled(*args)
+
+    return run
+
+
+# --------------------------------------------------------------------------- #
+# log_prob
+# --------------------------------------------------------------------------- #
+
+
+@benchmark(suite="distributions", warm_repeats=20)
+def normal_log_prob():
+    """Normal.log_prob over a 65536x64 batch."""
+    x = random.normal(random.PRNGKey(0), (BATCH, DIM))
+    return _jit_call(lambda x: dist.Normal(0.0, 1.0).log_prob(x).sum(), x)
+
+
+@benchmark(suite="distributions", warm_repeats=20)
+def multivariate_normal_log_prob():
+    """MultivariateNormal.log_prob -- triangular solve dominated."""
+    key = random.PRNGKey(0)
+    scale_tril = jnp.linalg.cholesky(
+        jnp.eye(MATRIX_DIM) + 0.1 * jnp.ones((MATRIX_DIM, MATRIX_DIM))
+    )
+    x = random.normal(key, (MATRIX_BATCH, MATRIX_DIM))
+
+    def fn(x, scale_tril):
+        d = dist.MultivariateNormal(jnp.zeros(MATRIX_DIM), scale_tril=scale_tril)
+        return d.log_prob(x).sum()
+
+    return _jit_call(fn, x, scale_tril)
+
+
+@benchmark(suite="distributions", warm_repeats=20)
+def dirichlet_log_prob():
+    """Dirichlet.log_prob -- lgamma heavy, simplex constrained."""
+    key = random.PRNGKey(0)
+    conc = jnp.full((DIM,), 2.0)
+    x = dist.Dirichlet(conc).sample(key, (DIRICHLET_BATCH,))
+    return _jit_call(lambda x, c: dist.Dirichlet(c).log_prob(x).sum(), x, conc)
+
+
+@benchmark(suite="distributions", warm_repeats=20)
+def categorical_log_prob():
+    """Categorical(logits).log_prob -- gather plus log_softmax."""
+    key = random.PRNGKey(0)
+    logits = random.normal(key, (BATCH, DIM))
+    x = random.randint(key, (BATCH,), 0, DIM)
+    return _jit_call(
+        lambda x, lg: dist.Categorical(logits=lg).log_prob(x).sum(), x, logits
+    )
+
+
+@benchmark(suite="distributions", warm_repeats=20)
+def gamma_log_prob():
+    """Gamma.log_prob over a 65536x64 batch."""
+    key = random.PRNGKey(0)
+    x = dist.Gamma(2.0, 1.0).sample(key, (BATCH, DIM))
+    return _jit_call(lambda x: dist.Gamma(2.0, 1.0).log_prob(x).sum(), x)
+
+
+@benchmark(suite="distributions", warm_repeats=20)
+def student_t_log_prob():
+    """StudentT.log_prob over a 65536x64 batch."""
+    x = random.normal(random.PRNGKey(0), (BATCH, DIM))
+    return _jit_call(lambda x: dist.StudentT(3.0, 0.0, 1.0).log_prob(x).sum(), x)
+
+
+@benchmark(suite="distributions", warm_repeats=20)
+def truncated_normal_log_prob():
+    """TruncatedNormal.log_prob -- CDF normalisation path."""
+    x = jnp.abs(random.normal(random.PRNGKey(0), (BATCH, DIM)))
+    return _jit_call(
+        lambda x: dist.TruncatedNormal(0.0, 1.0, low=0.0).log_prob(x).sum(), x
+    )
+
+
+@benchmark(suite="distributions", warm_repeats=20)
+def mixture_same_family_log_prob():
+    """MixtureSameFamily.log_prob with 8 Normal components."""
+    key = random.PRNGKey(0)
+    locs = random.normal(key, (8,))
+    x = random.normal(key, (BATCH,))
+
+    def fn(x, locs):
+        mixing = dist.Categorical(logits=jnp.zeros(8))
+        component = dist.Normal(locs, 1.0)
+        return dist.MixtureSameFamily(mixing, component).log_prob(x).sum()
+
+    return _jit_call(fn, x, locs)
+
+
+# --------------------------------------------------------------------------- #
+# sample
+# --------------------------------------------------------------------------- #
+
+
+@benchmark(suite="distributions", warm_repeats=20)
+def normal_sample():
+    """Normal.sample of a 65536x64 batch."""
+    return _jit_call(
+        lambda k: dist.Normal(0.0, 1.0).sample(k, (BATCH, DIM)), random.PRNGKey(0)
+    )
+
+
+@benchmark(suite="distributions", warm_repeats=10)
+def gamma_sample():
+    """Gamma.sample -- rejection sampler with custom JVP."""
+    return _jit_call(
+        lambda k: dist.Gamma(2.0, 1.0).sample(k, (SAMPLE_BATCH, MATRIX_DIM)),
+        random.PRNGKey(0),
+    )
+
+
+@benchmark(suite="distributions", warm_repeats=10)
+def dirichlet_sample():
+    """Dirichlet.sample of a 2048x64 batch -- gamma draws plus normalisation."""
+    conc = jnp.full((DIM,), 2.0)
+    return _jit_call(
+        lambda k, c: dist.Dirichlet(c).sample(k, (SAMPLE_BATCH,)),
+        random.PRNGKey(0),
+        conc,
+    )
+
+
+@benchmark(suite="distributions", warm_repeats=10)
+def lkj_cholesky_sample():
+    """LKJCholesky.sample -- onion method over 512 draws."""
+    return _jit_call(
+        lambda k: dist.LKJCholesky(8, concentration=1.0).sample(k, (512,)),
+        random.PRNGKey(0),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# transforms
+# --------------------------------------------------------------------------- #
+
+
+@benchmark(suite="distributions", warm_repeats=20)
+def stick_breaking_transform():
+    """StickBreakingTransform forward, inverse and log-det."""
+    x = random.normal(random.PRNGKey(0), (TRANSFORM_BATCH, MATRIX_DIM - 1))
+    transform = StickBreakingTransform()
+
+    def fn(x):
+        y = transform(x)
+        return transform.inv(y).sum() + transform.log_abs_det_jacobian(x, y).sum()
+
+    return _jit_call(fn, x)
+
+
+@benchmark(suite="distributions", warm_repeats=20)
+def biject_to_constraints():
+    """biject_to over the constraints NUTS unconstrains most often."""
+    x = random.normal(random.PRNGKey(0), (TRANSFORM_BATCH, MATRIX_DIM))
+
+    def fn(x):
+        total = biject_to(dist.constraints.positive)(x).sum()
+        total += biject_to(dist.constraints.unit_interval)(x).sum()
+        total += biject_to(dist.constraints.simplex)(x[..., :-1]).sum()
+        total += biject_to(dist.constraints.ordered_vector)(x).sum()
+        return total
+
+    return _jit_call(fn, x)

--- a/benchmarks/suites/distributions.py
+++ b/benchmarks/suites/distributions.py
@@ -49,14 +49,14 @@ def _jit_call(fn, *args):
 @benchmark(suite="distributions", warm_repeats=20)
 def normal_log_prob():
     """Normal.log_prob over a 65536x64 batch."""
-    x = random.normal(random.PRNGKey(0), (BATCH, DIM))
+    x = random.normal(random.key(0), (BATCH, DIM))
     return _jit_call(lambda x: dist.Normal(0.0, 1.0).log_prob(x).sum(), x)
 
 
 @benchmark(suite="distributions", warm_repeats=20)
 def multivariate_normal_log_prob():
     """MultivariateNormal.log_prob -- triangular solve dominated."""
-    key = random.PRNGKey(0)
+    key = random.key(0)
     scale_tril = jnp.linalg.cholesky(
         jnp.eye(MATRIX_DIM) + 0.1 * jnp.ones((MATRIX_DIM, MATRIX_DIM))
     )
@@ -72,7 +72,7 @@ def multivariate_normal_log_prob():
 @benchmark(suite="distributions", warm_repeats=20)
 def dirichlet_log_prob():
     """Dirichlet.log_prob -- lgamma heavy, simplex constrained."""
-    key = random.PRNGKey(0)
+    key = random.key(0)
     conc = jnp.full((DIM,), 2.0)
     x = dist.Dirichlet(conc).sample(key, (DIRICHLET_BATCH,))
     return _jit_call(lambda x, c: dist.Dirichlet(c).log_prob(x).sum(), x, conc)
@@ -81,7 +81,7 @@ def dirichlet_log_prob():
 @benchmark(suite="distributions", warm_repeats=20)
 def categorical_log_prob():
     """Categorical(logits).log_prob -- gather plus log_softmax."""
-    key = random.PRNGKey(0)
+    key = random.key(0)
     logits = random.normal(key, (BATCH, DIM))
     x = random.randint(key, (BATCH,), 0, DIM)
     return _jit_call(
@@ -92,7 +92,7 @@ def categorical_log_prob():
 @benchmark(suite="distributions", warm_repeats=20)
 def gamma_log_prob():
     """Gamma.log_prob over a 65536x64 batch."""
-    key = random.PRNGKey(0)
+    key = random.key(0)
     x = dist.Gamma(2.0, 1.0).sample(key, (BATCH, DIM))
     return _jit_call(lambda x: dist.Gamma(2.0, 1.0).log_prob(x).sum(), x)
 
@@ -100,14 +100,14 @@ def gamma_log_prob():
 @benchmark(suite="distributions", warm_repeats=20)
 def student_t_log_prob():
     """StudentT.log_prob over a 65536x64 batch."""
-    x = random.normal(random.PRNGKey(0), (BATCH, DIM))
+    x = random.normal(random.key(0), (BATCH, DIM))
     return _jit_call(lambda x: dist.StudentT(3.0, 0.0, 1.0).log_prob(x).sum(), x)
 
 
 @benchmark(suite="distributions", warm_repeats=20)
 def truncated_normal_log_prob():
     """TruncatedNormal.log_prob -- CDF normalisation path."""
-    x = jnp.abs(random.normal(random.PRNGKey(0), (BATCH, DIM)))
+    x = jnp.abs(random.normal(random.key(0), (BATCH, DIM)))
     return _jit_call(
         lambda x: dist.TruncatedNormal(0.0, 1.0, low=0.0).log_prob(x).sum(), x
     )
@@ -116,7 +116,7 @@ def truncated_normal_log_prob():
 @benchmark(suite="distributions", warm_repeats=20)
 def mixture_same_family_log_prob():
     """MixtureSameFamily.log_prob with 8 Normal components."""
-    key = random.PRNGKey(0)
+    key = random.key(0)
     locs = random.normal(key, (8,))
     x = random.normal(key, (BATCH,))
 
@@ -137,7 +137,7 @@ def mixture_same_family_log_prob():
 def normal_sample():
     """Normal.sample of a 65536x64 batch."""
     return _jit_call(
-        lambda k: dist.Normal(0.0, 1.0).sample(k, (BATCH, DIM)), random.PRNGKey(0)
+        lambda k: dist.Normal(0.0, 1.0).sample(k, (BATCH, DIM)), random.key(0)
     )
 
 
@@ -146,7 +146,7 @@ def gamma_sample():
     """Gamma.sample -- rejection sampler with custom JVP."""
     return _jit_call(
         lambda k: dist.Gamma(2.0, 1.0).sample(k, (SAMPLE_BATCH, MATRIX_DIM)),
-        random.PRNGKey(0),
+        random.key(0),
     )
 
 
@@ -156,7 +156,7 @@ def dirichlet_sample():
     conc = jnp.full((DIM,), 2.0)
     return _jit_call(
         lambda k, c: dist.Dirichlet(c).sample(k, (SAMPLE_BATCH,)),
-        random.PRNGKey(0),
+        random.key(0),
         conc,
     )
 
@@ -166,7 +166,7 @@ def lkj_cholesky_sample():
     """LKJCholesky.sample -- onion method over 512 draws."""
     return _jit_call(
         lambda k: dist.LKJCholesky(8, concentration=1.0).sample(k, (512,)),
-        random.PRNGKey(0),
+        random.key(0),
     )
 
 
@@ -178,7 +178,7 @@ def lkj_cholesky_sample():
 @benchmark(suite="distributions", warm_repeats=20)
 def stick_breaking_transform():
     """StickBreakingTransform forward, inverse and log-det."""
-    x = random.normal(random.PRNGKey(0), (TRANSFORM_BATCH, MATRIX_DIM - 1))
+    x = random.normal(random.key(0), (TRANSFORM_BATCH, MATRIX_DIM - 1))
     transform = StickBreakingTransform()
 
     def fn(x):
@@ -191,7 +191,7 @@ def stick_breaking_transform():
 @benchmark(suite="distributions", warm_repeats=20)
 def biject_to_constraints():
     """biject_to over the constraints NUTS unconstrains most often."""
-    x = random.normal(random.PRNGKey(0), (TRANSFORM_BATCH, MATRIX_DIM))
+    x = random.normal(random.key(0), (TRANSFORM_BATCH, MATRIX_DIM))
 
     def fn(x):
         total = biject_to(dist.constraints.positive)(x).sum()

--- a/benchmarks/suites/handlers.py
+++ b/benchmarks/suites/handlers.py
@@ -30,7 +30,7 @@ from numpyro.infer.util import initialize_model, log_density, potential_energy
 def trace_seeded_model():
     """trace(seed(model)).get_trace on logistic regression -- pure Python."""
     data = logistic_regression_data()
-    key = random.PRNGKey(0)
+    key = random.key(0)
 
     def run():
         return trace(seed(logistic_regression, key)).get_trace(**data)
@@ -42,7 +42,7 @@ def trace_seeded_model():
 def nested_handler_stack():
     """A four-deep substitute/condition/seed/trace stack on the hierarchical GLM."""
     data = hierarchical_glm_data()
-    key = random.PRNGKey(0)
+    key = random.key(0)
     params = {
         site: value["value"]
         for site, value in trace(seed(hierarchical_glm, key)).get_trace(**data).items()
@@ -62,7 +62,7 @@ def nested_handler_stack():
 def log_density_hierarchical():
     """log_density on the hierarchical GLM -- untraced, un-jitted."""
     data = hierarchical_glm_data()
-    key = random.PRNGKey(0)
+    key = random.key(0)
     params = {
         site: value["value"]
         for site, value in trace(seed(hierarchical_glm, key)).get_trace(**data).items()
@@ -79,7 +79,7 @@ def log_density_hierarchical():
 def potential_energy_and_grad():
     """jit(grad(potential_energy)) on logistic regression -- the NUTS inner loop."""
     data = logistic_regression_data()
-    key = random.PRNGKey(0)
+    key = random.key(0)
     # ``initialize_model`` hands back unconstrained values, which is exactly
     # what ``potential_energy`` expects.
     params = initialize_model(key, logistic_regression, model_kwargs=data).param_info.z
@@ -97,7 +97,7 @@ def potential_energy_and_grad():
 def initialize_model_hierarchical():
     """initialize_model on the hierarchical GLM -- tracing plus init strategy."""
     data = hierarchical_glm_data()
-    key = random.PRNGKey(0)
+    key = random.key(0)
 
     def run():
         info = initialize_model(key, hierarchical_glm, model_kwargs=data)
@@ -110,7 +110,7 @@ def initialize_model_hierarchical():
 def predictive_forward_sampling():
     """Predictive with 250 draws from the prior of the hierarchical GLM."""
     data = hierarchical_glm_data()
-    key = random.PRNGKey(0)
+    key = random.key(0)
     model_kwargs = {k: v for k, v in data.items() if k != "y"}
     predictive = Predictive(hierarchical_glm, num_samples=250)
 

--- a/benchmarks/suites/handlers.py
+++ b/benchmarks/suites/handlers.py
@@ -1,0 +1,120 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Effect-handler and model-tracing benchmarks.
+
+Several of these run entirely in Python with no ``jax.jit`` involved, so their
+compile-time column is expected to sit at zero and their run-time column
+measures pure interpreter overhead in ``numpyro/primitives.py`` and
+``numpyro/handlers.py``. Because every inference algorithm traces the model at
+least once, a regression here is felt everywhere -- including in the
+compile-time column of every other suite.
+"""
+
+import jax
+from jax import random
+
+from benchmarks.harness import benchmark
+from benchmarks.models import (
+    hierarchical_glm,
+    hierarchical_glm_data,
+    logistic_regression,
+    logistic_regression_data,
+)
+from numpyro.handlers import condition, seed, substitute, trace
+from numpyro.infer import Predictive
+from numpyro.infer.util import initialize_model, log_density, potential_energy
+
+
+@benchmark(suite="handlers", warm_repeats=20)
+def trace_seeded_model():
+    """trace(seed(model)).get_trace on logistic regression -- pure Python."""
+    data = logistic_regression_data()
+    key = random.PRNGKey(0)
+
+    def run():
+        return trace(seed(logistic_regression, key)).get_trace(**data)
+
+    return run
+
+
+@benchmark(suite="handlers", warm_repeats=20)
+def nested_handler_stack():
+    """A four-deep substitute/condition/seed/trace stack on the hierarchical GLM."""
+    data = hierarchical_glm_data()
+    key = random.PRNGKey(0)
+    params = {
+        site: value["value"]
+        for site, value in trace(seed(hierarchical_glm, key)).get_trace(**data).items()
+        if value["type"] == "sample" and not value.get("is_observed", False)
+    }
+    observed = {"obs": data["y"]}
+
+    def run():
+        model = substitute(hierarchical_glm, data=params)
+        model = condition(model, data=observed)
+        return trace(seed(model, key)).get_trace(**data)
+
+    return run
+
+
+@benchmark(suite="handlers", warm_repeats=20)
+def log_density_hierarchical():
+    """log_density on the hierarchical GLM -- untraced, un-jitted."""
+    data = hierarchical_glm_data()
+    key = random.PRNGKey(0)
+    params = {
+        site: value["value"]
+        for site, value in trace(seed(hierarchical_glm, key)).get_trace(**data).items()
+        if value["type"] == "sample" and not value.get("is_observed", False)
+    }
+
+    def run():
+        return log_density(hierarchical_glm, (), data, params)
+
+    return run
+
+
+@benchmark(suite="handlers", warm_repeats=20)
+def potential_energy_and_grad():
+    """jit(grad(potential_energy)) on logistic regression -- the NUTS inner loop."""
+    data = logistic_regression_data()
+    key = random.PRNGKey(0)
+    # ``initialize_model`` hands back unconstrained values, which is exactly
+    # what ``potential_energy`` expects.
+    params = initialize_model(key, logistic_regression, model_kwargs=data).param_info.z
+    grad_fn = jax.jit(
+        jax.grad(lambda p: potential_energy(logistic_regression, (), data, p))
+    )
+
+    def run():
+        return grad_fn(params)
+
+    return run
+
+
+@benchmark(suite="handlers", warm_repeats=5)
+def initialize_model_hierarchical():
+    """initialize_model on the hierarchical GLM -- tracing plus init strategy."""
+    data = hierarchical_glm_data()
+    key = random.PRNGKey(0)
+
+    def run():
+        info = initialize_model(key, hierarchical_glm, model_kwargs=data)
+        return info.param_info.z
+
+    return run
+
+
+@benchmark(suite="handlers", warm_repeats=5)
+def predictive_forward_sampling():
+    """Predictive with 250 draws from the prior of the hierarchical GLM."""
+    data = hierarchical_glm_data()
+    key = random.PRNGKey(0)
+    model_kwargs = {k: v for k, v in data.items() if k != "y"}
+    predictive = Predictive(hierarchical_glm, num_samples=250)
+
+    def run():
+        return predictive(key, **model_kwargs)
+
+    return run

--- a/benchmarks/suites/mcmc.py
+++ b/benchmarks/suites/mcmc.py
@@ -1,0 +1,96 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+"""MCMC benchmarks: end-to-end ``mcmc.run`` for HMC and NUTS.
+
+The cold call pays for tracing the model, building the ``lax.scan`` sampling
+loop and compiling it; warm calls hit :attr:`MCMC._cache` and re-execute the
+compiled loop. That split is exactly what the report shows as compile time
+versus run time.
+"""
+
+from functools import partial
+
+from jax import random
+
+from benchmarks.harness import benchmark
+from benchmarks.models import (
+    eight_schools,
+    eight_schools_data,
+    hierarchical_glm,
+    hierarchical_glm_data,
+    logistic_regression,
+    logistic_regression_data,
+    neals_funnel,
+)
+from numpyro.infer import HMC, MCMC, NUTS
+
+# Chains are short on purpose: this measures throughput and compilation, not
+# inference quality, and the whole suite runs four times per comparison.
+NUM_WARMUP = 200
+NUM_SAMPLES = 200
+
+
+def _mcmc(kernel, **kwargs):
+    return MCMC(
+        kernel,
+        num_warmup=kwargs.pop("num_warmup", NUM_WARMUP),
+        num_samples=kwargs.pop("num_samples", NUM_SAMPLES),
+        progress_bar=False,
+        **kwargs,
+    )
+
+
+def _runner(mcmc, key, **model_kwargs):
+    def run():
+        mcmc.run(key, **model_kwargs)
+        return mcmc.get_samples()
+
+    return run
+
+
+@benchmark(suite="mcmc", warm_repeats=3)
+def nuts_logistic_regression():
+    """NUTS on a dense 1000x10 logistic regression."""
+    data = logistic_regression_data()
+    mcmc = _mcmc(NUTS(logistic_regression))
+    return _runner(mcmc, random.PRNGKey(0), **data)
+
+
+@benchmark(suite="mcmc", warm_repeats=3)
+def nuts_eight_schools():
+    """NUTS on non-centred eight schools."""
+    data = eight_schools_data()
+    mcmc = _mcmc(NUTS(eight_schools), num_warmup=500, num_samples=500)
+    return _runner(mcmc, random.PRNGKey(0), **data)
+
+
+@benchmark(suite="mcmc", warm_repeats=3)
+def nuts_hierarchical_glm():
+    """NUTS on a partially pooled regression with 20 groups."""
+    data = hierarchical_glm_data()
+    mcmc = _mcmc(NUTS(hierarchical_glm))
+    return _runner(mcmc, random.PRNGKey(0), **data)
+
+
+@benchmark(suite="mcmc", warm_repeats=3)
+def nuts_dense_mass_funnel():
+    """NUTS with a dense mass matrix on Neal's funnel."""
+    mcmc = _mcmc(NUTS(partial(neals_funnel, dim=10), dense_mass=True))
+    return _runner(mcmc, random.PRNGKey(0))
+
+
+@benchmark(suite="mcmc", warm_repeats=3)
+def hmc_logistic_regression():
+    """HMC with a fixed trajectory length on logistic regression."""
+    data = logistic_regression_data()
+    mcmc = _mcmc(HMC(logistic_regression, trajectory_length=1.0))
+    return _runner(mcmc, random.PRNGKey(0), **data)
+
+
+@benchmark(suite="mcmc", warm_repeats=2)
+def nuts_vectorized_chains():
+    """Four vmapped NUTS chains on eight schools."""
+    data = eight_schools_data()
+    mcmc = _mcmc(NUTS(eight_schools), num_chains=4, chain_method="vectorized")
+    return _runner(mcmc, random.PRNGKey(0), **data)

--- a/benchmarks/suites/mcmc.py
+++ b/benchmarks/suites/mcmc.py
@@ -54,7 +54,7 @@ def nuts_logistic_regression():
     """NUTS on a dense 1000x10 logistic regression."""
     data = logistic_regression_data()
     mcmc = _mcmc(NUTS(logistic_regression))
-    return _runner(mcmc, random.PRNGKey(0), **data)
+    return _runner(mcmc, random.key(0), **data)
 
 
 @benchmark(suite="mcmc", warm_repeats=3)
@@ -62,7 +62,7 @@ def nuts_eight_schools():
     """NUTS on non-centred eight schools."""
     data = eight_schools_data()
     mcmc = _mcmc(NUTS(eight_schools), num_warmup=500, num_samples=500)
-    return _runner(mcmc, random.PRNGKey(0), **data)
+    return _runner(mcmc, random.key(0), **data)
 
 
 @benchmark(suite="mcmc", warm_repeats=3)
@@ -70,14 +70,14 @@ def nuts_hierarchical_glm():
     """NUTS on a partially pooled regression with 20 groups."""
     data = hierarchical_glm_data()
     mcmc = _mcmc(NUTS(hierarchical_glm))
-    return _runner(mcmc, random.PRNGKey(0), **data)
+    return _runner(mcmc, random.key(0), **data)
 
 
 @benchmark(suite="mcmc", warm_repeats=3)
 def nuts_dense_mass_funnel():
     """NUTS with a dense mass matrix on Neal's funnel."""
     mcmc = _mcmc(NUTS(partial(neals_funnel, dim=10), dense_mass=True))
-    return _runner(mcmc, random.PRNGKey(0))
+    return _runner(mcmc, random.key(0))
 
 
 @benchmark(suite="mcmc", warm_repeats=3)
@@ -85,7 +85,7 @@ def hmc_logistic_regression():
     """HMC with a fixed trajectory length on logistic regression."""
     data = logistic_regression_data()
     mcmc = _mcmc(HMC(logistic_regression, trajectory_length=1.0))
-    return _runner(mcmc, random.PRNGKey(0), **data)
+    return _runner(mcmc, random.key(0), **data)
 
 
 @benchmark(suite="mcmc", warm_repeats=2)
@@ -93,4 +93,4 @@ def nuts_vectorized_chains():
     """Four vmapped NUTS chains on eight schools."""
     data = eight_schools_data()
     mcmc = _mcmc(NUTS(eight_schools), num_chains=4, chain_method="vectorized")
-    return _runner(mcmc, random.PRNGKey(0), **data)
+    return _runner(mcmc, random.key(0), **data)

--- a/benchmarks/suites/svi.py
+++ b/benchmarks/suites/svi.py
@@ -1,0 +1,116 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+"""SVI benchmarks: ``svi.run`` with the common autoguides.
+
+With ``progress_bar=False`` the whole optimisation loop is a single
+``lax.scan``, so the cold call measures guide construction plus compilation of
+that loop and the warm calls measure raw step throughput.
+"""
+
+from jax import random
+
+from benchmarks.harness import benchmark
+from benchmarks.models import (
+    eight_schools,
+    eight_schools_data,
+    hierarchical_glm,
+    hierarchical_glm_data,
+    logistic_regression,
+    logistic_regression_data,
+)
+from numpyro.infer import SVI, Trace_ELBO, TraceMeanField_ELBO
+from numpyro.infer.autoguide import (
+    AutoDelta,
+    AutoDiagonalNormal,
+    AutoMultivariateNormal,
+    AutoNormal,
+)
+import numpyro.optim as optim
+
+NUM_STEPS = 1000
+
+
+def _runner(svi, key, num_steps=NUM_STEPS, **model_kwargs):
+    def run():
+        return svi.run(key, num_steps, progress_bar=False, **model_kwargs)
+
+    return run
+
+
+@benchmark(suite="svi", warm_repeats=3)
+def svi_autonormal_logistic():
+    """AutoNormal + Trace_ELBO on logistic regression."""
+    data = logistic_regression_data()
+    svi = SVI(
+        logistic_regression,
+        AutoNormal(logistic_regression),
+        optim.Adam(1e-3),
+        Trace_ELBO(),
+    )
+    return _runner(svi, random.PRNGKey(0), **data)
+
+
+@benchmark(suite="svi", warm_repeats=3)
+def svi_autodiagonalnormal_hierarchical():
+    """AutoDiagonalNormal + Trace_ELBO on the hierarchical GLM."""
+    data = hierarchical_glm_data()
+    svi = SVI(
+        hierarchical_glm,
+        AutoDiagonalNormal(hierarchical_glm),
+        optim.Adam(1e-3),
+        Trace_ELBO(),
+    )
+    return _runner(svi, random.PRNGKey(0), **data)
+
+
+@benchmark(suite="svi", warm_repeats=3)
+def svi_automultivariatenormal_eight_schools():
+    """AutoMultivariateNormal on eight schools -- exercises the Cholesky path."""
+    data = eight_schools_data()
+    svi = SVI(
+        eight_schools,
+        AutoMultivariateNormal(eight_schools),
+        optim.Adam(1e-3),
+        Trace_ELBO(),
+    )
+    return _runner(svi, random.PRNGKey(0), **data)
+
+
+@benchmark(suite="svi", warm_repeats=3)
+def svi_autodelta_map_logistic():
+    """AutoDelta (MAP estimation) on logistic regression."""
+    data = logistic_regression_data()
+    svi = SVI(
+        logistic_regression,
+        AutoDelta(logistic_regression),
+        optim.Adam(1e-2),
+        Trace_ELBO(),
+    )
+    return _runner(svi, random.PRNGKey(0), **data)
+
+
+@benchmark(suite="svi", warm_repeats=3)
+def svi_trace_mean_field_elbo():
+    """TraceMeanField_ELBO on the hierarchical GLM -- analytic KL path."""
+    data = hierarchical_glm_data()
+    svi = SVI(
+        hierarchical_glm,
+        AutoNormal(hierarchical_glm),
+        optim.Adam(1e-3),
+        TraceMeanField_ELBO(),
+    )
+    return _runner(svi, random.PRNGKey(0), **data)
+
+
+@benchmark(suite="svi", warm_repeats=3)
+def svi_multi_particle_elbo():
+    """Trace_ELBO with 16 particles -- vmapped ELBO estimation."""
+    data = logistic_regression_data()
+    svi = SVI(
+        logistic_regression,
+        AutoNormal(logistic_regression),
+        optim.Adam(1e-3),
+        Trace_ELBO(num_particles=16),
+    )
+    return _runner(svi, random.PRNGKey(0), num_steps=500, **data)

--- a/benchmarks/suites/svi.py
+++ b/benchmarks/suites/svi.py
@@ -48,7 +48,7 @@ def svi_autonormal_logistic():
         optim.Adam(1e-3),
         Trace_ELBO(),
     )
-    return _runner(svi, random.PRNGKey(0), **data)
+    return _runner(svi, random.key(0), **data)
 
 
 @benchmark(suite="svi", warm_repeats=3)
@@ -61,7 +61,7 @@ def svi_autodiagonalnormal_hierarchical():
         optim.Adam(1e-3),
         Trace_ELBO(),
     )
-    return _runner(svi, random.PRNGKey(0), **data)
+    return _runner(svi, random.key(0), **data)
 
 
 @benchmark(suite="svi", warm_repeats=3)
@@ -74,7 +74,7 @@ def svi_automultivariatenormal_eight_schools():
         optim.Adam(1e-3),
         Trace_ELBO(),
     )
-    return _runner(svi, random.PRNGKey(0), **data)
+    return _runner(svi, random.key(0), **data)
 
 
 @benchmark(suite="svi", warm_repeats=3)
@@ -87,7 +87,7 @@ def svi_autodelta_map_logistic():
         optim.Adam(1e-2),
         Trace_ELBO(),
     )
-    return _runner(svi, random.PRNGKey(0), **data)
+    return _runner(svi, random.key(0), **data)
 
 
 @benchmark(suite="svi", warm_repeats=3)
@@ -100,7 +100,7 @@ def svi_trace_mean_field_elbo():
         optim.Adam(1e-3),
         TraceMeanField_ELBO(),
     )
-    return _runner(svi, random.PRNGKey(0), **data)
+    return _runner(svi, random.key(0), **data)
 
 
 @benchmark(suite="svi", warm_repeats=3)
@@ -113,4 +113,4 @@ def svi_multi_particle_elbo():
         optim.Adam(1e-3),
         Trace_ELBO(num_particles=16),
     )
-    return _runner(svi, random.PRNGKey(0), num_steps=500, **data)
+    return _runner(svi, random.key(0), num_steps=500, **data)


### PR DESCRIPTION
Adds a benchmark suite and the CI mechanism that measures a pull request against its merge base, then posts the difference as a sticky comment.

benchmarks/ holds 32 benchmarks across four suites -- MCMC, SVI, distributions, and effect handlers. Each is a setup function returning a zero-argument run callable, so data generation stays out of the measurement. The harness clears the JAX caches, calls it once, then several times warm: the fastest warm call is reported as run time, and the excess of the cold call over it as compile time.

The workflow is opt-in behind a `run-benchmarks` label, because a full comparison takes tens of minutes. It builds a venv for the head and one for the merge base, pinning the base to the head's JAX version so the report measures NumPyro rather than JAX, and measures both with the head revision of benchmarks/ so a benchmark added by the PR still runs against the base. Where it cannot run there, the row is reported as n/a with the reason rather than dropped.

Commenting is split into a second workflow_run workflow: a pull_request build of a fork gets a read-only token, so the benchmark job holds no write permission and only uploads an artifact, and the privileged job never executes code from the pull request.

Thresholds come from an A/A control run -- identical code on both sides. Run time stayed within 2%, so 5% is the band. Compile time swung 20% on one benchmark, and 216% on one with no jitted work at all, hence the looser 25% band and the 50 ms floor below which a cold/warm gap is warm-up rather than compilation.

Fixes #454