### PR TITLE
Rename Predictive's exclude_deterministic to condition_deterministic

### DIFF
--- a/numpyro/infer/util.py
+++ b/numpyro/infer/util.py
@@ -970,7 +970,18 @@ class Predictive(object):
 
         + set `batch_ndims=1` to get predictions from a one dimensional batch of the guide and parameters
           with shapes `(num_samples x batch_size x ...)`
-    :param exclude_deterministic: indicates whether to ignore deterministic sites from the posterior samples.
+    :param condition_deterministic: if True, deterministic sites present in
+        `posterior_samples` are conditioned on (substituted into the model)
+        when predicting; if False (default), they are ignored and instead
+        re-computed from their parent sites. Note that this argument controls
+        how deterministic sites are *handled during substitution*, not whether
+        they appear in the returned dictionary — use `return_sites` to control
+        which sites are returned. Conditioning on deterministic sites can
+        produce wrong shapes or stale values when predicting on new data,
+        which is why it is disabled by default.
+    :param exclude_deterministic: deprecated alias, use
+        ``condition_deterministic`` instead (``exclude_deterministic=True``
+        corresponds to ``condition_deterministic=False``).
 
     :return: dict of samples from the predictive distribution.
 
@@ -1012,8 +1023,27 @@ class Predictive(object):
         infer_discrete: bool = False,
         parallel: bool = False,
         batch_ndims: Optional[int] = None,
-        exclude_deterministic: bool = True,
+        condition_deterministic: Optional[bool] = None,
+        exclude_deterministic: Optional[bool] = None,
     ):
+        if exclude_deterministic is not None:
+            if condition_deterministic is not None:
+                raise ValueError(
+                    "Only one of `condition_deterministic` or the deprecated "
+                    "`exclude_deterministic` can be provided, not both."
+                )
+            warnings.warn(
+                "`exclude_deterministic` is deprecated, use "
+                "`condition_deterministic` instead "
+                "(`exclude_deterministic=True` corresponds to "
+                "`condition_deterministic=False`).",
+                FutureWarning,
+                stacklevel=find_stack_level(),
+            )
+            condition_deterministic = not exclude_deterministic
+        elif condition_deterministic is None:
+            condition_deterministic = False
+
         if posterior_samples is None and num_samples is None:
             raise ValueError(
                 "Either posterior_samples or num_samples must be specified."
@@ -1073,7 +1103,28 @@ class Predictive(object):
         self.parallel = parallel
         self.batch_ndims = batch_ndims
         self._batch_shape = batch_shape
-        self.exclude_deterministic = exclude_deterministic
+        self.condition_deterministic = condition_deterministic
+
+    @property
+    def exclude_deterministic(self) -> bool:
+        """Deprecated alias for ``not condition_deterministic``."""
+        warnings.warn(
+            "`exclude_deterministic` is deprecated, use "
+            "`condition_deterministic` instead.",
+            FutureWarning,
+            stacklevel=find_stack_level(),
+        )
+        return not self.condition_deterministic
+
+    @exclude_deterministic.setter
+    def exclude_deterministic(self, value: bool) -> None:
+        warnings.warn(
+            "`exclude_deterministic` is deprecated, use "
+            "`condition_deterministic` instead.",
+            FutureWarning,
+            stacklevel=find_stack_level(),
+        )
+        self.condition_deterministic = not value
 
     def _call_with_params(self, rng_key, params, args, kwargs):
         posterior_samples = self.posterior_samples
@@ -1090,7 +1141,7 @@ class Predictive(object):
                 parallel=self.parallel,
                 model_args=args,
                 model_kwargs=kwargs,
-                exclude_deterministic=self.exclude_deterministic,
+                exclude_deterministic=not self.condition_deterministic,
             )
         model = substitute(self.model, self.params)
         return _predictive(
@@ -1103,7 +1154,7 @@ class Predictive(object):
             parallel=self.parallel,
             model_args=args,
             model_kwargs=kwargs,
-            exclude_deterministic=self.exclude_deterministic,
+            exclude_deterministic=not self.condition_deterministic,
         )
 
     def __call__(self, rng_key, *args, **kwargs):

