### PR TITLE
doc: link citation markers in the contrib API docstrings

### DIFF
--- a/numpyro/contrib/einstein/stein_kernels.py
+++ b/numpyro/contrib/einstein/stein_kernels.py
@@ -55,7 +55,7 @@ class SteinKernel(ABC):
 
 
 class RBFKernel(SteinKernel):
-    """Calculates the Gaussian RBF kernel function used in [1]. The kernel is given by
+    """Calculates the Gaussian RBF kernel function used in [`1 <rbfkernel-ref-1_>`__]. The kernel is given by
 
         :math:`k(x,y) = \\exp(\\frac{-1}{h} \\|x-y\\|^2)`,
 
@@ -75,7 +75,9 @@ class RBFKernel(SteinKernel):
 
     **References:**
 
-    1. Liu, Qiang, and Dilin Wang. "Stein Variational Gradient Descent: A General Purpose Bayesian Inference Algorithm."
+    1. .. _rbfkernel-ref-1:
+
+       Liu, Qiang, and Dilin Wang. "Stein Variational Gradient Descent: A General Purpose Bayesian Inference Algorithm."
         Advances in neural information processing systems 29 (2016).
     """
 
@@ -161,13 +163,15 @@ class IMQKernel(SteinKernel):
 
 class LinearKernel(SteinKernel):
     """
-    Calculates the linear kernel from Theorem 3.3 in [1]. The kernel is given by
+    Calculates the linear kernel from Theorem 3.3 in [`1 <linearkernel-ref-1_>`__]. The kernel is given by
 
         :math:`k(x,y) = x^T y + 1`.
 
     **References:**
 
-    1. Liu, Qiang, and Dilin Wang. "Stein Variational Gradient Descent as Moment Matching."
+    1. .. _linearkernel-ref-1:
+
+       Liu, Qiang, and Dilin Wang. "Stein Variational Gradient Descent as Moment Matching."
         Advances in Neural Information Processing Systems 31 (2018).
     """
 
@@ -190,7 +194,8 @@ class LinearKernel(SteinKernel):
 
 
 class RandomFeatureKernel(SteinKernel):
-    """Calculates the Gaussian variate of random kernel in eq. 5 and 6 of [1]. The kernel is given by
+    """Calculates the Gaussian variate of random kernel in eq. 5 and 6 of [`1 <randomfeaturekernel-ref-1_>`__]. The
+    kernel is given by
 
         :math:`k(x,y)= \\frac{1}{m}\\sum_{l=1}^{m}\\phi(x,w_l)\\phi(y,w_l)`,
 
@@ -209,7 +214,9 @@ class RandomFeatureKernel(SteinKernel):
 
     **References:**
 
-    1. Liu, Qiang, and Dilin Wang. "Stein Variational Gradient Descent as Moment Matching."
+    1. .. _randomfeaturekernel-ref-1:
+
+       Liu, Qiang, and Dilin Wang. "Stein Variational Gradient Descent as Moment Matching."
         Advances in Neural Information Processing Systems 31 (2018).
     """
 
@@ -282,7 +289,7 @@ class RandomFeatureKernel(SteinKernel):
 
 
 class MixtureKernel(SteinKernel):
-    """Calculates a mixture of multiple kernels from eq. 1 of [1]. The kernel is given by
+    """Calculates a mixture of multiple kernels from eq. 1 of [`1 <mixturekernel-ref-1_>`__]. The kernel is given by
 
         :math:`k(x,y) = \\sum_i w_ik_i(x,y)`,
 
@@ -293,7 +300,9 @@ class MixtureKernel(SteinKernel):
 
     **References:**
 
