### PR TITLE
ci: use pull_request_target for PR triage workflow

### DIFF
--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -1,13 +1,10 @@
 name: PR Triage
-
 on:
-  pull_request:
+  pull_request_target:
     types: [opened]
-
 permissions:
   contents: read
   pull-requests: write
-
 jobs:
   triage:
     runs-on: ubuntu-latest
@@ -18,7 +15,6 @@ jobs:
           script: |
             const reviewers = ["fehiepsi", "juanitorduz", "Qazalbash"]
               .filter((reviewer) => reviewer !== context.payload.pull_request.user.login);
-
             if (reviewers.length > 0) {
               await github.rest.pulls.requestReviewers({
                 owner: context.repo.owner,
@@ -27,7 +23,6 @@ jobs:
                 reviewers,
               });
             }
-
       - name: Add labels
         uses: actions/github-script@v7
         with:


### PR DESCRIPTION
Fork PRs get a read-only GITHUB_TOKEN under pull_request, which breaks requestReviewers (needs pull-requests: write).