### PR TITLE
Fix generator being appended instead of a list in scan `carry_shapes`

### DIFF
--- a/numpyro/contrib/control_flow/scan.py
+++ b/numpyro/contrib/control_flow/scan.py
@@ -192,7 +192,7 @@ def scan_enum(
             # store shape of new_carry at a global variable
             if len(carry_shapes) < (history + 1):
                 carry_shapes.append(
-                    [jnp.shape(x) for x in jax.tree.flatten(new_carry)[0]]  # ty: ignore[invalid-argument-type]
+                    [jnp.shape(x) for x in jax.tree.flatten(new_carry)[0]]
                 )
             # make new_carry have the same shape as carry
             # FIXME: is this rigorous?
@@ -225,7 +225,7 @@ def scan_enum(
                 # shape so we don't need to record them here
                 if (i >= history - 1) and (len(carry_shapes) < history + 1):
                     carry_shapes.append(
-                        jnp.shape(x) for x in jax.tree.flatten(wrapped_carry[-1])[0]
+                        [jnp.shape(x) for x in jax.tree.flatten(wrapped_carry[-1])[0]]
                     )
             else:
                 # this is the last rolling step


### PR DESCRIPTION
## Changes made

- `numpyro/contrib/control_flow/scan.py`: in the enumeration path of `scan_wrapper`, the unrolled-steps branch appended a bare generator expression to `carry_shapes`:

  ```python
  carry_shapes.append(
      jnp.shape(x) for x in jax.tree.flatten(wrapped_carry[-1])[0]
  )
  ```

  while the sibling append inside `body_fn` builds a list. This currently works only by accident: the generator's outermost iterable is evaluated eagerly (so the shapes are captured at the right time), and `carry_shapes[i]` happens to be consumed at most once (by the `zip` that reshapes the final carry) — a second consumption would silently yield nothing and leave the carry unreshaped. Added the missing brackets so both appends store a list of shapes.
- Removed the `# ty: ignore[invalid-argument-type]` on the sibling append in `body_fn`: with both appends now storing lists, the inferred element type of `carry_shapes` is consistent and `ty` reports the suppression as unused. (The type checker was in effect flagging the list/generator mix.)

No behavior change for current code paths; this removes a single-use-generator landmine and makes the two appends symmetric.

## Benchmarks

Not applicable — robustness fix, no perf-relevant change.

## Links to related issues/PRs

None.

## Tests

Existing coverage exercising the enum scan path with `history >= 1` (which populates `carry_shapes` via the fixed branch), all green locally:

- `pytest test/contrib/test_control_flow.py` — 8 passed, 1 xfailed
- `pytest test/contrib/test_funsor.py -k "scan or markov"` — 26 passed
- `ruff check` / `ruff format --check` / `ty check` clean (the previously suppressed `ty` diagnostic is gone)

## Dependencies

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)