### PR TITLE
fix(distributions): handle zero-mean negative binomial

### DIFF
--- a/numpyro/distributions/conjugate.py
+++ b/numpyro/distributions/conjugate.py
@@ -430,7 +430,7 @@ class GammaPoisson(Distribution):
         .. math::
             \mathrm{Var}[X] = \frac{\alpha}{\lambda^2}(1 + \lambda)
         """
-        return self.concentration / self.rate * (1 + 1 / self.rate)
+        return jnp.asarray(self.concentration / self.rate * (1 + 1 / self.rate))
 
     def cdf(self, value: ArrayLike) -> Array:
         r"""If :math:`X \sim \mathrm{GammaPoisson}(\alpha, \lambda)`, then the cumulative

--- a/numpyro/distributions/conjugate.py
+++ b/numpyro/distributions/conjugate.py
@@ -7,7 +7,7 @@ from typing import Optional
 import jax
 from jax import lax, nn, random
 import jax.numpy as jnp
-from jax.scipy.special import betainc, betaln, gammaln
+from jax.scipy.special import betainc, betaln, gammaln, xlog1py, xlogy
 from jax.typing import ArrayLike
 
 from numpyro.distributions import constraints
@@ -390,12 +390,16 @@ class GammaPoisson(Distribution):
         .. math::
             p_{X}(k) = \frac{\lambda^\alpha}{(\alpha + k)(1+\lambda)^{\alpha + k}\mathrm{B}(\alpha, k + 1)}
         """
-        post_value = self.concentration + value
+        dtype = jnp.result_type(float)
+        concentration = jnp.array(self.concentration, dtype=dtype)
+        rate = jnp.array(self.rate, dtype=dtype)
+        value = jnp.array(value, dtype=dtype)
+        post_value = concentration + value
         return (
-            -betaln(self.concentration, value + 1)
+            -betaln(concentration, value + 1)
             - jnp.log(post_value)
-            + self.concentration * jnp.log(self.rate)
-            - post_value * jnp.log1p(self.rate)
+            + xlogy(-concentration, 1 + 1 / rate)
+            - xlog1py(value, rate)
         )
 
     @property
@@ -414,7 +418,7 @@ class GammaPoisson(Distribution):
         .. math::
             \mathrm{Var}[X] = \frac{\alpha}{\lambda^2}(1 + \lambda)
         """
-        return self.concentration / jnp.square(self.rate) * (1 + self.rate)
+        return self.concentration / self.rate * (1 + 1 / self.rate)
 
     def cdf(self, value: ArrayLike) -> ArrayLike:
         r"""If :math:`X \sim \mathrm{GammaPoisson}(\alpha, \lambda)`, then the cumulative
@@ -427,7 +431,12 @@ class GammaPoisson(Distribution):
         which is the regularized incomplete beta function.
         This implementation uses :func:`~jax.scipy.special.betainc`.
         """
-        bt = betainc(self.concentration, value + 1.0, self.rate / (self.rate + 1.0))
+        rate_fraction = jnp.where(
+            jnp.isinf(self.rate),
+            jnp.ones_like(self.rate),
+            self.rate / (self.rate + 1.0),
+        )
+        bt = betainc(self.concentration, value + 1.0, rate_fraction)
         return bt
 
 
@@ -481,7 +490,7 @@ class NegativeBinomialProbs(GammaPoisson):
     ):
         self.total_count, self.probs = promote_shapes(total_count, probs)
         concentration = total_count
-        rate = 1.0 / probs - 1.0
+        rate = jnp.divide(1.0, probs) - 1.0
         super().__init__(concentration, rate, validate_args=validate_args)
 
 
@@ -539,7 +548,7 @@ class NegativeBinomial2(GammaPoisson):
     """
 
     arg_constraints = {
-        "mean": constraints.positive,
+        "mean": constraints.nonnegative,
         "concentration": constraints.positive,
     }
     support = constraints.nonnegative_integer
@@ -552,8 +561,15 @@ class NegativeBinomial2(GammaPoisson):
         *,
         validate_args: Optional[bool] = None,
     ):
-        rate = concentration / mean
+        rate = jnp.divide(concentration, mean)
         super().__init__(concentration, rate, validate_args=validate_args)
+
+
+class _HurdleNegativeBinomial2(NegativeBinomial2):
+    arg_constraints = {
+        **NegativeBinomial2.arg_constraints,
+        "mean": constraints.positive,
+    }
 
 
 def ZeroInflatedNegativeBinomial2(
@@ -612,7 +628,7 @@ def HurdleNegativeBinomial2(
        *Econometrica*, 39(5), 829-844.
     """
     return HurdleProbs(
-        NegativeBinomial2(mean, concentration, validate_args=validate_args),
+        _HurdleNegativeBinomial2(mean, concentration, validate_args=validate_args),
         gate,
         validate_args=validate_args,
     )

