### PR TITLE
Fix implicit Optional on GraphicalKernel.local_kernel_fns

### DIFF
--- a/numpyro/contrib/einstein/stein_kernels.py
+++ b/numpyro/contrib/einstein/stein_kernels.py
@@ -3,6 +3,7 @@
 
 from abc import ABC, abstractmethod
 from collections.abc import Callable
+from typing import Optional
 
 import numpy as np
 
@@ -350,7 +351,7 @@ class GraphicalKernel(SteinKernel):
     def __init__(
         self,
         mode="matrix",
-        local_kernel_fns: dict[str, SteinKernel] = None,
+        local_kernel_fns: Optional[dict[str, SteinKernel]] = None,
         default_kernel_fn: SteinKernel = RBFKernel(),
     ):
         assert mode == "matrix"


### PR DESCRIPTION
`GraphicalKernel.__init__` annotates `local_kernel_fns` as `dict[str, SteinKernel]` but defaults it to `None`:

```python
def __init__(
    self,
    mode="matrix",
    local_kernel_fns: dict[str, SteinKernel] = None,
    default_kernel_fn: SteinKernel = RBFKernel(),
):
```

`None` isn't part of that type. The body already treats `None` as the sentinel for "no per-parameter kernels":

```python
self.local_kernel_fns = local_kernel_fns if local_kernel_fns is not None else {}
```

and the docstring documents it as optional ("default to default_kernel_fn for each parameter"), so the behaviour is right and only the annotation is wrong.

`ruff` already has a rule for exactly this, and it fires on the current `master`:

```
$ ruff check --isolated --select RUF013 numpyro/
RUF013 PEP 484 prohibits implicit `Optional`
   --> numpyro/contrib/einstein/stein_kernels.py:353:27
    |
353 |         local_kernel_fns: dict[str, SteinKernel] = None,
    |                           ^^^^^^^^^^^^^^^^^^^^^^
    |
help: Convert to `T | None`

Found 1 error.
```

It isn't caught in CI because `[tool.ruff.lint] select` is `["ANN", "E", "F", "I", "W"]` and `RUF` isn't included. After this change that command reports `All checks passed!`, and it's the only occurrence in the package — so if you'd want `RUF013` added to `select` to keep it from coming back, that would be a zero-noise addition. Happy to do it here or leave it out, whichever you prefer.

I used `Optional[...]` rather than ruff's suggested `T | None` to match the einstein module, which uses `Optional[...]` throughout (e.g. `mixture_guide_predictive.py`) and has no `| None` annotations.

Since `GraphicalKernel` is exported in `numpyro.contrib.einstein.__all__` and documented with `autoclass` in `docs/source/contrib.rst`, the inaccurate signature is also what the rendered API docs show.

Checked with the repo's own gates: `ruff check .` → `All checks passed!`, `ruff format . --check` → `235 files already formatted`. No behaviour change.
