### PR TITLE
 Validate num_samples in MCMC initialization 

### DIFF
--- a/numpyro/infer/mcmc.py
+++ b/numpyro/infer/mcmc.py
@@ -340,12 +340,18 @@ class MCMC(object):
         self.sampler = sampler
         self._sample_field = sampler.sample_field
         self._default_fields = sampler.default_fields
+        if not isinstance(num_warmup, int) or num_warmup < 0:
+            raise ValueError("num_warmup must be a nonnegative integer")
         self.num_warmup = num_warmup
-        self.num_samples = num_samples
         self.num_chains = num_chains
         if not isinstance(thinning, int) or thinning < 1:
             raise ValueError("thinning must be a positive integer")
         self.thinning = thinning
+        if not isinstance(num_samples, int) or num_samples < thinning:
+            raise ValueError(
+                "num_samples must be a positive integer greater than thinning"
+            )
+        self.num_samples = num_samples
         self.postprocess_fn = postprocess_fn
         if not callable(chain_method) and chain_method not in [
             "parallel",


### PR DESCRIPTION
I tried to debug my MCMC kernel by doing just one iteration using
```py
mcmc = MCMC(kernel, num_warmup=1, num_samples=0)
```
<details>

<summary>I got this very long error message</summary>

```
---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
Cell In[55], line 4
      2 kernel = HMCGibbs(inner_kernel=hmc_kernel, gibbs_fn=gibbs_fn, gibbs_sites = ["ability"])
      3 mcmc = MCMC(kernel, num_warmup=11, num_samples = 0)
----> 4 mcmc.run(jax.random.key(0), y, 5)

File /nix/store/bkqp5piw63cwdwqcxpzwwm89zaisfhji-python3-3.13.13-env/lib/python3.13/site-packages/numpyro/infer/mcmc.py:711, in MCMC.run(self, rng_key, extra_fields, init_params, *args, **kwargs)
    709 map_args = (rng_key, init_state, init_params)
    710 if self.num_chains == 1:
--> 711     states_flat, last_state = partial_map_fn(map_args)
    712     states = jax.tree.map(lambda x: x[jnp.newaxis, ...], states_flat)
    713 else:

File /nix/store/bkqp5piw63cwdwqcxpzwwm89zaisfhji-python3-3.13.13-env/lib/python3.13/site-packages/numpyro/infer/mcmc.py:496, in MCMC._single_chain_mcmc(self, init, args, kwargs, collect_fields, remove_sites)
    490 collection_size = self._collection_params["collection_size"]
    491 collection_size = (
    492     collection_size
    493     if collection_size is None
    494     else collection_size // self.thinning
    495 )
--> 496 collect_vals = fori_collect(
    497     lower_idx,
    498     upper_idx,
    499     sample_fn,
    500     init_val,
    501     transform=_collect_and_postprocess(
    502         postprocess_fn, collect_fields, remove_sites
    503     ),
    504     progbar=self.progress_bar,
    505     progress_rate=self.progress_rate,
    506     return_last_val=True,
    507     thinning=self.thinning,
    508     collection_size=collection_size,
    509     progbar_desc=partial(_get_progbar_desc_str, lower_idx, phase),
    510     diagnostics_fn=diagnostics,
    511     num_chains=self.num_chains
    512     if (callable(self.chain_method) or self.chain_method == "parallel")
    513     else 1,
    514 )
    515 states, last_val = collect_vals
    516 # Get first argument of type `HMCState`

File /nix/store/bkqp5piw63cwdwqcxpzwwm89zaisfhji-python3-3.13.13-env/lib/python3.13/site-packages/numpyro/util.py:446, in fori_collect(lower, upper, body_fun, init_val, transform, progbar, progress_rate, return_last_val, collection_size, thinning, **progbar_opts)
    444 with tqdm.trange(upper, miniters=progress_rate) as t:
    445     for i in t:
--> 446         vals = _body_fn(i, *vals)
    448         t.set_description(progbar_desc(i), refresh=False)
    449         if diagnostics_fn:

    [... skipping hidden 1 frame]

File /nix/store/bkqp5piw63cwdwqcxpzwwm89zaisfhji-python3-3.13.13-env/lib/python3.13/site-packages/jax/_src/pjit.py:253, in _cpp_pjit.<locals>.cache_miss(*args, **kwargs)
    250 if config.no_tracing.value:
    251   raise RuntimeError(f"re-tracing function {jit_info.fun_sourceinfo} for "
    252                      "`jit`, but 'no_tracing' is set")
--> 253 p, args_flat = _infer_params(fun, jit_info, args, kwargs)
    254 (outs, out_flat, out_tree, args_flat, jaxpr,
    255  executable, pgle_profiler, const_args) = _run_python_pjit(
    256      p, args_flat, fun, args, kwargs)
    258 maybe_fastpath_data = _get_fastpath_data(
    259     executable, out_tree, args_flat, out_flat, jaxpr.effects, jaxpr.consts,
    260     pgle_profiler, const_args)

File /nix/store/bkqp5piw63cwdwqcxpzwwm89zaisfhji-python3-3.13.13-env/lib/python3.13/site-packages/jax/_src/pjit.py:624, in _infer_params(fun, ji, args, kwargs)
    621 if entry.pjit_params is not None:
    622   return entry.pjit_params, entry.pjit_params.consts + dynargs
--> 624 p = _trace_for_jit(fun, ji, ctx_mesh, dbg_fn(), avals, args, kwargs)
    625 if p.params['jaxpr'].jaxpr.is_high:
    626   return p, p.consts + dynargs

File /nix/store/bkqp5piw63cwdwqcxpzwwm89zaisfhji-python3-3.13.13-env/lib/python3.13/site-packages/jax/_src/pjit.py:526, in _trace_for_jit(fun, ji, ctx_mesh, dbg, avals, args, kwargs)
    524       jaxpr, out_avals = pe.trace_to_jaxpr(fun, in_type, dbg, qdd_token)
    525   else:
--> 526     jaxpr, out_avals = pe.trace_to_jaxpr(fun, in_type, dbg, qdd_token)
    528 if config.debug_key_reuse.value:
    529   # Import here to avoid circular imports
    530   from jax.experimental.key_reuse._core import check_key_reuse_jaxpr  # pytype: disable=import-error

File /nix/store/bkqp5piw63cwdwqcxpzwwm89zaisfhji-python3-3.13.13-env/lib/python3.13/site-packages/jax/_src/interpreters/partial_eval.py:2283, in trace_to_jaxpr(***failed resolving arguments***)
   2281 with core.set_current_trace(trace):
   2282   args, kwargs = in_tracers.unflatten()
-> 2283   ans_pytree = fun(*args, **kwargs)
   2284   if fun_returns_flat_tree:
   2285     # TODO(dougalm): make result paths optional
   2286     ans = ans_pytree

File /nix/store/bkqp5piw63cwdwqcxpzwwm89zaisfhji-python3-3.13.13-env/lib/python3.13/site-packages/numpyro/util.py:402, in fori_collect.<locals>._body_fn(i, val, collection, start_idx, thinning)
    399 def update_collection(collection, val):
    400     return jax.tree.map(update_fn, collection, transform(val))
--> 402 collection = update_collection(collection, val)
    403 return val, collection, start_idx, thinning

File /nix/store/bkqp5piw63cwdwqcxpzwwm89zaisfhji-python3-3.13.13-env/lib/python3.13/site-packages/numpyro/util.py:400, in fori_collect.<locals>._body_fn.<locals>.update_collection(collection, val)
    399 def update_collection(collection, val):
--> 400     return jax.tree.map(update_fn, collection, transform(val))

File /nix/store/bkqp5piw63cwdwqcxpzwwm89zaisfhji-python3-3.13.13-env/lib/python3.13/site-packages/jax/_src/tree.py:156, in map(f, tree, is_leaf, *rest)
    116 def map(f: Callable[..., Any],
    117         tree: Any,
    118         *rest: Any,
    119         is_leaf: Callable[[Any], bool] | None = None) -> Any:
    120   """Maps a multi-input function over pytree args to produce a new pytree.
    121
    122   Args:
   (...)    154     - :func:`jax.tree.reduce`
    155   """
--> 156   return tree_util.tree_map(f, tree, *rest, is_leaf=is_leaf)

File /nix/store/bkqp5piw63cwdwqcxpzwwm89zaisfhji-python3-3.13.13-env/lib/python3.13/site-packages/jax/_src/tree_util.py:397, in tree_map(f, tree, is_leaf, *rest)
    395 leaves, treedef = tree_flatten(tree, is_leaf)
    396 all_leaves = [leaves] + [treedef.flatten_up_to(r) for r in rest]
--> 397 return treedef.unflatten(f(*xs) for xs in zip(*all_leaves))

File /nix/store/bkqp5piw63cwdwqcxpzwwm89zaisfhji-python3-3.13.13-env/lib/python3.13/site-packages/jax/_src/tree_util.py:397, in <genexpr>(.0)
    395 leaves, treedef = tree_flatten(tree, is_leaf)
    396 all_leaves = [leaves] + [treedef.flatten_up_to(r) for r in rest]
--> 397 return treedef.unflatten(f(*xs) for xs in zip(*all_leaves))

File /nix/store/bkqp5piw63cwdwqcxpzwwm89zaisfhji-python3-3.13.13-env/lib/python3.13/site-packages/numpyro/util.py:391, in fori_collect.<locals>._body_fn.<locals>.update_fn(collect_array, new_val)
    390 def update_fn(collect_array, new_val):
--> 391     return cond(
    392         idx >= 0,
    393         collect_array,
    394         lambda x: x.at[idx].set(new_val),
    395         collect_array,
    396         identity,
    397     )

File /nix/store/bkqp5piw63cwdwqcxpzwwm89zaisfhji-python3-3.13.13-env/lib/python3.13/site-packages/numpyro/util.py:153, in cond(pred, true_operand, true_fun, false_operand, false_fun)
    151         return false_fun(false_operand)
    152 else:
--> 153     return lax.cond(pred, true_operand, true_fun, false_operand, false_fun)

    [... skipping hidden 1 frame]

File /nix/store/bkqp5piw63cwdwqcxpzwwm89zaisfhji-python3-3.13.13-env/lib/python3.13/site-packages/jax/_src/lax/control_flow/conditionals.py:231, in cond(pred, true_fun, false_fun, operand, *operands)
    229 if callable(false_fun) and len(operands) == 2 and callable(operands[1]):
    230   x_true, f_true, x_false, f_false = true_fun, false_fun, *operands
--> 231   return cond(pred, lambda x, _: f_true(x), lambda _, x: f_false(x), x_true, x_false)
    232 else:
    233   raise TypeError("lax.cond: true_fun and false_fun arguments should be callable.")

    [... skipping hidden 1 frame]

File /nix/store/bkqp5piw63cwdwqcxpzwwm89zaisfhji-python3-3.13.13-env/lib/python3.13/site-packages/jax/_src/lax/control_flow/conditionals.py:280, in cond(***failed resolving arguments***)
    277   api_util.check_no_aliased_ref_args(lambda: dbg_true, list(avals), list(args))
    278 dbg_false = api_util.debug_info("cond", false_fun, operands, {})
--> 280 true_jaxpr_, out_avals = pe.trace_to_jaxpr(true_fun, avals, dbg_true)
    281 true_jaxpr_, true_consts = pe.separate_consts(true_jaxpr_)
    282 false_jaxpr_, false_out_avals = pe.trace_to_jaxpr(false_fun, avals, dbg_false)

File /nix/store/bkqp5piw63cwdwqcxpzwwm89zaisfhji-python3-3.13.13-env/lib/python3.13/site-packages/jax/_src/interpreters/partial_eval.py:2283, in trace_to_jaxpr(***failed resolving arguments***)
   2281 with core.set_current_trace(trace):
   2282   args, kwargs = in_tracers.unflatten()
-> 2283   ans_pytree = fun(*args, **kwargs)
   2284   if fun_returns_flat_tree:
   2285     # TODO(dougalm): make result paths optional
   2286     ans = ans_pytree

File /nix/store/bkqp5piw63cwdwqcxpzwwm89zaisfhji-python3-3.13.13-env/lib/python3.13/site-packages/jax/_src/lax/control_flow/conditionals.py:231, in cond.<locals>.<lambda>(x, _)
    229 if callable(false_fun) and len(operands) == 2 and callable(operands[1]):
    230   x_true, f_true, x_false, f_false = true_fun, false_fun, *operands
--> 231   return cond(pred, lambda x, _: f_true(x), lambda _, x: f_false(x), x_true, x_false)
    232 else:
    233   raise TypeError("lax.cond: true_fun and false_fun arguments should be callable.")

File /nix/store/bkqp5piw63cwdwqcxpzwwm89zaisfhji-python3-3.13.13-env/lib/python3.13/site-packages/numpyro/util.py:394, in fori_collect.<locals>._body_fn.<locals>.update_fn.<locals>.<lambda>(x)
    390 def update_fn(collect_array, new_val):
    391     return cond(
    392         idx >= 0,
    393         collect_array,
--> 394         lambda x: x.at[idx].set(new_val),
    395         collect_array,
    396         identity,
    397     )

File /nix/store/bkqp5piw63cwdwqcxpzwwm89zaisfhji-python3-3.13.13-env/lib/python3.13/site-packages/jax/_src/numpy/array_methods.py:1178, in _IndexUpdateRef.set(self, values, indices_are_sorted, unique_indices, mode, out_sharding, wrap_negative_indices)
   1176   assert isinstance(out_sharding, (NamedSharding, PartitionSpec))
   1177   out_sharding = canonicalize_sharding(out_sharding, '.set')
-> 1178 return scatter._scatter_update(
   1179     self.array, self.index, values, lax_slicing.scatter,
   1180     indices_are_sorted=indices_are_sorted, unique_indices=unique_indices,
   1181     mode=mode, out_sharding=out_sharding,
   1182     normalize_indices=wrap_negative_indices)

File /nix/store/bkqp5piw63cwdwqcxpzwwm89zaisfhji-python3-3.13.13-env/lib/python3.13/site-packages/jax/_src/ops/scatter.py:88, in _scatter_update(x, idx, y, scatter_op, indices_are_sorted, unique_indices, mode, normalize_indices, out_sharding)
     84 if out_sharding is not None:
     85   return auto_axes(internal_scatter, out_sharding=out_sharding,
     86                    axes=out_sharding.mesh.explicit_axes
     87                    )(x, y, dynamic_idx)
---> 88 return internal_scatter(x, y, dynamic_idx)

File /nix/store/bkqp5piw63cwdwqcxpzwwm89zaisfhji-python3-3.13.13-env/lib/python3.13/site-packages/jax/_src/ops/scatter.py:111, in _scatter_impl(x, y, dynamic_idx, scatter_op, treedef, indices_are_sorted, unique_indices, mode, normalize_indices)
    103   warnings.warn(
    104     "scatter inputs have incompatible types: cannot safely cast value "
    105     f"from dtype={lax.dtype(y)} to dtype={lax.dtype(x)} with "
    106     f"jax_numpy_dtype_promotion={config.numpy_dtype_promotion.value}. "
    107     "In future JAX releases this will result in an error.",
    108     FutureWarning)
    110 general_indexer = tree_util.tree_unflatten(treedef, dynamic_idx)
--> 111 indexer = general_indexer.to_gather(
    112     core.typeof(x).sharding, normalize_indices=normalize_indices)
    114 # Avoid calling scatter if the slice shape is empty, both as a fast path and
    115 # to handle cases like zeros(0)[array([], int32)].
    116 if core.is_empty_shape(indexer.slice_shape):

File /nix/store/bkqp5piw63cwdwqcxpzwwm89zaisfhji-python3-3.13.13-env/lib/python3.13/site-packages/jax/_src/numpy/indexing.py:579, in NDIndexer.to_gather(self, x_sharding, normalize_indices)
    577 def to_gather(self, x_sharding: NamedSharding | Any,
    578               normalize_indices: bool = True) -> _GatherIndexer:
--> 579   return _index_to_gather(self, x_sharding=x_sharding, normalize_indices=normalize_indices)

File /nix/store/bkqp5piw63cwdwqcxpzwwm89zaisfhji-python3-3.13.13-env/lib/python3.13/site-packages/jax/_src/numpy/indexing.py:1387, in _index_to_gather(indexer, x_sharding, normalize_indices)
   1383 if index.typ in [IndexType.INTEGER, IndexType.ARRAY] and np.ndim(index.index) == 0:  # pyrefly: ignore[bad-argument-type]
   1384   # Basic scalar int indices
   1385   if core.definitely_equal(indexer.shape[x_axis], 0):
   1386     # XLA gives error when indexing into an axis of size 0
-> 1387     raise IndexError(f"index is out of bounds for axis {x_axis} with size 0")
   1388   i_converted = lax.convert_element_type(index.index, index_dtype)  # pyrefly: ignore[bad-argument-type]
   1389   gather_indices.append((i_converted, len(gather_indices_shape)))

IndexError: index is out of bounds for axis 0 with size 0
```

</details>

and spend a lot of time debugging my kernel for indexing mistakes.
This PR adds a check for `num_samples` that hopefully saves the next person from doing that.