-    1. Ai, Qingzhong, et al. "Stein variational gradient descent with multiple kernels."
+    1. .. _mixturekernel-ref-1:
+
+       Ai, Qingzhong, et al. "Stein variational gradient descent with multiple kernels."
         Cognitive Computation 15.2 (2023): 672-682.
     """
 
@@ -329,7 +338,8 @@ class MixtureKernel(SteinKernel):
 
 
 class GraphicalKernel(SteinKernel):
-    """Calculates the graphical kernel, also called the coordinate-wise kernel, from Theorem 1 in [1].
+    """Calculates the graphical kernel, also called the coordinate-wise kernel, from Theorem 1 in [`1
+    <graphicalkernel-ref-1_>`__].
     The kernel is given by
 
         :math:`k(x,y) = diag({k_l(x_l,y_l)})`,
@@ -343,7 +353,9 @@ class GraphicalKernel(SteinKernel):
 
     **References:**
 
-    1. Wang, Dilin, Zhe Zeng, and Qiang Liu. "Stein variational message passing for continuous graphical models."
+    1. .. _graphicalkernel-ref-1:
+
+       Wang, Dilin, Zhe Zeng, and Qiang Liu. "Stein variational message passing for continuous graphical models."
         International Conference on Machine Learning. PMLR, 2018.
     """
 
@@ -400,11 +412,14 @@ class GraphicalKernel(SteinKernel):
 
 
 class ProbabilityProductKernel(SteinKernel):
-    """**EXPERIMENTAL** Compute the unormalized probability product kernel for Gaussians given by eq. 5 in [1].
+    """**EXPERIMENTAL** Compute the unormalized probability product kernel for Gaussians given by eq. 5 in [`1
+    <probabilityproductkernel-ref-1_>`__].
 
     **References**:
 
-    1. Jebara, Tony, Risi Kondor, and Andrew Howard. "Probability product kernels."
+    1. .. _probabilityproductkernel-ref-1:
+
+       Jebara, Tony, Risi Kondor, and Andrew Howard. "Probability product kernels."
         The Journal of Machine Learning Research 5 (2004): 819-844.
     """
 

--- a/numpyro/contrib/einstein/steinvi.py
+++ b/numpyro/contrib/einstein/steinvi.py
@@ -35,7 +35,7 @@ def _numel(shape):
 
 
 class SteinVI:
-    """Variational inference with Stein mixtures inference [1].
+    """Variational inference with Stein mixtures inference [`1 <steinvi-class-ref-1_>`__].
 
     **Example:**
 
@@ -81,7 +81,7 @@ class SteinVI:
     :param Callable model: Python callable with NumPyro primitives for the model.
     :param Callable guide: Python callable with NumPyro primitives for the guide.
     :param _NumPyroOptim optim: An instance of :class:`~numpyro.optim._NumpyroOptim`.
-        Adagrad should be preferred over Adam [1].
+        Adagrad should be preferred over Adam [`1 <steinvi-class-ref-1_>`__].
     :param SteinKernel kernel_fn: Function that computes the reproducing kernel to use with Stein mixture
         inference. We currently recommend :class:`~numpyro.contrib.einstein.RBFKernel`.
         This may change as criteria for kernel selection are not well understood yet.
@@ -90,7 +90,7 @@ class SteinVI:
     :param num_elbo_particles: Number of Monte Carlo draws used to approximate the attractive force gradient.
         More particles give better gradient approximations. Default is `10`.
     :param Float loss_temperature: Scaling factor of the attractive force. Default is `1`.
-    :param Float repulsion_temperature: Scaling factor of the repulsive force [2].
+    :param Float repulsion_temperature: Scaling factor of the repulsive force [`2 <steinvi-class-ref-2_>`__].
         We recommend not scaling the repulsion. Default is `1`.
     :param Callable non_mixture_guide_param_fn: Predicate on names of parameters in the guide which should be optimized
         using one particle. This could be parameters for large normal networks or other transformation.
@@ -100,11 +100,17 @@ class SteinVI:
 
     **References:**
 
-    1. Rønning, Ola, et al. "ELBOing Stein: Variational Bayes with Stein Mixture Inference."
+    1. .. _steinvi-class-ref-1:
+
+       Rønning, Ola, et al. "ELBOing Stein: Variational Bayes with Stein Mixture Inference."
         arXiv preprint arXiv:2410.22948 (2024).
-    2. Liu, Chang, et al. "Understanding and Accelerating Particle-Based Variational Inference."
+    2. .. _steinvi-class-ref-2:
+
+       Liu, Chang, et al. "Understanding and Accelerating Particle-Based Variational Inference."
         International Conference on Machine Learning. PMLR, 2019.
-    3. Wang, Dilin, and Qiang Liu. "Nonlinear Stein Variational Gradient Descent for Learning Diversified Mixture Models."
+    3. .. _steinvi-class-ref-3:
+
+       Wang, Dilin, and Qiang Liu. "Nonlinear Stein Variational Gradient Descent for Learning Diversified Mixture Models."
         International Conference on Machine Learning. PMLR, 2019.
     """  # noqa: E501
 
