### PR TITLE
Speed up posterior diagnostics (summary 1.7x, effective_sample_size 2.1x)

### DIFF
--- a/numpyro/diagnostics.py
+++ b/numpyro/diagnostics.py
@@ -15,6 +15,23 @@ from numpy.typing import NDArray
 import jax
 from jax import device_get
 
+try:
+    import scipy.fft
+
+    def _rfft(x: NDArray, n: int, axis: int) -> NDArray:
+        return scipy.fft.rfft(x, n=n, axis=axis, workers=-1)
+
+    def _irfft(x: NDArray, n: int, axis: int) -> NDArray:
+        return scipy.fft.irfft(x, n=n, axis=axis, workers=-1)
+except ImportError:  # pragma: no cover
+    # scipy is not a direct dependency of numpyro (only a transitive one via jax)
+    def _rfft(x: NDArray, n: int, axis: int) -> NDArray:
+        return np.fft.rfft(x, n=n, axis=axis)
+
+    def _irfft(x: NDArray, n: int, axis: int) -> NDArray:
+        return np.fft.irfft(x, n=n, axis=axis)
+
+
 __all__ = [
     "autocorrelation",
     "autocovariance",
@@ -108,38 +125,11 @@ def autocorrelation(x: NDArray, axis: int = 0, bias: bool = True) -> NDArray:
     :return: autocorrelation of ``x``.
     :rtype: numpy.ndarray
     """
-    # Ref: https://en.wikipedia.org/wiki/Autocorrelation#Efficient_computation
-    # Adapted from Stan implementation
-    # https://github.com/stan-dev/math/blob/develop/stan/math/prim/mat/fun/autocorrelation.hpp
-    N = x.shape[axis]
-    M = _fft_next_fast_len(N)
-    M2 = 2 * M
-
-    # transpose axis with -1 for Fourier transform
-    x = np.swapaxes(x, axis, -1)
-
-    # centering x
-    centered_signal = x - x.mean(axis=-1, keepdims=True)
-
-    # Fourier transform
-    freqvec = np.fft.rfft(centered_signal, n=M2, axis=-1)
-    # take square of magnitude of freqvec (or freqvec x freqvec*)
-    freqvec_gram = freqvec * np.conjugate(freqvec)
-    # inverse Fourier transform
-    autocorr = np.fft.irfft(freqvec_gram, n=M2, axis=-1)
-
-    # truncate and normalize the result, then transpose back to original shape
-    autocorr = autocorr[..., :N]
-
-    # the unbiased estimator is known to have "wild" tails, due to few samples at longer lags.
-    # see Geyer (1992) and Priestley (1981) for a discussion. also note that it is only strictly
-    # unbiased when the mean is known, whereas we it estimate from samples here.
-    if not bias:
-        autocorr = autocorr / np.arange(N, 0.0, -1)
-
+    autocov = autocovariance(x, axis=axis, bias=bias)
+    # normalize by the lag-0 autocovariance (which is the same for the biased
+    # and unbiased estimators)
     with np.errstate(invalid="ignore", divide="ignore"):
-        autocorr = (autocorr / autocorr[..., :1]).astype(np.float64)
-    return np.swapaxes(autocorr, axis, -1)
+        return autocov / np.take(autocov, [0], axis=axis)
 
 
 def autocovariance(x: NDArray, axis: int = 0, bias: bool = True) -> NDArray:
@@ -152,7 +142,40 @@ def autocovariance(x: NDArray, axis: int = 0, bias: bool = True) -> NDArray:
     :return: autocovariance of ``x``.
     :rtype: numpy.ndarray
     """
-    return autocorrelation(x, axis, bias) * x.var(axis=axis, keepdims=True)
+    # Ref: https://en.wikipedia.org/wiki/Autocorrelation#Efficient_computation
+    # Adapted from Stan implementation
+    # https://github.com/stan-dev/math/blob/develop/stan/math/prim/mat/fun/autocorrelation.hpp
+    N = x.shape[axis]
+    M = _fft_next_fast_len(N)
+    M2 = 2 * M
+
+    # transpose axis with -1 for Fourier transform
+    x = np.swapaxes(x, axis, -1)
+
+    # centering x
+    centered_signal = x - x.mean(axis=-1, keepdims=True)
+    # np.fft promotes to double precision; keep doing so explicitly because
+    # scipy.fft computes in the input precision
+    centered_signal = centered_signal.astype(np.float64, copy=False)
+
+    # Fourier transform
+    freqvec = _rfft(centered_signal, n=M2, axis=-1)
+    # take square of magnitude of freqvec (or freqvec x freqvec*)
+    freqvec_gram = freqvec * np.conjugate(freqvec)
+    # inverse Fourier transform
+    autocov = _irfft(freqvec_gram, n=M2, axis=-1)
+
+    # truncate the result and normalize by the number of terms in each lag sum,
+    # then transpose back to original shape
+
+    # the unbiased estimator is known to have "wild" tails, due to few samples at longer lags.
+    # see Geyer (1992) and Priestley (1981) for a discussion. also note that it is only strictly
+    # unbiased when the mean is known, whereas we it estimate from samples here.
+    if bias:
+        autocov = autocov[..., :N] / N
+    else:
+        autocov = autocov[..., :N] / np.arange(N, 0.0, -1)
+    return np.swapaxes(autocov, axis, -1)
 
 
 def effective_sample_size(x: NDArray, bias: bool = True) -> NDArray:
@@ -218,7 +241,16 @@ def hpdi(x: NDArray, prob: float = 0.90, axis: int = 0) -> NDArray:
     """
     x = np.swapaxes(x, axis, 0)
     sorted_x = np.sort(x, axis=0)
-    mass = x.shape[0]
+    hpd_left, hpd_right = _hpdi_of_sorted(sorted_x, prob)
+    hpd_left = np.swapaxes(hpd_left, axis, 0)
+    hpd_right = np.swapaxes(hpd_right, axis, 0)
+    return np.concatenate([hpd_left, hpd_right], axis=axis)
+
+
+def _hpdi_of_sorted(sorted_x: NDArray, prob: float) -> tuple[NDArray, NDArray]:
+    # compute the hpdi bounds of samples already sorted along axis 0; both
+    # bounds are returned with a leading axis of size 1
+    mass = sorted_x.shape[0]
     index_length = int(prob * mass)
     intervals_left = sorted_x[: (mass - index_length)]
     intervals_right = sorted_x[index_length:]
@@ -226,10 +258,8 @@ def hpdi(x: NDArray, prob: float = 0.90, axis: int = 0) -> NDArray:
     index_start = intervals_length.argmin(axis=0)
     index_end = index_start + index_length
     hpd_left = np.take_along_axis(sorted_x, index_start[None, ...], axis=0)
-    hpd_left = np.swapaxes(hpd_left, axis, 0)
     hpd_right = np.take_along_axis(sorted_x, index_end[None, ...], axis=0)
-    hpd_right = np.swapaxes(hpd_right, axis, 0)
-    return np.concatenate([hpd_left, hpd_right], axis=axis)
+    return hpd_left, hpd_right
 
 
 def summary(
@@ -267,8 +297,14 @@ def summary(
         value_flat = np.reshape(value, (-1,) + value.shape[2:])
         mean = value_flat.mean(axis=0)
         std = value_flat.std(axis=0, ddof=1)
-        median = np.median(value_flat, axis=0)
-        hpd = hpdi(value_flat, prob=prob)
+        # sort once and reuse the result for both the median and the hpdi
+        sorted_flat = np.sort(value_flat, axis=0)
+        n = sorted_flat.shape[0]
+        median = (sorted_flat[(n - 1) // 2] + sorted_flat[n // 2]) / 2
+        # like np.median, return nan wherever any draw is nan (sorting puts
+        # nans last, so it suffices to check the last draw)
+        median = np.where(np.isnan(sorted_flat[-1]), median.dtype.type(np.nan), median)
+        hpd = np.concatenate(_hpdi_of_sorted(sorted_flat, prob), axis=0)
         n_eff = effective_sample_size(value)
         r_hat = split_gelman_rubin(value)
         hpd_lower = "{:.1f}%".format(50 * (1 - prob))

--- a/test/test_diagnostics.py
+++ b/test/test_diagnostics.py
@@ -14,6 +14,7 @@ from numpyro.diagnostics import (
     gelman_rubin,
     hpdi,
     split_gelman_rubin,
+    summary,
 )
 
 
@@ -106,3 +107,18 @@ def test_split_gelman_rubin_agree_with_gelman_rubin():
 def test_effective_sample_size():
     x = np.arange(1000.0).reshape(100, 10)
     assert_allclose(effective_sample_size(x, bias=False), 52.64, atol=0.01)
+
+
+@pytest.mark.parametrize("num_draws", [500, 501])
+def test_summary_median_matches_numpy(num_draws):
+    x = np.random.RandomState(0).randn(2, num_draws, 3)
+    stats = summary({"x": x})["x"]
+    assert_allclose(stats["median"], np.median(x.reshape(-1, 3), axis=0))
+
+
+def test_summary_median_propagates_nan():
+    x = np.random.RandomState(0).randn(2, 100, 3)
+    x[0, 5, 1] = np.nan
+    stats = summary({"x": x})["x"]
+    assert np.isnan(stats["median"][1])
+    assert not np.isnan(stats["median"][[0, 2]]).any()


### PR DESCRIPTION
## Changes made

All in `numpyro/diagnostics.py`:

- **`autocovariance` is now the FFT primitive, `autocorrelation` derives from it.** Previously `autocorrelation` normalized the raw FFT autocovariance by its lag-0 value, and `autocovariance` then multiplied the variance back in (`autocorrelation(x) * x.var()`) — two extra full-array passes plus a separate variance pass, and a redundant `.astype(np.float64)` copy (the FFT output is already float64). `effective_sample_size` consumes `autocovariance`, so its hot path drops all of these. `autocorrelation` still returns the same values, now computed as `autocov / autocov[lag 0]` (the lag-0 autocovariance is identical for the biased and unbiased estimators, which is what the old normalization relied on implicitly).
- **FFTs go through `scipy.fft` with `workers=-1`**, with an `np.fft` fallback. scipy is not a direct numpyro dependency but is guaranteed transitively via jax, and numpyro already uses it in several lazy imports (e.g. `distributions/continuous.py`, `infer/calibration.py`); the test suite also imports `scipy.fftpack` in `test_diagnostics.py`. `np.fft` is single-threaded; `scipy.fft` parallelizes across the batch dimensions, which is exactly the shape of the ESS workload (one FFT per chain per parameter column). Since `scipy.fft` computes in the input precision (unlike `np.fft`, which always promotes), the centered signal is explicitly cast to float64 to keep the double-precision behavior.
- **`summary()` sorts each parameter's draws once** and reuses the sorted array for both the median and the hpdi bounds. Previously `np.median` partitioned the very array that `hpdi` then fully sorted. The sliding-window part of `hpdi` is factored into a private `_hpdi_of_sorted` helper; the public `hpdi` is unchanged. The median-from-sorted matches `np.median` semantics including NaN propagation (sorting places NaNs last, so checking the last draw suffices).

Behavioral notes: float64 results agree with master to rtol 1e-9. For float32 inputs, results differ at the float32-round-off level (relative ~1e-7) because the old code normalized with a float32 `x.var()` while the new code stays in float64 throughout — the new values are the more precise ones. `autocovariance` of a constant series now returns 0 rather than NaN (the old NaN came from the 0/0 lag-0 normalization that the variance multiplication couldn't undo); `effective_sample_size` and `autocorrelation` still return NaN for that case as before.

## Benchmarks

Apple M2 (24 GB, 8 cores), CPU, numpy 2.x/scipy via jax 0.10.2, Python 3.11. Best of 3 after warmup.

| workload | master | this PR | speedup |
|---|---|---|---|
| `summary()` on {a: (4, 2000, 100), b: (4, 2000, 50, 10)} | 0.317 s | 0.199 s | 1.59× |
| `summary()` on (4, 5000, 2000) | 3.50 s | 2.08 s | 1.69× |
| `effective_sample_size` on (4, 2000, 50, 10) | 0.107 s | 0.052 s | 2.06× |
| `hpdi` standalone (8000, 500) | 0.100 s | 0.100 s | 1.0× (unchanged by design) |

This is the `mcmc.print_summary()` path, so every MCMC run with the default summary printout benefits.

## Links to related issues/PRs

None.

## Tests

- New `test_summary_median_matches_numpy` (odd and even draw counts) and `test_summary_median_propagates_nan` in `test/test_diagnostics.py` — lock in that the shared-sort median is exactly `np.median`, including NaN propagation.
- Existing coverage: `pytest test/test_diagnostics.py` — 28 passed (autocorrelation/autocovariance/ESS/hpdi/gelman-rubin values are asserted against fixed references there).
- Cross-checked patched vs master outputs on random, AR(1), float32, integer, and NaN-containing inputs for `autocorrelation`/`autocovariance` (bias=True/False), `effective_sample_size`, `hpdi`, and every `summary` statistic: float64 agrees to rtol 1e-9; float32 differs only at round-off as described above.
- `ruff check` / `ruff format --check` / `ty check` clean.

## Dependencies

None (scipy is used only behind a try/except fallback).