### PR TITLE
Fix provenance tracking for closed-over constants on JAX 0.11.1

### DIFF
--- a/numpyro/ops/provenance.py
+++ b/numpyro/ops/provenance.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import jax
-from jax.api_util import debug_info, flatten_fun, shaped_abstractify
+from jax.api_util import debug_info, flatten_fun
 from jax.extend.core import Literal
 from jax.extend.core.primitives import call_p, closed_call_p, jit_p
 
@@ -11,7 +11,6 @@ try:
 except ImportError:
     xla_pmap_p = None
 import jax.extend.linear_util as lu
-from jax.interpreters.partial_eval import trace_to_jaxpr_dynamic
 
 
 # Adapted from definition in jax v0.5.0
@@ -52,24 +51,9 @@ def eval_provenance(fn, **kwargs):
         else {}
     )
     wrapped_fun, out_tree = flatten_fun(lu.wrap_init(fn, **fn_info), in_tree)
-    # Abstract eval to get output pytree
-    avals = _safe_map(shaped_abstractify, args)
-    # Note: we split out the process of abstract evaluation and provenance tracking
-    # for simplicity. In principle, they can be merged so that we only need to walk
-    # through the equations once.
-
-    wrapped_info = (
-        dict(
-            debug_info=debug_info(
-                "eval_provenance wrapped", wrapped_fun.call_wrapped, args, {}
-            )
-        )
-        if debug_info is not None
-        else {}
-    )
-    jaxpr, avals_out, _ = trace_to_jaxpr_dynamic(
-        lu.wrap_init(wrapped_fun.call_wrapped, {}, **wrapped_info), avals
-    )
+    # Use JAX's public tracing API so closed-over constants remain separate from
+    # the explicit inputs whose provenance is tracked.
+    jaxpr = jax.make_jaxpr(wrapped_fun.call_wrapped)(*args)
 
     # get provenances of flatten kwargs
     aval_kwargs = {}
@@ -77,7 +61,7 @@ def eval_provenance(fn, **kwargs):
         aval_kwargs[n] = jax.tree.map(lambda _: frozenset({n}), v)
     provenance_inputs, _ = jax.tree.flatten(((), aval_kwargs))
 
-    provenance_outputs = track_deps_jaxpr(jaxpr, provenance_inputs)
+    provenance_outputs = track_deps_jaxpr(jaxpr.jaxpr, provenance_inputs)
     return jax.tree.unflatten(out_tree(), provenance_outputs)
 
 

--- a/test/ops/test_provenance.py
+++ b/test/ops/test_provenance.py
@@ -20,9 +20,13 @@ except ImportError:
 from numpyro.ops.provenance import eval_provenance
 
 _JAX_SUBFUNS_API = Version(jax.__version__) >= Version("0.9.2")
+_JAX_CALL_JAXPR_API = Version(jax.__version__) >= Version("0.11.1")
 
 
 def _call_bind(primitive, fn, *args):
+    if _JAX_CALL_JAXPR_API:
+        call_jaxpr = jax.make_jaxpr(fn.call_wrapped)(*args)
+        return primitive.bind(*args, call_jaxpr=call_jaxpr)
     if _JAX_SUBFUNS_API:
         return primitive.bind(*args, subfuns=(fn,))
     return primitive.bind(fn, *args)
@@ -55,6 +59,12 @@ def test_provenance_const():
     jaxpr = jax.make_jaxpr(f)(jnp.zeros((3, 4), jnp.float32))
     assert len(jaxpr.consts) == 1
     assert eval_provenance(f, x=3) == {"x"}
+
+
+def test_provenance_closed_over_const():
+    const = jnp.arange(5.0)
+
+    assert eval_provenance(lambda x: const * x, x=1.0) == {"x"}
 
 
 def test_provenance_fori():


### PR DESCRIPTION
Fixes #2244.

## Changes made

- Replace the private `trace_to_jaxpr_dynamic` call with the public `jax.make_jaxpr` tracing API.
- Keep closed-over constants separate from the explicit inputs whose provenance is tracked, including on JAX 0.11.1.
- Adapt the call-primitive regression helper to JAX 0.11.1's `call_jaxpr` binding protocol.
- Add regression coverage for an array constant captured by a closure.

## Why

JAX 0.11.1 hoists constants returned by `trace_to_jaxpr_dynamic` into `jaxpr.invars`. NumPyro then paired those invars with provenance values built only from explicit keyword arguments, causing a length mismatch whenever a traced function closed over an array.

`jax.make_jaxpr` preserves the distinction between constants and explicit inputs through its public API. Constants therefore retain empty provenance while tracked keyword arguments remain aligned with `jaxpr.invars`. This also removes a direct dependency on JAX's private partial-evaluation API.

## Tests

- JAX/JAXLIB 0.11.1, Python 3.13: `pytest -q test/ops test/infer/test_inspect.py test/infer/test_svi.py` — 415 passed, 4 skipped.
- JAX/JAXLIB 0.7.0, Python 3.11: `pytest -q test/ops/test_provenance.py` — 11 passed.
- `ruff check .`
- `ruff format . --check`
- `python scripts/update_headers.py --check`
- `ty check numpyro/ops/provenance.py test/ops/test_provenance.py`

## Dependencies

No new dependencies.