--- a/test/test_distributions.py
+++ b/test/test_distributions.py
@@ -2117,6 +2117,81 @@ def test_gamma_poisson_log_prob(shape):
     assert_allclose(actual, expected, rtol=0.05)
 
 
+@pytest.mark.parametrize(
+    "distribution_type",
+    [
+        "gamma_poisson",
+        "negative_binomial_probs",
+        "negative_binomial_factory",
+        "negative_binomial_2",
+    ],
+)
+def test_zero_mean_negative_binomial(distribution_type):
+    if distribution_type == "gamma_poisson":
+        distribution = dist.GammaPoisson(1.0, jnp.inf, validate_args=True)
+    elif distribution_type == "negative_binomial_probs":
+        distribution = dist.NegativeBinomialProbs(1.0, 0.0, validate_args=True)
+    elif distribution_type == "negative_binomial_factory":
+        distribution = dist.NegativeBinomial(1.0, probs=0.0, validate_args=True)
+    else:
+        distribution = dist.NegativeBinomial2(0.0, 1.0, validate_args=True)
+
+    actual = distribution.log_prob(jnp.arange(2))
+    expected = jnp.array([0.0, -jnp.inf])
+
+    assert_allclose(actual, expected, atol=1e-6)
+    assert_allclose(distribution.variance, 0.0)
+    assert_allclose(distribution.cdf(jnp.arange(2)), 1.0)
+    assert_array_equal(distribution.sample(random.key(0), (10,)), 0)
+
+
+@pytest.mark.parametrize(
+    "distribution_type",
+    ["gamma_poisson", "negative_binomial_probs", "negative_binomial_2"],
+)
+def test_negative_binomial_log_prob_gradient(distribution_type):
+    def log_prob(parameter):
+        if distribution_type == "gamma_poisson":
+            distribution = dist.GammaPoisson(10, parameter)
+        elif distribution_type == "negative_binomial_probs":
+            distribution = dist.NegativeBinomialProbs(10, parameter)
+        else:
+            distribution = dist.NegativeBinomial2(parameter, 10)
+        return distribution.log_prob(0)
+
+    parameter = {
+        "gamma_poisson": 2.0,
+        "negative_binomial_probs": 0.5,
+        "negative_binomial_2": 2.0,
+    }[distribution_type]
+    expected_gradient = {
+        "gamma_poisson": 10 / (2 * 3),
+        "negative_binomial_probs": -10 / 0.5,
+        "negative_binomial_2": -10 / 12,
+    }[distribution_type]
+    actual_gradient = jax.jit(jax.grad(log_prob))(parameter)
+    assert_allclose(actual_gradient, expected_gradient, atol=1e-6)
+
+
+def test_hurdle_negative_binomial_requires_positive_mean():
+    with pytest.raises(ValueError, match="mean"):
+        dist.HurdleNegativeBinomial2(0.4, 0.0, 1.0, validate_args=True)
+
+
+def test_gamma_poisson_mixed_finite_and_infinite_rates():
+    distribution = dist.GammaPoisson(
+        jnp.ones(2), jnp.array([2.0, jnp.inf]), validate_args=True
+    )
+
+    assert_allclose(
+        distribution.log_prob(jnp.zeros(2)),
+        jnp.array([jnp.log(2 / 3), 0.0]),
+        atol=1e-6,
+    )
+    assert_allclose(distribution.variance, jnp.array([0.75, 0.0]))
+    assert_allclose(distribution.cdf(jnp.zeros(2)), jnp.array([2 / 3, 1.0]), atol=1e-6)
+
+
 @pytest.mark.parametrize("conc", [15.0, 20.0, 30.0])
 def test_inverse_wishart_variance(conc):
     """Test InverseWishart variance formula against Monte Carlo samples.


### PR DESCRIPTION
## Summary

- Handle zero-mean Negative Binomial distributions without scalar division errors or NaN log probabilities.
- Evaluate infinite-rate GammaPoisson boundaries with stable log-probability, variance, CDF, and sampling behavior.
- Preserve the strict-positive mean requirement for `HurdleNegativeBinomial2`.

Fixes #2193

## Tests

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .\.venv\Scripts\python.exe -m pytest -q test/test_distributions.py -k 'zero_mean_negative_binomial or negative_binomial_log_prob_gradient or hurdle_negative_binomial_requires_positive_mean or gamma_poisson_mixed_finite_and_infinite_rates or gamma_poisson_log_prob or test_log_prob_gradient and (GammaPoisson or NegativeBinomial)'` (27 passed)
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .\.venv\Scripts\python.exe -m pytest -q test/test_distributions.py -k 'HurdleNegativeBinomial2'` (5 passed)
- `py -3.13 -m ruff check numpyro/distributions/conjugate.py test/test_distributions.py`
- `py -3.13 -m ruff format --check numpyro/distributions/conjugate.py test/test_distributions.py`

AI assistance disclosure: AI-assisted development tools were used during investigation and implementation. The reported tests were run against the final diff.