@@ -569,7 +575,7 @@ class SteinVI:
 
 
 class SVGD(SteinVI):
-    """Stein variational gradient descent [1].
+    """Stein variational gradient descent [`1 <svgd-ref-1_>`__].
 
     **Example:**
 
@@ -606,7 +612,7 @@ class SVGD(SteinVI):
     :param Callable model: Python callable with NumPyro primitives for the model.
     :param Callable guide: Python callable with NumPyro primitives for the guide.
     :param _NumPyroOptim optim: An instance of :class:`~numpyro.optim._NumpyroOptim`.
-        Adagrad should be preferred over Adam [1].
+        Adagrad should be preferred over Adam [`1 <svgd-ref-1_>`__].
     :param SteinKernel kernel_fn: Function that computes the reproducing kernel to use with SVGD.
         We currently recommend :class:`~numpyro.contrib.einstein.RBFKernel`. This may change as criteria for
         kernel selection are not well understood yet.
@@ -626,7 +632,9 @@ class SVGD(SteinVI):
 
     **References:**
 
-    1. Liu, Qiang, and Dilin Wang. "Stein Variational Gradient Descent: A General Purpose Bayesian Inference Algorithm."
+    1. .. _svgd-ref-1:
+
+       Liu, Qiang, and Dilin Wang. "Stein Variational Gradient Descent: A General Purpose Bayesian Inference Algorithm."
         Advances in neural information processing systems 29 (2016).
     """
 
@@ -664,7 +672,7 @@ ASVGDState = namedtuple(
 
 
 class ASVGD(SVGD):
-    """Annealing Stein variational gradient descent [1].
+    """Annealing Stein variational gradient descent [`1 <asvgd-ref-1_>`__].
 
     **Example:**
 
@@ -701,16 +709,17 @@ class ASVGD(SVGD):
     :param Callable model: Python callable with NumPyro primitives for the model.
     :param Callable guide: Python callable with NumPyro primitives for the guide.
     :param _NumPyroOptim optim: An instance of :class:`~numpyro.optim._NumpyroOptim`.
-        Adagrad should be preferred over Adam [1].
+        Adagrad should be preferred over Adam [`1 <asvgd-ref-1_>`__].
     :param SteinKernel kernel_fn: Function that computes the reproducing kernel to use with ASVGD.
         We currently recommend :class:`~numpyro.contrib.einstein.RBFKernel`.
         This may change as criteria for kernel selection are not well understood yet.
     :param num_stein_particles: Number of particles (i.e., mixture components) in the mixture approximation.
         Default is `10`.
-    :param num_cycles: The total number of cycles during inference. This corresponds to :math:`C` in eq. 4 of [1].
+    :param num_cycles: The total number of cycles during inference. This corresponds to :math:`C` in eq. 4 of [`1
+        <asvgd-ref-1_>`__].
         Default is `10`.
     :param trans_speed: Speed of transition between two phases during inference. This corresponds to :math:`p` in eq. 4
-        of [1]. Default is `10`.
+        of [`1 <asvgd-ref-1_>`__]. Default is `10`.
     :param Dict guide_kwargs: Keyword arguments for :class:`~numpyro.infer.autoguide.AutoDelta`.
         Default behaviour is the same as the default for :class:`~numpyro.infer.autoguide.AutoDelta`.
 
@@ -725,7 +734,9 @@ class ASVGD(SVGD):
 
     **References:**
 
-    1. D'Angelo, Francesco, and Vincent Fortuin. "Annealed Stein Variational Gradient Descent."
+    1. .. _asvgd-ref-1:
+
+       D'Angelo, Francesco, and Vincent Fortuin. "Annealed Stein Variational Gradient Descent."
         Third Symposium on Advances in Approximate Bayesian Inference, 2021.
     """
 

