### PR TITLE
Avoid per-step host sync in the SVI progress-bar loop

### DIFF
--- a/numpyro/infer/svi.py
+++ b/numpyro/infer/svi.py
@@ -403,12 +403,16 @@ class SVI(object):
             svi_state = init_state
         if progress_bar:
             losses = []
+            jitted_body_fn = jit(body_fn)
             with tqdm.trange(1, num_steps + 1) as t:
                 batch = max(num_steps // 20, 1)
                 for i in t:
-                    svi_state, loss = jit(body_fn)(svi_state, None)
-                    losses.append(jax.device_get(loss))
+                    svi_state, loss = jitted_body_fn(svi_state, None)
+                    losses.append(loss)
                     if i % batch == 0:
+                        # transfer the whole batch to the host at once instead of
+                        # blocking on the device at every step
+                        losses[i - batch :] = jax.device_get(losses[i - batch :])
                         if stable_update:
                             valid_losses = [x for x in losses[i - batch :] if x == x]
                             num_valid = len(valid_losses)

--- a/test/infer/test_svi.py
+++ b/test/infer/test_svi.py
@@ -282,6 +282,33 @@ def test_run(vectorize_particles, progress_bar):
     )
 
 
+def test_run_progress_bar_matches_scan_path():
+    data = jnp.array([1.0] * 8 + [0.0] * 2)
+
+    def model(data):
+        f = numpyro.sample("beta", dist.Beta(1.0, 1.0))
+        with numpyro.plate("N", len(data)):
+            numpyro.sample("obs", dist.Bernoulli(f), obs=data)
+
+    def guide(data):
+        alpha_q = numpyro.param("alpha_q", 1.0, constraint=constraints.positive)
+        beta_q = numpyro.param("beta_q", 1.0, constraint=constraints.positive)
+        numpyro.sample("beta", dist.Beta(alpha_q, beta_q))
+
+    svi = SVI(model, guide, optim.Adam(0.05), Trace_ELBO())
+    # use a step count that is not a multiple of the progress-bar update batch
+    # so that the last losses are collected outside a batch boundary
+    result_pbar = svi.run(random.key(1), 123, data, progress_bar=True)
+    result_scan = svi.run(random.key(1), 123, data, progress_bar=False)
+    assert result_pbar.losses.shape == result_scan.losses.shape == (123,)
+    assert result_pbar.losses.dtype == result_scan.losses.dtype
+    # the two paths run differently compiled programs (jitted python loop vs
+    # lax.scan), so they can differ by a few ulps
+    assert_allclose(result_pbar.losses, result_scan.losses, rtol=1e-5)
+    for name in result_scan.params:
+        assert_allclose(result_pbar.params[name], result_scan.params[name], rtol=1e-5)
+
+
 def test_jitted_update_fn():
     data = jnp.array([1.0] * 8 + [0.0] * 2)
 


### PR DESCRIPTION
## Changes made

- `numpyro/infer/svi.py`: the progress-bar loop in `SVI.run` called `jax.device_get(loss)` on every step, forcing a blocking device→host transfer per iteration — the host cannot dispatch step `i+1` until step `i` has finished computing, so JAX's async dispatch is defeated for the whole run. Losses are now appended as device arrays and each display batch (`num_steps // 20` steps, the existing postfix-update granularity) is fetched with a single `jax.device_get`, which also replaces the device scalars with host values as before so memory behavior is unchanged. `jit(body_fn)` is also hoisted out of the loop instead of being re-wrapped on every iteration.

Results are unchanged: the losses returned by the progress-bar path are bit-identical to master (verified locally on a 1234-step run), and the postfix string is computed from the same values as before.

## Benchmarks

Apple M2 (24 GB), CPU, jax 0.10.2, Python 3.11. Each variant runs in a fresh process; time is the best of 3 repeats after a warmup run of `svi.run(..., progress_bar=True)`.

| scenario | master | this PR | `progress_bar=False` (reference) |
|---|---|---|---|
| dispatch-bound: linear regression, N=100, D=3, 20,000 steps | 1.90 s | 1.00 s (1.9×) | 0.28 s |
| compute-bound: linear regression, N=200,000, D=100, 2,000 steps | 12.96 s | 12.63 s | 11.99 s |

The win comes from removing the per-step synchronization, so it scales with the ratio of dispatch overhead to per-step compute; on accelerators, where a device round-trip is more expensive than on CPU, the effect should be larger.

## Links to related issues/PRs

None.

## Tests

- New `test_run_progress_bar_matches_scan_path` in `test/infer/test_svi.py` — locks in that the progress-bar path returns the same losses and params as the `lax.scan` path, using a step count (123) that is not a multiple of the display batch so the tail losses collected outside a batch boundary are exercised. Tolerance is rtol=1e-5 because the two paths run differently compiled programs and already differ by a few ulps on master.
- `pytest test/infer/test_svi.py` — 66 passed, 4 skipped
- `ruff check` / `ruff format --check` clean; `ty check` reports only the diagnostic already present on master.

## Dependencies

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)