### PR TITLE
ci: grant issues:write to pr-cleanup workflow

### DIFF
--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -4,6 +4,7 @@ on:
     types: [closed]
 permissions:
   contents: read
+  issues: write
   pull-requests: write
 jobs:
   cleanup:


### PR DESCRIPTION
Removing a label requires issues:write, not just pull-requests:write, which was causing the label-removal step to fail with a 403.