--- a/numpyro/contrib/hsgp/approximation.py
+++ b/numpyro/contrib/hsgp/approximation.py
@@ -240,11 +240,13 @@ def hsgp_periodic_non_centered(
     """
     Low rank approximation for the periodic squared exponential kernel in the non-centered parametrization.
 
-    See Appendix B in [1].
+    See Appendix B in [`1 <hsgp-periodic-non-centered-ref-1_>`__].
 
     **References:**
 
-        1. Riutort-Mayol, G., Bürkner, PC., Andersen, M.R. et al. Practical Hilbert space
+        1. .. _hsgp-periodic-non-centered-ref-1:
+
+           Riutort-Mayol, G., Bürkner, PC., Andersen, M.R. et al. Practical Hilbert space
            approximate Bayesian Gaussian processes for probabilistic programming. Stat Comput 33, 17 (2023).
 
     :param ArrayLike x: input data

--- a/numpyro/contrib/hsgp/laplacian.py
+++ b/numpyro/contrib/hsgp/laplacian.py
@@ -21,11 +21,13 @@ def eigenindices(m: list[int] | int, dim: int) -> Array:
 
         m^\\star = \\prod_{i=1}^D m_i
 
-    For more details see Eq. (10) in [1].
+    For more details see Eq. (10) in [`1 <eigenindices-ref-1_>`__].
 
     **References:**
 
-        1. Riutort-Mayol, G., Bürkner, PC., Andersen, M.R. et al. Practical Hilbert space
+        1. .. _eigenindices-ref-1:
+
+           Riutort-Mayol, G., Bürkner, PC., Andersen, M.R. et al. Practical Hilbert space
            approximate Bayesian Gaussian processes for probabilistic programming. Stat Comput 33, 17 (2023).
 
     :param list[int] | int m: The number of desired eigenvalue indices in each dimension.
@@ -80,11 +82,13 @@ def sqrt_eigenvalues(
 ) -> Array:
     """
     The first :math:`m^\\star \\times D` square root of eigenvalues of the laplacian operator in
-    :math:`[-L_1, L_1] \\times ... \\times [-L_D, L_D]`. See Eq. (56) in [1].
+    :math:`[-L_1, L_1] \\times ... \\times [-L_D, L_D]`. See Eq. (56) in [`1 <sqrt-eigenvalues-ref-1_>`__].
 
     **References:**
 
-        1. Solin, A., Särkkä, S. Hilbert space methods for reduced-rank Gaussian process regression.
+        1. .. _sqrt-eigenvalues-ref-1:
+
+           Solin, A., Särkkä, S. Hilbert space methods for reduced-rank Gaussian process regression.
            Stat Comput 30, 419-446 (2020)
 
     :param int | float | list[int | float] ell: The length of the interval in each dimension divided by 2.
@@ -105,7 +109,7 @@ def eigenfunctions(x: ArrayLike, ell: float | list[float], m: int | list[int]) -
     """
     The first :math:`m^\\star` eigenfunctions of the laplacian operator in
     :math:`[-L_1, L_1] \\times ... \\times [-L_D, L_D]`
-    evaluated at values of `x`. See Eq. (56) in [1].
+    evaluated at values of `x`. See Eq. (56) in [`1 <eigenfunctions-ref-1_>`__].
     If `x` is 1D, the problem is assumed unidimensional.
     Otherwise, the dimension of the input space is inferred as the size of the last dimension of
     `x`. Other dimensions are treated as batch dimensions.
@@ -134,7 +138,9 @@ def eigenfunctions(x: ArrayLike, ell: float | list[float], m: int | list[int]) -
 
     **References:**
 
-        1. Solin, A., Särkkä, S. Hilbert space methods for reduced-rank Gaussian process regression.
+        1. .. _eigenfunctions-ref-1:
+
+           Solin, A., Särkkä, S. Hilbert space methods for reduced-rank Gaussian process regression.
            Stat Comput 30, 419-446 (2020)
 
     :param ArrayLike x: The points at which to evaluate the eigenfunctions.

--- a/numpyro/contrib/hsgp/spectral_densities.py
+++ b/numpyro/contrib/hsgp/spectral_densities.py
@@ -25,7 +25,8 @@ def spectral_density_squared_exponential(
     """
     Spectral density of the squared exponential kernel.
 
-    See Section 4.2 in [1] and Section 2.1 in [2].
+    See Section 4.2 in [`1 <spectral-density-squared-exponential-ref-1_>`__] and Section 2.1 in [`2
+    <spectral-density-squared-exponential-ref-2_>`__].
 
     .. math::
 
@@ -35,9 +36,13 @@ def spectral_density_squared_exponential(
 
     **References:**
 
-        1. Rasmussen, C. E., & Williams, C. K. I. (2006). Gaussian Processes for Machine Learning.
+        1. .. _spectral-density-squared-exponential-ref-1:
 
-        2. Riutort-Mayol, G., Bürkner, PC., Andersen, M.R. et al. Practical Hilbert space
+           Rasmussen, C. E., & Williams, C. K. I. (2006). Gaussian Processes for Machine Learning.
+
+        2. .. _spectral-density-squared-exponential-ref-2:
+
+           Riutort-Mayol, G., Bürkner, PC., Andersen, M.R. et al. Practical Hilbert space
            approximate Bayesian Gaussian processes for probabilistic programming. Stat Comput 33, 17 (2023).
 
     :param int dim: dimension
@@ -59,7 +64,7 @@ def spectral_density_matern(
     """
     Spectral density of the Matérn kernel.
 
-    See Eq. (4.15) in [1] and Section 2.1 in [2].
+    See Eq. (4.15) in [`1 <spectral-density-matern-ref-1_>`__] and Section 2.1 in [`2 <spectral-density-matern-ref-2_>`__].
 
     .. math::
 
@@ -70,9 +75,13 @@ def spectral_density_matern(
 
     **References:**
 
-        1. Rasmussen, C. E., & Williams, C. K. I. (2006). Gaussian Processes for Machine Learning.
+        1. .. _spectral-density-matern-ref-1:
 
-        2. Riutort-Mayol, G., Bürkner, PC., Andersen, M.R. et al. Practical Hilbert space
+           Rasmussen, C. E., & Williams, C. K. I. (2006). Gaussian Processes for Machine Learning.
+
+        2. .. _spectral-density-matern-ref-2:
+
+           Riutort-Mayol, G., Bürkner, PC., Andersen, M.R. et al. Practical Hilbert space
            approximate Bayesian Gaussian processes for probabilistic programming. Stat Comput 33, 17 (2023).
 
     :param int dim: dimension
@@ -362,11 +371,13 @@ def diag_spectral_density_periodic(
     """
     Not actually a spectral density but these are used in the same
     way. These are simply the first `m` coefficients of the low rank
-    approximation for the periodic kernel. See Appendix B in [1].
+    approximation for the periodic kernel. See Appendix B in [`1 <diag-spectral-density-periodic-ref-1_>`__].
 
     **References:**
 
-        1. Riutort-Mayol, G., Bürkner, PC., Andersen, M.R. et al. Practical Hilbert space
+        1. .. _diag-spectral-density-periodic-ref-1:
+
+           Riutort-Mayol, G., Bürkner, PC., Andersen, M.R. et al. Practical Hilbert space
            approximate Bayesian Gaussian processes for probabilistic programming. Stat Comput 33, 17 (2023).
 
     :param ArrayLike alpha: amplitude

--- a/numpyro/contrib/nested_sampling.py
+++ b/numpyro/contrib/nested_sampling.py
@@ -125,7 +125,7 @@ class NestedSampler:
     (EXPERIMENTAL) A wrapper for `jaxns <https://github.com/Joshuaalbert/jaxns>`_ ,
     a nested sampling package based on JAX.
 
-    See reference [1] for details on the meaning of each parameter.
+    See reference [`1 <nestedsampler-ref-1_>`__] for details on the meaning of each parameter.
     Please consider citing this reference if you use the nested sampler in your research.
 
     .. note:: To enumerate over a discrete latent variable, you can add the keyword
@@ -136,7 +136,9 @@ class NestedSampler:
 
     **References**
 
-    1. *JAXNS: a high-performance nested sampling package based on JAX*,
+    1. .. _nestedsampler-ref-1:
+
+       *JAXNS: a high-performance nested sampling package based on JAX*,
        Joshua G. Albert (https://arxiv.org/abs/2012.15286)
 
     :param callable model: a call with NumPyro primitives

--- a/numpyro/contrib/stochastic_support/dcc.py
+++ b/numpyro/contrib/stochastic_support/dcc.py
@@ -153,11 +153,13 @@ class StochasticSupportInference(ABC):
 class DCC(StochasticSupportInference):
     """
     Implements the Divide, Conquer, and Combine (DCC) algorithm for models with
-    stochastic support from [1].
+    stochastic support from [`1 <dcc-ref-1_>`__].
 
     **References:**
 
-    1. *Divide, Conquer, and Combine: a New Inference Strategy for Probabilistic Programs with Stochastic Support*,
+    1. .. _dcc-ref-1:
+
+       *Divide, Conquer, and Combine: a New Inference Strategy for Probabilistic Programs with Stochastic Support*,
        Yuan Zhou, Hongseok Yang, Yee Whye Teh, Tom Rainforth
 
     **Example:**

--- a/numpyro/contrib/stochastic_support/sdvi.py
+++ b/numpyro/contrib/stochastic_support/sdvi.py
@@ -28,13 +28,15 @@ VALID_ELBOS = (Trace_ELBO, TraceMeanField_ELBO, TraceEnum_ELBO, TraceGraph_ELBO)
 class SDVI(StochasticSupportInference):
     """
     Implements the Support Decomposition Variational Inference (SDVI) algorithm for models with
-    stochastic support from [1]. This implementation creates a separate guide for each SLP, trains
+    stochastic support from [`1 <sdvi-ref-1_>`__]. This implementation creates a separate guide for each SLP, trains
     the guides separately, and then combines the guides by weighting them proportional to their ELBO
     estimates.
 
     **References:**
 
-    1. *Rethinking Variational Inference for Probabilistic Programs with Stochastic Support*,
+    1. .. _sdvi-ref-1:
+
+       *Rethinking Variational Inference for Probabilistic Programs with Stochastic Support*,
        Tim Reichelt, Luke Ong, Tom Rainforth
 
     **Example:**


### PR DESCRIPTION
Follow-up to #2261, which only addressed the text at the top of the Contributed Code page. This one addresses the docstrings underneath it. 

Anchors are named after the object, and the SteinVI class uses `steinvi-class-` since the SteinVI section already took `steinvi-ref-*`.

Verified the built docs page against master; only links are clickable now; everything else is untouched.