### PR TITLE
Add cat constraint and CatTransform

### DIFF
--- a/numpyro/distributions/constraints.py
+++ b/numpyro/distributions/constraints.py
@@ -28,6 +28,7 @@
 
 __all__ = [
     "boolean",
+    "cat",
     "circular",
     "complex",
     "corr_cholesky",
@@ -65,7 +66,7 @@ __all__ = [
 ]
 
 import math
-from typing import ClassVar, Generic, Optional, cast
+from typing import ClassVar, Generic, Optional, Sequence, cast
 
 import numpy as np
 
@@ -425,6 +426,99 @@ class _IndependentConstraint(Constraint[NumLikeT]):
         if self.reinterpreted_batch_ndims != other.reinterpreted_batch_ndims:
             return False
         return self.base_constraint.eq(other.base_constraint, static=static)
+
+
+class _Cat(Constraint[NonScalarArray]):
+    """
+    Applies a sequence of constraints to slices along a dimension, in a way
+    compatible with :func:`jax.numpy.concatenate`.
+
+    :param cseq: Sequence of constraints to apply to consecutive slices.
+    :param int dim: Dimension along which to slice.
+    :param lengths: Length of each slice. Defaults to one per constraint.
+    """
+
+    def __init__(
+        self,
+        cseq: Sequence[Constraint],
+        dim: int = 0,
+        lengths: Optional[Sequence[int]] = None,
+    ) -> None:
+        assert all(isinstance(c, Constraint) for c in cseq)
+        assert cseq
+        assert isinstance(dim, int)
+        self.cseq = tuple(cseq)
+        if lengths is None:
+            lengths = (1,) * len(self.cseq)
+        assert len(lengths) == len(self.cseq)
+        assert all(isinstance(length, int) and length >= 0 for length in lengths)
+        self.lengths = tuple(lengths)
+        self.dim = dim
+
+    @property
+    def is_discrete(self) -> bool:
+        return any(c.is_discrete for c in self.cseq)
+
+    @property
+    def event_dim(self) -> int:
+        return max(c.event_dim for c in self.cseq)
+
+    def _slices(self, value: NonScalarArray) -> list[NonScalarArray]:
+        ndim = jnp.ndim(value)
+        if not -ndim <= self.dim < ndim:
+            raise ValueError(
+                f"dim {self.dim} out of range for value with {ndim} dimensions"
+            )
+        if jnp.shape(value)[self.dim] != sum(self.lengths):
+            raise ValueError(
+                f"value.shape[{self.dim}] = {jnp.shape(value)[self.dim]} must equal "
+                f"the sum of lengths {sum(self.lengths)}"
+            )
+
+        values = []
+        start = 0
+        for length in self.lengths:
+            values.append(
+                jax.lax.slice_in_dim(value, start, start + length, axis=self.dim)
+            )
+            start += length
+        return values
+
+    def __call__(self, x: NonScalarArray) -> ArrayLike:
+        checks = [
+            constraint(value) for constraint, value in zip(self.cseq, self._slices(x))
+        ]
+        return jnp.concatenate(checks, axis=self.dim)
+
+    def feasible_like(self, prototype: NonScalarArray) -> NonScalarArray:
+        values = [
+            constraint.feasible_like(value)
+            for constraint, value in zip(self.cseq, self._slices(prototype))
+        ]
+        return jnp.concatenate(values, axis=self.dim)
+
+    def __repr__(self) -> str:
+        return "{}({}, dim={}, lengths={})".format(
+            self.__class__.__name__[1:], self.cseq, self.dim, self.lengths
+        )
+
+    def tree_flatten(self):
+        return (self.cseq,), (
+            ("cseq",),
+            {"dim": self.dim, "lengths": self.lengths},
+        )
+
+    def eq(self, other: object, static: bool = False) -> ArrayLike:
+        if not isinstance(other, _Cat):
+            return False
+        if self.dim != other.dim or self.lengths != other.lengths:
+            return False
+        if static:
+            return all(c1.eq(c2, static=True) for c1, c2 in zip(self.cseq, other.cseq))
+        result = jnp.array(True)
+        for c1, c2 in zip(self.cseq, other.cseq):
+            result = result & c1.eq(c2, static=False)
+        return result
 
 
 class _RealVector(
@@ -874,6 +968,7 @@ class _ZeroSum(Constraint[NonScalarArray]):
 
 
 boolean = _Boolean()
+cat = _Cat
 circular = _Circular()
 complex = _Complex()
 corr_cholesky = _CorrCholesky()

--- a/numpyro/distributions/constraints.py
+++ b/numpyro/distributions/constraints.py
@@ -444,14 +444,20 @@ class _Cat(Constraint[NonScalarArray]):
         dim: int = 0,
         lengths: Optional[Sequence[int]] = None,
     ) -> None:
-        assert all(isinstance(c, Constraint) for c in cseq)
-        assert cseq
-        assert isinstance(dim, int)
+        assert cseq, "cseq cannot be empty"
+        assert all(isinstance(c, Constraint) for c in cseq), (
+            "cseq must contain only Constraint instances"
+        )
+        assert isinstance(dim, int), "dim must be an integer"
         self.cseq = tuple(cseq)
         if lengths is None:
             lengths = (1,) * len(self.cseq)
-        assert len(lengths) == len(self.cseq)
-        assert all(isinstance(length, int) and length >= 0 for length in lengths)
+        assert len(lengths) == len(self.cseq), (
+            "lengths must have the same number of elements as cseq"
+        )
+        assert all(isinstance(length, int) and length >= 0 for length in lengths), (
+            "lengths must contain only nonnegative integers"
+        )
         self.lengths = tuple(lengths)
         self.dim = dim
 

--- a/numpyro/distributions/transforms.py
+++ b/numpyro/distributions/transforms.py
@@ -471,14 +471,20 @@ class CatTransform(Transform[NonScalarArray]):
         dim: int = 0,
         lengths: Optional[Sequence[int]] = None,
     ) -> None:
