### PR TITLE
Add regression test for render_model with masked observations (#2254)

### DIFF
--- a/test/test_model_rendering.py
+++ b/test/test_model_rendering.py
@@ -183,3 +183,28 @@ def test_param_with_lambda_and_sample():
     assert "x" in relations["sample_dist"]
     assert relations["sample_dist"]["x"] == "CategoricalProbs"
     assert "p" in relations["sample_param"]["x"]
+
+
+def test_get_model_relations_masked_observations():
+    """
+    Regression test for https://github.com/pyro-ppl/numpyro/issues/2254.
+
+    On JAX >= 0.11, boolean masks passed through Distribution.mask() appear
+    as closed-over constants in the jaxpr, which used to crash provenance
+    tracking with "AssertionError: length mismatch" in track_deps_jaxpr.
+    """
+
+    def model(obs, mask):
+        alpha = numpyro.sample("alpha", dist.Normal(0.0, 1.0))
+        sigma = numpyro.sample("sigma", dist.LogNormal(0.0, 1.0))
+        with numpyro.plate("data", obs.shape[0]):
+            numpyro.sample("obs", dist.Normal(alpha, sigma).mask(mask), obs=obs)
+
+    obs = jnp.array([1.0, 2.0, jnp.nan, 4.0])
+    mask = jnp.array([True, True, False, True])
+
+    relations = get_model_relations(model, model_args=(obs, mask))
+
+    assert relations["observed"] == ["obs"]
+    assert relations["sample_dist"]["obs"] == "Normal"
+    assert set(relations["sample_sample"]["obs"]) == {"alpha", "sigma"}


### PR DESCRIPTION
Adds a regression test for #2254 (`render_model` / `get_model_relations` crashing with `AssertionError: length mismatch` in `track_deps_jaxpr` when the model uses `Distribution.mask()` on JAX >= 0.11).

**Empirical verification** (answering @juanitorduz's question on the issue):

| numpyro | jax | result |
|---|---|---|
| 0.21.0 (released) | 0.11.1 | ❌ `AssertionError: length mismatch: [4, 3]` at `numpyro/ops/provenance.py:22` |
| master (0059d3a) | 0.11.1 | ✅ renders fine |

So the underlying bug was indeed fixed by #2245. However, #2245's test (`test/ops/test_provenance.py`) covers closed-over constants generically — nothing exercises the `Distribution.mask()` path from the original report, which is the user-facing way to hit it. This PR adds that test to `test/test_model_rendering.py` so the scenario stays covered.

The test also asserts the derived relations (`observed`, `sample_dist`, dependencies) so it validates behaviour rather than just "does not crash".

Closes #2254
