### PR TITLE
ci: add PR triage workflow for auto review requests and labels

### DIFF
--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -36,5 +36,5 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,
-              labels: ["run-benchmarks", "awaiting review"],
+              labels: ["awaiting review"],
             });

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -1,0 +1,40 @@
+name: PR Triage
+
+on:
+  pull_request:
+    types: [opened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Request reviews
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const reviewers = ["fehiepsi", "juanitorduz", "Qazalbash"]
+              .filter((reviewer) => reviewer !== context.payload.pull_request.user.login);
+
+            if (reviewers.length > 0) {
+              await github.rest.pulls.requestReviewers({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.pull_request.number,
+                reviewers,
+              });
+            }
+
+      - name: Add labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              labels: ["run-benchmarks", "awaiting review"],
+            });


### PR DESCRIPTION
Requests reviews from @fehiepsi, @juanitorduz, and @Qazalbash and applies the 'awaiting review' label whenever a PR is opened.