--- a/test/infer/test_infer_util.py
+++ b/test/infer/test_infer_util.py
@@ -161,12 +161,65 @@ def test_discrete_predictive_with_deterministic(parallel):
         infer_discrete=True,
         batch_ndims=2,
         parallel=parallel,
-        exclude_deterministic=False,
+        condition_deterministic=True,
     )
 
     predictive_samples = predictive(random.key(1), probs=probs)
     assert predictive_samples.keys() == {"counts_categorical"}
     assert predictive_samples["counts_categorical"].shape == probs.shape
+
+
+def test_predictive_exclude_deterministic_deprecated():
+    """`exclude_deterministic` still works but warns; `condition_deterministic`
+    is the new name (see #2086)."""
+    model, probs = categorical_probs()
+
+    with pytest.warns(FutureWarning, match="exclude_deterministic"):
+        predictive = Predictive(
+            model=model,
+            posterior_samples=dict(probs=probs),
+            batch_ndims=2,
+            exclude_deterministic=False,
+        )
+    assert predictive.condition_deterministic is True
+
+    with pytest.warns(FutureWarning, match="exclude_deterministic"):
+        predictive = Predictive(
+            model=model,
+            posterior_samples=dict(probs=probs),
+            batch_ndims=2,
+            exclude_deterministic=True,
+        )
+    assert predictive.condition_deterministic is False
+
+    # attribute access keeps working, with a warning
+    with pytest.warns(FutureWarning, match="exclude_deterministic"):
+        assert predictive.exclude_deterministic is True
+    with pytest.warns(FutureWarning, match="exclude_deterministic"):
+        predictive.exclude_deterministic = False
+    assert predictive.condition_deterministic is True
+
+    # passing both raises
+    with pytest.raises(ValueError, match="Only one of"):
+        Predictive(
+            model=model,
+            posterior_samples=dict(probs=probs),
+            batch_ndims=2,
+            condition_deterministic=True,
+            exclude_deterministic=False,
+        )
+
+
+def test_predictive_condition_deterministic_default():
+    """By default deterministic sites are re-computed, not conditioned on."""
+    model, probs = categorical_probs()
+
+    predictive = Predictive(
+        model=model,
+        posterior_samples=dict(probs=probs),
+        batch_ndims=2,
+    )
+    assert predictive.condition_deterministic is False
 
 
 def test_predictive_with_guide():


### PR DESCRIPTION
Implements the rename discussed in #2086: `Predictive`'s `exclude_deterministic` → **`condition_deterministic`** (name suggested by @kylejcaron, endorsed by @juanitorduz).

**Why**: the old name reads as if it filters deterministic sites out of the *returned* dictionary, but it actually controls whether deterministic sites in `posterior_samples` are *conditioned on during substitution* — the returned sites are governed by `return_sites`. That mismatch is exactly what confused the issue reporter (and, per the thread, the argument's own author).

**What this PR does:**
- New keyword `condition_deterministic: bool = False` — the default is behaviour-identical to the old `exclude_deterministic=True` default, so nothing changes for existing users.
- **Full backward compatibility**: `exclude_deterministic=` is still accepted (mapped to `not condition_deterministic`) with a `FutureWarning`; passing both raises `ValueError`. The `predictive.exclude_deterministic` *attribute* is kept as a deprecated property (getter + setter) so code that flips it after construction keeps working.
- Docstring rewritten to say what the flag actually does, point at `return_sites` for output filtering, and explain why conditioning on deterministic sites is off by default (shape/staleness bugs when predicting on new data — see #1772).
- Tests: deprecation warnings for kwarg/getter/setter, both-kwargs `ValueError`, default value, and the existing discrete-predictive test migrated to the new name.

Note: `MCMC.print_summary(exclude_deterministic=...)` is a different API where the name *is* accurate (it filters printed output), so it is deliberately untouched.

`ruff check`, `ruff format --check`, and `ty check` all pass; relevant test selection (18 predictive tests) passes locally.

Closes #2086