-        assert all(isinstance(t, Transform) for t in tseq)
-        assert tseq
-        assert isinstance(dim, int)
+        assert tseq, "tseq cannot be empty"
+        assert all(isinstance(t, Transform) for t in tseq), (
+            "tseq must contain only Transform instances"
+        )
+        assert isinstance(dim, int), "dim must be an integer"
         self.transforms = tuple(tseq)
         if lengths is None:
             lengths = (1,) * len(self.transforms)
-        assert len(lengths) == len(self.transforms)
-        assert all(isinstance(length, int) and length >= 0 for length in lengths)
+        assert len(lengths) == len(self.transforms), (
+            "lengths must have the same number of elements as tseq"
+        )
+        assert all(isinstance(length, int) and length >= 0 for length in lengths), (
+            "lengths must contain only nonnegative integers"
+        )
         self.lengths = tuple(lengths)
         self.dim = dim
 

--- a/numpyro/distributions/transforms.py
+++ b/numpyro/distributions/transforms.py
@@ -41,6 +41,7 @@ __all__ = [
     "biject_to",
     "AbsTransform",
     "AffineTransform",
+    "CatTransform",
     "CholeskyTransform",
     "ComplexTransform",
     "ComposeTransform",
@@ -451,6 +452,157 @@ class ComposeTransform(Transform[NumLike]):
         result = jnp.array(True)
         for p1, p2 in zip(self.parts, other.parts):
             result = result & p1.eq(p2, static=False)
+        return result
+
+
+class CatTransform(Transform[NonScalarArray]):
+    """
+    Applies a sequence of transforms to consecutive slices along a dimension,
+    in a way compatible with :func:`jax.numpy.concatenate`.
+
+    :param tseq: Sequence of transforms to apply to consecutive slices.
+    :param int dim: Dimension along which to slice.
+    :param lengths: Length of each slice. Defaults to one per transform.
+    """
+
+    def __init__(
+        self,
+        tseq: Sequence[Transform],
+        dim: int = 0,
+        lengths: Optional[Sequence[int]] = None,
+    ) -> None:
+        assert all(isinstance(t, Transform) for t in tseq)
+        assert tseq
+        assert isinstance(dim, int)
+        self.transforms = tuple(tseq)
+        if lengths is None:
+            lengths = (1,) * len(self.transforms)
+        assert len(lengths) == len(self.transforms)
+        assert all(isinstance(length, int) and length >= 0 for length in lengths)
+        self.lengths = tuple(lengths)
+        self.dim = dim
+
+    @property
+    def length(self) -> int:
+        return sum(self.lengths)
+
+    @property
+    def domain(self) -> Constraint:
+        return constraints.cat(
+            [transform.domain for transform in self.transforms],
+            self.dim,
+            self.lengths,
+        )
+
+    @property
+    def codomain(self) -> Constraint:
+        return constraints.cat(
+            [transform.codomain for transform in self.transforms],
+            self.dim,
+            self.lengths,
+        )
+
+    def _slices(self, value: NonScalarArray) -> list[NonScalarArray]:
+        ndim = jnp.ndim(value)
+        if not -ndim <= self.dim < ndim:
+            raise ValueError(
+                f"dim {self.dim} out of range for value with {ndim} dimensions"
+            )
+        if jnp.shape(value)[self.dim] != self.length:
+            raise ValueError(
+                f"value.shape[{self.dim}] = {jnp.shape(value)[self.dim]} must equal "
+                f"the sum of lengths {self.length}"
+            )
+
+        values = []
+        start = 0
+        for length in self.lengths:
+            values.append(lax.slice_in_dim(value, start, start + length, axis=self.dim))
+            start += length
+        return values
+
+    def __call__(self, x: NonScalarArray) -> NonScalarArray:
+        return jnp.concatenate(
+            [
+                transform(value)
+                for transform, value in zip(self.transforms, self._slices(x))
+            ],
+            axis=self.dim,
+        )
+
+    def _inverse(self, y: NonScalarArray) -> NonScalarArray:
+        return jnp.concatenate(
+            [
+                transform.inv(value)
+                for transform, value in zip(self.transforms, self._slices(y))
+            ],
+            axis=self.dim,
+        )
+
+    def log_abs_det_jacobian(
+        self,
+        x: NonScalarArray,
+        y: NonScalarArray,
+        intermediates: Optional[PyTree] = None,
+    ) -> NumLike:
+        if intermediates is not None and len(intermediates) != len(self.transforms):
+            raise ValueError(
+                f"Intermediates array has length = {len(intermediates)}. "
+                f"Expected = {len(self.transforms)}."
+            )
+
+        event_dim = max(self.domain.event_dim, self.codomain.event_dim)
+        logdetjacs = []
+        for i, (transform, xslice, yslice) in enumerate(
+            zip(self.transforms, self._slices(x), self._slices(y))
+        ):
+            intermediate = None if intermediates is None else intermediates[i]
+            logdetjac = transform.log_abs_det_jacobian(
+                xslice, yslice, intermediates=intermediate
+            )
+            transform_event_dim = max(
+                transform.domain.event_dim, transform.codomain.event_dim
+            )
+            logdetjacs.append(sum_rightmost(logdetjac, event_dim - transform_event_dim))
+
+        dim = self.dim
+        if dim >= 0:
+            dim -= jnp.ndim(x)
+        dim += event_dim
+        if dim < 0:
+            return jnp.concatenate(logdetjacs, axis=dim)
+        return sum(logdetjacs)
+
+    def call_with_intermediates(
+        self, x: NonScalarArray
+    ) -> Tuple[NumLike, Optional[PyTree]]:
+        values = []
+        intermediates = []
+        for transform, value in zip(self.transforms, self._slices(x)):
+            value, intermediate = transform.call_with_intermediates(value)
+            values.append(value)
+            intermediates.append(intermediate)
+        return jnp.concatenate(values, axis=self.dim), intermediates
+
+    def tree_flatten(self):
+        return (self.transforms,), (
+            ("transforms",),
+            {"dim": self.dim, "lengths": self.lengths},
+        )
+
+    def eq(self, other: object, static: bool = False) -> ArrayLike:
+        if not isinstance(other, CatTransform):
+            return False
+        if self.dim != other.dim or self.lengths != other.lengths:
+            return False
+        if static:
+            return all(
+                t1.eq(t2, static=True)
+                for t1, t2 in zip(self.transforms, other.transforms)
+            )
+        result = jnp.array(True)
+        for t1, t2 in zip(self.transforms, other.transforms):
+            result = result & t1.eq(t2, static=False)
         return result
 
 
@@ -2098,6 +2250,13 @@ class ConstraintRegistry(object):
 
 
 biject_to = ConstraintRegistry()
+
+
+@biject_to.register(constraints.cat)
+def _biject_to_cat(constraint):
+    return CatTransform(
+        [biject_to(c) for c in constraint.cseq], constraint.dim, constraint.lengths
+    )
 
 
 @biject_to.register(constraints.corr_cholesky)

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -2650,6 +2650,15 @@ def test_beta_proportion_invalid_mean():
         (constraints.boolean, np.array([1, 1]), np.array([True, True])),
         (constraints.boolean, np.array([-1, 1]), np.array([False, True])),
         (
+            constraints.cat(
+                [constraints.interval(-1, 1), constraints.positive],
+                dim=-1,
+                lengths=[2, 1],
+            ),
+            np.array([[0.0, 2.0, 1.0], [-2.0, 0.5, -1.0]]),
+            np.array([[True, False, True], [False, True, False]]),
+        ),
+        (
             constraints.corr_cholesky,
             np.array([[[1, 0], [0, 1]], [[1, 0.1], [0, 1]]]),
             np.array([True, False]),
@@ -2781,6 +2790,23 @@ def test_constraints(constraint, x, expected):
         pass
     else:
         assert_allclose(inverse, jnp.zeros_like(inverse), atol=2e-7)
+
+
+def test_cat_constraint_pytree_and_validation():
+    constraint = constraints.cat(
+        [constraints.interval(-1.0, 1.0), constraints.positive],
+        dim=-1,
+        lengths=[2, 1],
+    )
+    value = jnp.array([[0.0, 2.0, 1.0], [-2.0, 0.5, -1.0]])
+    expected = jnp.array([[True, False, True], [False, True, False]])
+
+    assert_array_equal(jax.jit(lambda c, x: c(x))(constraint, value), expected)
+    leaves, treedef = jax.tree.flatten(constraint)
+    assert constraint.eq(jax.tree.unflatten(treedef, leaves), static=True)
+
+    with pytest.raises(ValueError, match="must equal the sum of lengths 3"):
+        constraint(jnp.ones(2))
 
 
 @pytest.mark.parametrize(

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -2659,6 +2659,29 @@ def test_beta_proportion_invalid_mean():
             np.array([[True, False, True], [False, True, False]]),
         ),
         (
+            constraints.cat([constraints.positive, constraints.unit_interval]),
+            np.array([[1.0, 0.0, -1.0], [0.0, 0.5, 2.0]]),
+            np.array([[True, False, False], [True, True, False]]),
+        ),
+        (
+            constraints.cat(
+                [constraints.less_than(0), constraints.nonnegative],
+                dim=1,
+                lengths=[1, 2],
+            ),
+            np.array([[-1.0, 0.0, 2.0], [1.0, -1.0, 0.0]]),
+            np.array([[True, True, True], [False, False, True]]),
+        ),
+        (
+            constraints.cat(
+                [constraints.positive, constraints.unit_interval],
+                dim=-1,
+                lengths=[0, 2],
+            ),
+            np.array([[0.0, 0.5], [-1.0, 2.0]]),
+            np.array([[True, True], [False, False]]),
+        ),
+        (
             constraints.corr_cholesky,
             np.array([[[1, 0], [0, 1]], [[1, 0.1], [0, 1]]]),
             np.array([True, False]),
@@ -2807,6 +2830,13 @@ def test_cat_constraint_pytree_and_validation():
 
     with pytest.raises(ValueError, match="must equal the sum of lengths 3"):
         constraint(jnp.ones(2))
+
+    with pytest.raises(AssertionError, match="cseq cannot be empty"):
+        constraints.cat([])
+    with pytest.raises(AssertionError, match="dim must be an integer"):
+        constraints.cat([constraints.real], dim=0.5)
+    with pytest.raises(AssertionError, match="nonnegative integers"):
+        constraints.cat([constraints.real], lengths=[-1])
 
 
 @pytest.mark.parametrize(

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -20,6 +20,7 @@ from numpyro.distributions.flows import (
 from numpyro.distributions.transforms import (
     AbsTransform,
     AffineTransform,
+    CatTransform,
     CholeskyTransform,
     ComplexTransform,
     ComposeTransform,
@@ -76,6 +77,11 @@ TRANSFORMS = {
             ],
         ),
         dict(),
+    ),
+    "cat": T(
+        CatTransform,
+        ([AffineTransform(np.array(1.0), np.array(2.0)), ExpTransform()],),
+        dict(dim=-1, lengths=(2, 1)),
     ),
     "independent": T(
         IndependentTransform,
@@ -259,6 +265,48 @@ def test_reshape_transform_invalid():
 
     with pytest.raises(TypeError, match="cannot reshape array"):
         ReshapeTransform((2, 3), (6,))(jnp.arange(2))
+
+
+def test_cat_transform():
+    transform = CatTransform(
+        [AffineTransform(1.0, 2.0), ExpTransform()], dim=-1, lengths=[2, 1]
+    )
+    x = jnp.array([[0.0, 1.0, 2.0], [-1.0, 3.0, 0.5]])
+    expected = jnp.concatenate([1.0 + 2.0 * x[..., :2], jnp.exp(x[..., 2:])], -1)
+
+    y, intermediates = jax.jit(transform.call_with_intermediates)(x)
+    assert jnp.allclose(y, expected)
+    assert jnp.allclose(jax.jit(lambda value: transform.inv(value))(y), x)
+    assert jnp.allclose(
+        jax.jit(transform.log_abs_det_jacobian)(x, y),
+        jnp.concatenate([jnp.full_like(x[..., :2], jnp.log(2.0)), x[..., 2:]], axis=-1),
+    )
+    assert jnp.allclose(
+        transform.log_abs_det_jacobian(x, y, intermediates),
+        transform.log_abs_det_jacobian(x, y),
+    )
+
+
+def test_biject_to_cat_constraint():
+    constraint = constraints.cat(
+        [constraints.interval(-2.0, 3.0), constraints.positive],
+        dim=-1,
+        lengths=[2, 1],
+    )
+    transform = biject_to(constraint)
+    x = jnp.array([[0.0, -1.0, 2.0], [1.0, 0.5, -2.0]])
+    y = jax.jit(lambda value: transform(value))(x)
+
+    assert transform.codomain.dim == constraint.dim
+    assert transform.codomain.lengths == constraint.lengths
+    assert jnp.array_equal(constraint(y), jnp.ones_like(y, dtype=bool))
+    assert jnp.allclose(jax.jit(lambda value: transform.inv(value))(y), x)
+
+
+def test_cat_transform_invalid_shape():
+    transform = CatTransform([ExpTransform(), ExpTransform()], lengths=[1, 2])
+    with pytest.raises(ValueError, match="must equal the sum of lengths 3"):
+        transform(jnp.ones(2))
 
 
 @pytest.mark.parametrize(

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -308,6 +308,13 @@ def test_cat_transform_invalid_shape():
     with pytest.raises(ValueError, match="must equal the sum of lengths 3"):
         transform(jnp.ones(2))
 
+    with pytest.raises(AssertionError, match="tseq cannot be empty"):
+        CatTransform([])
+    with pytest.raises(AssertionError, match="dim must be an integer"):
+        CatTransform([ExpTransform()], dim=0.5)
+    with pytest.raises(AssertionError, match="nonnegative integers"):
+        CatTransform([ExpTransform()], lengths=[-1])
+
 
 @pytest.mark.parametrize(
     "input_shape, shape, ndims",


### PR DESCRIPTION
Closes #1872.

## Summary

- add `constraints.cat` for applying heterogeneous constraints to consecutive slices, including shape validation, feasible-value construction, equality, and JAX pytree support
- add `CatTransform` with forward/inverse operations, per-component Jacobians, intermediate propagation, and `biject_to` registration
- cover mixed interval/positive domains, JIT execution, pytree round-trips, invalid layouts, and transform round-trips

The public API follows the corresponding PyTorch `constraints.cat` / `CatTransform` naming and slice semantics. Malformed layouts are rejected explicitly so a constraint cannot silently leave trailing values unchecked.

## Tests

- `pytest -q test/test_transforms.py` — 239 passed
- focused constraint tests — 42 passed
- `ruff check` and `ruff format` on changed files — passed
- `ty check numpyro/distributions/constraints.py numpyro/distributions/transforms.py` — passed
- `scripts/update_headers.py --check` — passed

No new dependencies.

I used OpenAI Codex to assist with source comparison, implementation, and test execution; I reviewed the final diff and validation results.
