### PR TITLE
Drop the masked logsumexp reduction in mixture `log_prob`

### DIFF
--- a/numpyro/distributions/mixtures.py
+++ b/numpyro/distributions/mixtures.py
@@ -168,14 +168,12 @@ class _MixtureBase(Distribution):
     def log_prob(self, value: ArrayLike, intermediates=None) -> ArrayLike:
         del intermediates
         sum_log_probs = self.component_log_probs(value)
+        # the value-preserving where stops gradients from flowing into -inf
+        # component log-probs (e.g. at zero mixing weights); see #1874
         safe_sum_log_probs = jnp.where(
             jnp.isneginf(sum_log_probs), -jnp.inf, sum_log_probs
         )
-        return jax.nn.logsumexp(
-            safe_sum_log_probs,
-            where=~jnp.isneginf(sum_log_probs),  # for numerical stability
-            axis=-1,
-        )
+        return jax.nn.logsumexp(safe_sum_log_probs, axis=-1)
 
 
 class MixtureSameFamily(_MixtureBase):

--- a/test/test_distributions_mixture.py
+++ b/test/test_distributions_mixture.py
@@ -203,3 +203,35 @@ def test_mixture_rejects_parameter_dependent_components(component_dist):
 def test_mixture_accepts_parameter_free_components(component_dist):
     mixing_dist = dist.Categorical(probs=np.array([0.3, 0.7]))
     dist.MixtureSameFamily(mixing_dist, component_dist)
+
+
+def test_mixture_log_prob_grad_at_zero_weights():
+    # regression test for #1874: gradients must not become NaN when some
+    # mixing weights are exactly zero
+    def loss(probs):
+        mixture = dist.MixtureSameFamily(
+            dist.Categorical(probs=probs),
+            dist.Normal(jnp.arange(3.0), jnp.ones(3)),
+        )
+        return mixture.log_prob(jnp.array([0.5, 2.0])).sum()
+
+    grad = jax.grad(loss)(jnp.array([0.5, 0.5, 0.0]))
+    assert not jnp.isnan(grad).any()
+
+
+def test_mixture_log_prob_grad_all_components_neg_inf():
+    # if every component assigns -inf to a value, the log_prob is -inf and
+    # gradients must not become NaN
+    mixture = dist.MixtureGeneral(
+        dist.Categorical(probs=jnp.array([0.5, 0.5])),
+        [
+            dist.HalfNormal(1.0, validate_args=False),
+            dist.HalfNormal(2.0, validate_args=False),
+        ],
+        support=dist.constraints.real,
+        validate_args=False,
+    )
+    value = jnp.array([-1.0, 1.0])
+    assert jnp.isneginf(mixture.log_prob(value)[0])
+    grad = jax.grad(lambda x: mixture.log_prob(x).sum())(value)
+    assert not jnp.isnan(grad).any()


### PR DESCRIPTION
## Changes made

- `numpyro/distributions/mixtures.py`: `_MixtureBase.log_prob` passed `where=~jnp.isneginf(sum_log_probs)` to `jax.nn.logsumexp`. A masked reduction prevents XLA from using its fused reduction path, which makes the reduction the dominant cost of mixture likelihood evaluation. The mask is redundant: the value-preserving `jnp.where(jnp.isneginf(...), -inf, ...)` introduced by #1874 already produces the same values and, through `where`'s select-based gradient, stops gradients from flowing into `-inf` component log-probs. The `where=` kwarg was not part of that fix — it slipped in with the type-hints PR #2032. This change restores the #1874 formulation and adds a comment explaining why the value-preserving `where` must stay.

Values and gradients are unchanged (verified identical for regular values, at zero mixing weights, and for rows where every component is `-inf`).

## Benchmarks

Apple M2 (24 GB), CPU, jax 0.10.2, Python 3.11. Jitted steady-state per-call time, best of 300 calls after warmup, 10,000 values, 5 components (3 for `MixtureGeneral` with StudentT).

| workload | master | this PR | speedup |
|---|---|---|---|
| `MixtureSameFamily(Categorical, Normal)` log_prob | 0.379 ms | 0.128 ms | 2.96× |
| same, grad of summed log_prob | 0.265 ms | 0.211 ms | 1.26× |
| `MixtureGeneral` (5 × Normal) log_prob | 0.14 ms | 0.11 ms | 1.25× |
| `MixtureGeneral` (2 × Normal + StudentT) log_prob | 0.11 ms | 0.13 ms | 0.85× |

The big win is `MixtureSameFamily`, where the component log-probs come from one broadcast producer and the masked reduction forced it to be rematerialized per pass. The last row shows a small absolute regression (~0.02 ms) for one composition where the component log_prob dominates; it appears to be an XLA fusion-choice artifact rather than a systematic cost.

## Links to related issues/PRs

#1874 introduced the `-inf` gradient protection this PR preserves; #2032 incidentally added the `where=` kwarg this PR removes.

## Tests

- New `test_mixture_log_prob_grad_at_zero_weights` and `test_mixture_log_prob_grad_all_components_neg_inf` in `test/test_distributions_mixture.py` — lock in the #1874 semantics (no NaN gradients at zero mixing weights and for all-`-inf` rows). Neither case was previously covered by a test.
- `pytest test/test_distributions_mixture.py` — 47 passed
- `ruff check` / `ruff format --check` clean; `ty check` reports the same 10 pre-existing diagnostics as master.

## Dependencies

None.